### PR TITLE
fix(ai-ops): repair agent stream crashes, empty answers, and history rendering

### DIFF
--- a/docs/known-issues/bedrock-orphaned-tooluse-stream-crash.md
+++ b/docs/known-issues/bedrock-orphaned-tooluse-stream-crash.md
@@ -1,6 +1,6 @@
 # Bug: Bedrock `ValidationException` (orphaned `tool_use`) crashes the chat stream
 
-> **Status:** Open — root cause identified, not yet fixed
+> **Status:** ✅ Fixed (2026-06-25) — `sanitizeMessagesForBedrock` now enforces tool_use/tool_result adjacency. See §8.
 > **Severity:** High — terminates an in-flight AI chat response with a 500-style stream error; user loses the answer
 > **First observed:** 2026-06-25, ~09:57:54 IST (production)
 > **Component:** Web UI AI Ops agent (`fast-agent`), Next.js chat streaming route
@@ -196,3 +196,37 @@ at handleError (.next/server/chunks/7181.js:7:21864)
 ```
 
 Model in use at the time: `global.anthropic.claude-sonnet-4-6` (fast-agent generator).
+
+---
+
+## 8. Resolution (2026-06-25)
+
+Applied **fix direction (A)** — `sanitizeMessagesForBedrock()` now enforces
+*adjacency*, not mere existence.
+
+The function was rewritten (`web-ui/lib/agent/agent-shared.ts`) to:
+
+1. **Index** every `ToolMessage` by its `tool_call_id` (first occurrence wins).
+2. **Skip** `ToolMessage`s where they sit in the input array, and instead
+   **re-emit** each result *immediately after* its owning AI `tool_use` message,
+   in `tool_use` order. A real `ToolMessage` is used if one exists anywhere in
+   the array (so a result separated from its `tool_use` by an injected
+   `"Proceed."` is pulled back into place); otherwise a synthetic placeholder is
+   inserted.
+3. **Drop** orphan `ToolMessage`s whose `tool_use` is absent from the window —
+   Bedrock also rejects a `toolResult` with no preceding `toolUse`.
+
+This removes the old "answered anywhere → skip placeholder" defect (the previous
+`if (answeredToolCallIds.has(id)) continue;` at line 396) and guarantees the
+Bedrock Converse adjacency contract regardless of how upstream windowing
+reordered the array.
+
+**Single fix point covers all call sites.** Because `fast-agent.ts`,
+`planning-agent.ts`, and `agent-ops/executor-graphs.ts` all funnel through this
+one shared function, the repair applies everywhere at once — no per-call-site
+change was needed.
+
+**Tests** (`web-ui/tests/agent-ops/agent-shared.test.ts`): added the §6 unit
+test (AI `tool_use` → `HumanMessage("Proceed.")` → `ToolMessage`, asserting the
+result is adjacent after sanitization) plus an orphan-result-dropped case. Full
+suite: 15/15 passing.

--- a/web-ui/app/api/chat/route.ts
+++ b/web-ui/app/api/chat/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server';
 import { createUIMessageStreamResponse, UIMessageChunk } from 'ai';
 import { createReflectionGraph, createFastGraph, createDeepGraph } from '@/lib/agent/graph-factory';
 import { resolveModelConfig } from '@/lib/agent/model-resolver';
+import { buildClientErrorText } from '@/lib/agent/stream-error';
 
 export const maxDuration = 300; // 5 minutes for complex multi-iteration tasks
 
@@ -381,6 +382,8 @@ function getPhaseFromNode(node: string): AgentPhase {
             return 'final';
         case 'agent':
             return 'execution';   // Fast Agent: render with execution phase header like planning agent
+        case 'finalize':
+            return 'final';       // Fast Agent: tool-free synthesis at the iteration cap — render in the same styled "COMPLETE" card as the planning agent's final summary
         case 'call_model':
             return 'text';        // Deep Agent main model node: same rationale
         case 'tools':
@@ -485,6 +488,14 @@ function processStream(
             // Reasoning parts and completed tool calls don't satisfy this requirement
             let hasEmittedTextContent = false;
 
+            // Memory recall/save nodes don't add messages to graph state, so they would be
+            // absent from reloaded history (present only in the live stream). Accumulate their
+            // streamed text here and persist them as DISPLAY-ONLY chat messages below, so the
+            // history view matches the live view. This never touches the agent's LLM context
+            // (that lives in the LangGraph checkpointer, not chat_messages).
+            let memoryRecallText = '';
+            let memorySaveText = '';
+
             const safeEnqueue = (chunk: UIMessageChunk) => {
                 try {
                     controller.enqueue(chunk);
@@ -552,6 +563,10 @@ function processStream(
                             }
 
                             if (text && streamStarted) {
+                                // Capture memory-phase text for display-only history persistence.
+                                if (currentPhase === 'memory_recall') memoryRecallText += text;
+                                else if (currentPhase === 'memory_save') memorySaveText += text;
+
                                 const chunkType = currentPhase !== 'text' ? 'reasoning' : 'text';
                                 if (!safeEnqueue({
                                     type: `${chunkType}-delta` as any,
@@ -672,11 +687,21 @@ function processStream(
                 }
 
                 try {
-                    // For abort errors, just close cleanly; for real errors, signal error
                     if (isAbortError) {
+                        // Client went away — just close cleanly.
                         controller.close();
                     } else {
-                        controller.error(error);
+                        // Surface the REAL backend error to the client instead of a generic
+                        // "network error". The AI SDK turns an `error` stream part into
+                        // `new Error(errorText)`, which the chat UI renders as error.message.
+                        const errorText = buildClientErrorText(error);
+                        if (safeEnqueue({ type: 'error', errorText })) {
+                            // Error part delivered — close cleanly so the client shows errorText.
+                            controller.close();
+                        } else {
+                            // Stream already torn down; fall back to erroring the controller.
+                            controller.error(error);
+                        }
                     }
                 } catch (e) {
                     // Ignore if already closed
@@ -696,7 +721,13 @@ function processStream(
                             let aiIndex = 0;
                             for (const msg of newMessages) {
                                 if (msg._getType() === 'ai') {
-                                    const phase = phaseList[aiIndex] ?? 'text';
+                                    // Prefer the phase tagged on the message by its originating
+                                    // graph node (exact). Fall back to the positional phaseList
+                                    // only for untagged messages (e.g. deep agent). The positional
+                                    // mapping drifts when non-persisted model calls (memory/reflector)
+                                    // add phaseList entries, so it must not be the primary source.
+                                    const taggedPhase = (msg as { response_metadata?: { agentPhase?: string } }).response_metadata?.agentPhase;
+                                    const phase = taggedPhase ?? phaseList[aiIndex] ?? 'text';
                                     if (phase !== 'text') {
                                         const marker = getPhaseMarker(phase);
                                         if (marker && typeof msg.content === 'string') {
@@ -727,8 +758,22 @@ function processStream(
                                 }
                                 return { role, content, metadata: Object.keys(metadata).length ? metadata : undefined };
                             });
+
+                            // Insert display-only memory messages so history matches the live view.
+                            // Phase markers are prepended here (these aren't graph-state messages, so
+                            // they bypass the marker loop above); the history route reconstructs them
+                            // as collapsible reasoning blocks.
+                            if (memoryRecallText.trim()) {
+                                const recallMsg = { role: 'ai', content: getPhaseMarker('memory_recall') + memoryRecallText, metadata: undefined };
+                                const humanIdx = mapped.findIndex(m => m.role === 'human');
+                                mapped.splice(humanIdx >= 0 ? humanIdx + 1 : 0, 0, recallMsg);
+                            }
+                            if (memorySaveText.trim()) {
+                                mapped.push({ role: 'ai', content: getPhaseMarker('memory_save') + memorySaveText, metadata: undefined });
+                            }
+
                             await chatHistory.addMessages(resolvedTenantId ?? 'default', resolvedUserId, threadId, mapped, sessionTitle);
-                            console.log(`[Chat API] Persisted ${newMessages.length} new messages for thread ${threadId} (userId=${resolvedUserId})`);
+                            console.log(`[Chat API] Persisted ${mapped.length} new messages for thread ${threadId} (userId=${resolvedUserId})`);
                         }
                     } catch (err) {
                         console.error('[Chat API] Failed to persist message history:', err);

--- a/web-ui/app/api/threads/[threadId]/history/route.ts
+++ b/web-ui/app/api/threads/[threadId]/history/route.ts
@@ -26,6 +26,8 @@ const PHASE_MARKERS = [
     'REFLECTION_PHASE_START\n',
     'REVISION_PHASE_START\n',
     'FINAL_PHASE_START\n',
+    'MEMORY_RECALL_PHASE_START\n',
+    'MEMORY_SAVE_PHASE_START\n',
 ];
 
 function convertPlainMessage(msg: { role: string; content: string; metadata?: Record<string, unknown> }, index: number): HistoryMessage | null {

--- a/web-ui/components/agent/chat-interface.tsx
+++ b/web-ui/components/agent/chat-interface.tsx
@@ -1053,6 +1053,35 @@ export function ChatInterface({
       );
     }
 
+    // Memory phases: collapsible and collapsed by default. Memory recall/save is
+    // supplementary context (often large JSON), so keep it compact and consistent
+    // with the reflection block instead of a big always-expanded card.
+    if (phase === "memory_recall" || phase === "memory_save") {
+      return (
+        <div key={key} className="w-full mb-2">
+          <div
+            className={cn(
+              "flex items-center gap-2 px-3 py-2 text-xs font-semibold border-l-4 rounded-r-md mb-2",
+              config.borderColor,
+              config.bgColor,
+              config.textColor,
+            )}
+          >
+            <Icon className="w-3.5 h-3.5" />
+            {config.label}
+          </div>
+          {/* isStreaming is intentionally false so the block stays collapsed by default
+              even while streaming live — memory is supplementary, expand on demand. */}
+          <Reasoning defaultOpen={false} isStreaming={false}>
+            <ReasoningTrigger
+              label={phase === "memory_recall" ? "Recalled Memory" : "Saved Memory"}
+            />
+            <ReasoningContent>{cleanedContent}</ReasoningContent>
+          </Reasoning>
+        </div>
+      );
+    }
+
     // Default phase block for other phases
     return (
       <div

--- a/web-ui/lib/agent/agent-shared.ts
+++ b/web-ui/lib/agent/agent-shared.ts
@@ -217,6 +217,25 @@ export function truncateOutput(text: string, maxChars: number = 500): string {
     return text;
 }
 
+/**
+ * Tags an AI message with the agent phase ("execution", "reflection", "final", …) that
+ * produced it, stored under `response_metadata.agentPhase`.
+ *
+ * Why: the chat route renders phase headers/cards from the LangGraph node a message came
+ * from. During LIVE streaming that node is read from each chunk's metadata, but when a
+ * conversation is reloaded from history the node is unknown — previously it was guessed
+ * positionally, which drifted out of alignment (extra reflector/memory model calls produce
+ * no persisted message) and mislabeled phases (e.g. a reflection rendered as EXECUTION).
+ * Tagging the phase at creation makes history reconstruction exact and identical to live.
+ *
+ * `response_metadata` is round-tripped by the checkpointer and is NOT sent back to the model
+ * as input, so it is a safe place for this UI hint.
+ */
+export function tagMessagePhase<T extends BaseMessage>(msg: T, phase: string): T {
+    (msg as any).response_metadata = { ...((msg as any).response_metadata ?? {}), agentPhase: phase };
+    return msg;
+}
+
 // Get recent messages safely - ensuring tool call/result pairs are kept together
 // Also filters out empty messages that cause Bedrock API errors
 export function getRecentMessages(messages: BaseMessage[], maxMessages: number = 30): BaseMessage[] {
@@ -343,22 +362,39 @@ export function getRecentMessages(messages: BaseMessage[], maxMessages: number =
  * Call this function immediately before invoking modelWithTools.
  */
 export function sanitizeMessagesForBedrock(messages: BaseMessage[]): BaseMessage[] {
-    // Pass 1: collect every tool_call_id that already has a ToolMessage response
-    // anywhere in the array (not just consecutively after the AI message).
-    const answeredToolCallIds = new Set<string>();
+    // Bedrock requires every toolResult to IMMEDIATELY follow the assistant
+    // toolUse that owns it — "answered somewhere in the array" is not enough.
+    // Upstream windowing (getRecentMessages) can inject a synthetic
+    // HumanMessage("Proceed.") between an AI tool_use and its ToolMessage, which
+    // breaks that adjacency and triggers:
+    //   ValidationException: Expected toolResult blocks at messages.N.content
+    //
+    // To guarantee adjacency regardless of how the array was reordered, we index
+    // every ToolMessage by its tool_call_id, then re-emit each result directly
+    // after its owning AI message. Results are NOT emitted in place; orphan
+    // results whose tool_use is absent are dropped (Bedrock also rejects a
+    // toolResult that has no preceding toolUse).
+
+    // Pass 1: map each tool_call_id → its ToolMessage (first occurrence wins).
+    const toolResultById = new Map<string, BaseMessage>();
     for (const msg of messages) {
         if (msg._getType() === 'tool') {
             const toolCallId: string | undefined = (msg as any).tool_call_id;
-            if (toolCallId) answeredToolCallIds.add(toolCallId);
+            if (toolCallId && !toolResultById.has(toolCallId)) {
+                toolResultById.set(toolCallId, msg);
+            }
         }
     }
 
-    // Pass 2: rebuild the array, inserting synthetic ToolMessages for any
-    // AI tool_call IDs that have no matching ToolMessage in the conversation.
+    // Pass 2: rebuild the array. ToolMessages are skipped where they sit and
+    // re-attached next to their owning AI message; missing results get a
+    // synthetic placeholder so no tool_use is ever left unanswered.
     const result: BaseMessage[] = [];
 
-    for (let i = 0; i < messages.length; i++) {
-        const msg = messages[i];
+    for (const msg of messages) {
+        // Skip ToolMessages here — they are re-emitted via their AI owner below.
+        if (msg._getType() === 'tool') continue;
+
         result.push(msg);
 
         if (msg._getType() !== 'ai') continue;
@@ -382,23 +418,21 @@ export function sanitizeMessagesForBedrock(messages: BaseMessage[]): BaseMessage
         }
         if (pendingIds.size === 0) continue;
 
-        // Consume consecutive ToolMessages (the normal case)
-        let j = i + 1;
-        while (j < messages.length && messages[j]._getType() === 'tool') {
-            result.push(messages[j]);
-            j++;
-        }
-        i = j - 1;
-
-        // Insert synthetic placeholders for any tool_call IDs that have no
-        // matching ToolMessage anywhere in the conversation.
+        // Emit one toolResult per tool_use id, immediately after the AI message
+        // and in tool_use order. Use the real ToolMessage if we have one
+        // (wherever it sat in the original array); otherwise a synthetic
+        // placeholder.
         for (const [id, name] of pendingIds) {
-            if (answeredToolCallIds.has(id)) continue;
-            result.push(new ToolMessage({
-                content: '[Tool result unavailable — synthetic placeholder]',
-                tool_call_id: id,
-                name,
-            }));
+            const realResult = toolResultById.get(id);
+            if (realResult) {
+                result.push(realResult);
+            } else {
+                result.push(new ToolMessage({
+                    content: '[Tool result unavailable — synthetic placeholder]',
+                    tool_call_id: id,
+                    name,
+                }));
+            }
         }
     }
 

--- a/web-ui/lib/agent/fast-agent.ts
+++ b/web-ui/lib/agent/fast-agent.ts
@@ -11,6 +11,7 @@ import {
     truncateOutput,
     getRecentMessages,
     sanitizeMessagesForBedrock,
+    tagMessagePhase,
     getCheckpointer,
     getStore,
 } from "./agent-shared";
@@ -125,7 +126,7 @@ Review the full conversation history before responding:
         }
 
         return {
-            messages: [response],
+            messages: [tagMessagePhase(response, 'execution')],
             iterationCount: iterationCount + 1
         };
     }
@@ -287,20 +288,111 @@ Please provide your critique.`
     }
 
     // ---------------------------------------------------------------------------
