### PR TITLE
feat(web-ui): provider-only LLM/embeddings (SaaS) + dynamic embedding detection

### DIFF
--- a/apps/web-ui/app/api/chat/route.ts
+++ b/apps/web-ui/app/api/chat/route.ts
@@ -2,8 +2,8 @@ import { HumanMessage, AIMessage, ToolMessage, BaseMessage } from '@langchain/co
 import { NextResponse } from 'next/server';
 import { createUIMessageStreamResponse, UIMessageChunk } from 'ai';
 import { createReflectionGraph, createFastGraph, createDeepGraph } from '@/lib/agent/graph-factory';
-import { resolveModelConfig } from '@/lib/agent/model-resolver';
-import { ProviderModelService } from '@/lib/provider-model-service';
+import { resolveModelConfig, resolveDefaultModelConfig } from '@/lib/agent/model-resolver';
+import { isProviderConfigError } from '@/lib/agent/provider-errors';
 import { buildClientErrorText } from '@/lib/agent/stream-error';
 
 export const maxDuration = 300; // 5 minutes for complex multi-iteration tasks
@@ -117,24 +117,26 @@ export async function POST(req: Request) {
         console.log(`   AWS Accounts: ${accounts?.length || 0} selected${accounts?.length ? ` (${accounts.map((a: any) => a.accountId).join(', ')})` : ' (none)'}`);
         console.log(`   Timestamp:    ${new Date().toISOString()}`);
 
-        // Resolve model string into a ResolvedModelConfig before graph creation.
+        // Resolve model into a ResolvedModelConfig before graph creation.
         // Selection precedence: explicit picker model → tenant default provider's
-        // chat model → native Bedrock fallback (keeps chat working with zero config).
-        let modelString = model as string | undefined;
-        if (!modelString) {
-            try {
-                const defaultProvider = await ProviderModelService.getDefaultConfig(resolvedTenantId);
-                if (defaultProvider?.chatModel) {
-                    modelString = `${defaultProvider.provider}:${defaultProvider.chatModel}:${defaultProvider.id}`;
-                }
-            } catch (e) {
-                console.warn('[chat] default provider lookup failed, falling back to Bedrock:', e);
+        // chat model. There is NO implicit Bedrock fallback — if nothing is
+        // configured we return a 400 telling the user to configure a provider.
+        const modelString = model as string | undefined;
+        let resolvedModel;
+        try {
+            resolvedModel = modelString
+                ? await resolveModelConfig(modelString, resolvedTenantId)
+                : await resolveDefaultModelConfig(resolvedTenantId);
+        } catch (e) {
+            releaseThreadLock();
+            if (isProviderConfigError(e)) {
+                return new Response(
+                    JSON.stringify({ error: e.message }),
+                    { status: 400, headers: { 'Content-Type': 'application/json' } },
+                );
             }
+            throw e;
         }
-        const resolvedModel = await resolveModelConfig(
-            modelString || 'global.anthropic.claude-sonnet-4-5-20250929-v1:0',
-            resolvedTenantId,
-        );
 
         // Create graph with configuration - supports multi-account
         const graphConfig = {

--- a/apps/web-ui/app/api/enhance-prompt/route.ts
+++ b/apps/web-ui/app/api/enhance-prompt/route.ts
@@ -1,23 +1,32 @@
 import { NextResponse } from 'next/server';
-import { ChatBedrockConverse } from "@langchain/aws";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
-import { env } from "@/env";
+import { getSessionTenantId } from "@/lib/auth-session";
+import { resolveDefaultModelConfig } from "@/lib/agent/model-resolver";
+import { createAgentModels } from "@/lib/agent/model-factory";
+import { isProviderConfigError } from "@/lib/agent/provider-errors";
 
 export async function POST(req: Request) {
     try {
-        const { prompt, model } = await req.json();
+        const { prompt } = await req.json();
 
         if (!prompt) {
             return NextResponse.json({ error: 'Prompt is required' }, { status: 400 });
         }
 
-        // Initialize Bedrock Client
-        const llm = new ChatBedrockConverse({
-            region: env.AWS_REGION || env.NEXT_PUBLIC_AWS_REGION || 'us-east-1',
-            model: 'global.anthropic.claude-haiku-4-5-20251001-v1:0', // Force Haiku for speed
-            maxTokens: 512,
-            temperature: 0.5, // Less creative, more concise
-        });
+        // Use the tenant's configured default provider — no hardcoded Bedrock.
+        // The reflector instance is the small, non-streaming model variant, ideal
+        // for a quick prompt-enhancement pass.
+        let llm;
+        try {
+            const tenantId = await getSessionTenantId();
+            const config = await resolveDefaultModelConfig(tenantId);
+            llm = createAgentModels({ ...config, maxTokens: 512 }).reflector;
+        } catch (e) {
+            if (isProviderConfigError(e)) {
+                return NextResponse.json({ error: e.message }, { status: 400 });
+            }
+            throw e;
+        }
 
         const systemPrompt = new SystemMessage(
             `You are an expert prompt engineer for an advanced AI DevOps Agent.

--- a/apps/web-ui/app/api/knowledge-base/query/route.ts
+++ b/apps/web-ui/app/api/knowledge-base/query/route.ts
@@ -1,41 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/app/api/auth/[...nextauth]/route';
-import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
-import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
-import { streamText } from 'ai';
+import { HumanMessage, AIMessage, SystemMessage } from '@langchain/core/messages';
 import { getEmbedding } from '@/lib/knowledge-base/embedder';
 import { KnowledgeBaseService } from '@/lib/knowledge-base/service';
 import { getSessionTenantId } from '@/lib/auth-session';
 import { getPrismaClient } from '@/lib/db/pg-config';
-import { env } from '@/env';
-
-// ============================================================================
-// AWS Clients
-// ============================================================================
-
-const credentialProvider = fromNodeProviderChain();
-
-function getBedrockClient() {
-  return createAmazonBedrock({
-    region: env.AWS_REGION || 'ap-south-1',
-    credentialProvider: async () => {
-      const creds = await credentialProvider();
-      return {
-        accessKeyId: creds.accessKeyId,
-        secretAccessKey: creds.secretAccessKey,
-        sessionToken: creds.sessionToken,
-      };
-    },
-  });
-}
-
-// ============================================================================
-// Config
-// ============================================================================
-
-const GENERATION_MODEL_ID =
-  env.ASK_AI_GENERATION_MODEL || 'global.anthropic.claude-sonnet-4-6';
+import { resolveDefaultModelConfig } from '@/lib/agent/model-resolver';
+import { createAgentModels } from '@/lib/agent/model-factory';
+import { isProviderConfigError } from '@/lib/agent/provider-errors';
 
 // ============================================================================
 // Types
@@ -98,8 +71,8 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    // 3. Embed the query
-    const embedding = await getEmbedding(query);
+    // 3. Embed the query via the tenant's configured provider
+    const embedding = await getEmbedding(query, tenantId);
     const vectorLiteral = `[${embedding.join(',')}]`;
 
     // 4. Query pgvector for similar chunks
@@ -157,17 +130,19 @@ ${contextString}`;
       .filter((m) => m.content && m.content.trim())
       .map((m) => ({ role: m.role, content: m.content }));
 
-    // 8. Stream response via Bedrock
-    const result = streamText({
-      model: getBedrockClient()(GENERATION_MODEL_ID),
-      system: systemPrompt,
-      messages: [
-        ...conversationHistory,
-        { role: 'user', content: query },
-      ],
+    // 8. Resolve the tenant's configured provider for generation (no Bedrock default)
+    const model = createAgentModels({
+      ...(await resolveDefaultModelConfig(tenantId)),
       maxTokens: 1500,
-      temperature: 0.1,
-    });
+    }).main;
+
+    const lcMessages = [
+      new SystemMessage(systemPrompt),
+      ...conversationHistory.map((m) =>
+        m.role === 'assistant' ? new AIMessage(m.content) : new HumanMessage(m.content),
+      ),
+      new HumanMessage(query),
+    ];
 
     // 9. Build sources for X-AI-Sources header
     const sources: KBSource[] = results.map((r) => ({
@@ -182,16 +157,44 @@ ${contextString}`;
 
     const sourcesJson = JSON.stringify(sources);
 
-    const response = result.toTextStreamResponse({
-      headers: {
-        'X-AI-Sources': encodeURIComponent(sourcesJson),
+    // 10. Stream the answer as plain text (provider-agnostic LangChain stream)
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        try {
+          const llmStream = await model.stream(lcMessages);
+          for await (const chunk of llmStream) {
+            const content = chunk.content;
+            const text =
+              typeof content === 'string'
+                ? content
+                : Array.isArray(content)
+                  ? content
+                      .filter((c): c is { type: string; text: string } => (c as { type?: string }).type === 'text')
+                      .map((c) => c.text)
+                      .join('')
+                  : '';
+            if (text) controller.enqueue(encoder.encode(text));
+          }
+          controller.close();
+        } catch (err) {
+          controller.error(err);
+        }
       },
     });
 
-    return response;
+    return new Response(stream, {
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'Cache-Control': 'no-cache',
+        'X-AI-Sources': encodeURIComponent(sourcesJson),
+      },
+    });
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : 'Internal Server Error';
     console.error('[KB Query] Error:', error);
-    return NextResponse.json({ error: message }, { status: 500 });
+    // No configured provider → 400 with a clear "configure a provider" message.
+    const status = isProviderConfigError(error) ? 400 : 500;
+    return NextResponse.json({ error: message }, { status });
   }
 }

--- a/apps/web-ui/app/api/settings/providers/probe-embedding/route.ts
+++ b/apps/web-ui/app/api/settings/providers/probe-embedding/route.ts
@@ -1,0 +1,136 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { authorize } from '@/lib/rbac/authorize';
+import { getSessionTenantId } from '@/lib/auth-session';
+import {
+    ProviderModelService,
+    isProviderType,
+    type ProviderRuntimeConfig,
+} from '@/lib/provider-model-service';
+import { probeEmbeddingDimensions, REQUIRED_EMBEDDING_DIMENSIONS } from '@/lib/agent/embeddings-factory';
+import { isProviderConfigError } from '@/lib/agent/provider-errors';
+
+/**
+ * POST /api/settings/providers/probe-embedding
+ *
+ * Embeds a tiny probe string with the given embedding model and returns its
+ * EFFECTIVE output dimension (after any text-embedding-3 reduction). The wizard
+ * uses this to auto-detect + validate dimensions against the platform's fixed
+ * 1024-dim pgvector columns before a provider is saved.
+ *
+ * Body: { providerType, embeddingModel, credentials?, region?, providerId? }
+ *   - create flow: pass credentials (+ region for bedrock).
+ *   - edit flow with kept credentials: pass providerId; saved creds are used.
+ */
+export async function POST(request: NextRequest) {
+    const authError = await authorize('update', 'Settings');
+    if (authError) return authError;
+
+    try {
+        const tenantId = await getSessionTenantId();
+        const body = await request.json();
+        const { providerType, embeddingModel, credentials, region, providerId } = body;
+
+        if (!isProviderType(providerType)) {
+            return NextResponse.json(
+                { success: false, error: `Invalid provider type: ${providerType}` },
+                { status: 400 },
+            );
+        }
+        if (!embeddingModel || typeof embeddingModel !== 'string') {
+            return NextResponse.json(
+                { success: false, error: 'embeddingModel is required' },
+                { status: 400 },
+            );
+        }
+
+        const hasCreds =
+            credentials &&
+            (credentials.apiKey || credentials.accessKeyId || credentials.secretAccessKey || credentials.baseUrl);
+
+        let config: ProviderRuntimeConfig;
+        if (hasCreds) {
+            // Create flow (or edit with re-entered creds) — build from plaintext input.
+            config = {
+                id: providerId ?? 'probe',
+                provider: providerType,
+                region: region || undefined,
+                embeddingModel,
+                baseUrl: credentials.baseUrl,
+                apiKey: credentials.apiKey,
+                accessKeyId: credentials.accessKeyId,
+                secretAccessKey: credentials.secretAccessKey,
+                models: [],
+            };
+        } else if (providerId) {
+            // Edit flow with kept credentials — reuse the saved, decrypted config.
+            const saved = await ProviderModelService.getConfigById(providerId, tenantId);
+            if (!saved) {
+                return NextResponse.json({ success: false, error: 'Provider not found' }, { status: 404 });
+            }
+            config = { ...saved, embeddingModel };
+        } else {
+            return NextResponse.json(
+                { success: false, error: 'credentials or providerId is required' },
+                { status: 400 },
+            );
+        }
+
+        console.log(
+            `[probe-embedding] attempting provider=${providerType} model="${embeddingModel}" region=${config.region ?? '(none)'} hasCreds=${Boolean(hasCreds)} providerId=${providerId ?? '(none)'}`,
+        );
+
+        let dimensions: number;
+        try {
+            dimensions = await probeEmbeddingDimensions(config);
+        } catch (embedError) {
+            // A failed invoke is a KNOWN outcome here, not a server error: the model
+            // uses a request schema the platform can't speak (e.g. Cohere, Nova,
+            // multimodal Titan/Marengo). Always return 200 with supported:false and
+            // a clean reason that INCLUDES the underlying error, so the wizard shows
+            // exactly why a model can't be used instead of swallowing it.
+            const raw = embedError instanceof Error ? embedError.message : String(embedError);
+            const clean = raw.replace(/^An error occurred while embedding documents with Bedrock:\s*/i, '');
+            const isUnsupportedSchema =
+                /Malformed|ValidationException|required (property|key)|input_?type|not found|one and only one schema/i.test(
+                    raw,
+                );
+            console.log(
+                `[probe-embedding] UNUSABLE provider=${providerType} model="${embeddingModel}" — ${raw}`,
+            );
+            return NextResponse.json({
+                success: true,
+                data: {
+                    compatible: false,
+                    supported: false,
+                    dimensions: null,
+                    required: REQUIRED_EMBEDDING_DIMENSIONS,
+                    reason: isUnsupportedSchema
+                        ? `This embedding model isn't supported here — its request format differs from Titan Text / OpenAI-compatible embeddings (${clean}). Pick a supported model.`
+                        : `Couldn't use this embedding model: ${clean}`,
+                },
+            });
+        }
+
+        const compatible = dimensions === REQUIRED_EMBEDDING_DIMENSIONS;
+        console.log(
+            `[probe-embedding] OK provider=${providerType} model="${embeddingModel}" → ${dimensions} dims (required ${REQUIRED_EMBEDDING_DIMENSIONS}, compatible=${compatible})`,
+        );
+        return NextResponse.json({
+            success: true,
+            data: {
+                compatible,
+                supported: true,
+                dimensions,
+                required: REQUIRED_EMBEDDING_DIMENSIONS,
+                reason: compatible
+                    ? null
+                    : `This model outputs ${dimensions}-dimension vectors, but the platform stores ${REQUIRED_EMBEDDING_DIMENSIONS}-dimension vectors. Choose a ${REQUIRED_EMBEDDING_DIMENSIONS}-dim embedding model.`,
+            },
+        });
+    } catch (error) {
+        console.error('API - Error probing embedding dimensions:', error);
+        const message = error instanceof Error ? error.message : 'Failed to probe embedding model';
+        const status = isProviderConfigError(error) ? 400 : 502;
+        return NextResponse.json({ success: false, error: message }, { status });
+    }
+}

--- a/apps/web-ui/app/api/settings/providers/route.ts
+++ b/apps/web-ui/app/api/settings/providers/route.ts
@@ -8,17 +8,6 @@ import {
 } from '@/lib/provider-model-service';
 import { AuditService } from '@/lib/audit-service';
 
-// Native Bedrock baseline (host/task-role credentials) — always available so the
-// chat model picker works even with zero tenant-configured providers.
-const BEDROCK_MODELS = [
-    { id: 'bedrock:global.anthropic.claude-sonnet-4-6', label: 'Claude 4.6 Sonnet', provider: 'bedrock' },
-    { id: 'bedrock:global.anthropic.claude-sonnet-4-5-20250929-v1:0', label: 'Claude 4.5 Sonnet', provider: 'bedrock' },
-    { id: 'bedrock:global.amazon.nova-2-lite-v1:0', label: 'Nova 2 Lite', provider: 'bedrock' },
-    { id: 'bedrock:global.anthropic.claude-haiku-4-5-20251001-v1:0', label: 'Claude 4.5 Haiku', provider: 'bedrock' },
-    { id: 'bedrock:global.anthropic.claude-opus-4-5-20251101-v1:0', label: 'Claude 4.5 Opus', provider: 'bedrock' },
-    { id: 'bedrock:global.anthropic.claude-opus-4-6-v1', label: 'Claude 4.6 Opus', provider: 'bedrock' },
-];
-
 export async function GET(_request: NextRequest) {
     console.log('API - GET /api/settings/providers - Fetching providers');
     const authError = await authorize('read', 'Settings');
@@ -29,7 +18,8 @@ export async function GET(_request: NextRequest) {
         const records = await ProviderModelService.listAllProviders(tenantId);
         const providers = records.map((r) => ProviderModelService.toClientProvider(r as never));
 
-        // Build the flat chat-picker list. Each model id is the composite
+        // Build the flat chat-picker list — ONLY tenant-configured providers, no
+        // hardcoded Bedrock baseline. Each model id is the composite
         // `{providerType}:{modelId}:{providerRecordId}` so model-resolver routes
         // it to the right transport (bedrock record / anthropic / openai-family).
         const configuredModels = providers
@@ -50,7 +40,7 @@ export async function GET(_request: NextRequest) {
             success: true,
             data: {
                 providers,
-                models: [...BEDROCK_MODELS, ...configuredModels],
+                models: configuredModels,
             },
         });
     } catch (error) {

--- a/apps/web-ui/components/agent/chat-interface.tsx
+++ b/apps/web-ui/components/agent/chat-interface.tsx
@@ -100,19 +100,8 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { ClientAccountService } from "@/lib/client-account-service";
 import { UIAccount } from "@/lib/types";
+import { useProviderModels } from "@/lib/queries/providers";
 import { FileUpload, FileAttachment } from "@/components/agent/file-upload";
-
-// Available models
-interface AvailableModel {
-  id: string;
-  label: string;
-  provider: string;
-}
-
-const DEFAULT_MODELS: AvailableModel[] = [
-  { id: "bedrock:global.anthropic.claude-sonnet-4-6", label: "Claude 4.6 Sonnet", provider: "bedrock" },
-  { id: "bedrock:global.anthropic.claude-sonnet-4-5-20250929-v1:0", label: "Claude 4.5 Sonnet", provider: "bedrock" },
-];
 
 // Phase types matching backend
 type AgentPhase =
@@ -474,23 +463,17 @@ export function ChatInterface({
   // Configuration state (before conversation starts)
   const [autoApprove, setAutoApprove] = useState(true);
   const [showTools, setShowTools] = useState(false);
-  const [selectedModel, setSelectedModel] = useState("bedrock:global.anthropic.claude-sonnet-4-6");
-  const [availableModels, setAvailableModels] = useState<AvailableModel[]>(DEFAULT_MODELS);
+  const [selectedModel, setSelectedModel] = useState("");
+  // Models are sourced ONLY from tenant-configured providers (shared TanStack
+  // Query hook — no hardcoded Bedrock baseline). Auto-select the first available
+  // model so a configured tenant has a sensible default without picking one.
+  const { data: availableModels = [] } = useProviderModels();
 
   useEffect(() => {
-    async function fetchModels() {
-      try {
-        const res = await fetch('/api/settings/providers');
-        const json = await res.json();
-        if (res.ok && json.success && json.data?.models?.length > 0) {
-          setAvailableModels(json.data.models);
-        }
-      } catch {
-        // Silently fall back to defaults
-      }
-    }
-    fetchModels();
-  }, []);
+    setSelectedModel((prev) =>
+      prev && availableModels.some((m) => m.id === prev) ? prev : availableModels[0]?.id ?? "",
+    );
+  }, [availableModels]);
   const [agentMode, setAgentMode] = useState("fast");
   const [hasStarted, setHasStarted] = useState(false);
   const [isLoadingHistory, setIsLoadingHistory] = useState(false);
@@ -1573,10 +1556,15 @@ export function ChatInterface({
                 <SelectTrigger className="h-7 text-xs border-transparent bg-transparent hover:bg-muted/50 focus:ring-0 gap-1 px-2 w-auto min-w-[180px]">
                   <div className="flex items-center gap-1.5">
                     <Sparkles className="w-3 h-3 text-primary" />
-                    <SelectValue placeholder="Select Model" />
+                    <SelectValue placeholder={availableModels.length === 0 ? "No providers configured" : "Select Model"} />
                   </div>
                 </SelectTrigger>
                 <SelectContent>
+                  {availableModels.length === 0 && (
+                    <div className="px-2 py-1.5 text-xs text-muted-foreground">
+                      No LLM providers configured. Add one in Settings → Providers.
+                    </div>
+                  )}
                   {(() => {
                     // Group label per provider type. Bedrock first, then the rest in a
                     // stable order; any unrecognised provider falls back to its raw key.

--- a/apps/web-ui/components/deep-agent/deep-agent-chat.tsx
+++ b/apps/web-ui/components/deep-agent/deep-agent-chat.tsx
@@ -5,6 +5,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { cn } from '@/lib/utils';
 import { formatTime } from '@/lib/date-utils';
 import { useTenant } from '@/lib/tenant-context';
+import { useProviderModels } from '@/lib/queries/providers';
 import { ThreadSidebar } from './thread-sidebar';
 import { TodoPanel } from './todo-panel';
 import { ApprovalDialog } from './approval-dialog';
@@ -66,20 +67,6 @@ interface ChatMessage {
   timestamp: Date;
 }
 
-interface ModelOption {
-  id: string;
-  label: string;
-}
-
-const MODELS: ModelOption[] = [
-  { id: 'global.anthropic.claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
-  { id: 'anthropic.claude-3-5-sonnet-20241022-v2:0', label: 'Claude 3.5 Sonnet v2' },
-  { id: 'anthropic.claude-3-7-sonnet-20250219-v1:0', label: 'Claude 3.7 Sonnet' },
-  { id: 'anthropic.claude-3-5-haiku-20241022-v1:0', label: 'Claude 3.5 Haiku' },
-  { id: 'amazon.nova-pro-v1:0', label: 'Nova Pro' },
-  { id: 'amazon.nova-lite-v1:0', label: 'Nova Lite' },
-];
-
 // ---------------------------------------------------------------------------
 // Main Component
 // ---------------------------------------------------------------------------
@@ -95,8 +82,19 @@ export function DeepAgentChat() {
   const [isLoading, setIsLoading] = useState(false);
   const [autoApprove, setAutoApprove] = useState(false);
   const [showTodos, setShowTodos] = useState(true);
-  const [selectedModel, setSelectedModel] = useState(MODELS[0].id);
+  const [selectedModel, setSelectedModel] = useState('');
   const [selectedSkills, setSelectedSkills] = useState<string[]>([]);
+
+  // Models come ONLY from tenant-configured providers (shared TanStack Query hook,
+  // no hardcoded Bedrock list). The composite id (`{provider}:{modelId}:{recordId}`)
+  // is what the deep-agent API resolves into the provider's credentials at runtime.
+  const { data: models = [] } = useProviderModels();
+
+  useEffect(() => {
+    setSelectedModel((prev) =>
+      prev && models.some((m) => m.id === prev) ? prev : models[0]?.id ?? '',
+    );
+  }, [models]);
   const [selectedMcpServers, setSelectedMcpServers] = useState<string[]>([]);
   const [selectedAccounts, setSelectedAccounts] = useState<Array<{ accountId: string; accountName: string }>>([]);
 
@@ -579,7 +577,8 @@ export function DeepAgentChat() {
                 onChange={e => setSelectedModel(e.target.value)}
                 className="text-xs bg-muted border border-border text-foreground rounded-lg px-2.5 py-1.5 outline-none focus:border-violet-500/50 transition-colors cursor-pointer"
               >
-                {MODELS.map(m => (
+                {models.length === 0 && <option value="">No providers configured</option>}
+                {models.map(m => (
                   <option key={m.id} value={m.id}>{m.label}</option>
                 ))}
               </select>

--- a/apps/web-ui/components/layout/app-sidebar.tsx
+++ b/apps/web-ui/components/layout/app-sidebar.tsx
@@ -12,7 +12,7 @@ import {
 import { NavMain } from "@/components/nav-main"
 import { NavUser } from "@/components/nav-user"
 import { OrgSwitcher } from "@/components/settings/org-switcher"
-import { navGroups } from "@/lib/nav-config"
+import { navMenus } from "@/lib/nav-config"
 
 export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
   return (
@@ -21,7 +21,7 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
         <OrgSwitcher />
       </SidebarHeader>
       <SidebarContent>
-        <NavMain groups={navGroups} />
+        <NavMain items={navMenus} />
       </SidebarContent>
       <SidebarFooter>
         <NavUser />

--- a/apps/web-ui/components/nav-main.tsx
+++ b/apps/web-ui/components/nav-main.tsx
@@ -12,9 +12,7 @@ import {
 } from "@/components/ui/collapsible"
 import {
   SidebarGroup,
-  SidebarGroupLabel,
   SidebarMenu,
-  SidebarMenuAction,
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarMenuSub,
@@ -29,14 +27,10 @@ export interface NavSubItem {
 
 export interface NavItem {
   title: string
-  href: string
   icon: LucideIcon
+  /** Optional direct route. Category items (with `items`) usually omit this. */
+  href?: string
   items?: NavSubItem[]
-}
-
-export interface NavGroup {
-  label: string
-  items: NavItem[]
 }
 
 /**
@@ -45,15 +39,13 @@ export interface NavGroup {
  * "overview" link (e.g. /app/settings) doesn't stay active on a deeper child
  * route (e.g. /app/settings/members).
  */
-function useBestMatch(groups: NavGroup[]): string | null {
+function useBestMatch(items: NavItem[]): string | null {
   const pathname = usePathname()
   return React.useMemo(() => {
     const hrefs: string[] = []
-    for (const group of groups) {
-      for (const item of group.items) {
-        hrefs.push(item.href)
-        item.items?.forEach((sub) => hrefs.push(sub.href))
-      }
+    for (const item of items) {
+      if (item.href) hrefs.push(item.href)
+      item.items?.forEach((sub) => hrefs.push(sub.href))
     }
     let best: string | null = null
     for (const href of hrefs) {
@@ -63,87 +55,78 @@ function useBestMatch(groups: NavGroup[]): string | null {
       }
     }
     return best
-  }, [groups, pathname])
+  }, [items, pathname])
 }
 
-export function NavMain({ groups }: { groups: NavGroup[] }) {
-  const bestMatch = useBestMatch(groups)
+export function NavMain({ items }: { items: NavItem[] }) {
+  const bestMatch = useBestMatch(items)
 
   return (
-    <>
-      {groups.map((group) => (
-        <SidebarGroup key={group.label}>
-          <SidebarGroupLabel>{group.label}</SidebarGroupLabel>
-          <SidebarMenu>
-            {group.items.map((item) => {
-              const childActive = item.items?.some((s) => s.href === bestMatch)
-              const itemActive = item.href === bestMatch
-              const Icon = item.icon
+    <SidebarGroup>
+      <SidebarMenu>
+        {items.map((item) => {
+          const Icon = item.icon
+          const childActive = item.items?.some((s) => s.href === bestMatch)
+          const itemActive = item.href === bestMatch
 
-              if (!item.items?.length) {
-                return (
-                  <SidebarMenuItem key={item.title}>
-                    <SidebarMenuButton
-                      asChild
-                      isActive={itemActive}
-                      tooltip={item.title}
-                    >
-                      <Link href={item.href}>
-                        <Icon />
-                        <span>{item.title}</span>
-                      </Link>
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                )
-              }
-
-              return (
-                <Collapsible
-                  key={item.title}
+          // Leaf item (no submenu) — render as a direct link.
+          if (!item.items?.length) {
+            return (
+              <SidebarMenuItem key={item.title}>
+                <SidebarMenuButton
                   asChild
-                  defaultOpen={itemActive || childActive}
-                  className="group/collapsible"
+                  isActive={itemActive}
+                  tooltip={item.title}
                 >
-                  <SidebarMenuItem>
-                    <SidebarMenuButton
-                      asChild
-                      isActive={itemActive}
-                      tooltip={item.title}
-                    >
-                      <Link href={item.href}>
-                        <Icon />
-                        <span>{item.title}</span>
-                      </Link>
-                    </SidebarMenuButton>
-                    <CollapsibleTrigger asChild>
-                      <SidebarMenuAction className="transition-transform data-[state=open]:rotate-90">
-                        <ChevronRight />
-                        <span className="sr-only">Toggle {item.title}</span>
-                      </SidebarMenuAction>
-                    </CollapsibleTrigger>
-                    <CollapsibleContent>
-                      <SidebarMenuSub>
-                        {item.items.map((sub) => (
-                          <SidebarMenuSubItem key={sub.title}>
-                            <SidebarMenuSubButton
-                              asChild
-                              isActive={sub.href === bestMatch}
-                            >
-                              <Link href={sub.href}>
-                                <span>{sub.title}</span>
-                              </Link>
-                            </SidebarMenuSubButton>
-                          </SidebarMenuSubItem>
-                        ))}
-                      </SidebarMenuSub>
-                    </CollapsibleContent>
-                  </SidebarMenuItem>
-                </Collapsible>
-              )
-            })}
-          </SidebarMenu>
-        </SidebarGroup>
-      ))}
-    </>
+                  <Link href={item.href ?? "#"}>
+                    <Icon />
+                    <span>{item.title}</span>
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            )
+          }
+
+          // Category — the button toggles its submenu (it has no page of its own).
+          return (
+            <Collapsible
+              key={item.title}
+              asChild
+              defaultOpen={itemActive || childActive}
+              className="group/collapsible"
+            >
+              <SidebarMenuItem>
+                <CollapsibleTrigger asChild>
+                  <SidebarMenuButton
+                    tooltip={item.title}
+                    isActive={childActive}
+                  >
+                    <Icon />
+                    <span>{item.title}</span>
+                    <ChevronRight className="ml-auto transition-transform group-data-[state=open]/collapsible:rotate-90" />
+                  </SidebarMenuButton>
+                </CollapsibleTrigger>
+                <CollapsibleContent>
+                  <SidebarMenuSub>
+                    {item.items.map((sub) => (
+                      <SidebarMenuSubItem key={sub.title}>
+                        <SidebarMenuSubButton
+                          asChild
+                          isActive={sub.href === bestMatch}
+                        >
+                          <Link href={sub.href}>
+                            <span>{sub.title}</span>
+                          </Link>
+                        </SidebarMenuSubButton>
+                      </SidebarMenuSubItem>
+                    ))}
+                  </SidebarMenuSub>
+                </CollapsibleContent>
+              </SidebarMenuItem>
+            </Collapsible>
+          )
+        })}
+      </SidebarMenu>
+    </SidebarGroup>
   )
 }

--- a/apps/web-ui/components/settings/provider-wizard.tsx
+++ b/apps/web-ui/components/settings/provider-wizard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { ArrowLeft, Loader2, Sparkles } from "lucide-react";
@@ -20,12 +20,14 @@ import {
     useCreateProvider,
     useUpdateProvider,
     useDiscoverModels,
+    useProbeEmbedding,
     type Provider,
     type ProviderType,
     type DiscoveredModel,
     type ProviderCredentialsInput,
     type CreateProviderInput,
     type ProviderModelEntry,
+    type EmbeddingProbeResult,
 } from "@/lib/queries/providers";
 
 /** Which credential fields a provider type exposes in the wizard. */
@@ -127,6 +129,9 @@ const FIELD_META: Record<CredentialField, { label: string; placeholder: string; 
 
 const NONE_VALUE = "__none__";
 
+/** Platform-wide embedding dimension (pgvector columns are fixed vector(1024)). */
+const PLATFORM_EMBEDDING_DIMS = 1024;
+
 /** A discovered model is chat-capable if it lists 'chat' or lists no capabilities at all. */
 function isChatModel(m: DiscoveredModel): boolean {
     return !m.capabilities || m.capabilities.length === 0 || m.capabilities.includes("chat");
@@ -147,6 +152,7 @@ export function ProviderWizard({
     const createProvider = useCreateProvider();
     const updateProvider = useUpdateProvider();
     const discoverModels = useDiscoverModels();
+    const probeEmbedding = useProbeEmbedding();
 
     const [step, setStep] = useState(0);
 
@@ -185,9 +191,10 @@ export function ProviderWizard({
     // Step 3
     const [chatModel, setChatModel] = useState(provider?.chatModel ?? "");
     const [embeddingModel, setEmbeddingModel] = useState(provider?.embeddingModel ?? "");
-    const [embeddingDimensions, setEmbeddingDimensions] = useState(
-        provider?.embeddingDimensions != null ? String(provider.embeddingDimensions) : "",
-    );
+    // Embedding dimensions are auto-detected by probing the selected model — not
+    // hand-entered — so the stored value always matches what the model emits.
+    const [probe, setProbe] = useState<EmbeddingProbeResult | null>(null);
+    const [probeError, setProbeError] = useState<string | null>(null);
     const [isDefault, setIsDefault] = useState(provider?.isDefault ?? false);
 
     const fieldValue = (f: CredentialField): string => {
@@ -280,10 +287,59 @@ export function ProviderWizard({
     const chatOptions = useMemo(() => discovered.filter(isChatModel), [discovered]);
     const embeddingOptions = useMemo(() => discovered.filter(isEmbeddingModel), [discovered]);
 
+    // Auto-detect the selected embedding model's effective dimension by probing
+    // it (shares the runtime embeddings code path, so what we detect is what gets
+    // stored). Re-runs whenever the embedding model or provider type changes.
+    useEffect(() => {
+        if (!embeddingModel) {
+            setProbe(null);
+            setProbeError(null);
+            return;
+        }
+        let cancelled = false;
+        setProbe(null);
+        setProbeError(null);
+        probeEmbedding
+            .mutateAsync({
+                providerType,
+                embeddingModel,
+                credentials: buildCredentials(),
+                region: meta.hasRegion ? region.trim() || undefined : undefined,
+                providerId: provider?.id,
+            })
+            .then((result) => {
+                if (!cancelled) setProbe(result);
+            })
+            .catch((err) => {
+                if (!cancelled) setProbeError(err instanceof Error ? err.message : "Failed to detect dimensions.");
+            });
+        return () => {
+            cancelled = true;
+        };
+        // buildCredentials/probeEmbedding are stable enough; re-probe only on model/type change.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [embeddingModel, providerType]);
+
+    const embeddingIncompatible = Boolean(embeddingModel) && (probeError != null || (probe != null && !probe.compatible));
+    const embeddingPending = Boolean(embeddingModel) && probeEmbedding.isPending;
+
     const handleSubmit = async () => {
         if (!chatModel) {
             toast.error("Select a chat model.");
             return;
+        }
+
+        if (embeddingModel) {
+            if (embeddingPending) {
+                toast.error("Detecting embedding dimensions — please wait.");
+                return;
+            }
+            if (embeddingIncompatible || !probe) {
+                toast.error(
+                    `Embedding model is incompatible (the platform requires ${PLATFORM_EMBEDDING_DIMS}-dim vectors). Choose a ${PLATFORM_EMBEDDING_DIMS}-dim model or set Embedding Model to None.`,
+                );
+                return;
+            }
         }
 
         // In edit mode with no re-discovery, reuse the provider's existing models.
@@ -292,15 +348,13 @@ export function ProviderWizard({
                 ? provider.models
                 : discovered.map((m) => ({ id: m.id, label: m.name, capabilities: m.capabilities }));
 
-        const dims = embeddingDimensions.trim() ? Number(embeddingDimensions.trim()) : undefined;
-
         const payload: CreateProviderInput = {
             name: name.trim(),
             provider: providerType,
             models,
             chatModel,
             embeddingModel: embeddingModel || undefined,
-            embeddingDimensions: dims != null && !Number.isNaN(dims) ? dims : undefined,
+            embeddingDimensions: embeddingModel && probe ? probe.dimensions ?? undefined : undefined,
             isDefault,
         };
 
@@ -499,25 +553,42 @@ export function ProviderWizard({
                         </Select>
                     </div>
 
-                    <div className="grid gap-1.5">
-                        <Label htmlFor="embedding-dims">
-                            Embedding Dimensions <span className="text-muted-foreground">(optional)</span>
-                        </Label>
-                        <Input
-                            id="embedding-dims"
-                            type="number"
-                            placeholder="1024"
-                            value={embeddingDimensions}
-                            onChange={(e) => setEmbeddingDimensions(e.target.value)}
-                        />
-                    </div>
+                    {embeddingModel && (
+                        <div className="grid gap-1.5">
+                            <Label>Embedding Dimensions</Label>
+                            {embeddingPending ? (
+                                <p className="flex items-center gap-2 text-sm text-muted-foreground">
+                                    <Spinner size="sm" /> Detecting dimensions…
+                                </p>
+                            ) : probeError ? (
+                                <p className="text-sm text-destructive">
+                                    Could not detect dimensions: {probeError}
+                                </p>
+                            ) : probe ? (
+                                probe.compatible ? (
+                                    <p className="text-sm text-emerald-600 dark:text-emerald-400">
+                                        Detected {probe.dimensions} dimensions — compatible ✓
+                                    </p>
+                                ) : (
+                                    <p className="text-sm text-amber-600 dark:text-amber-500">
+                                        {probe.reason ??
+                                            `Incompatible — the platform stores ${probe.required}-dim vectors.`}{" "}
+                                        Pick another model or set Embedding Model to None to save.
+                                    </p>
+                                )
+                            ) : null}
+                        </div>
+                    )}
 
                     <div className="flex items-center gap-3">
                         <Switch id="set-default" checked={isDefault} onCheckedChange={setIsDefault} />
                         <Label htmlFor="set-default">Set as default provider</Label>
                     </div>
 
-                    <Button onClick={handleSubmit} disabled={submitting || !chatModel}>
+                    <Button
+                        onClick={handleSubmit}
+                        disabled={submitting || !chatModel || embeddingPending || embeddingIncompatible}
+                    >
                         {submitting && <Loader2 className="mr-2 size-4 animate-spin" />}
                         {mode === "create" ? "Create Provider" : "Save Changes"}
                     </Button>

--- a/apps/web-ui/lib/agent-ops/agent-executor.ts
+++ b/apps/web-ui/lib/agent-ops/agent-executor.ts
@@ -13,6 +13,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import { HumanMessage } from '@langchain/core/messages';
 import { createDynamicExecutorGraph } from './executor-graphs';
+import { resolveModelConfig, resolveDefaultModelConfig } from '../agent/model-resolver';
 import { agentOpsService } from './agent-ops-service';
 import { getMCPManager } from '../agent/mcp-manager';
 import { registerRun, cleanupRun, isAborted } from './run-manager';
@@ -92,8 +93,13 @@ export async function executeAgentRun(run: AgentOpsRun, eventBus?: GatewayEventB
         });
 
         // ── Build graph ───────────────────────────────────────────────────────
+        // Resolve the configured provider — no hardcoded Bedrock default.
+        const modelString = (run as any).model as string | undefined;
+        const resolvedModel = modelString
+            ? await resolveModelConfig(modelString, tenantId)
+            : await resolveDefaultModelConfig(tenantId);
         const graphConfig = {
-            model: (run as any).model || 'global.anthropic.claude-sonnet-4-6',
+            model: resolvedModel,
             autoApprove,
             accounts: accountId ? [{ accountId, accountName: accountName || accountId }] : [],
             accountId,
@@ -515,8 +521,12 @@ export async function resumeApprovedRun(run: AgentOpsRun, eventBus?: GatewayEven
             console.warn(`[AgentExecutor] MCP reconnect failed (non-fatal):`, mcpErr);
         }
 
+        const modelString = (run as any).model as string | undefined;
+        const resolvedModel = modelString
+            ? await resolveModelConfig(modelString, tenantId)
+            : await resolveDefaultModelConfig(tenantId);
         const graphConfig = {
-            model: (run as any).model || 'global.anthropic.claude-sonnet-4-6',
+            model: resolvedModel,
             autoApprove: false, // keep approval mode — tools still need approval
             accounts: accountId ? [{ accountId, accountName: accountName || accountId }] : [],
             accountId,

--- a/apps/web-ui/lib/agent/embeddings-factory.ts
+++ b/apps/web-ui/lib/agent/embeddings-factory.ts
@@ -1,0 +1,127 @@
+/**
+ * embeddings-factory.ts
+ *
+ * Single source of truth for embedding-model initialization. Mirrors
+ * model-factory.ts (chat models) but for the Embeddings interface. Embeddings
+ * always come from the tenant's configured provider — there is NO implicit
+ * Bedrock fallback.
+ *
+ * NOTE on dimensions: the pgvector columns that store embeddings
+ * (`kb_document_chunks.embedding`, `inventory_resources.embedding`,
+ * `agent_memories.embedding`) are fixed at `vector(1024)`. Configuring an
+ * embedding model whose output dimension differs from 1024 requires a schema
+ * migration + full re-index of those tables. We guard against an explicit
+ * mismatch here so the failure is a clear message rather than an opaque
+ * Postgres dimension error at insert time.
+ */
+
+import { BedrockEmbeddings } from '@langchain/aws';
+import { OpenAIEmbeddings } from '@langchain/openai';
+import type { Embeddings } from '@langchain/core/embeddings';
+import {
+    ProviderModelService,
+    normalizeOpenAICompatibleBaseUrl,
+    type ProviderRuntimeConfig,
+} from '@/lib/provider-model-service';
+import { ProviderConfigError, NO_PROVIDER_MESSAGE } from './provider-errors';
+
+/** Fixed dimension of every pgvector embedding column in the schema. */
+export const REQUIRED_EMBEDDING_DIMENSIONS = 1024;
+
+/**
+ * OpenAI `text-embedding-3-*` models support the `dimensions` request param
+ * (Matryoshka representation learning), so a 1536/3072-native model can emit a
+ * 1024-dim vector that fits the platform's fixed columns. Any OpenAI-protocol
+ * server (openai, litellm, etc.) serving a text-embedding-3 model should honor
+ * it. Native ada-002 and most local models (ollama/vLLM) do NOT.
+ */
+function supportsDimensionReduction(model: string): boolean {
+    return /text-embedding-3/i.test(model);
+}
+
+/**
+ * Builds an Embeddings instance from a resolved provider runtime config.
+ * Throws ProviderConfigError when the provider cannot produce 1024-dim
+ * embeddings (no embedding model, wrong dimensions, unsupported provider, or
+ * missing credentials).
+ */
+export function createEmbeddings(config: ProviderRuntimeConfig): Embeddings {
+    if (!config.embeddingModel) {
+        throw new ProviderConfigError(
+            `Provider "${config.id}" has no embedding model configured. Set an embedding model on the provider in Settings → Providers.`,
+        );
+    }
+
+    if (config.embeddingDimensions && config.embeddingDimensions !== REQUIRED_EMBEDDING_DIMENSIONS) {
+        throw new ProviderConfigError(
+            `Embedding model produces ${config.embeddingDimensions}-dim vectors but the platform stores ${REQUIRED_EMBEDDING_DIMENSIONS}-dim vectors. ` +
+                `Choose a ${REQUIRED_EMBEDDING_DIMENSIONS}-dim embedding model, or migrate the pgvector columns and re-index.`,
+        );
+    }
+
+    if (config.provider === 'bedrock') {
+        if (!config.accessKeyId || !config.secretAccessKey || !config.region) {
+            throw new ProviderConfigError(
+                'Bedrock provider is missing an access key, secret key, or region. Re-configure the provider in Settings → Providers.',
+            );
+        }
+        // Titan Text Embeddings V2 supports the `dimensions` request param
+        // (256/512/1024) — request the platform's 1024 so it fits the fixed
+        // pgvector columns. V1 is fixed at 1536 and ignores it.
+        const titanV2 = /titan-embed-text-v2/i.test(config.embeddingModel);
+        return new BedrockEmbeddings({
+            region: config.region,
+            model: config.embeddingModel,
+            credentials: {
+                accessKeyId: config.accessKeyId,
+                secretAccessKey: config.secretAccessKey,
+            },
+            ...(titanV2 ? { dimensions: REQUIRED_EMBEDDING_DIMENSIONS } : {}),
+        });
+    }
+
+    if (config.provider === 'anthropic') {
+        throw new ProviderConfigError(
+            'The Anthropic provider does not expose an embeddings API. Configure a Bedrock or OpenAI-compatible provider as the default for embedding-backed features (knowledge base, agent memory).',
+        );
+    }
+
+    // Everything else (openai / ollama / vllm / lmstudio / litellm /
+    // openai-compatible) speaks the OpenAI /v1/embeddings protocol. For
+    // text-embedding-3-* models, request REQUIRED_EMBEDDING_DIMENSIONS so a
+    // 1536/3072-native model is truncated to the platform's 1024 columns.
+    return new OpenAIEmbeddings({
+        model: config.embeddingModel,
+        ...(supportsDimensionReduction(config.embeddingModel)
+            ? { dimensions: REQUIRED_EMBEDDING_DIMENSIONS }
+            : {}),
+        configuration: {
+            baseURL: normalizeOpenAICompatibleBaseUrl(config.provider, config.baseUrl),
+            apiKey: config.apiKey || 'not-needed',
+        },
+    });
+}
+
+/**
+ * Embeds a tiny probe string and returns the EFFECTIVE output dimension. Shares
+ * createEmbeddings' code path (including the text-embedding-3 reduction above),
+ * so the detected value is exactly what will be stored at runtime. Used by the
+ * provider wizard to auto-detect + validate embedding dimensions before saving.
+ */
+export async function probeEmbeddingDimensions(config: ProviderRuntimeConfig): Promise<number> {
+    const embeddings = createEmbeddings(config);
+    const vector = await embeddings.embedQuery('dimension probe');
+    return vector.length;
+}
+
+/**
+ * Resolves the tenant's default provider and builds its embeddings instance.
+ * Throws ProviderConfigError when no default provider exists.
+ */
+export async function getTenantEmbeddings(tenantId: string): Promise<Embeddings> {
+    const config = await ProviderModelService.getDefaultConfig(tenantId);
+    if (!config) {
+        throw new ProviderConfigError(NO_PROVIDER_MESSAGE);
+    }
+    return createEmbeddings(config);
+}

--- a/apps/web-ui/lib/agent/model-discovery.ts
+++ b/apps/web-ui/lib/agent/model-discovery.ts
@@ -75,6 +75,10 @@ async function discoverBedrock(creds: ProviderCredentials, region?: string): Pro
         const id = model.modelId.toLowerCase();
 
         if (id.includes('embed')) {
+            // Surface ALL embedding models so the user has the full list. Whether
+            // a given model is actually usable (supported request schema + 1024
+            // dims) is determined per-selection by the probe-embedding route; the
+            // wizard greys out / blocks the ones that don't work, with a reason.
             if (model.inferenceTypesSupported?.includes('ON_DEMAND')) {
                 models.push({
                     id: model.modelId,

--- a/apps/web-ui/lib/agent/model-factory.ts
+++ b/apps/web-ui/lib/agent/model-factory.ts
@@ -27,7 +27,8 @@ import { getActiveMCPTools, isOpenAICompatibleProvider, type AccountContext, typ
 import { tool } from "@langchain/core/tools";
 import { z } from "zod";
 import { saveMemory, searchMemory } from "./persistence";
-import { env } from "@/env";
+import { ProviderConfigError } from "./provider-errors";
+import { normalizeOpenAICompatibleBaseUrl } from "@/lib/provider-model-service";
 
 export interface AgentModels {
     /** Primary model: streaming. Used for all generation nodes. */
@@ -44,10 +45,18 @@ export function createAgentModels(config: ResolvedModelConfig): AgentModels {
     if (isOpenAICompatibleProvider(config.provider)) {
         // Ollama, LiteLLM, LM Studio, and generic OpenAI-compatible endpoints all
         // speak the same /v1 protocol, so they share this ChatOpenAI path.
+        // Self-hosted providers REQUIRE an explicit base URL — without it ChatOpenAI
+        // silently routes to api.openai.com, the exact implicit default this SaaS
+        // model forbids. Only native "openai" may omit baseUrl (defaults correctly).
+        if (config.provider !== "openai" && !config.baseUrl) {
+            throw new ProviderConfigError(
+                `Provider "${config.provider}" is missing a base URL. Set the endpoint on the provider in Settings → Providers.`,
+            );
+        }
         const openaiConfig = {
             modelName: config.modelId,
             configuration: {
-                baseURL: config.baseUrl,
+                baseURL: normalizeOpenAICompatibleBaseUrl(config.provider, config.baseUrl),
                 apiKey: config.apiKey || "not-needed",
             },
             temperature: 0,
@@ -90,19 +99,22 @@ export function createAgentModels(config: ResolvedModelConfig): AgentModels {
         };
     }
 
-    // Default: Bedrock. A record-backed Bedrock provider supplies an explicit
-    // region + static credentials; native Bedrock falls back to env region and
-    // the host/task-role credential chain (credentials omitted).
-    const region = config.region || env.AWS_REGION || env.NEXT_PUBLIC_AWS_REGION || 'us-east-1';
-    const explicitCredentials =
-        config.accessKeyId && config.secretAccessKey
-            ? { accessKeyId: config.accessKeyId, secretAccessKey: config.secretAccessKey }
-            : undefined;
+    // Default: Bedrock. A record-backed Bedrock provider MUST supply an explicit
+    // region + static credentials — there is no implicit host/task-role fallback
+    // (SaaS model: only the tenant-configured provider is ever used).
+    if (!config.accessKeyId || !config.secretAccessKey || !config.region) {
+        throw new ProviderConfigError(
+            'Bedrock provider is missing an access key, secret key, or region. Re-configure the provider in Settings → Providers.',
+        );
+    }
     const bedrockConfig = {
-        region,
+        region: config.region,
         model: config.modelId,
         temperature: 0,
-        ...(explicitCredentials ? { credentials: explicitCredentials } : {}),
+        credentials: {
+            accessKeyId: config.accessKeyId,
+            secretAccessKey: config.secretAccessKey,
+        },
     };
     const defaultMaxTokens = config.maxTokens || 4096;
     return {

--- a/apps/web-ui/lib/agent/model-resolver.test.ts
+++ b/apps/web-ui/lib/agent/model-resolver.test.ts
@@ -15,14 +15,14 @@ const UUID = '550e8400-e29b-41d4-a716-446655440000';
 describe('resolveModelConfig', () => {
     beforeEach(() => vi.clearAllMocks());
 
-    it('resolves bare Bedrock model ID (backward compat)', async () => {
-        const result = await resolveModelConfig('global.anthropic.claude-sonnet-4-6', 'tenant-1');
-        expect(result).toEqual({ provider: 'bedrock', modelId: 'global.anthropic.claude-sonnet-4-6' });
+    it('throws for a bare model ID — no implicit Bedrock fallback (SaaS)', async () => {
+        await expect(resolveModelConfig('global.anthropic.claude-sonnet-4-6', 'tenant-1'))
+            .rejects.toThrow('is not backed by a configured provider');
     });
 
-    it('resolves bedrock: prefixed native model ID (no provider record)', async () => {
-        const result = await resolveModelConfig('bedrock:global.anthropic.claude-sonnet-4-6', 'tenant-1');
-        expect(result).toEqual({ provider: 'bedrock', modelId: 'global.anthropic.claude-sonnet-4-6' });
+    it('throws for a bedrock: native model ID without a provider record (SaaS)', async () => {
+        await expect(resolveModelConfig('bedrock:global.anthropic.claude-sonnet-4-6', 'tenant-1'))
+            .rejects.toThrow('is not backed by a configured provider');
     });
 
     it('resolves record-backed Bedrock model with explicit credentials', async () => {

--- a/apps/web-ui/lib/agent/model-resolver.ts
+++ b/apps/web-ui/lib/agent/model-resolver.ts
@@ -1,6 +1,7 @@
-import { ProviderModelService } from '@/lib/provider-model-service';
+import { ProviderModelService, type ProviderRuntimeConfig } from '@/lib/provider-model-service';
 import type { ResolvedModelConfig } from './agent-shared';
 import { OPENAI_COMPATIBLE_PROVIDERS } from './agent-shared';
+import { ProviderConfigError, NO_PROVIDER_MESSAGE } from './provider-errors';
 
 /**
  * Provider prefixes that resolve via a ProviderModel DB record: anthropic plus
@@ -34,70 +35,99 @@ async function loadRecordModel(providerRecordId: string, modelId: string, tenant
 }
 
 /**
+ * Builds a ResolvedModelConfig from a decrypted provider runtime config.
+ * `provider` is authoritative (parsed from the model string / default record),
+ * not read from the config blob. Carries provider-appropriate credentials
+ * (Bedrock keys/region, or baseUrl/apiKey for the rest).
+ */
+function toResolvedConfig(
+    provider: ResolvedModelConfig['provider'],
+    config: Pick<ProviderRuntimeConfig, 'region' | 'accessKeyId' | 'secretAccessKey' | 'baseUrl' | 'apiKey'>,
+    modelId: string,
+    maxTokens?: number,
+): ResolvedModelConfig {
+    if (provider === 'bedrock') {
+        return {
+            provider: 'bedrock',
+            modelId,
+            region: config.region,
+            accessKeyId: config.accessKeyId,
+            secretAccessKey: config.secretAccessKey,
+            maxTokens,
+        };
+    }
+    return {
+        provider,
+        modelId,
+        baseUrl: config.baseUrl,
+        apiKey: config.apiKey,
+        maxTokens,
+    };
+}
+
+/**
  * Resolves a model identifier string into a provider-agnostic config.
+ *
+ * Every model MUST be backed by a tenant-configured provider record — the
+ * platform is SaaS-style with NO implicit Bedrock fallback. Bare model IDs,
+ * `global.*` ids, and bedrock ids without a provider-record UUID all throw a
+ * ProviderConfigError so the caller can surface a "configure a provider"
+ * message instead of silently using host/task-role credentials.
  *
  * Format: {provider}:{modelId}:{providerRecordId}
  * Examples:
- *   global.anthropic.claude-sonnet-4-6                       → native Bedrock
- *   bedrock:global.anthropic.claude-sonnet-4-6              → native Bedrock
  *   bedrock:us.anthropic.claude-sonnet-4-6-v1:0:<uuid>      → record-backed Bedrock (explicit creds)
  *   openai-compatible:meta-llama/Llama-3.3-70B:<uuid>       → record-backed OpenAI-compatible
  *   anthropic:claude-sonnet-4-20250514:<uuid>               → record-backed Anthropic
  *   ollama:llama3.3:70b:<uuid>                              → record-backed Ollama
- *
- * Bare strings (no colon prefix) are treated as native Bedrock for backward compat.
  */
 export async function resolveModelConfig(
     modelString: string,
     tenantId: string,
 ): Promise<ResolvedModelConfig> {
-    // Backward compat: bare Bedrock model IDs have no colon-separated provider prefix
-    if (!modelString.includes(':') || modelString.startsWith('global.')) {
-        return { provider: 'bedrock', modelId: modelString };
-    }
-
     const parts = modelString.split(':');
     const providerType = parts[0];
+    const last = parts[parts.length - 1];
 
-    if (providerType === 'bedrock') {
-        // Record-backed Bedrock when the last segment is a provider-record UUID;
-        // otherwise it's a native Bedrock model id (uses host/task-role creds).
-        const last = parts[parts.length - 1];
-        if (parts.length >= 3 && UUID_RE.test(last)) {
-            const modelId = parts.slice(1, -1).join(':');
-            const { record, modelEntry } = await loadRecordModel(last, modelId, tenantId);
-            const config = await ProviderModelService.getConfigById(record.id, tenantId);
-            return {
-                provider: 'bedrock',
-                modelId,
-                region: config?.region,
-                accessKeyId: config?.accessKeyId,
-                secretAccessKey: config?.secretAccessKey,
-                maxTokens: modelEntry.maxTokens,
-            };
-        }
-        return { provider: 'bedrock', modelId: parts.slice(1).join(':') };
+    if (providerType === 'bedrock' && parts.length >= 3 && UUID_RE.test(last)) {
+        const modelId = parts.slice(1, -1).join(':');
+        const { record, modelEntry } = await loadRecordModel(last, modelId, tenantId);
+        const config = await ProviderModelService.getConfigById(record.id, tenantId);
+        if (!config) throw new ProviderConfigError('Provider not found or disabled');
+        return toResolvedConfig('bedrock', config, modelId, modelEntry.maxTokens);
     }
 
     // Record-backed providers (anthropic + the OpenAI-compatible family).
-    if (isRecordBackedProvider(providerType)) {
+    if (isRecordBackedProvider(providerType) && parts.length >= 3 && UUID_RE.test(last)) {
         // providerRecordId is always the last segment (UUID); modelId is everything in between.
         // This handles model IDs that contain colons (e.g. "qwen3.6:35b-a3b", "llama3.3:70b").
-        const providerRecordId = parts[parts.length - 1];
         const modelId = parts.slice(1, -1).join(':');
-        const { record, modelEntry } = await loadRecordModel(providerRecordId, modelId, tenantId);
+        const { record, modelEntry } = await loadRecordModel(last, modelId, tenantId);
         // Secrets live in the encrypted `credentials` blob — resolve via getConfigById (decrypts).
         const config = await ProviderModelService.getConfigById(record.id, tenantId);
-
-        return {
-            provider: providerType,
-            modelId,
-            baseUrl: config?.baseUrl,
-            apiKey: config?.apiKey,
-            maxTokens: modelEntry.maxTokens,
-        };
+        if (!config) throw new ProviderConfigError('Provider not found or disabled');
+        return toResolvedConfig(providerType, config, modelId, modelEntry.maxTokens);
     }
 
-    // Unknown provider prefix — treat as native Bedrock
-    return { provider: 'bedrock', modelId: modelString };
+    throw new ProviderConfigError(
+        `Model "${modelString}" is not backed by a configured provider. ${NO_PROVIDER_MESSAGE}`,
+    );
+}
+
+/**
+ * Resolves the tenant's default provider into a ResolvedModelConfig using its
+ * configured chat model. Throws ProviderConfigError when no default provider is
+ * set or it has no chat model — used wherever a request doesn't carry an
+ * explicit model selection (Ask-AI, enhance-prompt, text-to-SQL, agent-ops).
+ */
+export async function resolveDefaultModelConfig(tenantId: string): Promise<ResolvedModelConfig> {
+    const config = await ProviderModelService.getDefaultConfig(tenantId);
+    if (!config) throw new ProviderConfigError(NO_PROVIDER_MESSAGE);
+    if (!config.chatModel) {
+        throw new ProviderConfigError(
+            'The default LLM provider has no chat model selected. Pick a chat model on the provider in Settings → Providers.',
+        );
+    }
+    const modelEntry = config.models.find((m) => m.id === config.chatModel);
+    return toResolvedConfig(config.provider, config, config.chatModel, modelEntry?.maxTokens);
 }

--- a/apps/web-ui/lib/agent/persistence.ts
+++ b/apps/web-ui/lib/agent/persistence.ts
@@ -10,10 +10,10 @@
  * Uses globalThis to survive Next.js hot reloads in dev mode.
  */
 
-import { BedrockEmbeddings } from "@langchain/aws";
+import type { Embeddings } from "@langchain/core/embeddings";
 import { PostgresSaver } from "@langchain/langgraph-checkpoint-postgres";
-import { HumanMessage, AIMessage, ToolMessage, SystemMessage } from "@langchain/core/messages";
 import { getPrismaClient } from "@/lib/db/pg-config";
+import { getTenantEmbeddings } from "./embeddings-factory";
 import { env } from "@/env";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -88,10 +88,22 @@ class PostgresChatHistory implements ChatHistoryInterface {
 // ─── PostgreSQL Memory Store ──────────────────────────────────────────────────
 
 class PostgresMemoryStore implements MemoryStoreInterface {
-    private embeddings: BedrockEmbeddings;
+    // Embeddings are resolved PER TENANT from the configured default provider —
+    // there is no shared/default Bedrock embedder. Cached per tenant to avoid
+    // re-decrypting credentials on every memory op. If a tenant has no
+    // embedding-capable provider, embedding is skipped and we fall back to
+    // recency-ordered text search (semantic search degrades gracefully).
+    private embeddingsCache = new Map<string, Promise<Embeddings>>();
 
-    constructor(embeddings: BedrockEmbeddings) {
-        this.embeddings = embeddings;
+    private getEmbeddings(tenantId: string): Promise<Embeddings> {
+        let cached = this.embeddingsCache.get(tenantId);
+        if (!cached) {
+            cached = getTenantEmbeddings(tenantId);
+            // Don't cache a rejected promise — a later provider config should retry.
+            cached.catch(() => this.embeddingsCache.delete(tenantId));
+            this.embeddingsCache.set(tenantId, cached);
+        }
+        return cached;
     }
 
     async batch(ops: unknown[], _config?: unknown): Promise<unknown[]> {
@@ -112,9 +124,10 @@ class PostgresMemoryStore implements MemoryStoreInterface {
                 let embeddingVector: number[] | null = null;
                 try {
                     const text = JSON.stringify(value);
-                    embeddingVector = await this.embeddings.embedQuery(text);
+                    const emb = await this.getEmbeddings(tenantId);
+                    embeddingVector = await emb.embedQuery(text);
                 } catch {
-                    // embedding failure is non-fatal — store without vector
+                    // no provider / embedding failure is non-fatal — store without vector
                 }
 
                 const embeddingStr = embeddingVector ? `[${embeddingVector.join(",")}]` : null;
@@ -145,9 +158,10 @@ class PostgresMemoryStore implements MemoryStoreInterface {
 
                 let queryEmbedding: number[] | null = null;
                 try {
-                    queryEmbedding = await this.embeddings.embedQuery(query);
+                    const emb = await this.getEmbeddings(tenantId);
+                    queryEmbedding = await emb.embedQuery(query);
                 } catch {
-                    // fallback to text search
+                    // no provider / embedding failure — fallback to text search
                 }
 
                 if (queryEmbedding) {
@@ -195,19 +209,15 @@ class PostgresMemoryStore implements MemoryStoreInterface {
 // ─── Init ─────────────────────────────────────────────────────────────────────
 
 async function initPersistence(): Promise<PersistenceInstances> {
-    const region = env.AWS_REGION || env.NEXT_PUBLIC_AWS_REGION || "us-east-1";
     const databaseUrl = env.DATABASE_URL!;
 
     // PostgresSaver manages its own schema — call setup() on first use
     const checkpointer = PostgresSaver.fromConnString(databaseUrl);
     await checkpointer.setup();
 
-    const embeddings = new BedrockEmbeddings({
-        region,
-        model: "amazon.titan-embed-text-v2:0",
-    });
-
-    const store = new PostgresMemoryStore(embeddings);
+    // Embeddings are resolved per-tenant from the configured provider inside
+    // PostgresMemoryStore — no shared Bedrock embedder is created here.
+    const store = new PostgresMemoryStore();
     const chatHistory = new PostgresChatHistory();
 
     console.log("[Persistence] Initialized PostgresSaver, PostgresMemoryStore, PostgresChatHistory");

--- a/apps/web-ui/lib/agent/provider-errors.ts
+++ b/apps/web-ui/lib/agent/provider-errors.ts
@@ -1,0 +1,23 @@
+/**
+ * provider-errors.ts
+ *
+ * Error type raised whenever an LLM/embedding operation is attempted without a
+ * usable tenant-configured provider. The platform is SaaS-style: there is NO
+ * implicit Bedrock fallback. Callers (API routes) translate this into a 400 with
+ * a clear "configure a provider" message instead of a generic 500.
+ */
+
+export class ProviderConfigError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'ProviderConfigError';
+    }
+}
+
+export function isProviderConfigError(err: unknown): err is ProviderConfigError {
+    return err instanceof ProviderConfigError || (err instanceof Error && err.name === 'ProviderConfigError');
+}
+
+/** Standard message used when a tenant has no usable default LLM provider. */
+export const NO_PROVIDER_MESSAGE =
+    'No LLM provider is configured. Add one in Settings → Providers and mark it as default.';

--- a/apps/web-ui/lib/agent/text-to-sql/index.ts
+++ b/apps/web-ui/lib/agent/text-to-sql/index.ts
@@ -1,5 +1,7 @@
 import { createTextToSQLGraph } from "./graph";
 import type { TextToSQLFilters, TextToSQLState } from "./state";
+import { resolveDefaultModelConfig } from "../model-resolver";
+import { isProviderConfigError } from "../provider-errors";
 
 export interface TextToSQLInput {
     question: string;
@@ -21,11 +23,28 @@ export interface TextToSQLEvent {
 export async function* invokeTextToSQL(input: TextToSQLInput): AsyncGenerator<TextToSQLEvent> {
     const graph = createTextToSQLGraph();
 
+    // Resolve the tenant's configured provider up-front so every LLM node uses
+    // it. No implicit Bedrock fallback — surface a clear error if none exists.
+    let modelConfig;
+    try {
+        modelConfig = await resolveDefaultModelConfig(input.tenantId);
+    } catch (err: unknown) {
+        const message = isProviderConfigError(err)
+            ? err.message
+            : err instanceof Error
+              ? err.message
+              : String(err);
+        yield { type: 'error', message };
+        yield { type: 'done' };
+        return;
+    }
+
     try {
         const stream = await graph.stream(
             {
                 question: input.question,
                 tenantId: input.tenantId,
+                modelConfig,
                 conversationHistory: input.conversationHistory ?? [],
                 filters: input.filters,
                 maxIterations: 3,

--- a/apps/web-ui/lib/agent/text-to-sql/nodes/generate-sql.ts
+++ b/apps/web-ui/lib/agent/text-to-sql/nodes/generate-sql.ts
@@ -1,19 +1,10 @@
-import { ChatBedrockConverse } from "@langchain/aws";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { buildSQLGenerationPrompt } from '../prompts';
-import type { TextToSQLState } from '../state';
-import { env } from '@/env';
+import { type TextToSQLState, requireModelConfig } from '../state';
+import { createAgentModels } from '@/lib/agent/model-factory';
 
 export async function generateSQLNode(state: TextToSQLState): Promise<Partial<TextToSQLState>> {
-    const region = env.AWS_REGION || 'us-east-1';
-    const modelId = env.ASK_AI_GENERATION_MODEL || 'us.anthropic.claude-sonnet-4-6-20250514';
-
-    const model = new ChatBedrockConverse({
-        region,
-        model: modelId,
-        temperature: 0,
-        maxTokens: 1024,
-    });
+    const model = createAgentModels({ ...requireModelConfig(state), maxTokens: 1024 }).reflector;
 
     const systemPrompt = buildSQLGenerationPrompt(
         state.schemaDescription,

--- a/apps/web-ui/lib/agent/text-to-sql/nodes/reflect.ts
+++ b/apps/web-ui/lib/agent/text-to-sql/nodes/reflect.ts
@@ -1,8 +1,7 @@
-import { ChatBedrockConverse } from "@langchain/aws";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { buildReflectionPrompt } from '../prompts';
-import type { TextToSQLState } from '../state';
-import { env } from '@/env';
+import { type TextToSQLState, requireModelConfig } from '../state';
+import { createAgentModels } from '@/lib/agent/model-factory';
 
 export async function reflectNode(state: TextToSQLState): Promise<Partial<TextToSQLState>> {
     const newIteration = state.iteration + 1;
@@ -20,16 +19,7 @@ export async function reflectNode(state: TextToSQLState): Promise<Partial<TextTo
         };
     }
 
-    const region = env.AWS_REGION || 'us-east-1';
-    const modelId = env.ASK_AI_GENERATION_MODEL || 'us.anthropic.claude-sonnet-4-6-20250514';
-
-    const model = new ChatBedrockConverse({
-        region,
-        model: modelId,
-        temperature: 0,
-        maxTokens: 1024,
-        streaming: false,
-    });
+    const model = createAgentModels({ ...requireModelConfig(state), maxTokens: 1024 }).reflector;
 
     const prompt = buildReflectionPrompt(
         state.question,

--- a/apps/web-ui/lib/agent/text-to-sql/nodes/synthesize.ts
+++ b/apps/web-ui/lib/agent/text-to-sql/nodes/synthesize.ts
@@ -1,8 +1,7 @@
-import { ChatBedrockConverse } from "@langchain/aws";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { buildSynthesisPrompt } from '../prompts';
-import type { TextToSQLState } from '../state';
-import { env } from '@/env';
+import { type TextToSQLState, requireModelConfig } from '../state';
+import { createAgentModels } from '@/lib/agent/model-factory';
 
 export async function synthesizeNode(state: TextToSQLState): Promise<Partial<TextToSQLState>> {
     // If no results (all retries failed), return error message
@@ -13,15 +12,7 @@ export async function synthesizeNode(state: TextToSQLState): Promise<Partial<Tex
         return { finalAnswer: errorMsg };
     }
 
-    const region = env.AWS_REGION || 'us-east-1';
-    const modelId = env.ASK_AI_GENERATION_MODEL || 'us.anthropic.claude-sonnet-4-6-20250514';
-
-    const model = new ChatBedrockConverse({
-        region,
-        model: modelId,
-        temperature: 0.1,
-        maxTokens: 4096,
-    });
+    const model = createAgentModels({ ...requireModelConfig(state), maxTokens: 4096 }).main;
 
     const wasRetried = state.iteration > 0;
     const prompt = buildSynthesisPrompt(

--- a/apps/web-ui/lib/agent/text-to-sql/state.ts
+++ b/apps/web-ui/lib/agent/text-to-sql/state.ts
@@ -1,4 +1,5 @@
 import { Annotation } from "@langchain/langgraph";
+import type { ResolvedModelConfig } from "../agent-shared";
 
 export interface SQLResult {
     rows: Record<string, unknown>[];
@@ -17,6 +18,8 @@ export const TextToSQLAnnotation = Annotation.Root({
         reducer: (_x, y) => y, default: () => [],
     }),
     tenantId: Annotation<string>({ reducer: (_x, y) => y, default: () => "" }),
+    /** Resolved config for the tenant's configured provider — drives every LLM node. */
+    modelConfig: Annotation<ResolvedModelConfig | null>({ reducer: (_x, y) => y, default: () => null }),
     filters: Annotation<TextToSQLFilters | undefined>({
         reducer: (_x, y) => y, default: () => undefined,
     }),
@@ -35,3 +38,18 @@ export const TextToSQLAnnotation = Annotation.Root({
 });
 
 export type TextToSQLState = typeof TextToSQLAnnotation.State;
+
+/**
+ * Returns the resolved provider config, throwing a clear error if it's missing.
+ * `invokeTextToSQL` always seeds `modelConfig`; this guard protects any direct
+ * `createTextToSQLGraph()` invocation that bypasses it (the annotation defaults
+ * to null), turning a confusing undefined-spread into an explicit failure.
+ */
+export function requireModelConfig(state: TextToSQLState): ResolvedModelConfig {
+    if (!state.modelConfig) {
+        throw new Error(
+            'Text-to-SQL graph was invoked without a resolved model config. Use invokeTextToSQL(), which resolves the tenant provider first.',
+        );
+    }
+    return state.modelConfig;
+}

--- a/apps/web-ui/lib/deep-agent/deep-agent-graph.ts
+++ b/apps/web-ui/lib/deep-agent/deep-agent-graph.ts
@@ -12,7 +12,6 @@
 // This file is fully isolated from the existing planning-agent.ts / fast-agent.ts.
 // ============================================================================
 
-import { ChatBedrockConverse } from '@langchain/aws';
 import {
     createDeepAgent,
     CompositeBackend,
@@ -22,6 +21,9 @@ import {
 } from 'deepagents';
 import { InMemoryStore, MemorySaver } from '@langchain/langgraph';
 import { env } from '@/env';
+import { resolveModelConfig } from '@/lib/agent/model-resolver';
+import { createAgentModels } from '@/lib/agent/model-factory';
+import { ProviderConfigError } from '@/lib/agent/provider-errors';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -134,14 +136,16 @@ export async function createDeepAgentGraph(config: DeepAgentConfig) {
         tenantId,
     } = config;
 
+    if (!tenantId) {
+        throw new ProviderConfigError('A tenant context is required to resolve the LLM provider.');
+    }
+
     // --- Model ---
-    const model = new ChatBedrockConverse({
-        region: env.AWS_REGION || env.NEXT_PUBLIC_AWS_REGION || 'us-east-1',
-        model: modelId,
-        maxTokens: 8192,
-        temperature: 0,
-        streaming: true,
-    });
+    // Resolve the configured provider (Bedrock with its keys, Ollama, etc.) from
+    // the composite model id. No implicit Bedrock fallback — createAgentModels /
+    // resolveModelConfig throw a ProviderConfigError if nothing is configured.
+    const resolvedModel = await resolveModelConfig(modelId, tenantId);
+    const { main: model } = createAgentModels({ ...resolvedModel, maxTokens: resolvedModel.maxTokens ?? 8192 });
 
     // --- MongoDB Checkpointer (deep-agent-specific, avoids DynamoDB schema conflicts) ---
     let agentCheckpointer: any;

--- a/apps/web-ui/lib/knowledge-base/embedder.ts
+++ b/apps/web-ui/lib/knowledge-base/embedder.ts
@@ -1,47 +1,28 @@
 /**
  * Knowledge Base Embedder
  *
- * Text chunking, Bedrock embedding (Titan v2), and pgvector store/delete
- * for the kb_document_chunks table.
+ * Text chunking, provider-configured embedding, and pgvector store/delete
+ * for the kb_document_chunks table. Embeddings come from the tenant's
+ * configured default provider (Bedrock/OpenAI-compatible) — there is no
+ * hardcoded Bedrock client. The embedding column is fixed `vector(1024)`, so
+ * the provider's embedding model must produce 1024-dim vectors (enforced by
+ * the embeddings factory).
  */
 
 import { createHash } from 'crypto';
-import { BedrockRuntimeClient, InvokeModelCommand } from '@aws-sdk/client-bedrock-runtime';
-import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { getPrismaClient } from '@/lib/db/pg-config';
+import { getTenantEmbeddings } from '@/lib/agent/embeddings-factory';
 import type { KBChunk, VectorMetadata } from './types';
-import { env } from '@/env';
 
 // ---------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------
-
-const EMBEDDING_MODEL_ID =
-  env.BEDROCK_MODEL_ID || 'amazon.titan-embed-text-v2:0';
-const AWS_REGION = env.AWS_REGION || 'ap-south-1';
 
 const CHUNK_SIZE = 1500;
 const CHUNK_OVERLAP = 200;
 const SEPARATORS = ['\n\n', '\n', '. ', ' '];
 const EMBEDDING_CONCURRENCY = 5;
 const VECTOR_BATCH_SIZE = 20;
-
-// ---------------------------------------------------------------------------
-// AWS Clients (lazy-initialised)
-// ---------------------------------------------------------------------------
-
-const credentialProvider = fromNodeProviderChain();
-
-let _bedrockClient: BedrockRuntimeClient | null = null;
-function getBedrockClient(): BedrockRuntimeClient {
-  if (!_bedrockClient) {
-    _bedrockClient = new BedrockRuntimeClient({
-      region: AWS_REGION,
-      credentials: credentialProvider,
-    });
-  }
-  return _bedrockClient;
-}
 
 // ---------------------------------------------------------------------------
 // Text chunking (recursive character splitter)
@@ -132,19 +113,12 @@ function forceChunk(text: string, maxLen: number): string[] {
 // ---------------------------------------------------------------------------
 
 /**
- * Generate a 1024-dim embedding via Bedrock Titan Embed Text v2.
+ * Generate a 1024-dim embedding using the tenant's configured provider.
+ * Throws ProviderConfigError if no embedding-capable provider is configured.
  */
-export async function getEmbedding(text: string): Promise<number[]> {
-  const response = await getBedrockClient().send(
-    new InvokeModelCommand({
-      modelId: EMBEDDING_MODEL_ID,
-      body: JSON.stringify({ inputText: text.slice(0, 8000) }),
-      contentType: 'application/json',
-      accept: 'application/json',
-    }),
-  );
-  const bodyString = new TextDecoder().decode(response.body);
-  return JSON.parse(bodyString).embedding;
+export async function getEmbedding(text: string, tenantId: string): Promise<number[]> {
+  const embeddings = await getTenantEmbeddings(tenantId);
+  return embeddings.embedQuery(text.slice(0, 8000));
 }
 
 // ---------------------------------------------------------------------------
@@ -182,7 +156,7 @@ export async function embedAndStoreChunks(params: {
   for (let i = 0; i < chunks.length; i += EMBEDDING_CONCURRENCY) {
     const batch = chunks.slice(i, i + EMBEDDING_CONCURRENCY);
     const batchEmbeddings = await Promise.all(
-      batch.map((chunk) => getEmbedding(chunk.text)),
+      batch.map((chunk) => getEmbedding(chunk.text, tenantId)),
     );
     embeddings.push(...batchEmbeddings);
   }

--- a/apps/web-ui/lib/nav-config.ts
+++ b/apps/web-ui/lib/nav-config.ts
@@ -1,117 +1,102 @@
 import {
-  Activity,
-  BookOpen,
   Bot,
-  Boxes,
   Cable,
-  CalendarClock,
   Gauge,
   LayoutDashboard,
   Server,
   Settings,
-  ShieldCheck,
-  Workflow,
 } from "lucide-react"
 
-import type { NavGroup } from "@/components/nav-main"
+import type { NavItem } from "@/components/nav-main"
 import { env } from "@/env"
 
 /**
- * Single source of truth for the sidebar information architecture (grouped +
- * nested). Consumed by AppSidebar (NavMain) and the top-bar Header (page title).
+ * Single source of truth for the sidebar information architecture: a two-level
+ * menu → submenu tree. Each top-level entry is a collapsible category (icon +
+ * label) whose `items` are the navigable links. Consumed by AppSidebar
+ * (NavMain) and the top-bar Header (page title).
  */
-export const navGroups: NavGroup[] = [
+export const navMenus: NavItem[] = [
   {
-    label: "Platform",
+    title: "Overview",
+    icon: LayoutDashboard,
     items: [
-      { title: "Dashboard", href: "/app/dashboard", icon: LayoutDashboard },
-      { title: "Audit Logs", href: "/app/audit", icon: Activity },
+      { title: "Dashboard", href: "/app/dashboard" },
+      { title: "Audit Logs", href: "/app/audit" },
     ],
   },
   {
-    label: "Operations",
+    title: "Agentic Ops",
+    icon: Bot,
     items: [
-      { title: "AI Ops", href: "/app/agent", icon: Bot },
-      {
-        title: "Agent Ops",
-        href: "/app/agent-ops",
-        icon: Workflow,
-        items: [
-          { title: "Overview", href: "/app/agent-ops" },
-          { title: "Scheduled Tasks", href: "/app/agent-ops/scheduled-tasks" },
-          { title: "Jira Settings", href: "/app/agent-ops/jira-settings" },
-          { title: "Slack Settings", href: "/app/agent-ops/slack-settings" },
-          { title: "MCP Settings", href: "/app/agent-ops/mcp-settings" },
-        ],
-      },
+      { title: "AI Ops", href: "/app/agent" },
+      { title: "Agent Ops", href: "/app/agent-ops" },
+      { title: "Scheduled Tasks", href: "/app/agent-ops/scheduled-tasks" },
+      { title: "Knowledge Base", href: "/app/knowledge-base" },
+      { title: "Ask", href: "/app/knowledge-base/ask" },
+      // LLM providers power the agents — grouped with Agentic Ops, not Settings.
+      { title: "Providers", href: "/app/settings/providers" },
     ],
   },
   {
-    label: "Resources",
+    title: "Cloud Operations",
+    icon: Server,
     items: [
-      { title: "AWS Accounts", href: "/app/accounts", icon: Server },
-      { title: "Inventory", href: "/app/inventory", icon: Boxes },
+      { title: "AWS Accounts", href: "/app/accounts" },
+      { title: "Inventory", href: "/app/inventory" },
+      { title: "Certificates", href: "/app/certificates" },
+    ],
+  },
+  {
+    title: "Cost Optimization",
+    icon: Gauge,
+    items: [
       // Right Sizing — hidden unless the feature flag is enabled (NEXT_PUBLIC_ inlined at build).
       ...(env.NEXT_PUBLIC_RIGHT_SIZING_ENABLED === "true"
-        ? [{ title: "Right Sizing", href: "/app/right-sizing", icon: Gauge }]
+        ? [{ title: "Right Sizing", href: "/app/right-sizing" }]
         : []),
-      { title: "Cost Scheduler", href: "/app/schedules", icon: CalendarClock },
-      { title: "Certificates", href: "/app/certificates", icon: ShieldCheck },
+      { title: "Cost Scheduler", href: "/app/schedules" },
     ],
   },
   {
-    label: "Knowledge",
+    title: "Connectors",
+    icon: Cable,
     items: [
-      {
-        title: "Knowledge Base",
-        href: "/app/knowledge-base",
-        icon: BookOpen,
-        items: [
-          { title: "All Bases", href: "/app/knowledge-base" },
-          { title: "Ask", href: "/app/knowledge-base/ask" },
-        ],
-      },
+      { title: "Channels", href: "/app/channels" },
+      { title: "Jira", href: "/app/agent-ops/jira-settings" },
+      { title: "Slack", href: "/app/agent-ops/slack-settings" },
+      { title: "MCP Servers", href: "/app/agent-ops/mcp-settings" },
     ],
   },
   {
-    label: "Integrations",
-    items: [{ title: "Channels", href: "/app/channels", icon: Cable }],
-  },
-  {
-    label: "Settings",
+    title: "Settings",
+    icon: Settings,
     items: [
-      {
-        title: "Settings",
-        href: "/app/settings",
-        icon: Settings,
-        items: [
-          { title: "Overview", href: "/app/settings" },
-          { title: "Members", href: "/app/settings/members" },
-          { title: "Roles & Permissions", href: "/app/settings/roles" },
-          { title: "Organization", href: "/app/settings/organization" },
-          { title: "Providers", href: "/app/settings/providers" },
-        ],
-      },
+      { title: "Overview", href: "/app/settings" },
+      { title: "Members", href: "/app/settings/members" },
+      { title: "Roles & Permissions", href: "/app/settings/roles" },
+      { title: "Organization", href: "/app/settings/organization" },
     ],
   },
 ]
 
 /**
  * Returns the page title for the top bar via longest-prefix match against the
- * nav config (parents + nested items). Falls back to the product name.
+ * nav config (categories + their links). Falls back to the product name.
  */
 export function getPageTitle(pathname: string): string {
-  let best: { href: string; title: string } | null = null
-  const consider = (href: string, title: string) => {
-    const matches = pathname === href || pathname.startsWith(`${href}/`)
-    if (matches && (best === null || href.length > best.href.length)) {
-      best = { href, title }
-    }
+  const candidates: { href: string; title: string }[] = []
+  for (const menu of navMenus) {
+    if (menu.href) candidates.push({ href: menu.href, title: menu.title })
+    menu.items?.forEach((sub) =>
+      candidates.push({ href: sub.href, title: sub.title })
+    )
   }
-  for (const group of navGroups) {
-    for (const item of group.items) {
-      consider(item.href, item.title)
-      item.items?.forEach((sub) => consider(sub.href, sub.title))
+  let best: { href: string; title: string } | null = null
+  for (const c of candidates) {
+    const matches = pathname === c.href || pathname.startsWith(`${c.href}/`)
+    if (matches && (best === null || c.href.length > best.href.length)) {
+      best = c
     }
   }
   return best ? best.title : "Nucleus Cloud Ops"

--- a/apps/web-ui/lib/provider-model-service.ts
+++ b/apps/web-ui/lib/provider-model-service.ts
@@ -28,6 +28,21 @@ export function isProviderType(value: unknown): value is ProviderType {
     return typeof value === 'string' && (PROVIDER_TYPES as readonly string[]).includes(value);
 }
 
+/**
+ * Normalizes the base URL for the OpenAI-compatible transport (ChatOpenAI /
+ * OpenAIEmbeddings, which POST to `{baseURL}/chat/completions` and
+ * `{baseURL}/embeddings`). Ollama serves its OpenAI-compatible API under `/v1`,
+ * but discovery stores the bare root (it talks to `/api/tags`), so we append
+ * `/v1` for inference. Other OpenAI-compatible providers already store a `/v1`
+ * base (their `/models` discovery requires it), so they're left as-is.
+ */
+export function normalizeOpenAICompatibleBaseUrl(provider: string, baseUrl?: string): string | undefined {
+    if (!baseUrl) return baseUrl;
+    const trimmed = baseUrl.replace(/\/+$/, '');
+    if (provider === 'ollama' && !/\/v1$/i.test(trimmed)) return `${trimmed}/v1`;
+    return trimmed;
+}
+
 /** A model entry stored on a provider record (discovered or manually entered). */
 export interface ProviderModelEntry {
     id: string;

--- a/apps/web-ui/lib/queries/providers.ts
+++ b/apps/web-ui/lib/queries/providers.ts
@@ -80,6 +80,14 @@ export interface CreateProviderInput {
 export type UpdateProviderInput = Partial<CreateProviderInput> & { isEnabled?: boolean };
 
 const providersKey = ['settings', 'providers'] as const;
+const providerModelsKey = ['settings', 'providers', 'models'] as const;
+
+/** A flat chat-model picker entry: composite id `{provider}:{modelId}:{recordId}`. */
+export interface ProviderModelOption {
+    id: string;
+    label: string;
+    provider: string;
+}
 
 export function useProviders() {
     return useQuery({
@@ -91,6 +99,25 @@ export function useProviders() {
                 throw new Error(json.error ?? 'Failed to load providers.');
             }
             return json.data.providers ?? [];
+        },
+    });
+}
+
+/**
+ * The flat chat-model picker list, sourced ONLY from tenant-configured providers
+ * (no hardcoded Bedrock baseline). Shared by every model dropdown so the fetch,
+ * response shape, and caching live in one place.
+ */
+export function useProviderModels() {
+    return useQuery({
+        queryKey: providerModelsKey,
+        queryFn: async (): Promise<ProviderModelOption[]> => {
+            const res = await fetch('/api/settings/providers');
+            const json = await res.json();
+            if (!res.ok || !json.success) {
+                throw new Error(json.error ?? 'Failed to load models.');
+            }
+            return (json.data.models ?? []) as ProviderModelOption[];
         },
     });
 }
@@ -215,6 +242,44 @@ export function useDiscoverModels() {
             const json = await res.json();
             if (!res.ok || !json.success) throw new Error(json.error ?? 'Failed to discover models');
             return (json.data?.models ?? []) as DiscoveredModel[];
+        },
+    });
+}
+
+export interface EmbeddingProbeResult {
+    /** True only when the model is invocable AND outputs `required`-dim vectors. */
+    compatible: boolean;
+    /** False when the model's request schema isn't supported (Cohere/Nova/multimodal). */
+    supported: boolean;
+    /** Effective output dimension, or null when the model couldn't be invoked. */
+    dimensions: number | null;
+    required: number;
+    /** Human-readable reason when not compatible; null when compatible. */
+    reason: string | null;
+}
+
+/**
+ * Probes an embedding model's effective output dimension (after any
+ * text-embedding-3 reduction) so the wizard can auto-detect + validate it
+ * against the platform's fixed vector columns. One-shot; no cache.
+ */
+export function useProbeEmbedding() {
+    return useMutation({
+        mutationFn: async (input: {
+            providerType: ProviderType;
+            embeddingModel: string;
+            credentials?: ProviderCredentialsInput;
+            region?: string;
+            providerId?: string;
+        }): Promise<EmbeddingProbeResult> => {
+            const res = await fetch('/api/settings/providers/probe-embedding', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(input),
+            });
+            const json = await res.json();
+            if (!res.ok || !json.success) throw new Error(json.error ?? 'Failed to probe embedding model');
+            return json.data as EmbeddingProbeResult;
         },
     });
 }

--- a/scripts/backfill-embeddings.ts
+++ b/scripts/backfill-embeddings.ts
@@ -5,6 +5,17 @@
  * Reads all inventory_resources rows with NULL embedding, generates Bedrock
  * Titan v2 embeddings, and writes them back to the embedding + contentHash columns.
  *
+ * ⚠️  PROVIDER MODEL CAVEAT (2026-06): the app now resolves embeddings from each
+ *     tenant's CONFIGURED provider (see lib/agent/embeddings-factory.ts), not a
+ *     hardcoded Bedrock Titan client. This script still embeds with Titan v2 via
+ *     host/task-role AWS creds. That is currently safe only because nothing
+ *     queries `inventory_resources.embedding` at runtime (the Ask-AI path is
+ *     text-to-SQL, not vector search; live vector search is kb_document_chunks +
+ *     agent_memories). If inventory vector search is ever re-enabled, this script
+ *     MUST be switched to the tenant's configured embedding model, or its vectors
+ *     will live in a different embedding space than query-time vectors and rank
+ *     garbage. Do NOT use this script to populate kb_document_chunks/agent_memories.
+ *
  * Prerequisites:
  *   - docker compose up -d postgres (or DATABASE_URL pointing to your DB)
  *   - AWS credentials with bedrock:InvokeModel permission


### PR DESCRIPTION
## Summary

Makes the **entire AIOps module use only the tenant-configured LLM/embedding provider** — true SaaS behavior with **no implicit Bedrock credentials and no hardcoded model lists**. When a tenant has no provider configured, the platform returns a clear "configure a provider" error rather than silently falling back to Bedrock.

Also adds **dynamic embedding-dimension detection** in the provider wizard and fixes provider-specific transport bugs surfaced during testing (Ollama base URL, multimodal/Cohere embedding models, Titan v2 reduction).

## What changed

**Core resolution layer**
- `lib/agent/provider-errors.ts` (new) — `ProviderConfigError` + helpers.
- `lib/agent/model-resolver.ts` — removed native-Bedrock fallbacks (unbacked model strings now throw); added `resolveDefaultModelConfig(tenantId)`; provider is parsed from the model id, not the config blob.
- `lib/agent/model-factory.ts` — Bedrock requires explicit creds+region; OpenAI-compatible requires a base URL (no silent `api.openai.com` fallback).
- `lib/agent/embeddings-factory.ts` (new) — `createEmbeddings` / `getTenantEmbeddings` / `probeEmbeddingDimensions`; requests 1024-dim for Titan v2 + OpenAI `text-embedding-3` (Matryoshka).
- `normalizeOpenAICompatibleBaseUrl` (in `provider-model-service.ts`) — appends `/v1` for Ollama (used by both chat and embeddings transports).

**Touchpoints migrated to the configured provider**
chat route (400 on misconfig), enhance-prompt, knowledge-base/query (provider-agnostic LangChain text stream), text-to-SQL nodes, agent-ops executor, deep-agent graph, KB embedder, and per-tenant agent-memory embeddings.

**UI**
- Removed hardcoded model lists (`DEFAULT_MODELS` / `BEDROCK_MODELS` / deep-agent `MODELS`); dropdowns now use a shared `useProviderModels()` TanStack Query hook.
- Provider wizard auto-detects the embedding dimension via a new `probe-embedding` route; shows the full model list and blocks save on incompatible/unsupported models with a clear, amber-coloured reason (errors propagated from the backend).
- Sidebar navigation restructured into collapsible categories (adds the **Providers** link).

## Architecture note
Providers are driven by a **unified transport** keyed on wire protocol, not per-vendor SDKs: Bedrock → `ChatBedrockConverse`, Anthropic → `ChatAnthropic`, and everything OpenAI-compatible (openai / ollama / vllm / lmstudio / **litellm** / openai-compatible) → `ChatOpenAI` at the provider's `/v1` base.

## Constraints / follow-ups
- pgvector columns are fixed `vector(1024)`; embedding models must resolve to 1024 dims (**Path 1**: show all models, allow only compatible). True multi-dimension flexibility (per-tenant re-embed) is a deliberate follow-up.
- Native Cohere/Nova/multimodal Bedrock embeddings aren't invocable directly (different request schemas) — routing them through **LiteLLM** is the supported path; a native adapter is a possible follow-up.
- `scripts/backfill-embeddings.ts` annotated with the provider-model caveat (it still uses Titan directly; `inventory_resources.embedding` is not read at runtime).

## Verification
- `tsc`: 185 errors (down from the 190 baseline; **zero new** errors from this change).
- Unit tests green (`model-resolver`, `persistence`, `text-to-sql`); `model-resolver.test.ts` updated for the new no-fallback behavior.
- Manually exercised: chat (Bedrock + Ollama), provider wizard embedding probe (Titan v2 / Marengo / Cohere), no-provider 400 path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
