### PR TITLE
fix(workers): surface discovery handler errors + fix scanfile path & tag enrichment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,7 +71,10 @@ HORIZONTAL_POLL_INTERVAL_MS=2000
 # ============================================================================
 CONCURRENT_REGIONS=5
 CONCURRENT_SERVICES=10
-SCANFILE_PATH=./scanfile.json
+# Optional override for the discovery scan config. Defaults to the scanfile.json
+# shipped beside the discovery module; a relative value is resolved against that
+# module dir (not the process cwd). Leave unset unless pointing at a custom file.
+# SCANFILE_PATH=/etc/nucleus/scanfile.json
 
 # ============================================================================
 # Misc

--- a/apps/workers/src/executor/horizontal.ts
+++ b/apps/workers/src/executor/horizontal.ts
@@ -23,6 +23,21 @@ function getRequiredEnv(name: string): string {
 
 export class HorizontalExecutor implements JobExecutor {
     async execute(jobName: string, jobData: unknown): Promise<void> {
+        try {
+            return await this.run(jobName, jobData);
+        } catch (err) {
+            // pg-boss records handler rejections to the job table but does not emit
+            // the 'error' event — without this, failures are invisible in the logs.
+            log.error('Job execution failed', {
+                jobName,
+                error: err instanceof Error ? err.message : String(err),
+                stack: err instanceof Error ? err.stack : undefined,
+            });
+            throw err;
+        }
+    }
+
+    private async run(jobName: string, jobData: unknown): Promise<void> {
         // Read and validate config at execute time so missing vars produce clear errors
         const clusterArn = getRequiredEnv('HORIZONTAL_CLUSTER_ARN');
         const taskDefArn = getRequiredEnv('HORIZONTAL_TASK_DEF_ARN');

--- a/apps/workers/src/executor/vertical.test.ts
+++ b/apps/workers/src/executor/vertical.test.ts
@@ -1,4 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
+
+const { errorSpy } = vi.hoisted(() => ({ errorSpy: vi.fn() }));
+vi.mock('../lib/logger.js', () => ({
+    createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: errorSpy }),
+}));
+
 import { VerticalExecutor } from './vertical.js';
 
 describe('VerticalExecutor', () => {
@@ -23,6 +29,19 @@ describe('VerticalExecutor', () => {
             throw new Error('handler error');
         });
         await expect(executor.execute('failing-job', {})).rejects.toThrow('handler error');
+    });
+
+    it('logs handler errors with jobName before rethrowing', async () => {
+        errorSpy.mockClear();
+        const executor = new VerticalExecutor();
+        executor.registerHandler('failing-job', async () => {
+            throw new Error('boom');
+        });
+        await expect(executor.execute('failing-job', {})).rejects.toThrow('boom');
+        expect(errorSpy).toHaveBeenCalledWith(
+            'Job execution failed',
+            expect.objectContaining({ jobName: 'failing-job', error: 'boom' }),
+        );
     });
 
     it('overwrites handler when registered twice for same jobName', async () => {

--- a/apps/workers/src/executor/vertical.ts
+++ b/apps/workers/src/executor/vertical.ts
@@ -16,6 +16,17 @@ export class VerticalExecutor implements JobExecutor {
             throw new Error(`No handler registered for job: ${jobName}`);
         }
         log.debug('Executing job in-process', { jobName });
-        return await handler(jobData);
+        try {
+            return await handler(jobData);
+        } catch (err) {
+            // pg-boss records handler rejections to the job table but does not emit
+            // the 'error' event — without this, failures are invisible in the logs.
+            log.error('Job execution failed', {
+                jobName,
+                error: err instanceof Error ? err.message : String(err),
+                stack: err instanceof Error ? err.stack : undefined,
+            });
+            throw err;
+        }
     }
 }

--- a/apps/workers/src/jobs/discovery/__tests__/index.test.ts
+++ b/apps/workers/src/jobs/discovery/__tests__/index.test.ts
@@ -38,7 +38,28 @@ vi.mock('../../scheduler/services/pg-service.js', () => ({
   updateTenantJobLastRun: vi.fn().mockResolvedValue(undefined),
 }));
 
-import { register } from '../index.js';
+import { register, resolveScanfilePath } from '../index.js';
+import { isAbsolute, join } from 'path';
+
+describe('resolveScanfilePath', () => {
+  const baseDir = '/app/dist/jobs/discovery';
+
+  it('defaults to scanfile.json next to the module when unset', () => {
+    expect(resolveScanfilePath(undefined, baseDir)).toBe(join(baseDir, 'scanfile.json'));
+  });
+
+  it('resolves a relative override against the module dir (cwd-independent)', () => {
+    const resolved = resolveScanfilePath('./scanfile.json', baseDir);
+    expect(resolved).toBe(join(baseDir, 'scanfile.json'));
+    expect(isAbsolute(resolved)).toBe(true);
+  });
+
+  it('passes an absolute override through unchanged', () => {
+    expect(resolveScanfilePath('/etc/nucleus/scanfile.json', baseDir)).toBe(
+      '/etc/nucleus/scanfile.json',
+    );
+  });
+});
 
 describe('discovery register', () => {
   beforeEach(() => vi.clearAllMocks());

--- a/apps/workers/src/jobs/discovery/__tests__/scanner.test.ts
+++ b/apps/workers/src/jobs/discovery/__tests__/scanner.test.ts
@@ -1,4 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __testDir = dirname(fileURLToPath(import.meta.url));
 
 // We'll build this test file incrementally across Tasks 6-9.
 // Task 6 covers: toCommandName, SERVICE_REGISTRY, invokeService
@@ -280,6 +285,53 @@ describe('scanner — applyEnrichments', () => {
 
     expect(enriched).toHaveLength(2);
     expect(enriched[0].Name).toBe('bucket1');
+  });
+
+  it('treats a missing tag set as empty tags rather than a failure', async () => {
+    const err = Object.assign(new Error('The TagSet does not exist'), { name: 'NoSuchTagSet' });
+    const mockClient = { send: vi.fn().mockRejectedValue(err) };
+    const resources = [{ Name: 'untagged-bucket' }];
+    const enrichments: EnrichmentStep[] = [
+      { type: 'tags', method: 'get_bucket_tagging', nameKey: 'Name', inputKey: 'Bucket' },
+    ];
+
+    const enriched = await applyEnrichments(mockClient as any, 's3', resources, enrichments);
+
+    expect(enriched[0].Tags).toEqual([]);
+  });
+
+  it('uses inputKey as the per-resource tag-call parameter name (e.g. CertificateArn)', async () => {
+    const mockClient = {
+      send: vi.fn().mockResolvedValue({ Tags: [{ Key: 'env', Value: 'prod' }] }),
+    };
+    const arn = 'arn:aws:acm:ap-south-1:123456789012:certificate/abc';
+    const resources = [{ CertificateArn: arn }];
+    const enrichments: EnrichmentStep[] = [
+      { type: 'tags', method: 'list_tags_for_certificate', arnKey: 'CertificateArn', inputKey: 'CertificateArn' },
+    ];
+
+    const enriched = await applyEnrichments(mockClient as any, 'acm', resources, enrichments);
+
+    expect(enriched[0].Tags).toEqual([{ Key: 'env', Value: 'prod' }]);
+    expect(mockClient.send.mock.calls[0][0].input).toEqual({ CertificateArn: arn });
+  });
+});
+
+describe('scanfile.json — tag enrichment parameter keys', () => {
+  const scanfile = JSON.parse(
+    readFileSync(join(__testDir, '../scanfile.json'), 'utf-8'),
+  ) as Array<any>;
+
+  it('ACM list_certificates tag enrichment sends CertificateArn', () => {
+    const acm = scanfile.find((c) => c.service === 'acm' && c.function === 'list_certificates');
+    const tagStep = acm?.enrichments?.find((e: any) => e.type === 'tags');
+    expect(tagStep?.inputKey).toBe('CertificateArn');
+  });
+
+  it('ECS list_clusters tag enrichment sends resourceArn', () => {
+    const ecs = scanfile.find((c) => c.service === 'ecs' && c.function === 'list_clusters');
+    const tagStep = ecs?.enrichments?.find((e: any) => e.type === 'tags');
+    expect(tagStep?.inputKey).toBe('resourceArn');
   });
 });
 

--- a/apps/workers/src/jobs/discovery/index.ts
+++ b/apps/workers/src/jobs/discovery/index.ts
@@ -8,7 +8,7 @@ import { writeResourcesToPg, saveSyncStatus } from './services/pg-writer.js';
 import { getTenantJobConfig, updateTenantJobLastRun } from '../scheduler/services/pg-service.js';
 import type { DiscoveryFanOutJob, DiscoveryScanJob } from './types.js';
 import { readFileSync } from 'fs';
-import { join, dirname } from 'path';
+import { join, dirname, isAbsolute } from 'path';
 import { fileURLToPath } from 'url';
 import { createLogger } from '../../lib/logger.js';
 import { env } from '../../env.js';
@@ -34,8 +34,17 @@ export function shouldRunTenant(
     return Date.now() - new Date(lastRunAt).getTime() >= periodToMs(period);
 }
 
+// Resolve the scanfile path cwd-independently: an absolute SCANFILE_PATH is used
+// verbatim, a relative one is resolved against the module dir (not process.cwd(),
+// which differs between `tsx` dev, `node dist` prod, and the local runner), and an
+// unset value falls back to the scanfile.json shipped beside this module.
+export function resolveScanfilePath(configured: string | undefined, baseDir: string): string {
+    if (!configured) return join(baseDir, 'scanfile.json');
+    return isAbsolute(configured) ? configured : join(baseDir, configured);
+}
+
 function loadScanConfigs() {
-    const scanfilePath = env.SCANFILE_PATH ?? join(__dirname, 'scanfile.json');
+    const scanfilePath = resolveScanfilePath(env.SCANFILE_PATH, __dirname);
     return JSON.parse(readFileSync(scanfilePath, 'utf-8'));
 }
 

--- a/apps/workers/src/jobs/discovery/local-runner.ts
+++ b/apps/workers/src/jobs/discovery/local-runner.ts
@@ -1,7 +1,8 @@
 // workers/src/jobs/discovery/local-runner.ts
 import { readFileSync } from 'fs';
-import { join, dirname } from 'path';
+import { dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { resolveScanfilePath } from './index.js';
 import { runInventoryScan } from './services/scanner.js';
 import { writeResourcesToPg, saveSyncStatus } from './services/pg-writer.js';
 import { getAllTenants, getTenantAccounts, updateAccountSyncStatus } from './services/account-service.js';
@@ -34,7 +35,7 @@ async function main() {
     process.env.LOG_LEVEL = 'debug';
   }
 
-  const scanfilePath = process.env.SCANFILE_PATH ?? join(__dirname, 'scanfile.json');
+  const scanfilePath = resolveScanfilePath(process.env.SCANFILE_PATH, __dirname);
   const scanConfigs: ScanConfig[] = JSON.parse(readFileSync(scanfilePath, 'utf-8'));
 
   if (opts.listServices) {

--- a/apps/workers/src/jobs/discovery/scanfile.json
+++ b/apps/workers/src/jobs/discovery/scanfile.json
@@ -64,7 +64,7 @@
     "result_key": "clusterArns",
     "enrichments": [
       { "type": "describe", "method": "describe_clusters", "inputKey": "clusters", "resultKey": "clusters", "batchSize": 100 },
-      { "type": "tags", "method": "list_tags_for_resource", "arnKey": "clusterArn" }
+      { "type": "tags", "method": "list_tags_for_resource", "arnKey": "clusterArn", "inputKey": "resourceArn" }
     ]
   },
   {
@@ -157,7 +157,7 @@
     "function": "list_certificates",
     "result_key": "CertificateSummaryList",
     "enrichments": [
-      { "type": "tags", "method": "list_tags_for_certificate", "arnKey": "CertificateArn" }
+      { "type": "tags", "method": "list_tags_for_certificate", "arnKey": "CertificateArn", "inputKey": "CertificateArn" }
     ]
   },
   {

--- a/apps/workers/src/jobs/discovery/services/scanner.ts
+++ b/apps/workers/src/jobs/discovery/services/scanner.ts
@@ -331,7 +331,16 @@ async function applyTagEnrichment(
         ? tags
         : Object.entries(tags).map(([Key, Value]) => ({ Key, Value }));
     } catch (error) {
-      log.warn('Tag fetch failed', { key, error: error instanceof Error ? error.message : String(error) });
+      const name = error instanceof Error ? error.name : '';
+      const message = error instanceof Error ? error.message : String(error);
+      // A missing tag set (S3 NoSuchTagSet) is a normal state — the resource simply
+      // has no tags — not a failure. Record empty tags and log at debug, not warn.
+      if (name === 'NoSuchTagSet' || /NoSuchTagSet|TagSet does not exist/i.test(message)) {
+        resource.Tags = [];
+        log.debug('No tags for resource', { key });
+      } else {
+        log.warn('Tag fetch failed', { key, error: message });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Discovery jobs were failing **silently** — the error was only visible in the `pgboss.job` table, never in the logs. Investigation surfaced three independent root causes, all fixed here.

### 1. Handler errors invisible in logs (primary)
pg-boss records `work()` handler rejections to the job table but does **not** fire `boss.on('error')` (that only catches pg-boss-internal errors), and neither the executor nor the work callback logged failures. `VerticalExecutor` + `HorizontalExecutor` now `catch → log.error({ jobName, error, stack }) → rethrow` so failures are logged while pg-boss still marks the job failed and retries.

### 2. `ENOENT ./scanfile.json` (the actual scan failure)
`SCANFILE_PATH=./scanfile.json` resolved against the process **cwd** (`apps/workers` under `tsx`), not the module dir, so `loadScanConfigs()` threw before the scan started — which is why logs showed "Executing job in-process" but never "Starting scan". New `resolveScanfilePath()` resolves a relative override against the **module dir** (cwd-independent across `tsx` dev, `node dist` prod, and the local runner); absolute paths pass through; unset falls back to the shipped `scanfile.json`. `.env.example` default commented out.

### 3. Tag-enrichment noise
- **ACM** `list_tags_for_certificate` and **ECS** `list_tags_for_resource` sent the default `ResourceArn` param instead of `CertificateArn` / `resourceArn`, failing every call → added correct `inputKey` in `scanfile.json` (mirrors how ECR already does it).
- **S3 `NoSuchTagSet`** (a normal no-tags state) logged as a warning → now treated as empty tags at `debug` level.

## Verification
- New tests (TDD red→green): executor error-logging, scanfile path resolution, tag-enrichment param key + `NoSuchTagSet` handling, scanfile config locks.
- `bun run typecheck` clean.
- No new test regressions — the remaining failures in `account-service` / `audit-service` / `custom-scanners` / `scheduler` are pre-existing (confirmed by re-running on baseline with changes stashed).
- Verified live: discovery now scans all accounts to completion; ACM/ECS tag errors and S3 no-tags noise gone.

## Out of scope (flagged)
S3 cross-region `config-bucket-*` → "must be addressed using the specified endpoint" is a genuine cross-region issue (bucket in a different region than the client), not a no-tags state, so it still warns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)