+    // FINALIZE NODE
+    // ---------------------------------------------------------------------------
+    // Reached only when the iteration cap is hit while the model still wants to call
+    // tools. Those tool calls will NOT run, so we make one final model call WITHOUT
+    // tools to synthesize a natural-language answer from everything gathered so far.
+    // Without this, the graph would end on an unanswered tool_use message and the
+    // user would receive an empty ("placeholder") response.
+    async function finalizeNode(state: ReflectionState): Promise<Partial<ReflectionState>> {
+        const { messages, memoryContext, toolResults } = state;
+
+        console.log(`\n================================================================================`);
+        console.log(`🏁 [FAST AGENT] Iteration cap reached — synthesizing final answer (no tools)`);
+        console.log(`   Model: ${modelId}`);
+        console.log(`================================================================================\n`);
+
+        // Original request = the first human message in the thread.
+        const firstHuman = messages.find(m => m._getType() === 'human');
+        const originalQuery = firstHuman ? getStringContent(firstHuman.content as any) : '(original request unavailable)';
+
+        // Gathered context as PLAIN TEXT. We must NOT pass the raw conversation history to a
+        // tool-less model.invoke(): the history contains tool_use/tool_result content blocks,
+        // and a request without `toolConfig` (which only modelWithTools sends) is rejected by
+        // Bedrock — "The toolConfig field must be defined when using toolUse and toolResult
+        // content blocks." So we embed findings as text and send one fresh HumanMessage, the
+        // same pattern the planning-agent's final node uses.
+        const toolSummary = toolResults.length > 0
+            ? toolResults
+                .slice(-8)
+                .map(e => `[${e.isError ? '❌ ERROR' : '✅'} ${e.toolName}]\n${truncateOutput(e.output, 600)}`)
+                .join('\n\n---\n\n')
+            : '(no tool output was captured)';
+
+        const baseIdentity = buildBaseIdentity(selectedSkill);
+        const memorySection = memoryContext
+            ? `\n## Relevant Context from Memory\n${memoryContext}\n`
+            : '';
+
+        const finalizeSystemPrompt = new SystemMessage(`${baseIdentity}
+${effectiveSkillSection}
+${accountContext}
+${memorySection}
+## Final Answer (iteration cap reached)
+
+You have reached the maximum number of tool-call iterations, so you can NOT run any more tools.
+Using ONLY the information already gathered (below), write a clear, complete answer to the
+user's original request.
+
+### Original request
+${truncateOutput(originalQuery, 2000)}
+
+### Most recent tool outputs
+${toolSummary}
+
+Write a clear, markdown-formatted answer that:
+- States the key findings directly — include resource IDs, metrics, and command outputs where available.
+- Explicitly calls out anything that could not be verified or completed, and why.
+- Ends with concrete, actionable next steps.`);
+
+        const finalizeInput = new HumanMessage({
+            content: `Provide the final answer now, based only on what has already been gathered.`,
+        });
+
+        try {
+            // Tool-less model: no toolConfig is sent, and neither message contains tool blocks.
+            const response = await model.invoke([finalizeSystemPrompt, finalizeInput]);
+            return { messages: [tagMessagePhase(response, 'final')], isComplete: true };
+        } catch (err: any) {
+            // A finalize failure must NEVER crash the stream — return a best-effort text answer
+            // so the user still gets the findings gathered before the cap was hit.
+            console.error(`⚠️ [FAST AGENT] Finalize synthesis failed: ${err?.message ?? err}`);
+            const fallback = `⚠️ I reached the maximum number of investigation steps before I could fully complete the analysis.
+
+**Original request:** ${truncateOutput(originalQuery, 300)}
+
+**What I gathered before stopping:**
+
+${toolSummary}
+
+Please narrow the question or ask me to continue from here.`;
+            return { messages: [tagMessagePhase(new AIMessage({ content: fallback }), 'final')], isComplete: true };
+        }
+    }
+
+    // ---------------------------------------------------------------------------
     // CONDITIONAL EDGES
     // ---------------------------------------------------------------------------
