### PR TITLE
feat(knowledge-base): Ask AI revamp — sessions, image upload, model selection

### DIFF
--- a/apps/web-ui/app/api/knowledge-base/query/route.ts
+++ b/apps/web-ui/app/api/knowledge-base/query/route.ts
@@ -2,11 +2,13 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/app/api/auth/[...nextauth]/route';
 import { HumanMessage, AIMessage, SystemMessage } from '@langchain/core/messages';
+import type { MessageContent } from '@langchain/core/messages';
 import { getEmbedding } from '@/lib/knowledge-base/embedder';
 import { KnowledgeBaseService } from '@/lib/knowledge-base/service';
-import { getSessionTenantId } from '@/lib/auth-session';
+import { getSessionTenantId, getSessionUserId } from '@/lib/auth-session';
 import { getPrismaClient } from '@/lib/db/pg-config';
-import { resolveDefaultModelConfig } from '@/lib/agent/model-resolver';
+import { kbChatStore } from '@/lib/store/kb-chat-store';
+import { resolveDefaultModelConfig, resolveModelConfig } from '@/lib/agent/model-resolver';
 import { createAgentModels } from '@/lib/agent/model-factory';
 import { isProviderConfigError } from '@/lib/agent/provider-errors';
 
@@ -50,11 +52,19 @@ export async function POST(req: NextRequest) {
 
     // 2. Validate request body
     const body = await req.json();
-    const { query, knowledgeBaseId, messages } = body as {
+    const { query, knowledgeBaseId, messages, sessionId, model, attachments } = body as {
       query?: string;
       knowledgeBaseId?: string;
       messages?: Array<{ role: 'user' | 'assistant'; content: string }>;
+      sessionId?: string;
+      model?: string;
+      attachments?: Array<{ name: string; contentType: string; url: string }>;
     };
+
+    // Image attachments (data URLs) for multimodal questions — images only.
+    const imageAttachments = (attachments ?? []).filter(
+      (a) => a && typeof a.url === 'string' && a.url.startsWith('data:image/'),
+    );
 
     if (!query || !query.trim()) {
       return NextResponse.json({ error: 'query is required' }, { status: 400 });
@@ -62,6 +72,7 @@ export async function POST(req: NextRequest) {
 
     // Always extract tenantId — needed for ownership check and tenant scoping
     const tenantId = await getSessionTenantId();
+    const userId = await getSessionUserId();
 
     // Validate knowledgeBaseId ownership if provided
     if (knowledgeBaseId) {
@@ -70,6 +81,38 @@ export async function POST(req: NextRequest) {
         return NextResponse.json({ error: 'Knowledge base not found' }, { status: 404 });
       }
     }
+
+    // Resolve (or create) the persisted chat session for this conversation.
+    let sid: string;
+    if (sessionId) {
+      const existing = await kbChatStore.getSession(tenantId, sessionId);
+      if (!existing) {
+        return NextResponse.json({ error: 'Session not found' }, { status: 404 });
+      }
+      sid = existing.id;
+      await kbChatStore.touchSession(tenantId, sid);
+    } else {
+      sid = `${tenantId}:${userId}:${Date.now()}`;
+      await kbChatStore.createSession({
+        sessionId: sid,
+        tenantId,
+        userId,
+        title: query.trim().slice(0, 60),
+        knowledgeBaseId: knowledgeBaseId ?? null,
+      });
+    }
+
+    // Persist the user message immediately (before opening the stream),
+    // including any image attachments so a reloaded session re-shows them.
+    await kbChatStore
+      .addMessages(tenantId, sid, [{
+        role: 'user',
+        content: query.trim(),
+        attachments: imageAttachments.length > 0
+          ? imageAttachments.map((a) => ({ name: a.name, url: a.url }))
+          : undefined,
+      }])
+      .catch((e) => console.error('[KB Query] Failed to persist user message:', e));
 
     // 3. Embed the query via the tenant's configured provider
     const embedding = await getEmbedding(query, tenantId);
@@ -130,18 +173,32 @@ ${contextString}`;
       .filter((m) => m.content && m.content.trim())
       .map((m) => ({ role: m.role, content: m.content }));
 
-    // 8. Resolve the tenant's configured provider for generation (no Bedrock default)
-    const model = createAgentModels({
-      ...(await resolveDefaultModelConfig(tenantId)),
+    // 8. Resolve the model — honor the user-selected model if provided, else the
+    //    tenant default. The resolver validates the model belongs to the tenant's
+    //    enabled provider and decrypts its credentials (no extra authz needed).
+    const resolvedModelConfig = model
+      ? await resolveModelConfig(model, tenantId)
+      : await resolveDefaultModelConfig(tenantId);
+    const llm = createAgentModels({
+      ...resolvedModelConfig,
       maxTokens: 1500,
     }).main;
+
+    // Current-turn user message — multimodal when images are attached.
+    const userContent: MessageContent =
+      imageAttachments.length > 0
+        ? [
+            { type: 'text', text: query },
+            ...imageAttachments.map((a) => ({ type: 'image_url', image_url: { url: a.url } })),
+          ]
+        : query;
 
     const lcMessages = [
       new SystemMessage(systemPrompt),
       ...conversationHistory.map((m) =>
         m.role === 'assistant' ? new AIMessage(m.content) : new HumanMessage(m.content),
       ),
-      new HumanMessage(query),
+      new HumanMessage({ content: userContent }),
     ];
 
     // 9. Build sources for X-AI-Sources header
@@ -161,8 +218,9 @@ ${contextString}`;
     const encoder = new TextEncoder();
     const stream = new ReadableStream<Uint8Array>({
       async start(controller) {
+        let full = '';
         try {
-          const llmStream = await model.stream(lcMessages);
+          const llmStream = await llm.stream(lcMessages);
           for await (const chunk of llmStream) {
             const content = chunk.content;
             const text =
@@ -174,11 +232,22 @@ ${contextString}`;
                       .map((c) => c.text)
                       .join('')
                   : '';
-            if (text) controller.enqueue(encoder.encode(text));
+            if (text) {
+              full += text;
+              controller.enqueue(encoder.encode(text));
+            }
           }
           controller.close();
         } catch (err) {
           controller.error(err);
+        } finally {
+          // Persist whatever was produced (handles partial/aborted streams too).
+          // Never awaited inside the read loop; failure must not break streaming.
+          if (full) {
+            kbChatStore
+              .addMessages(tenantId, sid, [{ role: 'assistant', content: full, sources }])
+              .catch((e) => console.error('[KB Query] Failed to persist assistant message:', e));
+          }
         }
       },
     });
@@ -188,6 +257,8 @@ ${contextString}`;
         'Content-Type': 'text/plain; charset=utf-8',
         'Cache-Control': 'no-cache',
         'X-AI-Sources': encodeURIComponent(sourcesJson),
+        'X-KB-Session-Id': sid,
+        'Access-Control-Expose-Headers': 'X-AI-Sources, X-KB-Session-Id',
       },
     });
   } catch (error: unknown) {

--- a/apps/web-ui/app/api/knowledge-base/sessions/[sessionId]/history/route.ts
+++ b/apps/web-ui/app/api/knowledge-base/sessions/[sessionId]/history/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+import { getSessionTenantId } from '@/lib/auth-session';
+import { kbChatStore } from '@/lib/store/kb-chat-store';
+
+// GET /api/knowledge-base/sessions/[sessionId]/history
+// Returns the session's messages plus its stored knowledgeBaseId so the client can
+// hydrate both the conversation and the KB selector in one call.
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ sessionId: string }> },
+) {
+  try {
+    const { sessionId } = await params;
+
+    let tenantId: string;
+    try {
+      tenantId = await getSessionTenantId();
+    } catch {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const session = await kbChatStore.getSession(tenantId, sessionId);
+    if (!session) {
+      return NextResponse.json({ error: 'Session not found' }, { status: 404 });
+    }
+
+    const messages = await kbChatStore.getMessages(tenantId, sessionId);
+    return NextResponse.json({
+      success: true,
+      data: { messages, knowledgeBaseId: session.knowledgeBaseId, title: session.title },
+    });
+  } catch (error) {
+    console.error('API - Error loading KB chat history:', error);
+    return NextResponse.json({ error: 'Failed to load history' }, { status: 500 });
+  }
+}

--- a/apps/web-ui/app/api/knowledge-base/sessions/[sessionId]/route.ts
+++ b/apps/web-ui/app/api/knowledge-base/sessions/[sessionId]/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server';
+import { getSessionTenantId, getSessionUserId } from '@/lib/auth-session';
+import { kbChatStore } from '@/lib/store/kb-chat-store';
+import { AuditService } from '@/lib/audit-service';
+
+// DELETE /api/knowledge-base/sessions/[sessionId] — delete a KB chat session (tenant-shared)
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ sessionId: string }> },
+) {
+  try {
+    const { sessionId } = await params;
+
+    let tenantId: string;
+    try {
+      tenantId = await getSessionTenantId();
+    } catch {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // Existence + tenant scope check (404 hides cross-tenant existence)
+    const existing = await kbChatStore.getSession(tenantId, sessionId);
+    if (!existing) {
+      return NextResponse.json({ error: 'Session not found' }, { status: 404 });
+    }
+
+    const ok = await kbChatStore.deleteSession(tenantId, sessionId);
+    if (!ok) {
+      return NextResponse.json({ error: 'Session not found' }, { status: 404 });
+    }
+
+    AuditService.logUserAction({
+      eventType: 'kb.chat.session.deleted',
+      severity: 'low',
+      apiRoute: 'DELETE /api/knowledge-base/sessions/[sessionId]',
+      httpMethod: 'DELETE',
+      action: 'Deleted KB Chat Session',
+      resourceType: 'kb-chat',
+      resourceId: sessionId,
+      resourceName: existing.title,
+      user: await getSessionUserId().catch(() => 'unknown'),
+      userType: 'user',
+      status: 'success',
+      details: `Deleted KB chat session ${sessionId}`,
+      tenantId,
+    }).catch(() => {});
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('API - Error deleting KB chat session:', error);
+    return NextResponse.json({ error: 'Failed to delete session' }, { status: 500 });
+  }
+}

--- a/apps/web-ui/app/api/knowledge-base/sessions/route.ts
+++ b/apps/web-ui/app/api/knowledge-base/sessions/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { getSessionTenantId } from '@/lib/auth-session';
+import { kbChatStore } from '@/lib/store/kb-chat-store';
+
+// GET /api/knowledge-base/sessions — list saved KB chat sessions (tenant-shared)
+export async function GET() {
+  try {
+    let tenantId: string;
+    try {
+      tenantId = await getSessionTenantId();
+    } catch {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const sessions = await kbChatStore.listSessions(tenantId);
+    return NextResponse.json({ success: true, data: sessions });
+  } catch (error) {
+    console.error('API - Error listing KB chat sessions:', error);
+    return NextResponse.json({ error: 'Failed to list sessions' }, { status: 500 });
+  }
+}

--- a/apps/web-ui/components/knowledge-base/kb-chat-sidebar.tsx
+++ b/apps/web-ui/components/knowledge-base/kb-chat-sidebar.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+import { Plus, Search, MoreVertical, Trash2, MessageSquare } from 'lucide-react';
+import { Spinner } from '@/components/ui/spinner';
+import { formatDistanceToNow } from 'date-fns';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { useKBChatSessions, useDeleteKBChatSession } from '@/lib/queries/kb-chat';
+
+interface KBChatSidebarProps {
+    className?: string;
+    currentSessionId: string | null;
+    onSessionSelect: (sessionId: string) => void;
+    onNewChat: () => void;
+}
+
+export function KBChatSidebar({
+    className,
+    currentSessionId,
+    onSessionSelect,
+    onNewChat,
+}: KBChatSidebarProps) {
+    const [searchQuery, setSearchQuery] = useState('');
+    const { data: sessions = [], isLoading } = useKBChatSessions();
+    const deleteSession = useDeleteKBChatSession();
+
+    const filtered = sessions.filter((s) =>
+        s.title.toLowerCase().includes(searchQuery.toLowerCase()),
+    );
+
+    const handleDelete = async (e: React.MouseEvent, id: string) => {
+        e.stopPropagation();
+        try {
+            await deleteSession.mutateAsync(id);
+            if (currentSessionId === id) onNewChat();
+        } catch {
+            /* surfaced via mutation state; sidebar stays usable */
+        }
+    };
+
+    return (
+        <div className={cn('flex flex-col h-full bg-muted/10 border-r', className)}>
+            {/* Header */}
+            <div className="px-3 pt-3 pb-2 border-b space-y-3">
+                <Button onClick={onNewChat} className="w-full justify-start gap-2">
+                    <Plus className="w-4 h-4" />
+                    New chat
+                </Button>
+                <div className="relative">
+                    <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+                    <Input
+                        placeholder="Search chats..."
+                        value={searchQuery}
+                        onChange={(e) => setSearchQuery(e.target.value)}
+                        className="pl-8 h-9 text-xs"
+                    />
+                </div>
+            </div>
+
+            {/* Section label */}
+            <div className="px-4 pt-3 pb-1">
+                <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                    Sessions
+                </span>
+            </div>
+
+            {/* List */}
+            <ScrollArea className="flex-1">
+                <div className="p-2 pt-1 space-y-1">
+                    {isLoading && (
+                        <div className="flex flex-col items-center justify-center py-10 gap-2 text-muted-foreground">
+                            <Spinner className="w-5 h-5" />
+                            <span className="text-xs">Loading sessions...</span>
+                        </div>
+                    )}
+
+                    {!isLoading &&
+                        filtered.map((session) => (
+                            <div
+                                key={session.id}
+                                onClick={() => onSessionSelect(session.id)}
+                                className={cn(
+                                    'group flex flex-col gap-1 p-3 rounded-lg text-sm transition-colors cursor-pointer hover:bg-accent/50 relative',
+                                    currentSessionId === session.id ? 'bg-accent shadow-sm' : 'transparent',
+                                )}
+                            >
+                                <div className="flex items-start justify-between gap-2">
+                                    <div className="flex items-start gap-2 min-w-0">
+                                        <MessageSquare className="h-3.5 w-3.5 mt-0.5 shrink-0 text-muted-foreground" />
+                                        <span className="font-medium truncate leading-tight">
+                                            {session.title || 'Untitled chat'}
+                                        </span>
+                                    </div>
+
+                                    <DropdownMenu>
+                                        <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
+                                            <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                className="h-6 w-6 -mt-1 -mr-2 opacity-0 group-hover:opacity-100 transition-opacity"
+                                            >
+                                                <MoreVertical className="h-3 w-3" />
+                                            </Button>
+                                        </DropdownMenuTrigger>
+                                        <DropdownMenuContent align="end">
+                                            <DropdownMenuItem
+                                                className="text-destructive focus:text-destructive"
+                                                onClick={(e) => handleDelete(e as unknown as React.MouseEvent, session.id)}
+                                            >
+                                                <Trash2 className="w-4 h-4 mr-2" />
+                                                Delete
+                                            </DropdownMenuItem>
+                                        </DropdownMenuContent>
+                                    </DropdownMenu>
+                                </div>
+                                <div className="flex items-center justify-between text-[10px] text-muted-foreground pl-5">
+                                    <span>
+                                        {session.updatedAt
+                                            ? formatDistanceToNow(session.updatedAt, { addSuffix: true })
+                                            : '—'}
+                                    </span>
+                                </div>
+                            </div>
+                        ))}
+
+                    {!isLoading && filtered.length === 0 && (
+                        <div className="text-center py-10 text-xs text-muted-foreground">
+                            {searchQuery ? 'No matching chats.' : 'No saved sessions yet.'}
+                        </div>
+                    )}
+                </div>
+            </ScrollArea>
+        </div>
+    );
+}

--- a/apps/web-ui/components/knowledge-base/kb-chat.tsx
+++ b/apps/web-ui/components/knowledge-base/kb-chat.tsx
@@ -1,15 +1,21 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import {
   Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
 } from "@/components/ui/select";
-import { Bot, Plus, Send, Sparkles, User } from "lucide-react";
+import { Bot, Cpu, Sparkles, User } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { KBChatSources, KBSource } from "./kb-chat-sources";
-import type { KnowledgeBase } from "@/lib/knowledge-base/types";
+import { KBChatSidebar } from "./kb-chat-sidebar";
+import { FileUpload, FileAttachment } from "@/components/agent/file-upload";
+import { useKnowledgeBases } from "@/lib/queries/knowledge-base";
+import { useKBChatMessages } from "@/lib/queries/kb-chat";
+import { useProviderModels } from "@/lib/queries/providers";
+import { queryKeys } from "@/lib/queries/query-keys";
 
 const EXAMPLE_PROMPTS = [
   "Summarize the key points in this knowledge base",
@@ -18,11 +24,14 @@ const EXAMPLE_PROMPTS = [
   "What does this document say about security?",
 ];
 
+type MessageAttachment = { name: string; url: string };
+
 type Message = {
   id: string;
   role: "user" | "assistant";
   content: string;
   sources?: KBSource[];
+  attachments?: MessageAttachment[];
 };
 
 interface KBChatProps {
@@ -30,6 +39,7 @@ interface KBChatProps {
 }
 
 export function KBChat({ initialKbId }: KBChatProps) {
+  const queryClient = useQueryClient();
   const scrollRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [input, setInput] = useState("");
@@ -37,15 +47,45 @@ export function KBChat({ initialKbId }: KBChatProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [isStreaming, setIsStreaming] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [knowledgeBases, setKnowledgeBases] = useState<KnowledgeBase[]>([]);
   const [selectedKbId, setSelectedKbId] = useState<string>(initialKbId || "__all__");
+  const [selectedModel, setSelectedModel] = useState<string>("");
+  const [attachments, setAttachments] = useState<FileAttachment[]>([]);
 
+  // Active persisted session for this conversation (sent back on each turn).
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  // Sidebar-selected session to hydrate. Kept separate from sessionId so an
+  // active/streaming conversation is never clobbered by a history refetch.
+  const [loadId, setLoadId] = useState<string | null>(null);
+
+  const { data: knowledgeBases = [] } = useKnowledgeBases();
+  const { data: availableModels = [] } = useProviderModels();
+  const { data: history, isFetching: isLoadingHistory } = useKBChatMessages(loadId);
+
+  // Default the model to the first available; keep current selection if still valid.
   useEffect(() => {
-    fetch("/api/knowledge-base")
-      .then((r) => r.json())
-      .then((data: { knowledgeBases?: KnowledgeBase[] }) => setKnowledgeBases(data.knowledgeBases || []))
-      .catch(() => {});
-  }, []);
+    setSelectedModel((prev) =>
+      prev && availableModels.some((m) => m.id === prev) ? prev : availableModels[0]?.id ?? "",
+    );
+  }, [availableModels]);
+
+  // Hydrate the pane when a sidebar session's history arrives.
+  useEffect(() => {
+    if (!loadId || !history) return;
+    setMessages(
+      history.messages.map((m, i) => ({
+        id: `${loadId}-${i}`,
+        role: m.role,
+        content: m.content,
+        sources: m.sources,
+        attachments: m.attachments,
+      })),
+    );
+    setSelectedKbId(history.knowledgeBaseId ?? "__all__");
+    setSessionId(loadId);
+    setError(null);
+    setInput("");
+    setLoadId(null);
+  }, [loadId, history]);
 
   // Auto-scroll on new content
   useEffect(() => {
@@ -62,6 +102,20 @@ export function KBChat({ initialKbId }: KBChatProps) {
     ta.style.height = Math.min(ta.scrollHeight, 160) + "px";
   }, [input]);
 
+  const handleNewChat = () => {
+    setSessionId(null);
+    setLoadId(null);
+    setMessages([]);
+    setError(null);
+    setInput("");
+    setAttachments([]);
+  };
+
+  const handleSelectSession = (id: string) => {
+    if (id === sessionId || id === loadId) return;
+    setLoadId(id);
+  };
+
   const handleSend = async (text: string) => {
     const trimmed = text.trim();
     if (!trimmed || isLoading || isStreaming) return;
@@ -69,8 +123,24 @@ export function KBChat({ initialKbId }: KBChatProps) {
     setInput("");
     setError(null);
 
-    const userMsg: Message = { id: Date.now().toString(), role: "user", content: trimmed };
-    const history = messages.map((m) => ({ role: m.role, content: m.content }));
+    // Snapshot + clear pending attachments for this turn.
+    const turnAttachments = attachments;
+    setAttachments([]);
+    const attachmentPayload = turnAttachments.map((f) => ({
+      name: f.name,
+      contentType: f.type,
+      url: `data:${f.type};base64,${f.data}`,
+    }));
+
+    const userMsg: Message = {
+      id: Date.now().toString(),
+      role: "user",
+      content: trimmed,
+      attachments: attachmentPayload.length > 0
+        ? attachmentPayload.map((a) => ({ name: a.name, url: a.url }))
+        : undefined,
+    };
+    const priorMessages = messages.map((m) => ({ role: m.role, content: m.content }));
     setMessages((prev) => [...prev, userMsg]);
     setIsLoading(true);
 
@@ -81,7 +151,10 @@ export function KBChat({ initialKbId }: KBChatProps) {
         body: JSON.stringify({
           query: trimmed,
           knowledgeBaseId: selectedKbId === "__all__" ? undefined : selectedKbId,
-          messages: history,
+          messages: priorMessages,
+          sessionId: sessionId ?? undefined,
+          model: selectedModel || undefined,
+          attachments: attachmentPayload.length > 0 ? attachmentPayload : undefined,
         }),
       });
 
@@ -89,6 +162,10 @@ export function KBChat({ initialKbId }: KBChatProps) {
         const d = await res.json().catch(() => ({})) as { error?: string };
         throw new Error(d.error || `HTTP ${res.status}`);
       }
+
+      // Adopt the persisted session id (brand-new chats learn it here).
+      const newSid = res.headers.get("X-KB-Session-Id");
+      if (newSid && newSid !== sessionId) setSessionId(newSid);
 
       const msgId = "ai-" + Date.now();
       let sources: KBSource[] = [];
@@ -115,6 +192,8 @@ export function KBChat({ initialKbId }: KBChatProps) {
         reader.releaseLock();
       }
       setIsStreaming(false);
+      // Refresh the sidebar so the (new or touched) session moves to the top.
+      queryClient.invalidateQueries({ queryKey: queryKeys.kbChat.sessions() });
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to get response");
     } finally {
@@ -126,172 +205,233 @@ export function KBChat({ initialKbId }: KBChatProps) {
   const isBusy = isLoading || isStreaming;
 
   return (
-    <div className="flex flex-col h-full overflow-hidden">
-      {/* Toolbar */}
-      <div className="flex items-center gap-3 px-6 py-3 border-b shrink-0 bg-background">
-        <span className="text-sm text-muted-foreground font-medium whitespace-nowrap">Knowledge Base:</span>
-        <Select value={selectedKbId} onValueChange={setSelectedKbId}>
-          <SelectTrigger className="w-56 h-8 text-sm">
-            <SelectValue placeholder="All Knowledge Bases" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="__all__">All Knowledge Bases</SelectItem>
-            {knowledgeBases.map((kb) => (
-              <SelectItem key={kb.id} value={kb.id}>{kb.name}</SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        {messages.length > 0 && (
-          <Button
-            variant="ghost" size="sm"
-            onClick={() => { setMessages([]); setError(null); setInput(""); }}
-            className="ml-auto h-8 gap-1.5 text-muted-foreground"
-          >
-            <Plus className="h-3.5 w-3.5" /> New chat
-          </Button>
-        )}
-      </div>
+    <div className="flex h-full overflow-hidden">
+      {/* Sessions sidebar */}
+      <KBChatSidebar
+        className="w-72 shrink-0 hidden md:flex"
+        currentSessionId={sessionId}
+        onSessionSelect={handleSelectSession}
+        onNewChat={handleNewChat}
+      />
 
-      {/* Messages — only scrolling region */}
-      <div className="flex-1 min-h-0 overflow-y-auto" ref={scrollRef}>
-        <div className="max-w-3xl mx-auto space-y-6 py-6 px-4 md:px-8">
+      {/* Chat column */}
+      <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
+        {/* Toolbar */}
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-2 px-6 py-3 border-b shrink-0 bg-background">
+          <span className="text-sm text-muted-foreground font-medium whitespace-nowrap">Knowledge Base:</span>
+          <Select value={selectedKbId} onValueChange={setSelectedKbId}>
+            <SelectTrigger className="w-56 h-8 text-sm">
+              <SelectValue placeholder="All Knowledge Bases" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__all__">All Knowledge Bases</SelectItem>
+              {knowledgeBases.map((kb) => (
+                <SelectItem key={kb.id} value={kb.id}>{kb.name}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
 
-          {/* Empty state */}
-          {messages.length === 0 && !isLoading && (
-            <div className="flex flex-col items-center justify-center pt-12 text-center animate-in fade-in zoom-in duration-300">
-              <div className="bg-primary/10 p-4 rounded-full mb-4">
-                <Sparkles className="h-8 w-8 text-primary" />
-              </div>
-              <h3 className="font-semibold text-lg mb-1">How can I help you?</h3>
-              <p className="text-sm text-muted-foreground max-w-sm mb-6">
-                Ask questions about your knowledge base documents using natural language.
-              </p>
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 w-full max-w-lg">
-                {EXAMPLE_PROMPTS.map((p) => (
-                  <button
-                    key={p}
-                    onClick={() => handleSend(p)}
-                    className="text-left text-sm bg-background border rounded-xl px-4 py-3 hover:bg-muted/60 hover:border-primary/40 transition-colors leading-snug"
-                  >
-                    {p}
-                  </button>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Message list */}
-          {messages.map((msg) => (
-            <div key={msg.id} className="animate-in slide-in-from-bottom-2 duration-200">
-              {msg.role === "user" ? (
-                /* User bubble — right aligned */
-                <div className="flex gap-3 justify-end">
-                  <div className="bg-primary text-primary-foreground rounded-2xl rounded-tr-sm px-4 py-2.5 text-sm max-w-[80%] leading-relaxed whitespace-pre-wrap">
-                    {msg.content}
-                  </div>
-                  <div className="mt-0.5 bg-muted rounded-full p-2 h-fit shrink-0">
-                    <User className="h-3.5 w-3.5" />
-                  </div>
-                </div>
-              ) : (
-                /* Assistant bubble — left aligned */
-                <div className="flex gap-3">
-                  <div className="mt-0.5 bg-primary/10 rounded-full p-2 h-fit shrink-0">
-                    <Bot className="h-3.5 w-3.5 text-primary" />
-                  </div>
-                  <div className="flex-1 min-w-0 space-y-1">
-                    {/* Markdown rendered response */}
-                    <div className={`
-                      prose prose-sm dark:prose-invert max-w-none
-                      prose-p:leading-relaxed prose-p:my-1.5
-                      prose-headings:font-semibold prose-headings:mt-4 prose-headings:mb-1.5
-                      prose-h1:text-base prose-h2:text-sm prose-h3:text-sm
-                      prose-ul:my-1.5 prose-ol:my-1.5 prose-li:my-0.5
-                      prose-table:text-xs prose-table:border-collapse
-                      prose-th:border prose-th:border-border prose-th:px-3 prose-th:py-1.5 prose-th:bg-muted/50 prose-th:font-semibold
-                      prose-td:border prose-td:border-border prose-td:px-3 prose-td:py-1.5
-                      prose-code:bg-muted prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:text-[11px] prose-code:font-mono
-                      prose-pre:bg-muted prose-pre:rounded-lg prose-pre:p-3 prose-pre:overflow-x-auto
-                      prose-blockquote:border-l-2 prose-blockquote:border-primary/40 prose-blockquote:pl-3 prose-blockquote:text-muted-foreground
-                      prose-strong:font-semibold prose-strong:text-foreground
-                      break-words
-                    `}>
-                      <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                        {msg.content || (isStreaming ? "​" : "")}
-                      </ReactMarkdown>
-                    </div>
-                    {/* Sources */}
-                    {msg.sources && msg.sources.length > 0 && (
-                      <KBChatSources sources={msg.sources} />
-                    )}
-                  </div>
-                </div>
-              )}
-            </div>
-          ))}
-
-          {/* Thinking indicator */}
-          {isLoading && (
-            <div className="flex gap-3 animate-in fade-in duration-200">
-              <div className="mt-0.5 bg-primary/10 rounded-full p-2 h-fit shrink-0">
-                <Bot className="h-3.5 w-3.5 text-primary" />
-              </div>
-              <div className="flex items-center gap-1 pt-2.5">
-                {[0, 150, 300].map((delay) => (
-                  <span
-                    key={delay}
-                    className="h-2 w-2 rounded-full bg-primary/50 animate-bounce"
-                    style={{ animationDelay: `${delay}ms` }}
-                  />
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Error */}
-          {error && (
-            <div className="p-3 rounded-lg bg-destructive/10 border border-destructive/20 text-destructive text-sm">
-              {error}
-            </div>
-          )}
+          <span className="text-sm text-muted-foreground font-medium whitespace-nowrap ml-auto">Model:</span>
+          <Select value={selectedModel} onValueChange={setSelectedModel} disabled={availableModels.length === 0}>
+            <SelectTrigger className="w-56 h-8 text-sm gap-1.5">
+              <Cpu className="h-3.5 w-3.5 text-primary shrink-0" />
+              <SelectValue placeholder={availableModels.length === 0 ? "No providers configured" : "Select model"} />
+            </SelectTrigger>
+            <SelectContent>
+              {availableModels.map((m) => (
+                <SelectItem key={m.id} value={m.id}>{m.label}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
-      </div>
 
-      {/* Input area — sticky footer */}
-      <div className="px-4 md:px-8 py-4 border-t shrink-0 bg-background">
-        <div className="max-w-3xl mx-auto">
-          <div className={`flex items-end gap-2 rounded-xl border bg-background px-3 py-2 transition-colors focus-within:border-primary/60 ${isBusy ? "opacity-60" : ""}`}>
-            <textarea
-              ref={textareaRef}
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" && !e.shiftKey) {
-                  e.preventDefault();
-                  handleSend(input);
-                }
-              }}
-              placeholder="Ask a question about your documents…"
-              disabled={isBusy}
-              rows={1}
-              className="flex-1 resize-none bg-transparent text-sm outline-none placeholder:text-muted-foreground min-h-[24px] max-h-[160px] py-0.5 leading-relaxed"
-            />
-            <Button
-              type="button"
-              size="icon"
-              className="h-8 w-8 shrink-0 rounded-lg"
-              disabled={isBusy || !input.trim()}
-              onClick={() => handleSend(input)}
-            >
-              <Send className="h-3.5 w-3.5" />
-              <span className="sr-only">Send</span>
-            </Button>
+        {/* Messages — only scrolling region */}
+        <div className="flex-1 min-h-0 overflow-y-auto" ref={scrollRef}>
+          <div className="max-w-3xl mx-auto space-y-6 py-6 px-4 md:px-8">
+
+            {/* Empty state */}
+            {messages.length === 0 && !isLoading && !isLoadingHistory && (
+              <div className="flex flex-col items-center justify-center pt-16 text-center animate-in fade-in zoom-in duration-300">
+                <div className="bg-muted p-4 rounded-full mb-5">
+                  <Sparkles className="h-7 w-7 text-foreground" />
+                </div>
+                <h3 className="font-semibold text-2xl mb-2">How can I help you today?</h3>
+                <p className="text-sm text-muted-foreground max-w-md mb-8">
+                  Ask questions about your knowledge base documents using natural language.
+                </p>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 w-full max-w-xl">
+                  {EXAMPLE_PROMPTS.map((p) => (
+                    <button
+                      key={p}
+                      onClick={() => handleSend(p)}
+                      className="text-left text-sm bg-background border rounded-xl px-4 py-3 hover:bg-muted/60 hover:border-primary/40 hover:shadow-sm transition-all leading-snug"
+                    >
+                      {p}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* History loading */}
+            {isLoadingHistory && messages.length === 0 && (
+              <div className="flex justify-center pt-16">
+                <div className="flex items-center gap-1">
+                  {[0, 150, 300].map((delay) => (
+                    <span
+                      key={delay}
+                      className="h-2 w-2 rounded-full bg-primary/50 animate-bounce"
+                      style={{ animationDelay: `${delay}ms` }}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Message list */}
+            {messages.map((msg) => (
+              <div key={msg.id} className="animate-in slide-in-from-bottom-2 duration-200">
+                {msg.role === "user" ? (
+                  /* User bubble — right aligned */
+                  <div className="flex gap-3 justify-end">
+                    <div className="flex flex-col items-end gap-1.5 max-w-[80%]">
+                      {msg.attachments && msg.attachments.length > 0 && (
+                        <div className="flex flex-wrap gap-2 justify-end">
+                          {msg.attachments.map((att, idx) => (
+                            // eslint-disable-next-line @next/next/no-img-element
+                            <img
+                              key={idx}
+                              src={att.url}
+                              alt={att.name}
+                              className="max-h-48 max-w-[12rem] rounded-lg border object-contain bg-background"
+                            />
+                          ))}
+                        </div>
+                      )}
+                      {msg.content && (
+                        <div className="bg-primary text-primary-foreground rounded-2xl rounded-tr-sm px-4 py-2.5 text-sm leading-relaxed whitespace-pre-wrap">
+                          {msg.content}
+                        </div>
+                      )}
+                    </div>
+                    <div className="mt-0.5 bg-muted rounded-full p-2 h-fit shrink-0">
+                      <User className="h-3.5 w-3.5" />
+                    </div>
+                  </div>
+                ) : (
+                  /* Assistant bubble — left aligned */
+                  <div className="flex gap-3">
+                    <div className="mt-0.5 bg-primary/10 rounded-full p-2 h-fit shrink-0">
+                      <Bot className="h-3.5 w-3.5 text-primary" />
+                    </div>
+                    <div className="flex-1 min-w-0 space-y-1">
+                      {/* Markdown rendered response */}
+                      <div className={`
+                        prose prose-sm dark:prose-invert max-w-none
+                        prose-p:leading-relaxed prose-p:my-1.5
+                        prose-headings:font-semibold prose-headings:mt-4 prose-headings:mb-1.5
+                        prose-h1:text-base prose-h2:text-sm prose-h3:text-sm
+                        prose-ul:my-1.5 prose-ol:my-1.5 prose-li:my-0.5
+                        prose-table:text-xs prose-table:border-collapse
+                        prose-th:border prose-th:border-border prose-th:px-3 prose-th:py-1.5 prose-th:bg-muted/50 prose-th:font-semibold
+                        prose-td:border prose-td:border-border prose-td:px-3 prose-td:py-1.5
+                        prose-code:bg-muted prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:text-[11px] prose-code:font-mono
+                        prose-pre:bg-muted prose-pre:rounded-lg prose-pre:p-3 prose-pre:overflow-x-auto
+                        prose-blockquote:border-l-2 prose-blockquote:border-primary/40 prose-blockquote:pl-3 prose-blockquote:text-muted-foreground
+                        prose-strong:font-semibold prose-strong:text-foreground
+                        break-words
+                      `}>
+                        <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                          {msg.content || (isStreaming ? "​" : "")}
+                        </ReactMarkdown>
+                      </div>
+                      {/* Sources */}
+                      {msg.sources && msg.sources.length > 0 && (
+                        <KBChatSources sources={msg.sources} />
+                      )}
+                    </div>
+                  </div>
+                )}
+              </div>
+            ))}
+
+            {/* Thinking indicator */}
+            {isLoading && (
+              <div className="flex gap-3 animate-in fade-in duration-200">
+                <div className="mt-0.5 bg-primary/10 rounded-full p-2 h-fit shrink-0">
+                  <Bot className="h-3.5 w-3.5 text-primary" />
+                </div>
+                <div className="flex items-center gap-1 pt-2.5">
+                  {[0, 150, 300].map((delay) => (
+                    <span
+                      key={delay}
+                      className="h-2 w-2 rounded-full bg-primary/50 animate-bounce"
+                      style={{ animationDelay: `${delay}ms` }}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Error */}
+            {error && (
+              <div className="p-3 rounded-lg bg-destructive/10 border border-destructive/20 text-destructive text-sm">
+                {error}
+              </div>
+            )}
           </div>
-          <p className="text-[10px] text-muted-foreground mt-1.5 text-center">
-            Answers are based on the documents in your knowledge base · Shift+Enter for new line
-          </p>
+        </div>
+
+        {/* Input area — sticky footer */}
+        <div className="px-4 md:px-8 py-4 border-t shrink-0 bg-background">
+          <div className="max-w-3xl mx-auto">
+            <div className={`flex flex-col gap-1.5 rounded-2xl border bg-background px-3.5 py-2.5 shadow-sm transition-colors focus-within:border-primary/60 focus-within:shadow ${isBusy ? "opacity-60" : ""}`}>
+              <div className="flex items-end gap-2">
+                <textarea
+                  ref={textareaRef}
+                  value={input}
+                  onChange={(e) => setInput(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && !e.shiftKey) {
+                      e.preventDefault();
+                      handleSend(input);
+                    }
+                  }}
+                  placeholder="Ask a question about your documents…"
+                  disabled={isBusy}
+                  rows={1}
+                  className="flex-1 resize-none bg-transparent text-sm outline-none placeholder:text-muted-foreground min-h-[24px] max-h-[160px] py-0.5 leading-relaxed"
+                />
+                <Button
+                  type="button"
+                  size="icon"
+                  className="h-9 w-9 shrink-0 rounded-xl"
+                  disabled={isBusy || !input.trim()}
+                  onClick={() => handleSend(input)}
+                >
+                  <SendIcon />
+                  <span className="sr-only">Send</span>
+                </Button>
+              </div>
+              {/* Image attachments (paperclip + thumbnails) */}
+              <FileUpload files={attachments} onFilesChange={setAttachments} disabled={isBusy} />
+            </div>
+            <p className="text-[10px] text-muted-foreground mt-1.5 text-center">
+              Answers are based on the documents in your knowledge base · Shift+Enter for new line
+            </p>
+          </div>
         </div>
       </div>
     </div>
+  );
+}
+
+function SendIcon() {
+  // Paper-plane send glyph (matches the chatbot reference)
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
+      <path d="m22 2-7 20-4-9-9-4Z" />
+      <path d="M22 2 11 13" />
+    </svg>
   );
 }

--- a/apps/web-ui/lib/queries/kb-chat.ts
+++ b/apps/web-ui/lib/queries/kb-chat.ts
@@ -1,0 +1,84 @@
+'use client';
+
+/**
+ * TanStack Query hooks for Knowledge Base "Ask AI" chat sessions.
+ * Sessions + message history are tenant-shared and persisted server-side.
+ * The streaming send itself stays a manual fetch in the component; after it
+ * completes the component invalidates queryKeys.kbChat.sessions().
+ */
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '@/lib/queries/query-keys';
+import type { KBSource } from '@/components/knowledge-base/kb-chat-sources';
+
+export interface KbChatSession {
+    id: string;
+    title: string;
+    knowledgeBaseId: string | null;
+    createdAt: number;
+    updatedAt: number;
+    ownerUserId: string;
+}
+
+export interface KbChatAttachment {
+    name: string;
+    url: string;
+}
+
+export interface KbChatHistoryMessage {
+    role: 'user' | 'assistant';
+    content: string;
+    sources?: KBSource[];
+    attachments?: KbChatAttachment[];
+    createdAt?: number;
+}
+
+export interface KbChatHistory {
+    messages: KbChatHistoryMessage[];
+    knowledgeBaseId: string | null;
+    title: string;
+}
+
+export function useKBChatSessions() {
+    return useQuery({
+        queryKey: queryKeys.kbChat.sessions(),
+        queryFn: async (): Promise<KbChatSession[]> => {
+            const res = await fetch('/api/knowledge-base/sessions');
+            if (!res.ok) throw new Error('Failed to fetch sessions');
+            const data = await res.json();
+            return data.data ?? [];
+        },
+    });
+}
+
+export function useKBChatMessages(sessionId: string | null) {
+    return useQuery({
+        queryKey: queryKeys.kbChat.messages(sessionId ?? 'new'),
+        enabled: !!sessionId,
+        queryFn: async (): Promise<KbChatHistory> => {
+            const res = await fetch(
+                `/api/knowledge-base/sessions/${encodeURIComponent(sessionId!)}/history`,
+            );
+            if (!res.ok) throw new Error('Failed to load history');
+            const data = await res.json();
+            return data.data as KbChatHistory;
+        },
+    });
+}
+
+export function useDeleteKBChatSession() {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async (sessionId: string) => {
+            const res = await fetch(
+                `/api/knowledge-base/sessions/${encodeURIComponent(sessionId)}`,
+                { method: 'DELETE' },
+            );
+            if (!res.ok) {
+                const data = await res.json().catch(() => ({}));
+                throw new Error(data.error ?? 'Delete failed');
+            }
+            return res.json().catch(() => ({}));
+        },
+        onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.kbChat.sessions() }),
+    });
+}

--- a/apps/web-ui/lib/queries/query-keys.ts
+++ b/apps/web-ui/lib/queries/query-keys.ts
@@ -55,4 +55,9 @@ export const queryKeys = {
         content: (id: string, versionId?: string) =>
             [...queryKeys.certificates.detail(id), 'content', versionId ?? 'active'] as const,
     },
+    kbChat: {
+        all: ['kb-chat'] as const,
+        sessions: () => [...queryKeys.kbChat.all, 'sessions'] as const,
+        messages: (sessionId: string) => [...queryKeys.kbChat.all, 'messages', sessionId] as const,
+    },
 } as const;

--- a/apps/web-ui/lib/store/kb-chat-store.ts
+++ b/apps/web-ui/lib/store/kb-chat-store.ts
@@ -1,0 +1,164 @@
+import { Prisma } from "@prisma/client";
+import { getPrismaClient } from "@/lib/db/pg-config";
+import type { KBSource } from "@/components/knowledge-base/kb-chat-sources";
+
+// Knowledge Base "Ask AI" chat persistence (tenant-shared).
+// Mirrors the agent ThreadStore pattern but is fully isolated from agent chat so the
+// agent sidebar (/api/threads) never lists KB sessions. Listing/delete are scoped by
+// tenantId only (sessions are visible to every member of the tenant). userId is kept
+// for attribution. Messages carry retrieved sources in metadata for reload.
+
+const TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+export interface KbChatSessionDTO {
+    id: string;
+    title: string;
+    knowledgeBaseId: string | null;
+    createdAt: number;
+    updatedAt: number;
+    ownerUserId: string;
+}
+
+export interface KbAttachment {
+    name: string;
+    url: string; // data URL (data:<type>;base64,<data>)
+}
+
+export interface KbStoredMessage {
+    role: "user" | "assistant";
+    content: string;
+    sources?: KBSource[];
+    attachments?: KbAttachment[];
+    createdAt?: number;
+}
+
+export class KbChatStore {
+    async listSessions(tenantId: string): Promise<KbChatSessionDTO[]> {
+        const prisma = getPrismaClient();
+        const sessions = await prisma.kbChatSession.findMany({
+            where: { tenantId },
+            orderBy: { updatedAt: "desc" },
+            take: 50,
+        });
+        return sessions.map((s) => ({
+            id: s.sessionId,
+            title: s.title,
+            knowledgeBaseId: s.knowledgeBaseId ?? null,
+            createdAt: s.createdAt.getTime(),
+            updatedAt: s.updatedAt.getTime(),
+            ownerUserId: s.userId,
+        }));
+    }
+
+    async getSession(tenantId: string, sessionId: string): Promise<KbChatSessionDTO | undefined> {
+        const prisma = getPrismaClient();
+        const s = await prisma.kbChatSession.findFirst({ where: { sessionId, tenantId } });
+        if (!s) return undefined;
+        return {
+            id: s.sessionId,
+            title: s.title,
+            knowledgeBaseId: s.knowledgeBaseId ?? null,
+            createdAt: s.createdAt.getTime(),
+            updatedAt: s.updatedAt.getTime(),
+            ownerUserId: s.userId,
+        };
+    }
+
+    async createSession(args: {
+        sessionId: string;
+        tenantId: string;
+        userId: string;
+        title?: string;
+        knowledgeBaseId?: string | null;
+    }): Promise<KbChatSessionDTO> {
+        const prisma = getPrismaClient();
+        const s = await prisma.kbChatSession.upsert({
+            where: { sessionId: args.sessionId },
+            create: {
+                tenantId: args.tenantId,
+                sessionId: args.sessionId,
+                userId: args.userId,
+                title: args.title?.trim() || "New Chat",
+                knowledgeBaseId: args.knowledgeBaseId ?? null,
+            },
+            update: { updatedAt: new Date() },
+        });
+        return {
+            id: s.sessionId,
+            title: s.title,
+            knowledgeBaseId: s.knowledgeBaseId ?? null,
+            createdAt: s.createdAt.getTime(),
+            updatedAt: s.updatedAt.getTime(),
+            ownerUserId: s.userId,
+        };
+    }
+
+    async touchSession(tenantId: string, sessionId: string): Promise<void> {
+        const prisma = getPrismaClient();
+        try {
+            await prisma.kbChatSession.updateMany({
+                where: { sessionId, tenantId },
+                data: { updatedAt: new Date() },
+            });
+        } catch {
+            /* ignore */
+        }
+    }
+
+    async deleteSession(tenantId: string, sessionId: string): Promise<boolean> {
+        const prisma = getPrismaClient();
+        try {
+            await prisma.kbChatMessage.deleteMany({ where: { tenantId, sessionId } });
+            const res = await prisma.kbChatSession.deleteMany({ where: { tenantId, sessionId } });
+            return res.count > 0;
+        } catch {
+            return false;
+        }
+    }
+
+    async getMessages(tenantId: string, sessionId: string): Promise<KbStoredMessage[]> {
+        const prisma = getPrismaClient();
+        const rows = await prisma.kbChatMessage.findMany({
+            where: { tenantId, sessionId },
+            orderBy: { createdAt: "asc" },
+        });
+        return rows.map((r) => {
+            const meta = (r.metadata as { sources?: KBSource[]; attachments?: KbAttachment[] } | null) ?? null;
+            return {
+                role: r.role === "assistant" ? "assistant" : "user",
+                content: r.content,
+                sources: meta?.sources,
+                attachments: meta?.attachments,
+                createdAt: r.createdAt.getTime(),
+            } as KbStoredMessage;
+        });
+    }
+
+    async addMessages(
+        tenantId: string,
+        sessionId: string,
+        messages: KbStoredMessage[],
+    ): Promise<void> {
+        if (messages.length === 0) return;
+        const prisma = getPrismaClient();
+        const expiresAt = new Date(Date.now() + TTL_MS);
+        await prisma.kbChatMessage.createMany({
+            data: messages.map((m) => {
+                const meta: { sources?: KBSource[]; attachments?: KbAttachment[] } = {};
+                if (m.sources && m.sources.length > 0) meta.sources = m.sources;
+                if (m.attachments && m.attachments.length > 0) meta.attachments = m.attachments;
+                return {
+                    tenantId,
+                    sessionId,
+                    role: m.role,
+                    content: m.content,
+                    metadata: Object.keys(meta).length > 0 ? (meta as Prisma.InputJsonValue) : undefined,
+                    expiresAt,
+                };
+            }),
+            skipDuplicates: true,
+        });
+    }
+}
+
+export const kbChatStore = new KbChatStore();

--- a/libs/prisma/migrations/20260630000000_add_kb_chat_sessions/migration.sql
+++ b/libs/prisma/migrations/20260630000000_add_kb_chat_sessions/migration.sql
@@ -1,0 +1,39 @@
+-- CreateTable
+CREATE TABLE "kb_chat_sessions" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "title" TEXT NOT NULL DEFAULT 'New Chat',
+    "knowledgeBaseId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "kb_chat_sessions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "kb_chat_messages" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "role" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "kb_chat_messages_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "kb_chat_sessions_sessionId_key" ON "kb_chat_sessions"("sessionId");
+
+-- CreateIndex
+CREATE INDEX "kb_chat_sessions_tenantId_updatedAt_idx" ON "kb_chat_sessions"("tenantId", "updatedAt");
+
+-- CreateIndex
+CREATE INDEX "kb_chat_messages_tenantId_sessionId_createdAt_idx" ON "kb_chat_messages"("tenantId", "sessionId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "kb_chat_messages_expiresAt_idx" ON "kb_chat_messages"("expiresAt");

--- a/libs/prisma/schema.prisma
+++ b/libs/prisma/schema.prisma
@@ -547,6 +547,41 @@ model ChatSession {
   @@map("chat_sessions")
 }
 
+// KbChatSession — saved Knowledge Base "Ask AI" chat sessions (tenant-shared)
+// Isolated from agent ChatSession so the agent sidebar (/api/threads) never mixes in KB chats.
+// knowledgeBaseId: null = "All Knowledge Bases". userId is creator attribution only.
+model KbChatSession {
+  id              String   @id @default(cuid())
+  tenantId        String
+  sessionId       String   @unique // tenantId:userId:timestamp
+  userId          String
+  title           String   @default("New Chat")
+  knowledgeBaseId String?
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+
+  @@index([tenantId, updatedAt])
+  @@map("kb_chat_sessions")
+}
+
+// KbChatMessage — message history for KB "Ask AI" sessions
+// role: user|assistant. metadata stores retrieved sources ({ sources?: KBSource[] }).
+// expiresAt: 30-day TTL (same cleanup pattern as ChatMessage).
+model KbChatMessage {
+  id        String   @id @default(cuid())
+  tenantId  String
+  sessionId String
+  role      String   // user|assistant
+  content   String
+  metadata  Json?
+  createdAt DateTime @default(now())
+  expiresAt DateTime // 30-day TTL
+
+  @@index([tenantId, sessionId, createdAt])
+  @@index([expiresAt])
+  @@map("kb_chat_messages")
+}
+
 // CustomRole — preset (global) and tenant-scoped custom roles with per-module permission sets (Phase 13 RBAC)
 // type: 'preset' = global (tenantId=null), 'custom' = tenant-scoped
 // permissions column stores PermissionSet shape: { Accounts: ['read','update'], ... }


### PR DESCRIPTION
## Summary

Turns the Knowledge Base **Ask AI** page into a polished, chatbot-style assistant with three additions, all mirroring patterns already proven in the AIOps console.

### 1. Persistent sessions (tenant-shared)
- New Prisma models `KbChatSession` + `KbChatMessage` (`kb_chat_sessions` / `kb_chat_messages`, 30-day TTL, `knowledgeBaseId` per session). **Isolated** from agent chat so the agent sidebar (`/api/threads`) never mixes in KB sessions. Migration `20260630000000_add_kb_chat_sessions`.
- `kbChatStore` (`lib/store/kb-chat-store.ts`) + routes: `GET /api/knowledge-base/sessions`, `DELETE /sessions/[id]`, `GET /sessions/[id]/history`. The query route creates/resolves a session, persists the user + assistant messages, and returns the id via `X-KB-Session-Id`.
- TanStack hooks `lib/queries/kb-chat.ts` (+ `queryKeys.kbChat`). New two-pane UI: a **Sessions** sidebar (`kb-chat-sidebar.tsx`) that lists, loads, and deletes conversations, beside a refreshed empty state + input.

### 2. Image upload (images only, persisted)
- Reuses the AIOps `components/agent/file-upload.tsx` (paperclip, thumbnails, 5MB, image MIME allowlist, base64). Attachments are sent as data URLs and built into a multimodal LangChain `HumanMessage`. Images **persist in message metadata** and re-hydrate when a saved session is reopened. Retrieval/embedding stays text-only.

### 3. Model selection
- A **Model** dropdown in the toolbar (via `useProviderModels()`); the query route honors the chosen model through `resolveModelConfig()`, falling back to the tenant default. The resolver already validates tenant ownership + decrypts credentials.

No new components beyond the sidebar; image upload and model selection are pure reuse. One DB migration (the new chat tables); attachments ride in the existing `metadata` JSONB.

## Verification
- `tsc` adds **zero new type errors** vs baseline; ESLint clean on all changed files.
- Playwright (authenticated) end-to-end: send → persist (DB-confirmed) → reload → sidebar list → click → hydrate → delete → reset; model dropdown + Attach Images render; the send request carries `query` + `attachments` (data URLs) + `model`; the uploaded image persists to `kb_chat_messages.metadata` and re-hydrates on session reload; graceful "No LLM provider configured" error path intact.
- `tests/agent/file-upload.test.ts`: 6/7 pass (the 1 failure is a pre-existing `FileReader is not defined` node-env issue, unrelated to this change).
- Full multimodal *answer* not exercised live (test tenant has no vision-capable provider); request shape, persistence, and reload are all confirmed.

## Notes for reviewers
- Multi-tenant: every session/message query is tenant-scoped; cross-tenant get/delete return 404 (verified). `$queryRawUnsafe` pgvector search already passes `tenantId` explicitly.
- Run `prisma migrate deploy` (the migration only creates the two new tables — it does **not** touch existing pgvector indexes or LangGraph checkpoint tables).

🤖 Generated with [Claude Code](https://claude.com/claude-code)