### PR TITLE
feat: add long-term memory to AI agent (recall + save)

### DIFF
--- a/docs/superpowers/plans/2026-04-28-agent-memory.md
+++ b/docs/superpowers/plans/2026-04-28-agent-memory.md
@@ -1,0 +1,707 @@
+# Agent Long-Term Memory Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the AI agent automatically recall relevant memories before every task and save new learnings after every task, enabling self-improvement across sessions.
+
+**Architecture:** Two new deterministic graph nodes (`memory_recall`, `memory_save`) added to both fast-agent and planning-agent. Recall runs semantic search + LLM relevance filter before the first working node. Save runs LLM extraction after the final node. Both use the reflector model (non-streaming, cheap).
+
+**Tech Stack:** LangGraph StateGraph, PostgreSQL + pgvector via Prisma, Bedrock Titan embeddings, `@langchain/core` messages
+
+**Spec:** `docs/superpowers/specs/2026-04-28-agent-memory-design.md`
+
+---
+
+### Task 1: Fix namespace prefix filter bug in persistence.ts
+
+**Files:**
+- Modify: `web-ui/lib/agent/persistence.ts:136-166`
+
+The search operation ignores the `namespacePrefix` parameter — it returns all tenant memories regardless of namespace. This must be fixed before the new nodes can do targeted searches.
+
+- [ ] **Step 1: Fix the vector search query to filter by namespace prefix**
+
+In `web-ui/lib/agent/persistence.ts`, find the search operation branch (line ~136). Replace the vector search query (lines 150-157) with one that filters by namespace prefix:
+
+```typescript
+// Inside the `else if (op.namespacePrefix !== undefined && op.query !== undefined)` branch:
+
+// Search operation
+const query = String(op.query);
+const limit = Number(op.limit ?? 5);
+const tenantId = configurable?.tenant_id as string ?? "default";
+const namespacePrefix = Array.isArray(op.namespacePrefix)
+    ? (op.namespacePrefix as string[]).join("/")
+    : "";
+
+let queryEmbedding: number[] | null = null;
+try {
+    queryEmbedding = await this.embeddings.embedQuery(query);
+} catch {
+    // fallback to text search
+}
+
+if (queryEmbedding) {
+    const embeddingStr = `[${queryEmbedding.join(",")}]`;
+    const rows = namespacePrefix
+        ? await prisma.$queryRaw<Array<{ key: string; value: unknown; namespace: string }>>`
+            SELECT "key", "value", "namespace"
+            FROM agent_memories
+            WHERE "tenantId" = ${tenantId}
+              AND "namespace" LIKE ${namespacePrefix + '%'}
+            ORDER BY embedding <=> ${embeddingStr}::vector
+            LIMIT ${limit}
+          `
+        : await prisma.$queryRaw<Array<{ key: string; value: unknown; namespace: string }>>`
+            SELECT "key", "value", "namespace"
+            FROM agent_memories
+            WHERE "tenantId" = ${tenantId}
+            ORDER BY embedding <=> ${embeddingStr}::vector
+            LIMIT ${limit}
+          `;
+    results.push(rows.map((r) => ({ key: r.key, value: r.value, namespace: r.namespace })));
+} else {
+    const rows = namespacePrefix
+        ? await prisma.agentMemory.findMany({
+            where: { tenantId, namespace: { startsWith: namespacePrefix } },
+            take: limit,
+            orderBy: { createdAt: "desc" },
+          })
+        : await prisma.agentMemory.findMany({
+            where: { tenantId },
+            take: limit,
+            orderBy: { createdAt: "desc" },
+          });
+    results.push(rows.map((r) => ({ key: r.key, value: r.value, namespace: r.namespace })));
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add web-ui/lib/agent/persistence.ts
+git commit -m "fix: add namespace prefix filtering to memory search queries"
+```
+
+---
+
+### Task 2: Remove dead LONG_TERM_MEMORY_GUIDANCE from prompt-templates.ts
+
+**Files:**
+- Modify: `web-ui/lib/agent/prompt-templates.ts:266-291`
+
+- [ ] **Step 1: Delete the dead constant**
+
+In `web-ui/lib/agent/prompt-templates.ts`, delete lines 266-291 (the entire `LONG_TERM_MEMORY_GUIDANCE` export and its JSDoc comment). This constant is never imported anywhere and will be replaced by dynamic `memoryContext` from the recall node.
+
+Remove this entire block:
+
+```typescript
+// ---------------------------------------------------------------------------
+// LONG-TERM MEMORY
+// ---------------------------------------------------------------------------
+
+/**
+ * Injected when the memory store is available.
+ * Instructs the agent on how to use cross-session long-term memory.
+ */
+export const LONG_TERM_MEMORY_GUIDANCE = `
+## Long-Term Memory
+...
+`;
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add web-ui/lib/agent/prompt-templates.ts
+git commit -m "refactor: remove dead LONG_TERM_MEMORY_GUIDANCE constant"
+```
+
+---
+
+### Task 3: Add memoryContext to ReflectionState in agent-shared.ts
+
+**Files:**
+- Modify: `web-ui/lib/agent/agent-shared.ts:28-93`
+
+- [ ] **Step 1: Add memoryContext field to the ReflectionState interface**
+
+In `web-ui/lib/agent/agent-shared.ts`, add `memoryContext` to the `ReflectionState` interface (after line 39, the `toolResults` field):
+
+```typescript
+export interface ReflectionState {
+    messages: BaseMessage[];
+    taskDescription: string;
+    plan: PlanStep[];
+    code: string;
+    executionOutput: string;
+    errors: string[];
+    reflection: string;
+    iterationCount: number;
+    nextAction: string;
+    isComplete: boolean;
+    toolResults: ToolResultEntry[];
+    memoryContext: string; // Formatted relevant memories from recall node
+}
+```
+
+- [ ] **Step 2: Add memoryContext channel to graphState**
+
+In the same file, add the `memoryContext` channel to the `graphState` object (after the `toolResults` channel, before the closing `}`):
+
+```typescript
+    memoryContext: {
+        reducer: (x: string, y: string) => y || x,
+        default: () => "",
+    },
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web-ui/lib/agent/agent-shared.ts
+git commit -m "feat: add memoryContext field to ReflectionState and graphState"
+```
+
+---
+
+### Task 4: Create shared memory node functions in a new memory-nodes.ts
+
+**Files:**
+- Create: `web-ui/lib/agent/memory-nodes.ts`
+
+Both agents need identical memory_recall and memory_save logic. Extract into a shared module to avoid duplication.
+
+- [ ] **Step 1: Create memory-nodes.ts with the memoryRecallNode function**
+
+Create `web-ui/lib/agent/memory-nodes.ts`:
+
+```typescript
+/**
+ * memory-nodes.ts
+ *
+ * Shared memory_recall and memory_save graph nodes for all agent types.
+ * memory_recall: semantic search + LLM relevance filter before task execution.
+ * memory_save: LLM extraction of learnings after task completion.
+ */
+
+import { HumanMessage, SystemMessage } from "@langchain/core/messages";
+import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
+import { ReflectionState, truncateOutput } from "./agent-shared";
+import { searchMemory, saveMemory } from "./persistence";
+
+interface MemoryNodeDeps {
+    reflectorModel: BaseChatModel;
+    tenantId?: string;
+    userId?: string;
+    store: unknown | null;
+}
+
+export function createMemoryRecallNode(deps: MemoryNodeDeps) {
+    const { reflectorModel, tenantId, userId, store } = deps;
+
+    return async function memoryRecallNode(state: ReflectionState): Promise<Partial<ReflectionState>> {
+        if (!store || !tenantId || !userId) {
+            console.log("[MemoryRecall] Skipped — store, tenantId, or userId not available");
+            return { memoryContext: "" };
+        }
+
+        const { messages } = state;
+        const lastHuman = [...messages].reverse().find(m => m._getType() === "human");
+        if (!lastHuman) {
+            console.log("[MemoryRecall] Skipped — no human message found");
+            return { memoryContext: "" };
+        }
+
+        const query = typeof lastHuman.content === "string"
+            ? lastHuman.content
+            : JSON.stringify(lastHuman.content);
+
+        console.log(`\n🧠 [MEMORY RECALL] Searching memories for: "${truncateOutput(query, 100)}"`);
+
+        let rawResults: Array<{ key: string; value: unknown; namespace: string }>;
+        try {
+            const results = await searchMemory(tenantId, userId, [], query, 10);
+            rawResults = (results as Array<{ key: string; value: unknown; namespace: string }>) ?? [];
+        } catch (err: any) {
+            console.warn(`[MemoryRecall] Search failed: ${err?.message ?? err}`);
+            return { memoryContext: "" };
+        }
+
+        if (rawResults.length === 0) {
+            console.log("[MemoryRecall] No memories found");
+            return { memoryContext: "" };
+        }
+
+        console.log(`[MemoryRecall] Found ${rawResults.length} raw memories, filtering for relevance...`);
+
+        const memorySummary = rawResults.map((m, i) =>
+            `${i + 1}. [${m.namespace}/${m.key}] ${JSON.stringify(m.value)}`
+        ).join("\n");
+
+        let relevantMemories: string;
+        try {
+            const filterPrompt = new SystemMessage(
+                `You are a relevance filter. Given a user task and a list of memories from previous sessions, return ONLY the memories that are directly relevant to the current task.
+
+Return a markdown list of relevant memories, each on its own line with the format:
+- [namespace/key] One-line summary of the relevant fact
+
+If no memories are relevant, return exactly: NONE`
+            );
+
+            const filterInput = new HumanMessage({
+                content: `**User Task:** ${truncateOutput(query, 2000)}
+
+**Available Memories:**
+${memorySummary}
+
+Return only the relevant memories.`
+            });
+
+            const response = await reflectorModel.invoke([filterPrompt, filterInput]);
+            const content = typeof response.content === "string"
+                ? response.content
+                : JSON.stringify(response.content);
+
+            if (content.trim() === "NONE" || !content.trim()) {
+                console.log("[MemoryRecall] No relevant memories after filtering");
+                return { memoryContext: "" };
+            }
+
+            relevantMemories = content.trim();
+        } catch (err: any) {
+            console.warn(`[MemoryRecall] Relevance filter failed: ${err?.message ?? err}`);
+            relevantMemories = rawResults.slice(0, 5).map(m =>
+                `- [${m.namespace}/${m.key}] ${JSON.stringify(m.value)}`
+            ).join("\n");
+        }
+
+        console.log(`🧠 [MEMORY RECALL] Injecting relevant memories into context`);
+
+        return { memoryContext: relevantMemories };
+    };
+}
+```
+
+- [ ] **Step 2: Add the createMemorySaveNode function to memory-nodes.ts**
+
+Append to `web-ui/lib/agent/memory-nodes.ts`:
+
+```typescript
+export function createMemorySaveNode(deps: MemoryNodeDeps) {
+    const { reflectorModel, tenantId, userId, store } = deps;
+
+    return async function memorySaveNode(state: ReflectionState): Promise<Partial<ReflectionState>> {
+        if (!store || !tenantId || !userId) {
+            console.log("[MemorySave] Skipped — store, tenantId, or userId not available");
+            return {};
+        }
+
+        const { messages, taskDescription, memoryContext } = state;
+        if (messages.length < 2) {
+            console.log("[MemorySave] Skipped — conversation too short to extract learnings");
+            return {};
+        }
+
+        console.log(`\n🧠 [MEMORY SAVE] Analyzing session for learnings...`);
+
+        const recentMessages = messages.slice(-20);
+        const conversationSummary = recentMessages.map(m => {
+            const role = m._getType();
+            const content = typeof m.content === "string"
+                ? m.content
+                : JSON.stringify(m.content);
+            return `[${role}] ${truncateOutput(content, 500)}`;
+        }).join("\n\n");
+
+        const extractPrompt = new SystemMessage(
+            `You are a memory extraction engine. Analyze the completed agent session and extract facts worth remembering for future sessions.
+
+**Categories and namespace conventions:**
+- Infrastructure facts → namespace: ["infra", "<account-id-or-general>"]
+  Examples: cluster regions, instance types, service configurations, resource counts
+- User preferences → namespace: ["user", "preferences"]
+  Examples: preferred output format, naming conventions, default regions, workflow preferences
+- Task outcomes / solutions → namespace: ["patterns", "<service-type>"]
+  Examples: how a scaling issue was resolved, successful deployment patterns
+- Error resolutions → namespace: ["errors", "<service-type>"]
+  Examples: how an OOM was fixed, what caused a timeout, permission error workarounds
+
+**Rules:**
+- Only extract facts that would be useful in a FUTURE session — skip ephemeral details
+- Each memory must have confidence "high" or "medium" — skip anything uncertain
+- Use descriptive, unique keys (e.g., "prod-ecs-cluster-region" not "fact-1")
+- Do NOT re-save facts that already exist in the known memories below
+
+**Return format:** A JSON array of objects:
+\`\`\`json
+[{ "namespace": ["infra", "123456789"], "key": "prod-cluster-region", "value": { "fact": "Production ECS cluster runs in us-east-1", "source": "discovered via describe-clusters", "confidence": "high" } }]
+\`\`\`
+
+Return an empty array \`[]\` if nothing new is worth saving.`
+        );
+
+        const extractInput = new HumanMessage({
+            content: `**Original Task:** ${truncateOutput(taskDescription || "Unknown", 500)}
+
+**Already Known (do NOT re-save):**
+${memoryContext || "No existing memories."}
+
+**Session Transcript (recent):**
+${truncateOutput(conversationSummary, 8000)}
+
+Extract memories to save.`
+        });
+
+        try {
+            const response = await reflectorModel.invoke([extractPrompt, extractInput]);
+            const content = typeof response.content === "string"
+                ? response.content
+                : JSON.stringify(response.content);
+
+            const jsonMatch = content.match(/\[[\s\S]*\]/);
+            if (!jsonMatch) {
+                console.log("[MemorySave] No JSON array found in response — nothing to save");
+                return {};
+            }
+
+            const memories: Array<{
+                namespace: string[];
+                key: string;
+                value: { fact: string; source: string; confidence: string };
+            }> = JSON.parse(jsonMatch[0]);
+
+            const toSave = memories.filter(m =>
+                m.confidence === undefined || m.value?.confidence === "high" || m.value?.confidence === "medium"
+            );
+
+            if (toSave.length === 0) {
+                console.log("[MemorySave] No high/medium confidence memories to save");
+                return {};
+            }
+
+            console.log(`🧠 [MEMORY SAVE] Saving ${toSave.length} memories...`);
+
+            for (const mem of toSave) {
+                try {
+                    await saveMemory(tenantId, userId, mem.namespace, mem.key, mem.value as Record<string, unknown>);
+                    console.log(`   ✅ Saved: ${mem.namespace.join("/")}/${mem.key}`);
+                } catch (err: any) {
+                    console.warn(`   ⚠️ Failed to save ${mem.key}: ${err?.message ?? err}`);
+                }
+            }
+        } catch (err: any) {
+            console.warn(`[MemorySave] Extraction failed: ${err?.message ?? err}`);
+        }
+
+        return {};
+    };
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web-ui/lib/agent/memory-nodes.ts
+git commit -m "feat: create shared memory_recall and memory_save node functions"
+```
+
+---
+
+### Task 5: Wire memory nodes into fast-agent.ts
+
+**Files:**
+- Modify: `web-ui/lib/agent/fast-agent.ts`
+
+- [ ] **Step 1: Add imports for memory node creators**
+
+At the top of `web-ui/lib/agent/fast-agent.ts`, add the import after the existing imports (after line 29):
+
+```typescript
+import { createMemoryRecallNode, createMemorySaveNode } from "./memory-nodes";
+```
+
+- [ ] **Step 2: Create memory node instances after model/tool setup**
+
+In `createFastGraph`, after the tool assembly block (after line 64, `const toolNode = new ToolNode(tools);`), add:
+
+```typescript
+    // --- Memory Nodes ---
+    const memoryDeps = { reflectorModel, tenantId, userId: config.userId, store };
+    const memoryRecallNode = createMemoryRecallNode(memoryDeps);
+    const memorySaveNode = createMemorySaveNode(memoryDeps);
+```
+
+- [ ] **Step 3: Inject memoryContext into the agent system prompt**
+
+In the `agentNode` function (line ~79), add the memory section to the system prompt. Find the line that builds `systemPrompt` (line 79) and add `memorySection` into the template:
+
+```typescript
+    async function agentNode(state: ReflectionState): Promise<Partial<ReflectionState>> {
+        const { messages, iterationCount, memoryContext } = state;
+
+        // ... existing logging ...
+
+        const baseIdentity = buildBaseIdentity(selectedSkill);
+
+        const memorySection = memoryContext
+            ? `\n## Relevant Context from Memory\n${memoryContext}\n`
+            : '';
+
+        const systemPrompt = new SystemMessage(`${baseIdentity}
+${effectiveSkillSection}
+${CORE_PRINCIPLES}
+${awsCliStandards}
+${autoApproveGuidance}
+${operationalWorkflows}
+${accountContext}
+${memorySection}
+// ... rest of the prompt unchanged ...
+```
+
+Note: Only the destructuring line and the `memorySection` variable + injection are new. The rest of the system prompt stays exactly as-is.
+
+- [ ] **Step 4: Register memory nodes and rewire the graph**
+
+Replace the graph construction section (lines 313-341) with:
+
+```typescript
+    // ---------------------------------------------------------------------------
+    // GRAPH CONSTRUCTION
+    // ---------------------------------------------------------------------------
+    const workflow = new StateGraph<ReflectionState>({ channels: graphState })
+        .addNode("memory_recall", memoryRecallNode)
+        .addNode("agent", agentNode)
+        .addNode("tools", collectingToolNode)
+        .addNode("reflect", reflectNode)
+        .addNode("memory_save", memorySaveNode)
+
+        .addEdge(START, "memory_recall")
+        .addEdge("memory_recall", "agent")
+
+        .addConditionalEdges("agent", shouldContinue, {
+            tools: "tools",
+            reflect: "reflect",
+            __end__: "memory_save"
+        })
+
+        .addConditionalEdges("reflect", shouldContinueFromReflect, {
+            agent: "agent",
+            __end__: "memory_save"
+        })
+
+        .addEdge("tools", "agent")
+        .addEdge("memory_save", END);
+```
+
+Note: The conditional edges that previously returned `END` (`__end__`) now route to `"memory_save"` instead. The `memory_save` node has an unconditional edge to `END`.
+
+- [ ] **Step 5: Update shouldContinue return type**
+
+The `shouldContinue` function (line ~278) currently returns `"tools" | "reflect" | "__end__"`. Update the `__end__` case to return `"memory_save"` instead:
+
+```typescript
+    function shouldContinue(state: ReflectionState): "tools" | "reflect" | "memory_save" {
+        const messages = state.messages;
+        const lastMessage = messages[messages.length - 1] as AIMessage;
+        const { iterationCount } = state;
+
+        if (lastMessage.tool_calls && lastMessage.tool_calls.length > 0) {
+            return "tools";
+        }
+
+        if (iterationCount >= MAX_ITERATIONS) {
+            console.log(`⚠️ Max iterations (${MAX_ITERATIONS}) reached. Stopping.`);
+            return "memory_save";
+        }
+
+        if (iterationCount >= MAX_REFLECT_ITERATIONS) {
+            console.log(`⚠️ Max reflection cycles (${MAX_REFLECT_ITERATIONS}) reached. Accepting answer.`);
+            return "memory_save";
+        }
+
+        return "reflect";
+    }
+
+    function shouldContinueFromReflect(state: ReflectionState): "agent" | "memory_save" {
+        if (state.isComplete) {
+            return "memory_save";
+        }
+        return "agent";
+    }
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web-ui/lib/agent/fast-agent.ts
+git commit -m "feat: wire memory_recall and memory_save nodes into fast-agent graph"
+```
+
+---
+
+### Task 6: Wire memory nodes into planning-agent.ts
+
+**Files:**
+- Modify: `web-ui/lib/agent/planning-agent.ts`
+
+- [ ] **Step 1: Add imports for memory node creators**
+
+At the top of `web-ui/lib/agent/planning-agent.ts`, add the import after the existing imports (after line 29):
+
+```typescript
+import { createMemoryRecallNode, createMemorySaveNode } from "./memory-nodes";
+```
+
+- [ ] **Step 2: Create memory node instances after model/tool setup**
+
+In `createReflectionGraph`, after the tool assembly block (after line 66, `const toolNode = new ToolNode(tools);`), add:
+
+```typescript
+    // --- Memory Nodes ---
+    const memoryDeps = { reflectorModel, tenantId, userId: config.userId, store };
+    const memoryRecallNode = createMemoryRecallNode(memoryDeps);
+    const memorySaveNode = createMemorySaveNode(memoryDeps);
+```
+
+- [ ] **Step 3: Inject memoryContext into the planner system prompt**
+
+In the `planNode` function (line ~70), destructure `memoryContext` from state and add it to the planner system prompt:
+
+```typescript
+    async function planNode(state: ReflectionState): Promise<Partial<ReflectionState>> {
+        const { messages, memoryContext } = state;
+        // ... existing code ...
+
+        const memorySection = memoryContext
+            ? `\n## Relevant Context from Memory\n${memoryContext}\n`
+            : '';
+
+        const plannerSystemPrompt = new SystemMessage(`${baseIdentity}
+Your role is to decompose the user's task into a precise, dependency-ordered execution plan.
+${effectiveSkillSection}
+${CORE_PRINCIPLES}
+${memorySection}
+## Planning Methodology
+// ... rest unchanged ...
+```
+
+- [ ] **Step 4: Inject memoryContext into the executor system prompt**
+
+In the `generateNode` function (line ~163), destructure `memoryContext` from state and add it:
+
+```typescript
+    async function generateNode(state: ReflectionState): Promise<Partial<ReflectionState>> {
+        const { messages, plan, iterationCount, memoryContext } = state;
+        // ... existing code ...
+
+        const memorySection = memoryContext
+            ? `\n## Relevant Context from Memory\n${memoryContext}\n`
+            : '';
+
+        const executorSystemPrompt = new SystemMessage(`${baseIdentity}
+Your role is to execute the current plan step precisely and completely using available tools.
+${effectiveSkillSection}
+${CORE_PRINCIPLES}
+${memorySection}
+## Current Execution Context
+// ... rest unchanged ...
+```
+
+- [ ] **Step 5: Register memory nodes and rewire the graph**
+
+Replace the graph construction section (lines 623-668) with:
+
+```typescript
+    // ---------------------------------------------------------------------------
+    // GRAPH CONSTRUCTION
+    // ---------------------------------------------------------------------------
+    const workflow = new StateGraph<ReflectionState>({ channels: graphState })
+        .addNode("memory_recall", memoryRecallNode)
+        .addNode("planner", planNode)
+        .addNode("generate", generateNode)
+        .addNode("tools", collectingToolNode)
+        .addNode("reflect", reflectNode)
+        .addNode("revise", reviseNode)
+        .addNode("final", finalNode)
+        .addNode("memory_save", memorySaveNode)
+
+        .addEdge(START, "memory_recall")
+        .addEdge("memory_recall", "planner")
+        .addEdge("planner", "generate")
+
+        .addConditionalEdges("generate", shouldContinueFromGenerate, {
+            tools: "tools",
+            reflect: "reflect",
+            final: "final"
+        })
+
+        .addConditionalEdges("tools", shouldContinueFromTools, {
+            generate: "generate",
+            reflect: "reflect"
+        })
+
+        .addConditionalEdges("reflect", shouldContinueFromReflect, {
+            revise: "revise",
+            final: "final"
+        })
+
+        .addConditionalEdges("revise", shouldContinueFromRevise, {
+            tools: "tools",
+            reflect: "reflect"
+        })
+
+        .addEdge("final", "memory_save")
+        .addEdge("memory_save", END);
+```
+
+Note: The only topology change is: `START → memory_recall → planner` (instead of `START → planner`) and `final → memory_save → END` (instead of `final → END`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web-ui/lib/agent/planning-agent.ts
+git commit -m "feat: wire memory_recall and memory_save nodes into planning-agent graph"
+```
+
+---
+
+### Task 7: Verify TypeScript compilation
+
+**Files:**
+- None (verification only)
+
+- [ ] **Step 1: Run TypeScript type check on web-ui**
+
+```bash
+cd web-ui && npx tsc --noEmit
+```
+
+Expected: No type errors. If there are errors, they will be in the files we modified — fix them before proceeding.
+
+- [ ] **Step 2: Run existing agent tests to check for regressions**
+
+```bash
+cd web-ui && npm run test -- --run
+```
+
+Expected: All existing tests pass. The memory nodes are additive — they shouldn't break existing behavior.
+
+- [ ] **Step 3: Run lint**
+
+```bash
+cd web-ui && npm run lint
+```
+
+Expected: No new lint errors.
+
+- [ ] **Step 4: Commit any fixes if needed**
+
+```bash
+git add -A
+git commit -m "fix: resolve type/lint issues from memory node integration"
+```
+
+Only run this step if Steps 1-3 surfaced issues that required fixes.

--- a/docs/superpowers/specs/2026-04-28-agent-memory-design.md
+++ b/docs/superpowers/specs/2026-04-28-agent-memory-design.md
@@ -1,0 +1,140 @@
+# Agent Long-Term Memory — Design Spec
+
+**Date:** 2026-04-28
+**Branch:** ai-memory
+**Status:** Approved
+
+## Problem
+
+The AI agent has memory tools (`save_memory`, `search_memory`) registered but never uses them because:
+
+1. `LONG_TERM_MEMORY_GUIDANCE` in `prompt-templates.ts` is dead code — never imported into any agent
+2. No graph node proactively searches memory before starting a task
+3. No graph node proactively saves learnings after completing a task
+4. The search query in `persistence.ts` ignores the `namespacePrefix` filter — returns all tenant memories
+5. The guidance text references "DynamoDB" when the store is PostgreSQL
+
+The agent has a filing cabinet but nobody told it to check or file anything.
+
+## Goal
+
+The agent should automatically recall relevant memories before every task and save new learnings after every task, enabling self-improvement across sessions.
+
+## Approach: Deterministic Graph Nodes
+
+Add two new nodes to both fast-agent and planning-agent graphs:
+
+- **`memory_recall`** — runs once before the first working node
+- **`memory_save`** — runs once after the final node
+
+These are graph nodes, not prompt hints. Memory usage is deterministic, not LLM-discretionary.
+
+## Design
+
+### State Schema Change
+
+One new field in `ReflectionState` and `graphState`:
+
+```typescript
+memoryContext: {
+    reducer: (x: string, y: string) => y || x,
+    default: () => "",
+}
+```
+
+### memory_recall Node
+
+**Position in graph:** `START → memory_recall → [first working node]`
+
+**Steps:**
+
+1. Extract the user's last human message as the search query
+2. Semantic search across all namespaces (no prefix filter), limit 10 results
+3. Pass results through the reflector model with a relevance-filter prompt:
+   - Input: user task + raw memory results
+   - Output: JSON array of relevant memory keys with one-line reasons
+4. Format relevant memories as a markdown section for injection into system prompts
+5. Return `{ memoryContext: formattedString }`
+
+**Failure handling:** Log warning, return empty `memoryContext`. Memory never blocks task execution.
+
+**Skip condition:** If no store is available (store is null), skip entirely and return empty memoryContext.
+
+### memory_save Node
+
+**Position in graph:**
+- Fast agent: after the agent's final response (before `END`)
+- Planning agent: after the `final` node (before `END`)
+
+**Steps:**
+
+1. Single reflector model call analyzing the completed session
+2. Extract memories across four categories:
+   - Infrastructure facts → `["infra", "<account-id-or-general>"]`
+   - User preferences → `["user", "preferences"]`
+   - Task outcomes → `["patterns", "<service-type>"]`
+   - Error resolutions → `["errors", "<service-type>"]`
+3. LLM returns JSON array: `{ namespace: string[], key: string, value: { fact, source, confidence } }`
+4. Filter to `confidence: "high"` or `"medium"` only
+5. Call `saveMemory()` for each extracted memory
+6. Deduplication: prompt includes existing memories from recall to avoid re-saving known facts
+
+**Failure handling:** Log warning, continue. Failed save doesn't affect user response.
+
+### Prompt Integration
+
+All system prompts in both agents get a conditional memory section:
+
+```typescript
+const memorySection = state.memoryContext
+  ? `\n## Relevant Context from Memory\n${state.memoryContext}\n`
+  : '';
+```
+
+Inserted alongside identity, skills, account context sections.
+
+### Graph Topology Changes
+
+**Fast Agent:**
+```
+START → memory_recall → agent → tools ↔ agent → reflect ↔ agent → memory_save → END
+```
+Note: The fast agent currently ends via conditional edges returning `__end__`. With the save node, those edges route to `memory_save` instead of `END`, and `memory_save` has an unconditional edge to `END`.
+
+**Planning Agent:**
+```
+START → memory_recall → planner → generate → tools ↔ generate → reflect ↔ revise → final → memory_save → END
+```
+
+### Bug Fixes
+
+1. **Remove dead `LONG_TERM_MEMORY_GUIDANCE`** from `prompt-templates.ts` — replaced by dynamic memoryContext
+2. **Fix namespace filter in search** (`persistence.ts`): add `WHERE namespace LIKE ${prefix}%` to both vector and fallback queries
+3. **Fix `namespacePrefix` handling**: when empty array, search all; when populated, filter by joined prefix
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `web-ui/lib/agent/agent-shared.ts` | Add `memoryContext` to `ReflectionState` and `graphState` |
+| `web-ui/lib/agent/fast-agent.ts` | Add `memory_recall` and `memory_save` nodes, rewire graph |
+| `web-ui/lib/agent/planning-agent.ts` | Add `memory_recall` and `memory_save` nodes, rewire graph |
+| `web-ui/lib/agent/prompt-templates.ts` | Remove dead `LONG_TERM_MEMORY_GUIDANCE` constant |
+| `web-ui/lib/agent/persistence.ts` | Fix namespace prefix filtering in search query |
+| `web-ui/lib/agent/model-factory.ts` | No changes needed — memory tools already wired correctly |
+
+## Memory Namespace Conventions
+
+| Category | Namespace | Example Key |
+|----------|-----------|-------------|
+| Infrastructure facts | `["infra", "<account-id>"]` | `prod-ecs-cluster-region` |
+| User preferences | `["user", "preferences"]` | `preferred-output-format` |
+| Task outcomes | `["patterns", "<service>"]` | `ecs-oom-resolution` |
+| Error resolutions | `["errors", "<service>"]` | `rds-connection-timeout-fix` |
+
+## Non-Goals
+
+- Memory expiration/cleanup (existing 90-day TTL handles this)
+- Memory UI in the frontend (future work)
+- Cross-tenant memory sharing
+- Memory versioning or conflict resolution

--- a/web-ui/app/api/chat/route.ts
+++ b/web-ui/app/api/chat/route.ts
@@ -12,7 +12,7 @@ export const maxDuration = 300; // 5 minutes for complex multi-iteration tasks
 const activeThreads = new Map<string, boolean>();
 
 // Phase types for UI segregation
-type AgentPhase = 'planning' | 'execution' | 'reflection' | 'revision' | 'final' | 'text';
+type AgentPhase = 'planning' | 'execution' | 'reflection' | 'revision' | 'final' | 'memory_recall' | 'memory_save' | 'text';
 
 interface Message {
     role: string;
@@ -386,8 +386,9 @@ function getPhaseFromNode(node: string): AgentPhase {
         case 'tools':
             return 'execution';   // Deep Agent tool execution
         case 'memory_recall':
+            return 'memory_recall';
         case 'memory_save':
-            return 'reflection';  // Memory nodes: render as reasoning (collapsible), not visible text
+            return 'memory_save';
         default:
             return 'text';
     }
@@ -405,6 +406,10 @@ function getPhaseMarker(phase: AgentPhase): string {
             return 'REVISION_PHASE_START\n';
         case 'final':
             return 'FINAL_PHASE_START\n';
+        case 'memory_recall':
+            return 'MEMORY_RECALL_PHASE_START\n';
+        case 'memory_save':
+            return 'MEMORY_SAVE_PHASE_START\n';
         default:
             return '';
     }

--- a/web-ui/app/api/chat/route.ts
+++ b/web-ui/app/api/chat/route.ts
@@ -385,6 +385,9 @@ function getPhaseFromNode(node: string): AgentPhase {
             return 'text';        // Deep Agent main model node: same rationale
         case 'tools':
             return 'execution';   // Deep Agent tool execution
+        case 'memory_recall':
+        case 'memory_save':
+            return 'reflection';  // Memory nodes: render as reasoning (collapsible), not visible text
         default:
             return 'text';
     }

--- a/web-ui/components/agent/chat-interface.tsx
+++ b/web-ui/components/agent/chat-interface.tsx
@@ -32,6 +32,8 @@ import {
   FileText,
   ChevronDown,
   Clock,
+  Database,
+  BookOpen,
 } from "lucide-react";
 import {
   copyToClipboard,
@@ -117,6 +119,8 @@ type AgentPhase =
   | "reflection"
   | "revision"
   | "final"
+  | "memory_recall"
+  | "memory_save"
   | "text";
 
 // Parse phase from content
@@ -148,6 +152,16 @@ function parsePhaseFromContent(content: string): {
     return {
       phase: "final",
       cleanContent: content.replace("FINAL_PHASE_START\n", ""),
+    };
+  } else if (content.startsWith("MEMORY_RECALL_PHASE_START\n")) {
+    return {
+      phase: "memory_recall",
+      cleanContent: content.replace("MEMORY_RECALL_PHASE_START\n", ""),
+    };
+  } else if (content.startsWith("MEMORY_SAVE_PHASE_START\n")) {
+    return {
+      phase: "memory_save",
+      cleanContent: content.replace("MEMORY_SAVE_PHASE_START\n", ""),
     };
   }
   return { phase: "text", cleanContent: content };
@@ -205,6 +219,20 @@ const phaseConfig: Record<
     borderColor: "border-muted",
     bgColor: "bg-muted/10",
     textColor: "text-muted-foreground",
+  },
+  memory_recall: {
+    icon: BookOpen,
+    label: "MEMORY RECALL",
+    borderColor: "border-emerald-500",
+    bgColor: "bg-emerald-500/5",
+    textColor: "text-emerald-600",
+  },
+  memory_save: {
+    icon: Database,
+    label: "MEMORY SAVE",
+    borderColor: "border-emerald-500",
+    bgColor: "bg-emerald-500/5",
+    textColor: "text-emerald-600",
   },
 };
 
@@ -655,6 +683,8 @@ export function ChatInterface({
         if (part.text.includes("REFLECTION_PHASE_START")) return "Reflecting";
         if (part.text.includes("REVISION_PHASE_START")) return "Revising";
         if (part.text.includes("FINAL_PHASE_START")) return "Finalizing";
+        if (part.text.includes("MEMORY_RECALL_PHASE_START")) return "Recalling";
+        if (part.text.includes("MEMORY_SAVE_PHASE_START")) return "Saving";
       }
     }
     return "Processing";
@@ -885,7 +915,7 @@ export function ChatInterface({
 
     // Skip rendering if content is just the phase marker with no actual content
     const cleanedContent = content
-      .replace(/^(PLANNING_PHASE_START|EXECUTION_PHASE_START|REFLECTION_PHASE_START|REVISION_PHASE_START|FINAL_PHASE_START)\n*/i, '')
+      .replace(/^(PLANNING_PHASE_START|EXECUTION_PHASE_START|REFLECTION_PHASE_START|REVISION_PHASE_START|FINAL_PHASE_START|MEMORY_RECALL_PHASE_START|MEMORY_SAVE_PHASE_START)\n*/i, '')
       .trim();
 
     if (!cleanedContent) {

--- a/web-ui/lib/agent/agent-shared.ts
+++ b/web-ui/lib/agent/agent-shared.ts
@@ -37,6 +37,7 @@ export interface ReflectionState {
     nextAction: string;
     isComplete: boolean;
     toolResults: ToolResultEntry[]; // Structured tool results for reflection/summary
+    memoryContext: string; // Formatted relevant memories from recall node
 }
 
 // --- Schema for StateGraph ---
@@ -89,6 +90,10 @@ export const graphState: StateGraphArgs<ReflectionState>["channels"] = {
     toolResults: {
         reducer: (x: ToolResultEntry[], y: ToolResultEntry[]) => [...x, ...y].slice(-10), // cap at 10 to prevent unbounded growth
         default: () => [],
+    },
+    memoryContext: {
+        reducer: (x: string, y: string) => y || x,
+        default: () => "",
     },
 };
 

--- a/web-ui/lib/agent/fast-agent.ts
+++ b/web-ui/lib/agent/fast-agent.ts
@@ -60,7 +60,8 @@ export async function createFastGraph(config: GraphConfig) {
     const { main: model, reflector: reflectorModel } = createAgentModels(modelConfig);
 
     // --- Tool Assembly (fast-agent does not use S3 tools) ---
-    const tools = await assembleTools({ includeS3Tools: false, includeMemoryTools: !!store, userId: config.userId, mcpServerIds, tenantId, accounts });
+    // Memory tools excluded — memory_recall and memory_save graph nodes handle memory deterministically
+    const tools = await assembleTools({ includeS3Tools: false, includeMemoryTools: false, userId: config.userId, mcpServerIds, tenantId, accounts });
     const modelWithTools = model.bindTools!(tools);
     const toolNode = new ToolNode(tools);
 

--- a/web-ui/lib/agent/fast-agent.ts
+++ b/web-ui/lib/agent/fast-agent.ts
@@ -27,6 +27,7 @@ import {
     CORE_PRINCIPLES,
 } from "./prompt-templates";
 import { createAgentModels, assembleTools } from "./model-factory";
+import { createMemoryRecallNode, createMemorySaveNode } from "./memory-nodes";
 
 // --- FAST GRAPH (Reflection Agent Mode) ---
 export async function createFastGraph(config: GraphConfig) {
@@ -63,11 +64,16 @@ export async function createFastGraph(config: GraphConfig) {
     const modelWithTools = model.bindTools!(tools);
     const toolNode = new ToolNode(tools);
 
+    // --- Memory Nodes ---
+    const memoryDeps = { reflectorModel, tenantId, userId: config.userId, store };
+    const memoryRecallNode = createMemoryRecallNode(memoryDeps);
+    const memorySaveNode = createMemorySaveNode(memoryDeps);
+
     // ---------------------------------------------------------------------------
     // AGENT NODE
     // ---------------------------------------------------------------------------
     async function agentNode(state: ReflectionState): Promise<Partial<ReflectionState>> {
-        const { messages, iterationCount } = state;
+        const { messages, iterationCount, memoryContext } = state;
 
         console.log(`\n================================================================================`);
         console.log(`🚀 [FAST AGENT] Generator Iteration ${iterationCount + 1}/${MAX_ITERATIONS}`);
@@ -76,6 +82,10 @@ export async function createFastGraph(config: GraphConfig) {
 
         const baseIdentity = buildBaseIdentity(selectedSkill);
 
+        const memorySection = memoryContext
+            ? `\n## Relevant Context from Memory\n${memoryContext}\n`
+            : '';
+
         const systemPrompt = new SystemMessage(`${baseIdentity}
 ${effectiveSkillSection}
 ${CORE_PRINCIPLES}
@@ -83,7 +93,7 @@ ${awsCliStandards}
 ${autoApproveGuidance}
 ${operationalWorkflows}
 ${accountContext}
-
+${memorySection}
 ## Conversation Continuity
 
 Review the full conversation history before responding:
@@ -275,7 +285,7 @@ Please provide your critique.`
     // ---------------------------------------------------------------------------
     // CONDITIONAL EDGES
     // ---------------------------------------------------------------------------
-    function shouldContinue(state: ReflectionState): "tools" | "reflect" | "__end__" {
+    function shouldContinue(state: ReflectionState): "tools" | "reflect" | "memory_save" {
         const messages = state.messages;
         const lastMessage = messages[messages.length - 1] as AIMessage;
         const { iterationCount } = state;
@@ -287,22 +297,22 @@ Please provide your critique.`
         // Hard cap: if too many total iterations, stop regardless
         if (iterationCount >= MAX_ITERATIONS) {
             console.log(`⚠️ Max iterations (${MAX_ITERATIONS}) reached. Stopping.`);
-            return END;
+            return "memory_save";
         }
 
         // Soft cap: if we've exceeded the reflection cycle limit, accept the answer as-is
         // This prevents the reflection loop from burning tokens on diminishing returns
         if (iterationCount >= MAX_REFLECT_ITERATIONS) {
             console.log(`⚠️ Max reflection cycles (${MAX_REFLECT_ITERATIONS}) reached. Accepting answer.`);
-            return END;
+            return "memory_save";
         }
 
         return "reflect";
     }
 
-    function shouldContinueFromReflect(state: ReflectionState): "agent" | "__end__" {
+    function shouldContinueFromReflect(state: ReflectionState): "agent" | "memory_save" {
         if (state.isComplete) {
-            return END;
+            return "memory_save";
         }
         return "agent";
     }
@@ -311,24 +321,28 @@ Please provide your critique.`
     // GRAPH CONSTRUCTION
     // ---------------------------------------------------------------------------
     const workflow = new StateGraph<ReflectionState>({ channels: graphState })
+        .addNode("memory_recall", memoryRecallNode)
         .addNode("agent", agentNode)
         .addNode("tools", collectingToolNode)
         .addNode("reflect", reflectNode)
+        .addNode("memory_save", memorySaveNode)
 
-        .addEdge(START, "agent")
+        .addEdge(START, "memory_recall")
+        .addEdge("memory_recall", "agent")
 
         .addConditionalEdges("agent", shouldContinue, {
             tools: "tools",
             reflect: "reflect",
-            __end__: END
+            memory_save: "memory_save"
         })
 
         .addConditionalEdges("reflect", shouldContinueFromReflect, {
             agent: "agent",
-            __end__: END
+            memory_save: "memory_save"
         })
 
-        .addEdge("tools", "agent");
+        .addEdge("tools", "agent")
+        .addEdge("memory_save", END);
 
     if (autoApprove) {
         return workflow.compile({ checkpointer, ...(store && { store }) });

--- a/web-ui/lib/agent/memory-nodes.ts
+++ b/web-ui/lib/agent/memory-nodes.ts
@@ -188,7 +188,7 @@ Extract memories to save.`
             }> = JSON.parse(jsonMatch[0]);
 
             const toSave = memories.filter(m =>
-                m.confidence === undefined || m.value?.confidence === "high" || m.value?.confidence === "medium"
+                m.value?.confidence === "high" || m.value?.confidence === "medium"
             );
 
             if (toSave.length === 0) {

--- a/web-ui/lib/agent/memory-nodes.ts
+++ b/web-ui/lib/agent/memory-nodes.ts
@@ -150,11 +150,11 @@ export function createMemorySaveNode(deps: MemoryNodeDeps) {
 - Do NOT re-save facts that already exist in the known memories below
 
 **Return format:** A JSON array of objects:
-\`\`\`json
+` + '```' + `json
 [{ "namespace": ["infra", "123456789"], "key": "prod-cluster-region", "value": { "fact": "Production ECS cluster runs in us-east-1", "source": "discovered via describe-clusters", "confidence": "high" } }]
-\`\`\`
+` + '```' + `
 
-Return an empty array \`[]\` if nothing new is worth saving.`
+Return an empty array ` + '`[]`' + ` if nothing new is worth saving.`
         );
 
         const extractInput = new HumanMessage({

--- a/web-ui/lib/agent/memory-nodes.ts
+++ b/web-ui/lib/agent/memory-nodes.ts
@@ -1,0 +1,215 @@
+/**
+ * memory-nodes.ts
+ *
+ * Shared memory_recall and memory_save graph nodes for all agent types.
+ * memory_recall: semantic search + LLM relevance filter before task execution.
+ * memory_save: LLM extraction of learnings after task completion.
+ */
+
+import { HumanMessage, SystemMessage } from "@langchain/core/messages";
+import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
+import { ReflectionState, truncateOutput } from "./agent-shared";
+import { searchMemory, saveMemory } from "./persistence";
+
+interface MemoryNodeDeps {
+    reflectorModel: BaseChatModel;
+    tenantId?: string;
+    userId?: string;
+    store: unknown | null;
+}
+
+export function createMemoryRecallNode(deps: MemoryNodeDeps) {
+    const { reflectorModel, tenantId, userId, store } = deps;
+
+    return async function memoryRecallNode(state: ReflectionState): Promise<Partial<ReflectionState>> {
+        if (!store || !tenantId || !userId) {
+            console.log("[MemoryRecall] Skipped — store, tenantId, or userId not available");
+            return { memoryContext: "" };
+        }
+
+        const { messages } = state;
+        const lastHuman = [...messages].reverse().find(m => m._getType() === "human");
+        if (!lastHuman) {
+            console.log("[MemoryRecall] Skipped — no human message found");
+            return { memoryContext: "" };
+        }
+
+        const query = typeof lastHuman.content === "string"
+            ? lastHuman.content
+            : JSON.stringify(lastHuman.content);
+
+        console.log(`\n🧠 [MEMORY RECALL] Searching memories for: "${truncateOutput(query, 100)}"`);
+
+        let rawResults: Array<{ key: string; value: unknown; namespace: string }>;
+        try {
+            const results = await searchMemory(tenantId, userId, [], query, 10);
+            rawResults = (results as Array<{ key: string; value: unknown; namespace: string }>) ?? [];
+        } catch (err: any) {
+            console.warn(`[MemoryRecall] Search failed: ${err?.message ?? err}`);
+            return { memoryContext: "" };
+        }
+
+        if (rawResults.length === 0) {
+            console.log("[MemoryRecall] No memories found");
+            return { memoryContext: "" };
+        }
+
+        console.log(`[MemoryRecall] Found ${rawResults.length} raw memories, filtering for relevance...`);
+
+        const memorySummary = rawResults.map((m, i) =>
+            `${i + 1}. [${m.namespace}/${m.key}] ${JSON.stringify(m.value)}`
+        ).join("\n");
+
+        let relevantMemories: string;
+        try {
+            const filterPrompt = new SystemMessage(
+                `You are a relevance filter. Given a user task and a list of memories from previous sessions, return ONLY the memories that are directly relevant to the current task.
+
+Return a markdown list of relevant memories, each on its own line with the format:
+- [namespace/key] One-line summary of the relevant fact
+
+If no memories are relevant, return exactly: NONE`
+            );
+
+            const filterInput = new HumanMessage({
+                content: `**User Task:** ${truncateOutput(query, 2000)}
+
+**Available Memories:**
+${memorySummary}
+
+Return only the relevant memories.`
+            });
+
+            const response = await reflectorModel.invoke([filterPrompt, filterInput]);
+            const content = typeof response.content === "string"
+                ? response.content
+                : JSON.stringify(response.content);
+
+            if (content.trim() === "NONE" || !content.trim()) {
+                console.log("[MemoryRecall] No relevant memories after filtering");
+                return { memoryContext: "" };
+            }
+
+            relevantMemories = content.trim();
+        } catch (err: any) {
+            console.warn(`[MemoryRecall] Relevance filter failed: ${err?.message ?? err}`);
+            relevantMemories = rawResults.slice(0, 5).map(m =>
+                `- [${m.namespace}/${m.key}] ${JSON.stringify(m.value)}`
+            ).join("\n");
+        }
+
+        console.log(`🧠 [MEMORY RECALL] Injecting relevant memories into context`);
+
+        return { memoryContext: relevantMemories };
+    };
+}
+
+export function createMemorySaveNode(deps: MemoryNodeDeps) {
+    const { reflectorModel, tenantId, userId, store } = deps;
+
+    return async function memorySaveNode(state: ReflectionState): Promise<Partial<ReflectionState>> {
+        if (!store || !tenantId || !userId) {
+            console.log("[MemorySave] Skipped — store, tenantId, or userId not available");
+            return {};
+        }
+
+        const { messages, taskDescription, memoryContext } = state;
+        if (messages.length < 2) {
+            console.log("[MemorySave] Skipped — conversation too short to extract learnings");
+            return {};
+        }
+
+        console.log(`\n🧠 [MEMORY SAVE] Analyzing session for learnings...`);
+
+        const recentMessages = messages.slice(-20);
+        const conversationSummary = recentMessages.map(m => {
+            const role = m._getType();
+            const content = typeof m.content === "string"
+                ? m.content
+                : JSON.stringify(m.content);
+            return `[${role}] ${truncateOutput(content, 500)}`;
+        }).join("\n\n");
+
+        const extractPrompt = new SystemMessage(
+            `You are a memory extraction engine. Analyze the completed agent session and extract facts worth remembering for future sessions.
+
+**Categories and namespace conventions:**
+- Infrastructure facts → namespace: ["infra", "<account-id-or-general>"]
+  Examples: cluster regions, instance types, service configurations, resource counts
+- User preferences → namespace: ["user", "preferences"]
+  Examples: preferred output format, naming conventions, default regions, workflow preferences
+- Task outcomes / solutions → namespace: ["patterns", "<service-type>"]
+  Examples: how a scaling issue was resolved, successful deployment patterns
+- Error resolutions → namespace: ["errors", "<service-type>"]
+  Examples: how an OOM was fixed, what caused a timeout, permission error workarounds
+
+**Rules:**
+- Only extract facts that would be useful in a FUTURE session — skip ephemeral details
+- Each memory must have confidence "high" or "medium" — skip anything uncertain
+- Use descriptive, unique keys (e.g., "prod-ecs-cluster-region" not "fact-1")
+- Do NOT re-save facts that already exist in the known memories below
+
+**Return format:** A JSON array of objects:
+\`\`\`json
+[{ "namespace": ["infra", "123456789"], "key": "prod-cluster-region", "value": { "fact": "Production ECS cluster runs in us-east-1", "source": "discovered via describe-clusters", "confidence": "high" } }]
+\`\`\`
+
+Return an empty array \`[]\` if nothing new is worth saving.`
+        );
+
+        const extractInput = new HumanMessage({
+            content: `**Original Task:** ${truncateOutput(taskDescription || "Unknown", 500)}
+
+**Already Known (do NOT re-save):**
+${memoryContext || "No existing memories."}
+
+**Session Transcript (recent):**
+${truncateOutput(conversationSummary, 8000)}
+
+Extract memories to save.`
+        });
+
+        try {
+            const response = await reflectorModel.invoke([extractPrompt, extractInput]);
+            const content = typeof response.content === "string"
+                ? response.content
+                : JSON.stringify(response.content);
+
+            const jsonMatch = content.match(/\[[\s\S]*\]/);
+            if (!jsonMatch) {
+                console.log("[MemorySave] No JSON array found in response — nothing to save");
+                return {};
+            }
+
+            const memories: Array<{
+                namespace: string[];
+                key: string;
+                value: { fact: string; source: string; confidence: string };
+            }> = JSON.parse(jsonMatch[0]);
+
+            const toSave = memories.filter(m =>
+                m.confidence === undefined || m.value?.confidence === "high" || m.value?.confidence === "medium"
+            );
+
+            if (toSave.length === 0) {
+                console.log("[MemorySave] No high/medium confidence memories to save");
+                return {};
+            }
+
+            console.log(`🧠 [MEMORY SAVE] Saving ${toSave.length} memories...`);
+
+            for (const mem of toSave) {
+                try {
+                    await saveMemory(tenantId, userId, mem.namespace, mem.key, mem.value as Record<string, unknown>);
+                    console.log(`   ✅ Saved: ${mem.namespace.join("/")}/${mem.key}`);
+                } catch (err: any) {
+                    console.warn(`   ⚠️ Failed to save ${mem.key}: ${err?.message ?? err}`);
+                }
+            }
+        } catch (err: any) {
+            console.warn(`[MemorySave] Extraction failed: ${err?.message ?? err}`);
+        }
+
+        return {};
+    };
+}

--- a/web-ui/lib/agent/persistence.ts
+++ b/web-ui/lib/agent/persistence.ts
@@ -138,6 +138,9 @@ class PostgresMemoryStore implements MemoryStoreInterface {
                 const query = String(op.query);
                 const limit = Number(op.limit ?? 5);
                 const tenantId = configurable?.tenant_id as string ?? "default";
+                const namespacePrefix = Array.isArray(op.namespacePrefix)
+                    ? (op.namespacePrefix as string[]).join("/")
+                    : "";
 
                 let queryEmbedding: number[] | null = null;
                 try {
@@ -148,20 +151,35 @@ class PostgresMemoryStore implements MemoryStoreInterface {
 
                 if (queryEmbedding) {
                     const embeddingStr = `[${queryEmbedding.join(",")}]`;
-                    const rows = await prisma.$queryRaw<Array<{ key: string; value: unknown; namespace: string }>>`
-                        SELECT "key", "value", "namespace"
-                        FROM agent_memories
-                        WHERE "tenantId" = ${tenantId}
-                        ORDER BY embedding <=> ${embeddingStr}::vector
-                        LIMIT ${limit}
-                    `;
+                    const rows = namespacePrefix
+                        ? await prisma.$queryRaw<Array<{ key: string; value: unknown; namespace: string }>>`
+                            SELECT "key", "value", "namespace"
+                            FROM agent_memories
+                            WHERE "tenantId" = ${tenantId}
+                              AND "namespace" LIKE ${namespacePrefix + '%'}
+                            ORDER BY embedding <=> ${embeddingStr}::vector
+                            LIMIT ${limit}
+                          `
+                        : await prisma.$queryRaw<Array<{ key: string; value: unknown; namespace: string }>>`
+                            SELECT "key", "value", "namespace"
+                            FROM agent_memories
+                            WHERE "tenantId" = ${tenantId}
+                            ORDER BY embedding <=> ${embeddingStr}::vector
+                            LIMIT ${limit}
+                          `;
                     results.push(rows.map((r) => ({ key: r.key, value: r.value, namespace: r.namespace })));
                 } else {
-                    const rows = await prisma.agentMemory.findMany({
-                        where: { tenantId: tenantId },
-                        take: limit,
-                        orderBy: { createdAt: "desc" },
-                    });
+                    const rows = namespacePrefix
+                        ? await prisma.agentMemory.findMany({
+                            where: { tenantId, namespace: { startsWith: namespacePrefix } },
+                            take: limit,
+                            orderBy: { createdAt: "desc" },
+                          })
+                        : await prisma.agentMemory.findMany({
+                            where: { tenantId },
+                            take: limit,
+                            orderBy: { createdAt: "desc" },
+                          });
                     results.push(rows.map((r) => ({ key: r.key, value: r.value, namespace: r.namespace })));
                 }
             } else {

--- a/web-ui/lib/agent/planning-agent.ts
+++ b/web-ui/lib/agent/planning-agent.ts
@@ -27,6 +27,7 @@ import {
     CORE_PRINCIPLES,
 } from "./prompt-templates";
 import { createAgentModels, assembleTools } from "./model-factory";
+import { createMemoryRecallNode, createMemorySaveNode } from "./memory-nodes";
 
 // Factory function to create a configured reflection graph
 export async function createReflectionGraph(config: GraphConfig) {
@@ -65,11 +66,16 @@ export async function createReflectionGraph(config: GraphConfig) {
     const modelWithTools = model.bindTools!(tools);
     const toolNode = new ToolNode(tools);
 
+    // --- Memory Nodes ---
+    const memoryDeps = { reflectorModel, tenantId, userId: config.userId, store };
+    const memoryRecallNode = createMemoryRecallNode(memoryDeps);
+    const memorySaveNode = createMemorySaveNode(memoryDeps);
+
     // ---------------------------------------------------------------------------
     // PLANNER NODE
     // ---------------------------------------------------------------------------
     async function planNode(state: ReflectionState): Promise<Partial<ReflectionState>> {
-        const { messages } = state;
+        const { messages, memoryContext } = state;
         const lastMessage = messages[messages.length - 1];
         const taskDescription = typeof lastMessage.content === 'string'
             ? lastMessage.content
@@ -85,6 +91,7 @@ export async function createReflectionGraph(config: GraphConfig) {
 Your role is to decompose the user's task into a precise, dependency-ordered execution plan.
 ${effectiveSkillSection}
 ${CORE_PRINCIPLES}
+${memoryContext ? `\n## Relevant Context from Memory\n${memoryContext}\n` : ''}
 ## Planning Methodology
 
 Work through three phases when building the plan:
@@ -161,7 +168,7 @@ Only return the JSON array, nothing else.`);
     // GENERATOR (EXECUTOR) NODE
     // ---------------------------------------------------------------------------
     async function generateNode(state: ReflectionState): Promise<Partial<ReflectionState>> {
-        const { messages, plan, iterationCount } = state;
+        const { messages, plan, iterationCount, memoryContext } = state;
 
         console.log(`\n================================================================================`);
         console.log(`⚡ [EXECUTOR] Iteration ${iterationCount + 1}/${MAX_ITERATIONS}`);
@@ -176,6 +183,7 @@ Only return the JSON array, nothing else.`);
 Your role is to execute the current plan step precisely and completely using available tools.
 ${effectiveSkillSection}
 ${CORE_PRINCIPLES}
+${memoryContext ? `\n## Relevant Context from Memory\n${memoryContext}\n` : ''}
 ## Current Execution Context
 
 Current Step: ${currentStep}
@@ -621,14 +629,17 @@ ${summaryContent}`;
     // GRAPH CONSTRUCTION
     // ---------------------------------------------------------------------------
     const workflow = new StateGraph<ReflectionState>({ channels: graphState })
+        .addNode("memory_recall", memoryRecallNode)
         .addNode("planner", planNode)
         .addNode("generate", generateNode)
         .addNode("tools", collectingToolNode)
         .addNode("reflect", reflectNode)
         .addNode("revise", reviseNode)
         .addNode("final", finalNode)
+        .addNode("memory_save", memorySaveNode)
 
-        .addEdge(START, "planner")
+        .addEdge(START, "memory_recall")
+        .addEdge("memory_recall", "planner")
         .addEdge("planner", "generate")
 
         .addConditionalEdges("generate", shouldContinueFromGenerate, {
@@ -652,7 +663,8 @@ ${summaryContent}`;
             reflect: "reflect"
         })
 
-        .addEdge("final", END);
+        .addEdge("final", "memory_save")
+        .addEdge("memory_save", END);
 
     if (autoApprove) {
         console.log(`[Graph] Creating graph with autoApprove=true (no interrupts)`);

--- a/web-ui/lib/agent/planning-agent.ts
+++ b/web-ui/lib/agent/planning-agent.ts
@@ -62,7 +62,8 @@ export async function createReflectionGraph(config: GraphConfig) {
     const { main: model, reflector: reflectorModel } = createAgentModels(modelConfig);
 
     // --- Tool Assembly ---
-    const tools = await assembleTools({ includeS3Tools: true, includeMemoryTools: !!store, userId: config.userId, mcpServerIds, tenantId, accounts });
+    // Memory tools excluded — memory_recall and memory_save graph nodes handle memory deterministically
+    const tools = await assembleTools({ includeS3Tools: true, includeMemoryTools: false, userId: config.userId, mcpServerIds, tenantId, accounts });
     const modelWithTools = model.bindTools!(tools);
     const toolNode = new ToolNode(tools);
 

--- a/web-ui/lib/agent/prompt-templates.ts
+++ b/web-ui/lib/agent/prompt-templates.ts
@@ -259,32 +259,3 @@ export function buildOperationalWorkflows(): string {
 5. If applicable, check scheduled scaling actions and verify they align with traffic patterns.
 `;
 }
-
-// ---------------------------------------------------------------------------
-// LONG-TERM MEMORY
-// ---------------------------------------------------------------------------
-
-/**
- * Injected when the memory store is available.
- * Instructs the agent on how to use cross-session long-term memory.
- */
-export const LONG_TERM_MEMORY_GUIDANCE = `
-## Long-Term Memory
-
-You have access to a persistent long-term memory store (DynamoDB) scoped to the current user.
-Use it to remember facts, preferences, and findings that are useful across sessions.
-
-**When to save a memory:**
-- User states a preference (e.g., preferred AWS region, naming conventions, team structure)
-- You discover a key fact about their infrastructure (e.g., "prod ECS cluster is in us-east-1")
-- A recurring task pattern is identified
-
-**When to search memory:**
-- At the start of a new task, search for relevant context before querying AWS
-- When the user references something from a previous session
-
-**Namespace conventions:**
-- User preferences: \`["user", "preferences"]\`
-- Infrastructure facts: \`["infra", "<account-id>"]\`
-- Task patterns: \`["patterns", "<service-type>"]\`
-`;


### PR DESCRIPTION
## Summary

- Add deterministic `memory_recall` and `memory_save` graph nodes to both fast-agent and planning-agent
- `memory_recall` runs before every task: semantic search (pgvector) + LLM relevance filter → injects context into system prompts
- `memory_save` runs after every task: LLM extracts learnings across 4 categories (infra facts, user preferences, task outcomes, error resolutions) → persists to PostgreSQL
- Fix namespace prefix filter bug in `persistence.ts` — search queries now respect the `namespacePrefix` parameter
- Remove dead `LONG_TERM_MEMORY_GUIDANCE` constant from `prompt-templates.ts`
- Add dedicated "MEMORY RECALL" and "MEMORY SAVE" UI phases with emerald-colored collapsible sections (BookOpen/Database icons)
- Remove redundant `search_memory`/`save_memory` tools from agent tool lists — graph nodes handle memory deterministically

## Files changed

| File | Change |
|------|--------|
| `web-ui/lib/agent/memory-nodes.ts` | New shared module with `createMemoryRecallNode` and `createMemorySaveNode` |
| `web-ui/lib/agent/agent-shared.ts` | Add `memoryContext: string` to `ReflectionState` and `graphState` |
| `web-ui/lib/agent/fast-agent.ts` | Wire memory nodes, inject memoryContext into prompt, disable memory tools |
| `web-ui/lib/agent/planning-agent.ts` | Wire memory nodes, inject memoryContext into planner + executor prompts, disable memory tools |
| `web-ui/lib/agent/persistence.ts` | Fix namespace prefix filtering in vector and fallback search queries |
| `web-ui/lib/agent/prompt-templates.ts` | Remove dead `LONG_TERM_MEMORY_GUIDANCE` export |
| `web-ui/app/api/chat/route.ts` | Add `memory_recall`/`memory_save` phase types and markers |
| `web-ui/components/agent/chat-interface.tsx` | Add memory phase UI config, parser, status labels |
| `docs/superpowers/specs/2026-04-28-agent-memory-design.md` | Design spec |
| `docs/superpowers/plans/2026-04-28-agent-memory.md` | Implementation plan |

## How it works

```
Fast Agent:     START → memory_recall → agent → tools ↔ reflect → memory_save → END
Planning Agent: START → memory_recall → planner → generate → tools ↔ reflect → final → memory_save → END
```

- **Recall**: Searches all memory namespaces with the user's message, then uses the reflector model to filter for relevance. Injects relevant memories into system prompts as a "Relevant Context from Memory" section.
- **Save**: After task completion, the reflector model analyzes the session transcript and extracts structured memories with namespace, key, and confidence level. Only high/medium confidence memories are persisted. Existing memories from recall are passed to avoid duplicates.
- **Failure handling**: Both nodes log warnings and continue if the store or LLM calls fail — memory never blocks task execution.

## Test plan

- [x] TypeScript compilation passes (no new errors in modified files)
- [x] Existing Vitest tests pass (no regressions)
- [x] ESLint passes (no new errors in modified files)
- [x] Manual E2E: memory recall finds and filters relevant memories before task
- [x] Manual E2E: memory save extracts and persists learnings after task
- [x] Manual E2E: memory UI renders as dedicated collapsible sections (not under Reflection)
- [x] Manual E2E: no duplicate search_memory tool calls during execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)