-    function shouldContinue(state: ReflectionState): "tools" | "reflect" | "memory_save" {
+    function shouldContinue(state: ReflectionState): "tools" | "reflect" | "finalize" | "memory_save" {
         const messages = state.messages;
         const lastMessage = messages[messages.length - 1] as AIMessage;
         const { iterationCount } = state;
+        const hasPendingToolCalls = !!(lastMessage.tool_calls && lastMessage.tool_calls.length > 0);
 
         // Hard cap FIRST — prevents unbounded loops when model keeps generating tool_calls
         if (iterationCount >= MAX_ITERATIONS) {
+            // If the model still wants tools, they will not run — synthesize a final answer
+            // so the user never gets an empty response and we never persist an orphaned tool_use.
+            if (hasPendingToolCalls) {
+                console.log(`⚠️ Max iterations (${MAX_ITERATIONS}) reached with pending tool calls. Synthesizing final answer.`);
+                return "finalize";
+            }
             console.log(`⚠️ Max iterations (${MAX_ITERATIONS}) reached. Stopping.`);
             return "memory_save";
         }
 
-        if (lastMessage.tool_calls && lastMessage.tool_calls.length > 0) {
+        if (hasPendingToolCalls) {
             return "tools";
         }
 
@@ -328,6 +420,7 @@ Please provide your critique.`
         .addNode("agent", agentNode)
         .addNode("tools", collectingToolNode)
         .addNode("reflect", reflectNode)
+        .addNode("finalize", finalizeNode)
         .addNode("memory_save", memorySaveNode)
 
         .addEdge(START, "memory_recall")
@@ -336,6 +429,7 @@ Please provide your critique.`
         .addConditionalEdges("agent", shouldContinue, {
             tools: "tools",
             reflect: "reflect",
+            finalize: "finalize",
             memory_save: "memory_save"
         })
 
@@ -345,6 +439,7 @@ Please provide your critique.`
         })
 
         .addEdge("tools", "agent")
+        .addEdge("finalize", "memory_save")
         .addEdge("memory_save", END);
 
     if (autoApprove) {

--- a/web-ui/lib/agent/planning-agent.ts
+++ b/web-ui/lib/agent/planning-agent.ts
@@ -12,6 +12,7 @@ import {
     truncateOutput,
     getRecentMessages,
     sanitizeMessagesForBedrock,
+    tagMessagePhase,
     llmAuditLog,
     getCheckpointer,
     getStore,
@@ -160,7 +161,7 @@ Only return the JSON array, nothing else.`);
         return {
             plan: planSteps,
             taskDescription,
-            messages: [new AIMessage({ content: `📋 **Plan Created:**\n${planText}` })],
+            messages: [tagMessagePhase(new AIMessage({ content: `📋 **Plan Created:**\n${planText}` }), 'planning')],
             nextAction: "generate"
         };
     }
@@ -236,7 +237,7 @@ ${accountContext}
         });
 
         return {
-            messages: [response],
+            messages: [tagMessagePhase(response, 'execution')],
             iterationCount: iterationCount + 1,
             plan: updatedPlan
         };
@@ -449,7 +450,7 @@ ${suggestions !== "None" ? `💡 **Suggestions:** ${suggestions}` : ""}
         }
 
         const resultState: Partial<ReflectionState> = {
-            messages: [new AIMessage({ content: feedback })],
+            messages: [tagMessagePhase(new AIMessage({ content: feedback }), 'reflection')],
             reflection: analysis,
             errors: issues !== "None" ? [issues] : [],
             isComplete,
@@ -514,7 +515,7 @@ ${accountContext}`);
         }
 
         return {
-            messages: [response],
+            messages: [tagMessagePhase(response, 'revision')],
             nextAction: "generate"
         };
     }
@@ -575,7 +576,7 @@ ${summaryContent}`;
         console.log(`--- FINAL: Summary generated ---`);
 
         return {
-            messages: [new AIMessage({ content: finalMessage })],
+            messages: [tagMessagePhase(new AIMessage({ content: finalMessage }), 'final')],
             isComplete: true
         };
     }

--- a/web-ui/lib/agent/stream-error.ts
+++ b/web-ui/lib/agent/stream-error.ts
@@ -1,0 +1,37 @@
+/**
+ * Builds a descriptive, developer-friendly error string for the chat client.
+ *
+ * The AI SDK turns an `{ type: "error", errorText }` UI-message-stream part into
+ * `new Error(errorText)` on the client, and the chat UI renders `error.message`.
+ * Previously the stream was torn down with `controller.error()`, which the SDK
+ * surfaced as a generic "network error" — hiding the real backend failure.
+ *
+ * This formatter exposes the actual error: its name + message, plus the underlying
+ * `cause` for wrapped SDK errors (e.g. Bedrock `ValidationException`), so developers
+ * see the exact failure instead of a generic message.
+ */
+export function buildClientErrorText(error: unknown): string {
+    if (error instanceof Error) {
+        const head = error.name && error.name !== 'Error'
+            ? `${error.name}: ${error.message}`
+            : error.message;
+        const parts: string[] = [head];
+
+        const cause = (error as { cause?: unknown }).cause;
+        if (cause) {
+            const causeMsg = cause instanceof Error
+                ? `${cause.name}: ${cause.message}`
+                : String(cause);
+            if (causeMsg && !head.includes(causeMsg)) {
+                parts.push(`Cause: ${causeMsg}`);
+            }
+        }
+        return parts.join(' — ');
+    }
+    if (typeof error === 'string') return error;
+    try {
+        return JSON.stringify(error);
+    } catch {
+        return 'Unknown error';
+    }
+}

--- a/web-ui/tests/agent-ops/agent-shared.test.ts
+++ b/web-ui/tests/agent-ops/agent-shared.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { AIMessage, HumanMessage, ToolMessage, BaseMessage } from '@langchain/core/messages';
-import { sanitizeMessagesForBedrock, getRecentMessages, graphState } from '../../lib/agent/agent-shared';
+import { sanitizeMessagesForBedrock, getRecentMessages, graphState, tagMessagePhase } from '../../lib/agent/agent-shared';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -97,6 +97,41 @@ describe('sanitizeMessagesForBedrock', () => {
         expect(result).toHaveLength(6);
     });
 
+    it('keeps a tool_result adjacent to its tool_use when an intervening message separated them', () => {
+        // Reproduces the production ValidationException: getRecentMessages' role-alternation
+        // formatter can inject a HumanMessage("Proceed.") between an AI tool_use and its
+        // ToolMessage. Bedrock requires the toolResult to IMMEDIATELY follow the toolUse —
+        // "answered somewhere" is not enough.
+        const ai = makeAIWithToolCalls([{ id: 'tooluse_7eO4', name: 'execute_command' }]);
+        const tool = makeToolResult('tooluse_7eO4', 'execute_command');
+        const input = [ai, new HumanMessage('Proceed.'), tool];
+
+        const result = sanitizeMessagesForBedrock(input);
+
+        // The AI tool_use must be immediately followed by its toolResult.
+        const aiIdx = result.findIndex(
+            m => m._getType() === 'ai' && (m as AIMessage).tool_calls?.some(tc => tc.id === 'tooluse_7eO4')
+        );
+        expect(aiIdx).toBeGreaterThanOrEqual(0);
+        const next = result[aiIdx + 1];
+        expect(next._getType()).toBe('tool');
+        expect((next as any).tool_call_id).toBe('tooluse_7eO4');
+        // Exactly one tool_result for the id (no duplicate, no dropped result).
+        const matches = result.filter(m => m._getType() === 'tool' && (m as any).tool_call_id === 'tooluse_7eO4');
+        expect(matches).toHaveLength(1);
+    });
+
+    it('drops an orphaned tool_result whose tool_use is not in the window', () => {
+        // A ToolMessage with no owning AI tool_use anywhere is invalid for Bedrock
+        // (toolResult without toolUse) and must not be forwarded.
+        const orphan = makeToolResult('tc-ghost', 'ghost_tool');
+        const input = [new HumanMessage('Go'), orphan, new AIMessage('done')];
+
+        const result = sanitizeMessagesForBedrock(input);
+
+        expect(result.some(m => m._getType() === 'tool')).toBe(false);
+    });
+
     it('returns empty array for empty input', () => {
         expect(sanitizeMessagesForBedrock([])).toHaveLength(0);
     });
@@ -109,6 +144,37 @@ describe('sanitizeMessagesForBedrock', () => {
         const result = sanitizeMessagesForBedrock(msgs);
         expect(result).toHaveLength(2);
         expect(result[1].content).toBe('Hello there!');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// tagMessagePhase — phase tagging for exact history reconstruction
+// ---------------------------------------------------------------------------
+
+describe('tagMessagePhase', () => {
+    it('tags an AI message with the originating agent phase under response_metadata', () => {
+        const msg = new AIMessage({ content: 'reflection output' });
+        const tagged = tagMessagePhase(msg, 'reflection');
+
+        expect((tagged as any).response_metadata?.agentPhase).toBe('reflection');
+        // Returns the same instance (mutates in place) so node return values stay simple.
+        expect(tagged).toBe(msg);
+    });
+
+    it('preserves existing response_metadata (e.g. provider usage) when tagging', () => {
+        const msg = new AIMessage({ content: 'x' });
+        (msg as any).response_metadata = { usage: { tokens: 42 } };
+
+        tagMessagePhase(msg, 'execution');
+
+        expect((msg as any).response_metadata.usage).toEqual({ tokens: 42 });
+        expect((msg as any).response_metadata.agentPhase).toBe('execution');
+    });
+
+    it('round-trips through a JSON serialize/parse like the checkpointer does', () => {
+        const tagged = tagMessagePhase(new AIMessage({ content: 'final answer' }), 'final');
+        const revived = JSON.parse(JSON.stringify({ response_metadata: (tagged as any).response_metadata }));
+        expect(revived.response_metadata.agentPhase).toBe('final');
     });
 });
 

--- a/web-ui/tests/agent-ops/stream-error.test.ts
+++ b/web-ui/tests/agent-ops/stream-error.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Unit tests for buildClientErrorText — turns a thrown backend error into a
+ * descriptive message the chat UI can render (instead of a generic "network error").
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildClientErrorText } from '../../lib/agent/stream-error';
+
+describe('buildClientErrorText', () => {
+    it('includes the error name and message for a named error', () => {
+        const err = new Error('The toolConfig field must be defined when using toolUse and toolResult content blocks.');
+        err.name = 'ValidationException';
+
+        const text = buildClientErrorText(err);
+
+        expect(text).toContain('ValidationException');
+        expect(text).toContain('toolConfig field must be defined');
+        // Must NOT collapse to a generic message.
+        expect(text).not.toBe('network error');
+    });
+
+    it('surfaces the underlying cause of a wrapped error', () => {
+        const cause = new Error('Expected toolResult blocks at messages.0.content');
+        cause.name = 'ValidationException';
+        const wrapper = new Error('failed to pipe response', { cause });
+
+        const text = buildClientErrorText(wrapper);
+
+        expect(text).toContain('failed to pipe response');
+        expect(text).toContain('Cause:');
+        expect(text).toContain('Expected toolResult blocks');
+    });
+
+    it('does not duplicate the cause when it already appears in the message', () => {
+        const cause = new Error('boom');
+        const wrapper = new Error('wrapper boom', { cause });
+        // head does not contain "boom" exactly as "Error: boom", so cause is appended once
+        const text = buildClientErrorText(wrapper);
+        expect(text.match(/Cause:/g)?.length ?? 0).toBeLessThanOrEqual(1);
+    });
+
+    it('drops the redundant "Error:" prefix for a plain Error', () => {
+        const text = buildClientErrorText(new Error('something broke'));
+        expect(text).toBe('something broke');
+    });
+
+    it('passes a string error through unchanged', () => {
+        expect(buildClientErrorText('raw failure')).toBe('raw failure');
+    });
+
+    it('falls back to a readable string for non-error values', () => {
+        expect(buildClientErrorText({ code: 500 })).toContain('500');
+        expect(buildClientErrorText(null)).toBe('null');
+    });
+});


### PR DESCRIPTION
## Summary

Repairs a cluster of AI Ops agent issues found by reviewing production execution logs (`/ecs/nucleus-cloud-ops-web-ui-service`). Each fix was verified by `tsc` and unit tests; the full investigation/fix flow is captured below.

## Fixes

### 1. Bedrock `ValidationException` crashed the chat stream (orphaned `tool_use`)
`sanitizeMessagesForBedrock` only checked that a `tool_result` existed *somewhere*, but Bedrock requires it **adjacent** to its `tool_use`. When the windowing formatter injected a `"Proceed."` message between them, the orphan slipped through and crashed the stream. Rewrote the function to re-attach each `toolResult` directly after its owning `toolUse` (and drop orphan results). Fixes all call sites at once (fast / planning / executor).

### 2. Fast-agent returned an empty answer at the iteration cap
On hitting `MAX_ITERATIONS` with a pending tool call, the graph went straight to `END` with an unanswered `tool_use` → user got a blank/placeholder response. Added a tool-free **`finalize`** node that synthesizes an answer from gathered context (embedded as plain text to avoid the `toolConfig` ValidationException) and can never crash the stream.

### 3. Generic "network error" → descriptive errors
Stream errors were reported to the client as a generic "network error". The route now emits a structured `error` stream part carrying the real backend message (name + message + cause), which the chat UI renders verbatim.

### 4. History rendered with the wrong phase cards
Phase markers were assigned **positionally** during persistence, which drifted (memory/reflector model calls produce no persisted message) and mislabeled blocks (e.g. reflection shown as EXECUTION). Messages are now tagged with their originating phase (`response_metadata.agentPhase`), so reloaded history matches live execution exactly.

### 5. Memory blocks: collapsible + present in history
Memory recall/save now render as collapsible blocks (collapsed by default) instead of large always-expanded cards, and are persisted as **display-only** chat messages so they appear in history too. This only touches the UI history store (`chat_messages`) — the agent's LLM context (the LangGraph checkpointer) is untouched.

## Tests
- New/extended unit coverage: sanitize adjacency + orphan drop, `tagMessagePhase`, and the client error formatter.
- **24 tests passing**; `tsc --noEmit` clean (0 errors).

## Verification notes / caveats
- UI-rendering outcomes (collapsible memory, history-vs-live parity) were verified by data-flow reasoning + type/unit checks; an end-to-end browser run was not performed in this environment.
- History fixes apply to **newly-run** conversations; chats saved before this change keep their previously-stored markers.
- Excluded from this PR: an unrelated `bun.lock` dependency change (`@aws-sdk/client-acm`) and the raw `docs/known-issues/execution-logs.md` log dump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
