### PR TITLE
Memory data-table revamp, skill distillation redesign, MCP form UI overhaul

### DIFF
--- a/apps/web-ui/app/api/agent-memories/agent-memories-api.test.ts
+++ b/apps/web-ui/app/api/agent-memories/agent-memories-api.test.ts
@@ -75,6 +75,33 @@ describe('GET /api/agent-memories', () => {
             expect.objectContaining({ categories: [] })
         );
     });
+
+    it('parses a valid sort field + direction', async () => {
+        repo.listByTenant.mockResolvedValue({ memories: [], total: 0 });
+        const req = new Request('http://localhost/api/agent-memories?sort=createdAt&dir=desc');
+        await GET(req as any);
+        expect(repo.listByTenant).toHaveBeenCalledWith(
+            expect.objectContaining({ sortBy: 'createdAt', sortDir: 'desc' })
+        );
+    });
+
+    it('ignores an invalid sort field and leaves sort undefined', async () => {
+        repo.listByTenant.mockResolvedValue({ memories: [], total: 0 });
+        const req = new Request('http://localhost/api/agent-memories?sort=bogus&dir=asc');
+        await GET(req as any);
+        expect(repo.listByTenant).toHaveBeenCalledWith(
+            expect.objectContaining({ sortBy: undefined, sortDir: undefined })
+        );
+    });
+
+    it('defaults sort direction to asc for a valid field', async () => {
+        repo.listByTenant.mockResolvedValue({ memories: [], total: 0 });
+        const req = new Request('http://localhost/api/agent-memories?sort=key');
+        await GET(req as any);
+        expect(repo.listByTenant).toHaveBeenCalledWith(
+            expect.objectContaining({ sortBy: 'key', sortDir: 'asc' })
+        );
+    });
 });
 
 describe('DELETE /api/agent-memories/[id]', () => {

--- a/apps/web-ui/app/api/agent-memories/agent-memories-api.test.ts
+++ b/apps/web-ui/app/api/agent-memories/agent-memories-api.test.ts
@@ -43,7 +43,7 @@ describe('GET /api/agent-memories', () => {
         const body = await res.json();
 
         expect(repo.listByTenant).toHaveBeenCalledWith(
-            expect.objectContaining({ tenantId: 'tenant-a', category: 'infra', search: 'ecs' })
+            expect.objectContaining({ tenantId: 'tenant-a', categories: ['infra'], search: 'ecs' })
         );
         expect(body).toEqual({ success: true, data: [{ id: 'mem-1' }], total: 1 });
     });
@@ -56,6 +56,24 @@ describe('GET /api/agent-memories', () => {
         const res = await GET(req as any);
         expect(res.status).toBe(403);
         expect(repo.listByTenant).not.toHaveBeenCalled();
+    });
+
+    it('parses a comma-separated category param into a validated categories array', async () => {
+        repo.listByTenant.mockResolvedValue({ memories: [], total: 0 });
+        const req = new Request('http://localhost/api/agent-memories?category=infra,user,bogus');
+        await GET(req as any);
+        expect(repo.listByTenant).toHaveBeenCalledWith(
+            expect.objectContaining({ categories: ['infra', 'user'] })
+        );
+    });
+
+    it('passes an empty categories array when no category param is present', async () => {
+        repo.listByTenant.mockResolvedValue({ memories: [], total: 0 });
+        const req = new Request('http://localhost/api/agent-memories');
+        await GET(req as any);
+        expect(repo.listByTenant).toHaveBeenCalledWith(
+            expect.objectContaining({ categories: [] })
+        );
     });
 });
 

--- a/apps/web-ui/app/api/agent-memories/route.ts
+++ b/apps/web-ui/app/api/agent-memories/route.ts
@@ -13,16 +13,15 @@ export async function GET(request: NextRequest) {
         if (authError) return authError;
 
         const { searchParams } = new URL(request.url);
-        const rawCategory = searchParams.get('category');
-        const category =
-            rawCategory && VALID_CATEGORIES.has(rawCategory as MemoryCategory)
-                ? (rawCategory as MemoryCategory)
-                : undefined;
+        const categories = (searchParams.get('category') ?? '')
+            .split(',')
+            .map((c) => c.trim())
+            .filter((c): c is MemoryCategory => VALID_CATEGORIES.has(c as MemoryCategory));
 
         const repo = getAgentMemoryRepository();
         const result = await repo.listByTenant({
             tenantId,
-            category,
+            categories,
             search: searchParams.get('search') || undefined,
             limit: parseInt(searchParams.get('limit') || '100', 10),
             page: parseInt(searchParams.get('page') || '1', 10),

--- a/apps/web-ui/app/api/agent-memories/route.ts
+++ b/apps/web-ui/app/api/agent-memories/route.ts
@@ -3,8 +3,10 @@ import { getAgentMemoryRepository } from '@/lib/db/repository-factory';
 import { getSessionTenantId } from '@/lib/auth-session';
 import { authorize } from '@/lib/rbac/authorize';
 import type { MemoryCategory } from '@/lib/agent-memory/category';
+import type { AgentMemorySortField, SortDirection } from '@/lib/db/repositories/agent-memory/interface';
 
 const VALID_CATEGORIES = new Set<MemoryCategory>(['infra', 'user', 'patterns', 'errors', 'other']);
+const VALID_SORT_FIELDS = new Set<AgentMemorySortField>(['category', 'key', 'createdAt', 'expiresAt']);
 
 export async function GET(request: NextRequest) {
     try {
@@ -18,6 +20,12 @@ export async function GET(request: NextRequest) {
             .map((c) => c.trim())
             .filter((c): c is MemoryCategory => VALID_CATEGORIES.has(c as MemoryCategory));
 
+        const sortParam = searchParams.get('sort');
+        const sortBy = sortParam && VALID_SORT_FIELDS.has(sortParam as AgentMemorySortField)
+            ? (sortParam as AgentMemorySortField)
+            : undefined;
+        const sortDir: SortDirection = searchParams.get('dir') === 'desc' ? 'desc' : 'asc';
+
         const repo = getAgentMemoryRepository();
         const result = await repo.listByTenant({
             tenantId,
@@ -25,6 +33,8 @@ export async function GET(request: NextRequest) {
             search: searchParams.get('search') || undefined,
             limit: parseInt(searchParams.get('limit') || '100', 10),
             page: parseInt(searchParams.get('page') || '1', 10),
+            sortBy,
+            sortDir: sortBy ? sortDir : undefined,
         });
 
         return NextResponse.json({ success: true, data: result.memories, total: result.total });

--- a/apps/web-ui/app/api/skills/[id]/route.ts
+++ b/apps/web-ui/app/api/skills/[id]/route.ts
@@ -22,6 +22,7 @@ function toDTO(s: SkillRecord) {
         isEnabled: s.isEnabled,
         createdBy: s.createdBy,
         content: s.content,
+        createdAt: s.createdAt,
         updatedAt: s.updatedAt,
     };
 }

--- a/apps/web-ui/app/api/skills/distill/route.test.ts
+++ b/apps/web-ui/app/api/skills/distill/route.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('next/server', () => ({
+    NextRequest: vi.fn(),
+    NextResponse: {
+        json: vi.fn((data: unknown, init?: { status?: number }) => ({
+            _data: data,
+            _status: init?.status ?? 200,
+            status: init?.status ?? 200,
+            json: async () => data,
+        })),
+    },
+}));
+
+vi.mock('@/lib/rbac/authorize', () => ({ authorize: vi.fn() }));
+vi.mock('@/lib/auth-session', () => ({ getSessionTenantId: vi.fn() }));
+vi.mock('@/lib/agent/model-resolver', () => ({ resolveDefaultModelConfig: vi.fn() }));
+vi.mock('@/lib/agent/model-factory', () => ({ createAgentModels: vi.fn() }));
+vi.mock('@/lib/agent/provider-errors', () => ({
+    isProviderConfigError: vi.fn((err: unknown) => err instanceof ProviderConfigError),
+    ProviderConfigError: class ProviderConfigError extends Error {
+        constructor(message: string) {
+            super(message);
+            this.name = 'ProviderConfigError';
+        }
+    },
+}));
+
+import { POST } from './route';
+import { authorize } from '@/lib/rbac/authorize';
+import { getSessionTenantId } from '@/lib/auth-session';
+import { resolveDefaultModelConfig } from '@/lib/agent/model-resolver';
+import { createAgentModels } from '@/lib/agent/model-factory';
+import { ProviderConfigError, isProviderConfigError } from '@/lib/agent/provider-errors';
+
+const makeRequest = (body?: unknown) => ({ json: vi.fn().mockResolvedValue(body ?? {}) }) as any;
+
+const validDraftJson = JSON.stringify({
+    name: 'Review Cost Trends',
+    description: 'Use when asked to review AWS cost trends.',
+    tier: 'read-only',
+    content: '# Review Cost Trends\n1. Run `aws ce get-cost-and-usage`.',
+});
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authorize).mockResolvedValue(null);
+    vi.mocked(getSessionTenantId).mockResolvedValue('t1');
+    vi.mocked(resolveDefaultModelConfig).mockResolvedValue({ provider: 'anthropic', modelId: 'm1' } as any);
+});
+
+describe('POST /api/skills/distill', () => {
+    it('403s when authorize denies', async () => {
+        vi.mocked(authorize).mockResolvedValue({ status: 403, _data: { error: 'Forbidden' }, _status: 403 } as any);
+        const res = await POST(makeRequest({ transcript: 'USER: hi' }));
+        expect(res).toEqual({ status: 403, _data: { error: 'Forbidden' }, _status: 403 });
+    });
+
+    it('400s on missing transcript', async () => {
+        const res = await POST(makeRequest({}));
+        expect((res as any)._status).toBe(400);
+        expect((res as any)._data.success).toBe(false);
+    });
+
+    it('413s when transcript exceeds the size guard, without calling the model', async () => {
+        const hugeTranscript = 'a'.repeat(600_001);
+        const invoke = vi.fn();
+        vi.mocked(createAgentModels).mockReturnValue({ main: { invoke }, reflector: {} } as any);
+        const res = await POST(makeRequest({ transcript: hugeTranscript }));
+        expect((res as any)._status).toBe(413);
+        expect((res as any)._data.success).toBe(false);
+        expect(invoke).not.toHaveBeenCalled();
+    });
+
+    it('sends the full transcript to the model with no truncation', async () => {
+        const longTranscript = `USER: ${'b'.repeat(100_000)}`;
+        const invoke = vi.fn().mockResolvedValue({ content: validDraftJson });
+        vi.mocked(createAgentModels).mockReturnValue({ main: { invoke }, reflector: {} } as any);
+        await POST(makeRequest({ transcript: longTranscript }));
+        expect(invoke).toHaveBeenCalledOnce();
+        const promptSent = invoke.mock.calls[0][0] as string;
+        expect(promptSent).toContain(longTranscript);
+    });
+
+    it('returns the parsed draft on success', async () => {
+        const invoke = vi.fn().mockResolvedValue({ content: validDraftJson });
+        vi.mocked(createAgentModels).mockReturnValue({ main: { invoke }, reflector: {} } as any);
+        const res = await POST(makeRequest({ transcript: 'USER: check my costs' }));
+        expect((res as any)._status).toBe(200);
+        expect((res as any)._data).toEqual({
+            success: true,
+            data: {
+                name: 'Review Cost Trends',
+                description: 'Use when asked to review AWS cost trends.',
+                tier: 'read-only',
+                content: '# Review Cost Trends\n1. Run `aws ce get-cost-and-usage`.',
+            },
+        });
+    });
+
+    it('502s when the model does not return valid JSON', async () => {
+        const invoke = vi.fn().mockResolvedValue({ content: 'not json' });
+        vi.mocked(createAgentModels).mockReturnValue({ main: { invoke }, reflector: {} } as any);
+        const res = await POST(makeRequest({ transcript: 'USER: hi' }));
+        expect((res as any)._status).toBe(502);
+        expect((res as any)._data.success).toBe(false);
+    });
+
+    it('falls back to read-only when the model returns an invalid tier', async () => {
+        const invoke = vi.fn().mockResolvedValue({
+            content: JSON.stringify({ name: 'X', description: 'd', tier: 'nonsense', content: 'c' }),
+        });
+        vi.mocked(createAgentModels).mockReturnValue({ main: { invoke }, reflector: {} } as any);
+        const res = await POST(makeRequest({ transcript: 'USER: hi' }));
+        expect((res as any)._data.data.tier).toBe('read-only');
+    });
+
+    it('400s with the provider message when no default provider is configured', async () => {
+        vi.mocked(resolveDefaultModelConfig).mockRejectedValue(new ProviderConfigError('No LLM provider is configured.'));
+        const res = await POST(makeRequest({ transcript: 'USER: hi' }));
+        expect((res as any)._status).toBe(400);
+        expect((res as any)._data.error).toBe('No LLM provider is configured.');
+    });
+});

--- a/apps/web-ui/app/api/skills/distill/route.ts
+++ b/apps/web-ui/app/api/skills/distill/route.ts
@@ -9,12 +9,42 @@ import { resolveDefaultModelConfig } from '@/lib/agent/model-resolver';
 import { createAgentModels } from '@/lib/agent/model-factory';
 import { isProviderConfigError } from '@/lib/agent/provider-errors';
 
-const DISTILL_PROMPT = `You are distilling a CloudOps chat transcript into a reusable agent "skill".
+/**
+ * No per-model context-window figure is tracked anywhere in this codebase (the
+ * `maxTokens` field on provider records is the output completion cap, not input
+ * size). This is a conservative, provider-agnostic backstop against pathological
+ * input (~150k tokens at ~4 chars/token) — comfortably under mainstream
+ * 128k-200k-token context windows — not a routine limiter.
+ */
+const MAX_TRANSCRIPT_CHARS = 600_000;
+
+const DISTILL_PROMPT = `You are distilling an AI agent's chat transcript into a reusable "skill" — a
+generalized procedure the same agent can follow again for similar future requests.
+
+The transcript may include TOOL_CALL / TOOL_RESULT blocks showing the exact
+tools, commands, or API calls the agent actually used (AWS CLI, AWS SDK calls,
+Slack/Jira/other MCP tool calls, file operations, etc.) — this platform is not
+limited to any one domain. Infer the actual domain and tools from the
+transcript itself; do not assume AWS or any other specific system.
+
 Return ONLY a JSON object (no markdown fences) with keys:
 - "name": short Title Case name (max 5 words)
 - "description": one sentence describing when to use this skill
-- "tier": one of "read-only" | "mutation" | "approval-gated" (pick based on whether the procedure only reads, or also creates/updates/deletes resources)
-- "content": a markdown SKILL body with a one-line intro and a numbered, generalized step-by-step procedure (strip account-specific IDs; describe the repeatable method, not the one-off answer).
+- "tier": one of "read-only" | "mutation" | "approval-gated" — pick based on
+  what the actual tool calls did:
+  - "read-only": every tool call only queried/read/listed state, nothing was
+    changed anywhere
+  - "mutation": at least one tool call created, updated, deleted, sent, or
+    posted something in any external system (cloud resources, tickets,
+    messages, files, etc.)
+  - "approval-gated": the transcript shows a destructive/irreversible action,
+    or the agent explicitly asked for human confirmation before proceeding
+- "content": a markdown SKILL body with a one-line intro and a numbered,
+  generalized step-by-step procedure GROUNDED in the actual tool calls made
+  (name the real commands/API calls/tool names used, not generic UI
+  navigation). Strip one-off identifiers (specific account/resource IDs,
+  ticket numbers, usernames) and replace with placeholders — describe the
+  repeatable method, not the one-off answer.
 
 Transcript:
 `;
@@ -32,9 +62,18 @@ export async function POST(request: NextRequest) {
                 { status: 400 }
             );
         }
+        if (transcript.length > MAX_TRANSCRIPT_CHARS) {
+            return NextResponse.json(
+                {
+                    success: false,
+                    error: `This conversation is too long to distill in a single pass (~${Math.round(transcript.length / 1000)}k chars, limit ~${Math.round(MAX_TRANSCRIPT_CHARS / 1000)}k). Try a shorter portion of the chat, or configure a larger-context model as your tenant default.`,
+                },
+                { status: 413 }
+            );
+        }
         const modelConfig = await resolveDefaultModelConfig(tenantId);
         const { main } = createAgentModels(modelConfig);
-        const resp = await main.invoke(`${DISTILL_PROMPT}\n${transcript.slice(0, 24000)}`);
+        const resp = await main.invoke(`${DISTILL_PROMPT}\n${transcript}`);
         const raw = typeof resp.content === 'string' ? resp.content : JSON.stringify(resp.content);
         const jsonText = raw.replace(/^```(?:json)?/i, '').replace(/```$/i, '').trim();
         let draft: { name?: string; description?: string; tier?: string; content?: string };

--- a/apps/web-ui/app/api/skills/route.ts
+++ b/apps/web-ui/app/api/skills/route.ts
@@ -20,6 +20,7 @@ function toDTO(s: SkillRecord) {
         source: s.source,
         isEnabled: s.isEnabled,
         createdBy: s.createdBy,
+        createdAt: s.createdAt,
         updatedAt: s.updatedAt,
     };
 }

--- a/apps/web-ui/components/agent/chat-interface.tsx
+++ b/apps/web-ui/components/agent/chat-interface.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
+import { buildChatTranscript } from "@/lib/agent/build-chat-transcript";
 import { MarkdownContent } from "@/components/ui/markdown-content";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import {
@@ -783,13 +784,7 @@ export function ChatInterface({
 
   const handleSaveAsSkill = async () => {
     if (messages.length === 0) return;
-    const transcript = messages.map((m: any) => {
-      const text = (m.parts ?? [])
-        .filter((p: { type: string }) => p.type === "text")
-        .map((p: { text?: string }) => p.text ?? "")
-        .join("\n") || (typeof m.content === "string" ? m.content : "");
-      return `${m.role.toUpperCase()}: ${text}`;
-    }).join("\n\n");
+    const transcript = buildChatTranscript(messages as any);
     try {
       const draft = await distillSkill.mutateAsync({ threadId, transcript });
       setSkillDraft(draft);

--- a/apps/web-ui/components/agent/chat-interface.tsx
+++ b/apps/web-ui/components/agent/chat-interface.tsx
@@ -4,6 +4,7 @@ import { useChat } from "@ai-sdk/react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { SpinnerOverlay } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
 import { buildChatTranscript } from "@/lib/agent/build-chat-transcript";
 import { MarkdownContent } from "@/components/ui/markdown-content";
@@ -836,7 +837,7 @@ export function ChatInterface({
 
   const handleFormSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!inputValue.trim() || isLoading) return;
+    if (!inputValue.trim() || isLoading || distillSkill.isPending) return;
 
     const value = inputValue;
     const files = attachments;
@@ -1243,7 +1244,12 @@ export function ChatInterface({
 
   return (
     <>
-    <div className="flex flex-col h-full w-full overflow-hidden bg-background max-w-[95%] mx-auto border rounded-xl shadow-lg">
+    <div className="relative flex flex-col h-full w-full overflow-hidden bg-background max-w-[95%] mx-auto border rounded-xl shadow-lg">
+      {distillSkill.isPending && (
+        <div className="absolute inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm rounded-xl">
+          <SpinnerOverlay label="Generating skill..." />
+        </div>
+      )}
       {/* Header */}
       <div className="px-4 py-3 border-b bg-gradient-to-r from-primary/10 to-primary/5 flex items-center gap-3">
         <Avatar className="h-9 w-9 border shadow-sm shrink-0">
@@ -1436,7 +1442,7 @@ export function ChatInterface({
                   variant="ghost"
                   size="sm"
                   type="button"
-                  disabled={isLoading}
+                  disabled={isLoading || distillSkill.isPending}
                   className="h-7 text-xs border-transparent bg-transparent hover:bg-muted/50 focus:ring-0 gap-1 px-2 w-auto min-w-[150px] justify-start"
                   onClick={() => !isLoading && setAccountDropdownOpen(!accountDropdownOpen)}
                 >
@@ -1574,7 +1580,7 @@ export function ChatInterface({
               </div>
 
               {/* Model Selector */}
-              <Select value={selectedModel} onValueChange={setSelectedModel} disabled={isLoading}>
+              <Select value={selectedModel} onValueChange={setSelectedModel} disabled={isLoading || distillSkill.isPending}>
                 <SelectTrigger className="h-7 text-xs border-transparent bg-transparent hover:bg-muted/50 focus:ring-0 gap-1 px-2 w-auto min-w-[180px]">
                   <div className="flex items-center gap-1.5">
                     <Sparkles className="w-3 h-3 text-primary" />
@@ -1641,7 +1647,7 @@ export function ChatInterface({
                 onValueChange={(value) =>
                   setSelectedSkill(value === "none" ? null : value)
                 }
-                disabled={hasStarted || isLoading}
+                disabled={hasStarted || isLoading || distillSkill.isPending}
               >
                 <SelectTrigger className="h-7 text-xs border-transparent bg-transparent hover:bg-muted/50 focus:ring-0 gap-1 px-2 w-auto min-w-[180px]">
                   <div className="flex items-center gap-1.5">
@@ -1695,7 +1701,7 @@ export function ChatInterface({
                         variant="ghost"
                         size="sm"
                         type="button"
-                        disabled={isLoading}
+                        disabled={isLoading || distillSkill.isPending}
                         className="h-7 text-xs border-transparent bg-transparent hover:bg-muted/50 focus:ring-0 gap-1 px-2 w-auto min-w-[140px] justify-start"
                       >
                         <div className="flex items-center gap-1.5">
@@ -1869,7 +1875,7 @@ export function ChatInterface({
                 size="icon"
                 className="h-7 w-7 rounded-md text-muted-foreground hover:text-destructive"
                 onClick={handleClear}
-                disabled={isLoading}
+                disabled={isLoading || distillSkill.isPending}
                 title="Clear conversation"
               >
                 <Trash2 className="w-3.5 h-3.5" />
@@ -1884,7 +1890,7 @@ export function ChatInterface({
               onChange={handleInputChange}
               onKeyDown={handleKeyDown}
               placeholder="Ask the agent to plan, execute, reflect, and revise..."
-              disabled={isLoading}
+              disabled={isLoading || distillSkill.isPending}
               data-testid="chat-input"
               className="min-h-[80px] max-h-[500px] w-full border-0 focus-visible:ring-0 resize-y overflow-y-auto p-3 text-xs bg-transparent"
             />
@@ -1895,7 +1901,7 @@ export function ChatInterface({
             <FileUpload
               files={attachments}
               onFilesChange={setAttachments}
-              disabled={isLoading}
+              disabled={isLoading || distillSkill.isPending}
             />
           </div>
 
@@ -1903,7 +1909,7 @@ export function ChatInterface({
           <div className="flex items-center justify-between px-3 py-2 border-t bg-muted/10">
             <div className="flex items-center gap-4">
               <div className="flex items-center space-x-2">
-                <Select value={agentMode} onValueChange={setAgentMode} disabled={isLoading}>
+                <Select value={agentMode} onValueChange={setAgentMode} disabled={isLoading || distillSkill.isPending}>
                   <SelectTrigger className="h-7 text-xs border-transparent bg-transparent hover:bg-muted/50 focus:ring-0 gap-1 px-2 w-auto min-w-[100px]">
                     <SelectValue placeholder="Mode" />
                   </SelectTrigger>
@@ -1928,7 +1934,7 @@ export function ChatInterface({
                   onCheckedChange={(checked) =>
                     setAutoApprove(checked === true)
                   }
-                  disabled={isLoading}
+                  disabled={isLoading || distillSkill.isPending}
                   className="data-[state=checked]:bg-green-600 data-[state=checked]:border-green-600 h-4 w-4"
                 />
                 <Label
@@ -1944,7 +1950,7 @@ export function ChatInterface({
                   id="show-tools"
                   checked={showTools}
                   onCheckedChange={(checked) => setShowTools(checked === true)}
-                  disabled={isLoading}
+                  disabled={isLoading || distillSkill.isPending}
                   className="h-4 w-4 rounded-sm"
                 />
                 <Label
@@ -1966,7 +1972,7 @@ export function ChatInterface({
                 size="icon"
                 onClick={handleEnhancePrompt}
                 disabled={
-                  !inputValue.trim() || isLoading || isEnhancing
+                  !inputValue.trim() || isLoading || isEnhancing || distillSkill.isPending
                 }
                 className={cn(
                   "h-8 w-8 rounded-full shrink-0 transition-all text-muted-foreground hover:text-primary",
@@ -1983,7 +1989,7 @@ export function ChatInterface({
               <Button
                 type={isLoading ? "button" : "submit"}
                 onClick={isLoading ? handleStop : undefined}
-                disabled={!isLoading && !inputValue.trim()}
+                disabled={(!isLoading && !inputValue.trim()) || distillSkill.isPending}
                 size="icon"
                 data-testid="chat-send-button"
                 className={cn(

--- a/apps/web-ui/components/memory/memory-client-component.tsx
+++ b/apps/web-ui/components/memory/memory-client-component.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import type { ColumnDef, PaginationState } from "@tanstack/react-table";
+import type { ColumnDef, PaginationState, SortingState } from "@tanstack/react-table";
 import { Brain, MoreHorizontal, Eye, Trash2, Search, X } from "lucide-react";
 import { toast } from "sonner";
 import { PageHeader } from "@/components/shared/page-header";
@@ -9,6 +9,7 @@ import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
+import { DataTableColumnHeader } from "@/components/ui/data-table-column-header";
 import { DataTableFacetedFilter } from "@/components/ui/data-table-faceted-filter";
 import {
     DropdownMenu,
@@ -21,6 +22,7 @@ import {
     useAgentMemories,
     useDeleteAgentMemory,
     type MemoryRow,
+    type MemorySortField,
 } from "@/lib/queries/agent-memories";
 import { useDebounce } from "@/hooks/use-debounce";
 import { MemoryDetailDialog } from "./memory-detail-dialog";
@@ -39,17 +41,21 @@ function confidenceVariant(c: string | null): "default" | "secondary" | "outline
 
 export function MemoryClientComponent() {
     const [pagination, setPagination] = useState<PaginationState>({ pageIndex: 0, pageSize: 10 });
+    const [sorting, setSorting] = useState<SortingState>([]);
     const [searchInput, setSearchInput] = useState("");
     const search = useDebounce(searchInput, 300);
     const [categories, setCategories] = useState<MemoryCategory[]>([]);
     const [detail, setDetail] = useState<MemoryRow | null>(null);
     const [deleteTarget, setDeleteTarget] = useState<MemoryRow | null>(null);
 
+    const sort = sorting[0];
     const { data, isLoading } = useAgentMemories({
         page: pagination.pageIndex + 1,
         limit: pagination.pageSize,
         categories: categories.length ? categories : undefined,
         search: search || undefined,
+        sortBy: sort ? (sort.id as MemorySortField) : undefined,
+        sortDir: sort ? (sort.desc ? "desc" : "asc") : undefined,
     });
     const memories = data?.data ?? [];
     const total = data?.total ?? 0;
@@ -57,6 +63,11 @@ export function MemoryClientComponent() {
 
     // Any server-side filter change must return to the first page.
     const resetToFirstPage = () => setPagination((p) => ({ ...p, pageIndex: 0 }));
+    // Sorting is server-side too, so a new sort must also reset to page 1.
+    const handleSortingChange: typeof setSorting = (updater) => {
+        setSorting(updater);
+        resetToFirstPage();
+    };
     const handleSearchChange = (v: string) => {
         setSearchInput(v);
         resetToFirstPage();
@@ -91,14 +102,12 @@ export function MemoryClientComponent() {
         () => [
             {
                 accessorKey: "category",
-                header: "Category",
-                enableSorting: false,
+                header: ({ column }) => <DataTableColumnHeader column={column} title="Category" />,
                 cell: ({ row }) => <Badge variant="outline">{row.original.category}</Badge>,
             },
             {
                 accessorKey: "key",
-                header: "Key",
-                enableSorting: false,
+                header: ({ column }) => <DataTableColumnHeader column={column} title="Key" />,
                 cell: ({ row }) => (
                     <button
                         type="button"
@@ -132,8 +141,7 @@ export function MemoryClientComponent() {
             },
             {
                 accessorKey: "createdAt",
-                header: "Created",
-                enableSorting: false,
+                header: ({ column }) => <DataTableColumnHeader column={column} title="Created" />,
                 cell: ({ row }) => (
                     <span className="whitespace-nowrap text-sm text-muted-foreground">
                         {new Date(row.original.createdAt).toLocaleDateString()}
@@ -142,8 +150,7 @@ export function MemoryClientComponent() {
             },
             {
                 accessorKey: "expiresAt",
-                header: "Expires",
-                enableSorting: false,
+                header: ({ column }) => <DataTableColumnHeader column={column} title="Expires" />,
                 cell: ({ row }) => (
                     <span className="whitespace-nowrap text-sm text-muted-foreground">
                         {new Date(row.original.expiresAt).toLocaleDateString()}
@@ -201,9 +208,11 @@ export function MemoryClientComponent() {
                 columns={columns}
                 data={memories}
                 loading={isLoading}
-                enableSorting={false}
                 enableFiltering={false}
                 manualPagination
+                manualSorting
+                sorting={sorting}
+                onSortingChange={handleSortingChange}
                 rowCount={total}
                 pagination={pagination}
                 onPaginationChange={setPagination}

--- a/apps/web-ui/components/memory/memory-client-component.tsx
+++ b/apps/web-ui/components/memory/memory-client-component.tsx
@@ -1,21 +1,21 @@
 "use client";
 
-import { useState } from "react";
-import { Brain } from "lucide-react";
+import { useMemo, useState } from "react";
+import type { ColumnDef, PaginationState } from "@tanstack/react-table";
+import { Brain, MoreHorizontal, Eye, Trash2, Search, X } from "lucide-react";
 import { toast } from "sonner";
 import { PageHeader } from "@/components/shared/page-header";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Spinner } from "@/components/ui/spinner";
+import { DataTable } from "@/components/ui/data-table";
+import { DataTableFacetedFilter } from "@/components/ui/data-table-faceted-filter";
 import {
-    Table,
-    TableBody,
-    TableCell,
-    TableHead,
-    TableHeader,
-    TableRow,
-} from "@/components/ui/table";
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { KNOWN_CATEGORIES, type MemoryCategory } from "@/lib/agent-memory/category";
 import {
     useAgentMemories,
@@ -26,31 +26,50 @@ import { useDebounce } from "@/hooks/use-debounce";
 import { MemoryDetailDialog } from "./memory-detail-dialog";
 import { DeleteMemoryDialog } from "./delete-memory-dialog";
 
-type Tab = "all" | MemoryCategory;
-const TABS: Tab[] = ["all", ...KNOWN_CATEGORIES, "other"];
-const TAB_LABEL: Record<Tab, string> = {
-    all: "All",
-    infra: "Infra",
-    user: "User",
-    patterns: "Patterns",
-    errors: "Errors",
-    other: "Other",
-};
+const CATEGORY_OPTIONS: { label: string; value: MemoryCategory }[] = [
+    ...KNOWN_CATEGORIES,
+    "other" as const,
+].map((c) => ({ label: c.charAt(0).toUpperCase() + c.slice(1), value: c }));
+
+function confidenceVariant(c: string | null): "default" | "secondary" | "outline" {
+    if (c === "high") return "default";
+    if (c === "medium") return "secondary";
+    return "outline";
+}
 
 export function MemoryClientComponent() {
-    const [tab, setTab] = useState<Tab>("all");
+    const [pagination, setPagination] = useState<PaginationState>({ pageIndex: 0, pageSize: 10 });
     const [searchInput, setSearchInput] = useState("");
     const search = useDebounce(searchInput, 300);
+    const [categories, setCategories] = useState<MemoryCategory[]>([]);
     const [detail, setDetail] = useState<MemoryRow | null>(null);
     const [deleteTarget, setDeleteTarget] = useState<MemoryRow | null>(null);
 
     const { data, isLoading } = useAgentMemories({
-        category: tab === "all" ? undefined : tab,
+        page: pagination.pageIndex + 1,
+        limit: pagination.pageSize,
+        categories: categories.length ? categories : undefined,
         search: search || undefined,
-        limit: 200,
     });
     const memories = data?.data ?? [];
+    const total = data?.total ?? 0;
     const del = useDeleteAgentMemory();
+
+    // Any server-side filter change must return to the first page.
+    const resetToFirstPage = () => setPagination((p) => ({ ...p, pageIndex: 0 }));
+    const handleSearchChange = (v: string) => {
+        setSearchInput(v);
+        resetToFirstPage();
+    };
+    const handleCategoriesChange = (values: string[]) => {
+        setCategories(values as MemoryCategory[]);
+        resetToFirstPage();
+    };
+    const clearFilters = () => {
+        setSearchInput("");
+        setCategories([]);
+        resetToFirstPage();
+    };
 
     const handleDelete = () => {
         if (!deleteTarget) return;
@@ -68,6 +87,108 @@ export function MemoryClientComponent() {
         });
     };
 
+    const columns = useMemo<ColumnDef<MemoryRow>[]>(
+        () => [
+            {
+                accessorKey: "category",
+                header: "Category",
+                enableSorting: false,
+                cell: ({ row }) => <Badge variant="outline">{row.original.category}</Badge>,
+            },
+            {
+                accessorKey: "key",
+                header: "Key",
+                enableSorting: false,
+                cell: ({ row }) => (
+                    <button
+                        type="button"
+                        onClick={() => setDetail(row.original)}
+                        className="text-left font-medium hover:underline"
+                    >
+                        {row.original.key}
+                    </button>
+                ),
+            },
+            {
+                accessorKey: "fact",
+                header: "Fact",
+                enableSorting: false,
+                cell: ({ row }) => (
+                    <span className="block max-w-md truncate">{row.original.fact}</span>
+                ),
+            },
+            {
+                accessorKey: "confidence",
+                header: "Confidence",
+                enableSorting: false,
+                cell: ({ row }) =>
+                    row.original.confidence ? (
+                        <Badge variant={confidenceVariant(row.original.confidence)}>
+                            {row.original.confidence}
+                        </Badge>
+                    ) : (
+                        <span className="text-muted-foreground">—</span>
+                    ),
+            },
+            {
+                accessorKey: "createdAt",
+                header: "Created",
+                enableSorting: false,
+                cell: ({ row }) => (
+                    <span className="whitespace-nowrap text-sm text-muted-foreground">
+                        {new Date(row.original.createdAt).toLocaleDateString()}
+                    </span>
+                ),
+            },
+            {
+                accessorKey: "expiresAt",
+                header: "Expires",
+                enableSorting: false,
+                cell: ({ row }) => (
+                    <span className="whitespace-nowrap text-sm text-muted-foreground">
+                        {new Date(row.original.expiresAt).toLocaleDateString()}
+                    </span>
+                ),
+            },
+            {
+                id: "actions",
+                header: () => <div className="text-right">Actions</div>,
+                enableSorting: false,
+                cell: ({ row }) => {
+                    const m = row.original;
+                    return (
+                        <div className="flex justify-end">
+                            <DropdownMenu>
+                                <DropdownMenuTrigger asChild>
+                                    <Button variant="ghost" className="h-8 w-8 p-0">
+                                        <span className="sr-only">Open actions</span>
+                                        <MoreHorizontal className="h-4 w-4" />
+                                    </Button>
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent align="end">
+                                    <DropdownMenuItem onClick={() => setDetail(m)}>
+                                        <Eye className="mr-2 h-4 w-4" />
+                                        View details
+                                    </DropdownMenuItem>
+                                    <DropdownMenuItem
+                                        onClick={() => setDeleteTarget(m)}
+                                        className="text-destructive"
+                                    >
+                                        <Trash2 className="mr-2 h-4 w-4" />
+                                        Delete
+                                    </DropdownMenuItem>
+                                </DropdownMenuContent>
+                            </DropdownMenu>
+                        </div>
+                    );
+                },
+            },
+        ],
+        []
+    );
+
+    const hasFilters = search.length > 0 || categories.length > 0;
+
     return (
         <div className="space-y-4">
             <PageHeader
@@ -76,82 +197,52 @@ export function MemoryClientComponent() {
                 description="What the AI Ops agent has learned across sessions. Review and prune as needed."
             />
 
-            <div className="flex flex-wrap items-center justify-between gap-3">
-                <div className="flex flex-wrap gap-1">
-                    {TABS.map((t) => (
-                        <Button
-                            key={t}
-                            variant={tab === t ? "default" : "outline"}
-                            size="sm"
-                            onClick={() => setTab(t)}
-                        >
-                            {TAB_LABEL[t]}
-                        </Button>
-                    ))}
-                </div>
-                <Input
-                    placeholder="Search key or fact…"
-                    value={searchInput}
-                    onChange={(e) => setSearchInput(e.target.value)}
-                    className="w-full max-w-xs"
-                />
-            </div>
-
-            {isLoading ? (
-                <div className="flex justify-center py-16">
-                    <Spinner />
-                </div>
-            ) : memories.length === 0 ? (
-                <div className="rounded-lg border border-dashed py-16 text-center text-muted-foreground">
-                    No memories yet — the AI Ops agent will populate these as it works.
-                </div>
-            ) : (
-                <div className="overflow-x-auto rounded-lg border">
-                    <Table>
-                        <TableHeader>
-                            <TableRow>
-                                <TableHead>Category</TableHead>
-                                <TableHead>Key</TableHead>
-                                <TableHead>Fact</TableHead>
-                                <TableHead>Confidence</TableHead>
-                                <TableHead>Created</TableHead>
-                                <TableHead>Expires</TableHead>
-                                <TableHead className="text-right">Actions</TableHead>
-                            </TableRow>
-                        </TableHeader>
-                        <TableBody>
-                            {memories.map((m) => (
-                                <TableRow
-                                    key={m.id}
-                                    className="cursor-pointer"
-                                    onClick={() => setDetail(m)}
-                                >
-                                    <TableCell>
-                                        <Badge variant="outline">{m.category}</Badge>
-                                    </TableCell>
-                                    <TableCell className="font-medium">{m.key}</TableCell>
-                                    <TableCell className="max-w-md truncate">{m.fact}</TableCell>
-                                    <TableCell>{m.confidence ?? "—"}</TableCell>
-                                    <TableCell>{new Date(m.createdAt).toLocaleDateString()}</TableCell>
-                                    <TableCell>{new Date(m.expiresAt).toLocaleDateString()}</TableCell>
-                                    <TableCell className="text-right">
-                                        <Button
-                                            variant="ghost"
-                                            size="sm"
-                                            onClick={(e) => {
-                                                e.stopPropagation();
-                                                setDeleteTarget(m);
-                                            }}
-                                        >
-                                            Delete
-                                        </Button>
-                                    </TableCell>
-                                </TableRow>
-                            ))}
-                        </TableBody>
-                    </Table>
-                </div>
-            )}
+            <DataTable
+                columns={columns}
+                data={memories}
+                loading={isLoading}
+                enableSorting={false}
+                enableFiltering={false}
+                manualPagination
+                rowCount={total}
+                pagination={pagination}
+                onPaginationChange={setPagination}
+                emptyMessage={
+                    hasFilters
+                        ? "No memories match your filters."
+                        : "No memories yet — the AI Ops agent will populate these as it works."
+                }
+                header={
+                    <div className="flex flex-wrap items-center gap-2">
+                        <div className="relative max-w-xs flex-1">
+                            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                            <Input
+                                placeholder="Search key or fact…"
+                                value={searchInput}
+                                onChange={(e) => handleSearchChange(e.target.value)}
+                                className="pl-9"
+                            />
+                        </div>
+                        <DataTableFacetedFilter
+                            title="Category"
+                            options={CATEGORY_OPTIONS}
+                            selected={categories}
+                            onChange={handleCategoriesChange}
+                        />
+                        {hasFilters && (
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={clearFilters}
+                                className="h-9 px-2 lg:px-3"
+                            >
+                                Reset
+                                <X className="ml-2 h-4 w-4" />
+                            </Button>
+                        )}
+                    </div>
+                }
+            />
 
             <MemoryDetailDialog memory={detail} onClose={() => setDetail(null)} />
             <DeleteMemoryDialog

--- a/apps/web-ui/components/memory/memory-detail-dialog.tsx
+++ b/apps/web-ui/components/memory/memory-detail-dialog.tsx
@@ -12,9 +12,9 @@ import type { MemoryRow } from "@/lib/queries/agent-memories";
 
 function Row({ label, value }: { label: string; value: React.ReactNode }) {
     return (
-        <div className="grid grid-cols-[120px_1fr] gap-2 text-sm">
+        <div className="grid grid-cols-[120px_minmax(0,1fr)] gap-2 text-sm">
             <span className="text-muted-foreground">{label}</span>
-            <span className="break-words">{value}</span>
+            <span className="min-w-0 break-words">{value}</span>
         </div>
     );
 }
@@ -29,12 +29,12 @@ export function MemoryDetailDialog({
     return (
         <Dialog open={!!memory} onOpenChange={(open) => { if (!open) onClose(); }}>
             <DialogContent className="max-w-2xl">
-                <DialogHeader>
+                <DialogHeader className="min-w-0">
                     <DialogTitle className="break-words">{memory?.key}</DialogTitle>
-                    <DialogDescription>{memory?.namespace}</DialogDescription>
+                    <DialogDescription className="break-words">{memory?.namespace}</DialogDescription>
                 </DialogHeader>
                 {memory ? (
-                    <div className="space-y-3">
+                    <div className="min-w-0 space-y-3">
                         <Row label="Fact" value={memory.fact || <em className="text-muted-foreground">none</em>} />
                         <Row label="Source" value={memory.source ?? "—"} />
                         <Row
@@ -47,7 +47,7 @@ export function MemoryDetailDialog({
                         <Row label="Expires" value={new Date(memory.expiresAt).toLocaleString()} />
                         <div className="space-y-1">
                             <span className="text-sm text-muted-foreground">Raw value</span>
-                            <pre className="max-h-64 overflow-auto rounded-md bg-muted p-3 text-xs">
+                            <pre className="max-h-64 min-w-0 overflow-auto whitespace-pre-wrap break-all rounded-md bg-muted p-3 text-xs">
                                 {JSON.stringify(memory.value, null, 2)}
                             </pre>
                         </div>

--- a/apps/web-ui/components/settings/mcp-server-form.tsx
+++ b/apps/web-ui/components/settings/mcp-server-form.tsx
@@ -1,16 +1,32 @@
 'use client';
 
-import { Card, CardContent } from '@/components/ui/card';
+import { useMemo, useState } from 'react';
+import type { ColumnDef } from '@tanstack/react-table';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
 import { Switch } from '@/components/ui/switch';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { DataTable } from '@/components/ui/data-table';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from '@/components/ui/sheet';
 import { KeyValueEditor } from './key-value-editor';
 import { useTestMcpServer } from '@/lib/queries/mcp-servers';
 import { formRowsToConfig, type McpFormRow, type McpFormValues } from '@/lib/agent/mcp-form-schema';
-import { Plus, Trash2, Plug, Loader2, CheckCircle2 } from 'lucide-react';
-import { useState } from 'react';
+import { Plus, Trash2, Plug, Loader2, CheckCircle2, Pencil, MoreHorizontal } from 'lucide-react';
 import { toast } from 'sonner';
 
 interface McpServerFormProps {
@@ -23,16 +39,49 @@ function blankStdioRow(): McpFormRow {
   return { id: '', type: 'stdio', command: '', args: [], env: [], requiresAwsCredentials: false, disabled: false };
 }
 
+function transportLabel(t: McpFormRow['type']) {
+  if (t === 'stdio') return 'stdio (local)';
+  if (t === 'sse') return 'SSE (remote)';
+  return 'HTTP (remote)';
+}
+
+function summaryLine(row: McpFormRow) {
+  if (row.type === 'stdio') return [row.command, ...row.args].filter(Boolean).join(' ') || 'No command set';
+  return row.url || 'No URL set';
+}
+
 export function McpServerForm({ value, onChange, apiPath }: McpServerFormProps) {
   const rows = value.servers;
   const test = useTestMcpServer(apiPath);
   const [testingId, setTestingId] = useState<string | null>(null);
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
 
   const updateRow = (i: number, next: McpFormRow) => {
     onChange({ servers: rows.map((r, idx) => (idx === i ? next : r)) });
   };
-  const removeRow = (i: number) => onChange({ servers: rows.filter((_, idx) => idx !== i) });
-  const addRow = () => onChange({ servers: [...rows, blankStdioRow()] });
+
+  const removeRow = (i: number) => {
+    const row = rows[i];
+    if (!confirm(`Delete MCP server "${row.id || 'this server'}"?`)) return;
+    onChange({ servers: rows.filter((_, idx) => idx !== i) });
+    setEditingIndex((current) => {
+      if (current === null) return current;
+      if (current === i) { setSheetOpen(false); return null; }
+      return current > i ? current - 1 : current;
+    });
+  };
+
+  const addRow = () => {
+    onChange({ servers: [...rows, blankStdioRow()] });
+    setEditingIndex(rows.length);
+    setSheetOpen(true);
+  };
+
+  const openEdit = (i: number) => {
+    setEditingIndex(i);
+    setSheetOpen(true);
+  };
 
   const changeTransport = (i: number, t: 'stdio' | 'sse' | 'http') => {
     const r = rows[i];
@@ -59,29 +108,119 @@ export function McpServerForm({ value, onChange, apiPath }: McpServerFormProps) 
     }
   };
 
+  const editing = editingIndex !== null ? rows[editingIndex] : null;
+  const editingBusy = editing !== null && testingId === editing.id && test.isPending;
+
+  const columns = useMemo<ColumnDef<McpFormRow>[]>(() => [
+    {
+      accessorKey: 'id',
+      header: 'Server',
+      cell: ({ row }) => {
+        const r = row.original;
+        return (
+          <button type="button" onClick={() => openEdit(row.index)} className="text-left min-w-0 max-w-[380px] block">
+            <div className={`font-medium font-mono text-sm truncate hover:underline ${r.id.trim() ? '' : 'italic text-muted-foreground'}`}>
+              {r.id.trim() || 'Untitled server'}
+            </div>
+            <div className="text-xs text-muted-foreground truncate font-mono">{summaryLine(r)}</div>
+          </button>
+        );
+      },
+    },
+    {
+      accessorKey: 'type',
+      header: 'Transport',
+      cell: ({ row }) => <Badge variant="outline" className="font-mono text-[11px]">{transportLabel(row.original.type)}</Badge>,
+    },
+    {
+      accessorKey: 'disabled',
+      header: 'Status',
+      cell: ({ row }) => {
+        const r = row.original;
+        return (
+          <div className="flex items-center gap-2">
+            <Switch checked={!r.disabled} onCheckedChange={(c) => updateRow(row.index, { ...r, disabled: !c })} aria-label={r.disabled ? 'Enable server' : 'Disable server'} />
+            <span className="text-xs text-muted-foreground w-14">{r.disabled ? 'Disabled' : 'Enabled'}</span>
+          </div>
+        );
+      },
+    },
+    {
+      id: 'actions',
+      header: () => <div className="text-right">Actions</div>,
+      cell: ({ row }) => {
+        const r = row.original;
+        const busy = testingId === r.id && test.isPending;
+        return (
+          <div className="flex justify-end">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" className="h-8 w-8 p-0" aria-label="Open actions menu">
+                  {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <MoreHorizontal className="h-4 w-4" />}
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={() => openEdit(row.index)}><Pencil className="mr-2 h-4 w-4" /> Edit</DropdownMenuItem>
+                <DropdownMenuItem onClick={() => runTest(r)} disabled={busy}><CheckCircle2 className="mr-2 h-4 w-4" /> Test connection</DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={() => removeRow(row.index)} className="text-destructive"><Trash2 className="mr-2 h-4 w-4" /> Delete</DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        );
+      },
+    },
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  ], [rows, testingId, test.isPending]);
+
   return (
     <div className="space-y-3">
-      {rows.length === 0 && (
-        <p className="text-sm text-muted-foreground py-6 text-center">No MCP servers configured. Add one below.</p>
-      )}
+      <DataTable
+        columns={columns}
+        data={rows}
+        enableSorting={false}
+        enableFiltering={false}
+        enablePagination={false}
+        emptyMessage="No MCP servers configured. Add one to get started."
+        header={
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-muted-foreground">
+              {rows.length} server{rows.length !== 1 ? 's' : ''} configured
+            </span>
+            <Button type="button" size="sm" onClick={addRow} className="h-8 text-xs gap-1.5">
+              <Plus className="h-3.5 w-3.5" /> Add MCP server
+            </Button>
+          </div>
+        }
+      />
 
-      {rows.map((row, i) => {
-        const busy = testingId === row.id && test.isPending;
-        return (
-          <Card key={i}>
-            <CardContent className="pt-4 space-y-3">
-              <div className="flex items-start gap-3">
-                <div className="h-8 w-8 rounded-md bg-primary/10 flex items-center justify-center flex-shrink-0">
-                  <Plug className="h-4 w-4 text-primary" />
+      <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
+        <SheetContent className="sm:max-w-lg overflow-y-auto flex flex-col gap-0">
+          {editing && editingIndex !== null && (
+            <>
+              <SheetHeader>
+                <div className="flex items-center gap-2">
+                  <div className="h-8 w-8 rounded-md bg-primary/10 flex items-center justify-center flex-shrink-0">
+                    <Plug className="h-4 w-4 text-primary" />
+                  </div>
+                  <div className="min-w-0">
+                    <SheetTitle className="font-mono text-base truncate">{editing.id.trim() || 'New MCP server'}</SheetTitle>
+                    <SheetDescription>
+                      {editing.type === 'stdio' ? 'Local process launched via stdio' : `Remote server over ${editing.type.toUpperCase()}`}
+                    </SheetDescription>
+                  </div>
                 </div>
-                <div className="grid gap-1.5 flex-1">
+              </SheetHeader>
+
+              <div className="space-y-4 py-4 flex-1">
+                <div className="grid gap-1.5">
                   <Label className="text-xs">Server ID</Label>
-                  <Input className="h-8 text-sm" value={row.id} placeholder="my-server" onChange={(e) => updateRow(i, { ...row, id: e.target.value })} />
+                  <Input className="h-9 text-sm" value={editing.id} placeholder="my-server" onChange={(e) => updateRow(editingIndex, { ...editing, id: e.target.value })} />
                 </div>
-                <div className="grid gap-1.5 w-40">
+                <div className="grid gap-1.5">
                   <Label className="text-xs">Transport</Label>
-                  <Select value={row.type} onValueChange={(v) => changeTransport(i, v as 'stdio' | 'sse' | 'http')}>
-                    <SelectTrigger className="h-8 text-sm"><SelectValue /></SelectTrigger>
+                  <Select value={editing.type} onValueChange={(v) => changeTransport(editingIndex, v as 'stdio' | 'sse' | 'http')}>
+                    <SelectTrigger className="h-9 text-sm"><SelectValue /></SelectTrigger>
                     <SelectContent>
                       <SelectItem value="stdio">stdio (local)</SelectItem>
                       <SelectItem value="sse">SSE (remote)</SelectItem>
@@ -89,60 +228,57 @@ export function McpServerForm({ value, onChange, apiPath }: McpServerFormProps) 
                     </SelectContent>
                   </Select>
                 </div>
-                <Button type="button" size="icon" variant="ghost" className="h-8 w-8 mt-5 flex-shrink-0 text-destructive" onClick={() => removeRow(i)} aria-label="Remove server">
-                  <Trash2 className="h-4 w-4" />
-                </Button>
+
+                {editing.type === 'stdio' ? (
+                  <>
+                    <div className="grid gap-1.5">
+                      <Label className="text-xs">Command</Label>
+                      <Input className="h-9 text-sm font-mono" value={editing.command} placeholder="uvx" onChange={(e) => updateRow(editingIndex, { ...editing, command: e.target.value })} />
+                    </div>
+                    <div className="grid gap-1.5">
+                      <Label className="text-xs">Arguments (one per line)</Label>
+                      <textarea
+                        className="min-h-[64px] rounded-md border bg-background px-3 py-2 text-xs font-mono"
+                        value={editing.args.join('\n')}
+                        placeholder={'-y\n@modelcontextprotocol/server-filesystem'}
+                        onChange={(e) => updateRow(editingIndex, { ...editing, args: e.target.value.split('\n') })}
+                      />
+                    </div>
+                    <KeyValueEditor label="Environment variables" value={editing.env} onChange={(env) => updateRow(editingIndex, { ...editing, env })} keyPlaceholder="VAR_NAME" />
+                    <div className="flex items-center gap-2">
+                      <Switch checked={editing.requiresAwsCredentials} onCheckedChange={(c) => updateRow(editingIndex, { ...editing, requiresAwsCredentials: c })} id="aws-creds" />
+                      <Label htmlFor="aws-creds" className="text-xs">Inject AWS credentials for the selected account</Label>
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <div className="grid gap-1.5">
+                      <Label className="text-xs">Endpoint URL</Label>
+                      <Input className="h-9 text-sm font-mono" value={editing.url} placeholder="https://api.example.com/sse" onChange={(e) => updateRow(editingIndex, { ...editing, url: e.target.value })} />
+                    </div>
+                    <KeyValueEditor label="Headers" value={editing.headers} onChange={(headers) => updateRow(editingIndex, { ...editing, headers })} keyPlaceholder="Authorization" valuePlaceholder="Bearer ..." />
+                  </>
+                )}
+
+                <div className="flex items-center gap-2 pt-1">
+                  <Switch checked={!editing.disabled} onCheckedChange={(c) => updateRow(editingIndex, { ...editing, disabled: !c })} id="enabled" />
+                  <Label htmlFor="enabled" className="text-xs">Enabled</Label>
+                </div>
               </div>
 
-              {row.type === 'stdio' ? (
-                <div className="space-y-3 pl-11">
-                  <div className="grid gap-1.5">
-                    <Label className="text-xs">Command</Label>
-                    <Input className="h-8 text-sm font-mono" value={row.command} placeholder="uvx" onChange={(e) => updateRow(i, { ...row, command: e.target.value })} />
-                  </div>
-                  <div className="grid gap-1.5">
-                    <Label className="text-xs">Arguments (one per line)</Label>
-                    <textarea
-                      className="min-h-[64px] rounded-md border bg-background px-3 py-2 text-xs font-mono"
-                      value={row.args.join('\n')}
-                      placeholder={'-y\n@modelcontextprotocol/server-filesystem'}
-                      onChange={(e) => updateRow(i, { ...row, args: e.target.value.split('\n') })}
-                    />
-                  </div>
-                  <KeyValueEditor label="Environment variables" value={row.env} onChange={(env) => updateRow(i, { ...row, env })} keyPlaceholder="VAR_NAME" />
-                  <div className="flex items-center gap-2">
-                    <Switch checked={row.requiresAwsCredentials} onCheckedChange={(c) => updateRow(i, { ...row, requiresAwsCredentials: c })} id={`aws-${i}`} />
-                    <Label htmlFor={`aws-${i}`} className="text-xs">Inject AWS credentials for the selected account</Label>
-                  </div>
-                </div>
-              ) : (
-                <div className="space-y-3 pl-11">
-                  <div className="grid gap-1.5">
-                    <Label className="text-xs">Endpoint URL</Label>
-                    <Input className="h-8 text-sm font-mono" value={row.url} placeholder="https://api.example.com/sse" onChange={(e) => updateRow(i, { ...row, url: e.target.value })} />
-                  </div>
-                  <KeyValueEditor label="Headers" value={row.headers} onChange={(headers) => updateRow(i, { ...row, headers })} keyPlaceholder="Authorization" valuePlaceholder="Bearer ..." />
-                </div>
-              )}
-
-              <div className="flex items-center justify-between pl-11">
-                <div className="flex items-center gap-2">
-                  <Switch checked={!row.disabled} onCheckedChange={(c) => updateRow(i, { ...row, disabled: !c })} id={`enabled-${i}`} />
-                  <Label htmlFor={`enabled-${i}`} className="text-xs">Enabled</Label>
-                </div>
-                <Button type="button" size="sm" variant="outline" className="h-7 text-xs gap-1.5" disabled={busy} onClick={() => runTest(row)}>
-                  {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <CheckCircle2 className="h-3.5 w-3.5" />}
+              <div className="flex items-center justify-between border-t pt-4">
+                <Button type="button" variant="ghost" className="h-8 text-xs gap-1.5 text-destructive hover:text-destructive" onClick={() => removeRow(editingIndex)}>
+                  <Trash2 className="h-3.5 w-3.5" /> Delete server
+                </Button>
+                <Button type="button" size="sm" variant="outline" className="h-8 text-xs gap-1.5" disabled={editingBusy} onClick={() => runTest(editing)}>
+                  {editingBusy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <CheckCircle2 className="h-3.5 w-3.5" />}
                   Test connection
                 </Button>
               </div>
-            </CardContent>
-          </Card>
-        );
-      })}
-
-      <Button type="button" variant="outline" className="w-full gap-1.5" onClick={addRow}>
-        <Plus className="h-4 w-4" /> Add MCP server
-      </Button>
+            </>
+          )}
+        </SheetContent>
+      </Sheet>
     </div>
   );
 }

--- a/apps/web-ui/components/skills/skill-detail-dialog.tsx
+++ b/apps/web-ui/components/skills/skill-detail-dialog.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState } from "react";
+import Editor from "@monaco-editor/react";
+import { useTheme } from "next-themes";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Spinner } from "@/components/ui/spinner";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { MarkdownContent } from "@/components/ui/markdown-content";
+import { useSkill } from "@/lib/queries/skills";
+import type { SkillDTO } from "@/lib/client-skill-service";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  skill?: SkillDTO | null;
+  onEdit?: (s: SkillDTO) => void;
+}
+
+export function SkillDetailDialog({ open, onOpenChange, skill, onEdit }: Props) {
+  const { resolvedTheme } = useTheme();
+  const [view, setView] = useState<"preview" | "raw">("preview");
+  // List DTOs omit `content`; fetch the full skill (incl. content) for display.
+  const { data: fullSkill, isLoading } = useSkill(open ? skill?.id ?? null : null);
+  const src = fullSkill ?? skill;
+  const content = src?.content ?? "";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            {src?.name ?? "Skill"}
+            {src && <Badge variant="outline">{src.tier}</Badge>}
+            {src && <Badge variant={src.source === "system" ? "secondary" : "default"}>{src.source === "system" ? "System" : "User"}</Badge>}
+            {src && !src.isEnabled && <Badge variant="outline" className="text-muted-foreground">Disabled</Badge>}
+          </DialogTitle>
+          <DialogDescription>{src?.description}</DialogDescription>
+        </DialogHeader>
+
+        {isLoading && !content ? (
+          <div className="flex justify-center py-12"><Spinner /></div>
+        ) : (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <div className="text-sm font-medium">Skill content</div>
+              <Tabs value={view} onValueChange={(v) => setView(v as "preview" | "raw")}>
+                <TabsList className="h-8">
+                  <TabsTrigger value="preview" className="text-xs">Preview</TabsTrigger>
+                  <TabsTrigger value="raw" className="text-xs">Raw</TabsTrigger>
+                </TabsList>
+              </Tabs>
+            </div>
+            <Tabs value={view}>
+              <TabsContent value="preview" className="mt-0">
+                <div className="border rounded-md p-4 h-[420px] overflow-y-auto">
+                  {content ? <MarkdownContent content={content} /> : <p className="text-sm text-muted-foreground">No content.</p>}
+                </div>
+              </TabsContent>
+              <TabsContent value="raw" className="mt-0">
+                <div className="border rounded-md overflow-hidden">
+                  <Editor height="420px" defaultLanguage="markdown" value={content}
+                    theme={resolvedTheme === "dark" ? "vs-dark" : "light"}
+                    options={{ readOnly: true, domReadOnly: true, minimap: { enabled: false }, fontSize: 13, wordWrap: "on", scrollBeyondLastLine: false, automaticLayout: true, padding: { top: 12, bottom: 12 } }} />
+                </div>
+              </TabsContent>
+            </Tabs>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>Close</Button>
+          {src && onEdit && (
+            <Button type="button" onClick={() => { onOpenChange(false); onEdit(src); }}>Edit</Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web-ui/components/skills/skill-form-dialog.tsx
+++ b/apps/web-ui/components/skills/skill-form-dialog.tsx
@@ -30,17 +30,18 @@ interface Props {
   open: boolean;
   onOpenChange: (v: boolean) => void;
   skill?: SkillDTO | null;
+  cloneFrom?: SkillDTO | null;
   initialDraft?: { name: string; description: string; tier: string; content: string } | null;
   sourceRunId?: string | null;
 }
 
-export function SkillFormDialog({ open, onOpenChange, skill, initialDraft, sourceRunId }: Props) {
+export function SkillFormDialog({ open, onOpenChange, skill, cloneFrom, initialDraft, sourceRunId }: Props) {
   const { resolvedTheme } = useTheme();
   const createSkill = useCreateSkill();
   const updateSkill = useUpdateSkill();
   const isEdit = !!skill;
-  // List DTOs omit `content`; fetch the full skill (incl. content) when editing.
-  const { data: fullSkill } = useSkill(skill?.id ?? null);
+  // List DTOs omit `content`; fetch the full skill (incl. content) when editing or cloning.
+  const { data: fullSkill } = useSkill(skill?.id ?? cloneFrom?.id ?? null);
 
   const form = useForm<FormValues>({
     resolver: zodResolver(schema),
@@ -52,12 +53,15 @@ export function SkillFormDialog({ open, onOpenChange, skill, initialDraft, sourc
     if (skill) {
       const src = fullSkill ?? skill;
       form.reset({ name: src.name, description: src.description, tier: src.tier as FormValues["tier"], content: src.content ?? "", isEnabled: src.isEnabled });
+    } else if (cloneFrom) {
+      const src = fullSkill ?? cloneFrom;
+      form.reset({ name: `Copy of ${src.name}`, description: src.description, tier: src.tier as FormValues["tier"], content: src.content ?? "", isEnabled: src.isEnabled });
     } else if (initialDraft) {
       form.reset({ name: initialDraft.name, description: initialDraft.description, tier: (["read-only", "mutation", "approval-gated"].includes(initialDraft.tier) ? initialDraft.tier : "read-only") as FormValues["tier"], content: initialDraft.content, isEnabled: true });
     } else {
       form.reset({ name: "", description: "", tier: "read-only", content: "", isEnabled: true });
     }
-  }, [open, skill, fullSkill, initialDraft, form]);
+  }, [open, skill, cloneFrom, fullSkill, initialDraft, form]);
 
   const onSubmit = async (values: FormValues) => {
     try {
@@ -80,7 +84,7 @@ export function SkillFormDialog({ open, onOpenChange, skill, initialDraft, sourc
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>{isEdit ? "Edit Skill" : "Create Skill"}</DialogTitle>
+          <DialogTitle>{isEdit ? "Edit Skill" : cloneFrom ? "Clone Skill" : "Create Skill"}</DialogTitle>
           <DialogDescription>Skills are available to everyone in your organization in AI Ops and Agent Ops.</DialogDescription>
         </DialogHeader>
         <Form {...form}>
@@ -115,14 +119,17 @@ export function SkillFormDialog({ open, onOpenChange, skill, initialDraft, sourc
               </FormItem>
             )} />
             <FormField control={form.control} name="isEnabled" render={({ field }) => (
-              <FormItem className="flex items-center justify-between rounded-md border p-3">
-                <FormLabel className="mb-0">Enabled (visible in AI Ops / Agent Ops)</FormLabel>
-                <FormControl><Switch checked={field.value} onCheckedChange={field.onChange} /></FormControl>
+              <FormItem className="flex items-center justify-between rounded-md border p-3 gap-4">
+                <div className="space-y-0.5">
+                  <FormLabel className="mb-0">{field.value ? "Enabled" : "Disabled"}</FormLabel>
+                  <p className="text-xs text-muted-foreground">When enabled, this skill applies across all AI implementations in the project — not limited to any single module or use case.</p>
+                </div>
+                <FormControl><Switch checked={field.value} onCheckedChange={field.onChange} aria-label="Enable or disable skill" /></FormControl>
               </FormItem>
             )} />
             <DialogFooter>
               <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
-              <Button type="submit" disabled={submitting}>{submitting ? "Saving…" : isEdit ? "Save changes" : "Create skill"}</Button>
+              <Button type="submit" disabled={submitting}>{submitting ? "Saving…" : isEdit ? "Save changes" : cloneFrom ? "Create clone" : "Create skill"}</Button>
             </DialogFooter>
           </form>
         </Form>

--- a/apps/web-ui/components/skills/skills-client.tsx
+++ b/apps/web-ui/components/skills/skills-client.tsx
@@ -1,28 +1,139 @@
 "use client";
 
-import { useState } from "react";
-import { Plus, Pencil, Trash2 } from "lucide-react";
+import { useMemo, useState } from "react";
+import type { ColumnDef } from "@tanstack/react-table";
+import { Plus, Eye, Copy, Pencil, Trash2, Search, MoreHorizontal } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Spinner } from "@/components/ui/spinner";
-import { useSkills, useDeleteSkill } from "@/lib/queries/skills";
+import { Switch } from "@/components/ui/switch";
+import { Input } from "@/components/ui/input";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import { DataTable } from "@/components/ui/data-table";
+import { DataTableColumnHeader } from "@/components/ui/data-table-column-header";
+import { useSkills, useDeleteSkill, useUpdateSkill } from "@/lib/queries/skills";
 import { SkillFormDialog } from "./skill-form-dialog";
+import { SkillDetailDialog } from "./skill-detail-dialog";
 import type { SkillDTO } from "@/lib/client-skill-service";
+
+function formatDate(value: string) {
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleString(undefined, { year: "numeric", month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+}
 
 export function SkillsClient() {
   const { data: skills, isLoading } = useSkills(true);
   const deleteSkill = useDeleteSkill();
+  const updateSkill = useUpdateSkill();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editing, setEditing] = useState<SkillDTO | null>(null);
+  const [cloning, setCloning] = useState<SkillDTO | null>(null);
+  const [viewOpen, setViewOpen] = useState(false);
+  const [viewing, setViewing] = useState<SkillDTO | null>(null);
+  const [search, setSearch] = useState("");
 
-  const openCreate = () => { setEditing(null); setDialogOpen(true); };
-  const openEdit = (s: SkillDTO) => { setEditing(s); setDialogOpen(true); };
+  const openCreate = () => { setEditing(null); setCloning(null); setDialogOpen(true); };
+  const openEdit = (s: SkillDTO) => { setEditing(s); setCloning(null); setDialogOpen(true); };
+  const openClone = (s: SkillDTO) => { setEditing(null); setCloning(s); setDialogOpen(true); };
+  const openView = (s: SkillDTO) => { setViewing(s); setViewOpen(true); };
   const onDelete = async (s: SkillDTO) => {
     if (!confirm(`Delete skill "${s.name}"?`)) return;
     try { await deleteSkill.mutateAsync(s.id); toast.success("Skill deleted", { description: s.name }); }
     catch (e) { toast.error("Delete failed", { description: e instanceof Error ? e.message : "Try again" }); }
   };
+  const onToggleEnabled = async (s: SkillDTO, next: boolean) => {
+    try {
+      await updateSkill.mutateAsync({ id: s.id, input: { isEnabled: next } });
+      toast.success(next ? "Skill enabled" : "Skill disabled", { description: s.name });
+    } catch (e) {
+      toast.error("Update failed", { description: e instanceof Error ? e.message : "Try again" });
+    }
+  };
+
+  // Filter by search term (name / description / tier), then default-sort newest first.
+  const rows = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    const filtered = (skills ?? []).filter((s) =>
+      !q || s.name.toLowerCase().includes(q) || s.description.toLowerCase().includes(q) || s.tier.toLowerCase().includes(q)
+    );
+    return [...filtered].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  }, [skills, search]);
+
+  const columns = useMemo<ColumnDef<SkillDTO>[]>(() => [
+    {
+      accessorKey: "name",
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Name" />,
+      cell: ({ row }) => {
+        const s = row.original;
+        return (
+          <button type="button" onClick={() => openView(s)} className="text-left min-w-0 max-w-[420px]">
+            <div className="font-medium truncate hover:underline">{s.name}</div>
+            <div className="text-xs text-muted-foreground truncate">{s.description}</div>
+          </button>
+        );
+      },
+    },
+    {
+      accessorKey: "tier",
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Tier" />,
+      cell: ({ row }) => <Badge variant="outline">{row.original.tier}</Badge>,
+    },
+    {
+      accessorKey: "source",
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Source" />,
+      cell: ({ row }) => {
+        const s = row.original;
+        return <Badge variant={s.source === "system" ? "secondary" : "default"}>{s.source === "system" ? "System" : "User"}</Badge>;
+      },
+    },
+    {
+      accessorKey: "isEnabled",
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Status" />,
+      cell: ({ row }) => {
+        const s = row.original;
+        return (
+          <div className="flex items-center gap-2">
+            <Switch checked={s.isEnabled} disabled={updateSkill.isPending} onCheckedChange={(v) => onToggleEnabled(s, v)} aria-label={s.isEnabled ? "Disable skill" : "Enable skill"} />
+            <span className="text-xs text-muted-foreground w-14">{s.isEnabled ? "Enabled" : "Disabled"}</span>
+          </div>
+        );
+      },
+    },
+    {
+      accessorKey: "createdAt",
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Created" />,
+      cell: ({ row }) => <span className="text-sm text-muted-foreground whitespace-nowrap">{formatDate(row.original.createdAt)}</span>,
+      sortingFn: "datetime",
+    },
+    {
+      id: "actions",
+      header: () => <div className="text-right">Actions</div>,
+      enableSorting: false,
+      cell: ({ row }) => {
+        const s = row.original;
+        return (
+          <div className="flex justify-end">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" className="h-8 w-8 p-0" aria-label="Open actions menu">
+                  <MoreHorizontal className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={() => openView(s)}><Eye className="mr-2 h-4 w-4" /> View</DropdownMenuItem>
+                <DropdownMenuItem onClick={() => openEdit(s)}><Pencil className="mr-2 h-4 w-4" /> Edit</DropdownMenuItem>
+                <DropdownMenuItem onClick={() => openClone(s)}><Copy className="mr-2 h-4 w-4" /> Clone</DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={() => onDelete(s)} className="text-destructive"><Trash2 className="mr-2 h-4 w-4" /> Delete</DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        );
+      },
+    },
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  ], [updateSkill.isPending]);
 
   return (
     <div className="space-y-6">
@@ -34,33 +145,23 @@ export function SkillsClient() {
         <Button onClick={openCreate}><Plus className="w-4 h-4 mr-1" /> Create skill</Button>
       </div>
 
-      {isLoading ? (
-        <div className="flex justify-center py-12"><Spinner /></div>
-      ) : !skills?.length ? (
-        <div className="text-center py-12 text-muted-foreground">No skills yet. Create your first skill.</div>
-      ) : (
-        <div className="border rounded-lg divide-y">
-          {skills.map((s) => (
-            <div key={s.id} className="flex items-center justify-between p-4 gap-4">
-              <div className="min-w-0">
-                <div className="flex items-center gap-2">
-                  <span className="font-medium truncate">{s.name}</span>
-                  <Badge variant="outline">{s.tier}</Badge>
-                  <Badge variant={s.source === "system" ? "secondary" : "default"}>{s.source === "system" ? "System" : "User"}</Badge>
-                  {!s.isEnabled && <Badge variant="outline" className="text-muted-foreground">Disabled</Badge>}
-                </div>
-                <p className="text-sm text-muted-foreground truncate">{s.description}</p>
-              </div>
-              <div className="flex items-center gap-1 shrink-0">
-                <Button variant="ghost" size="icon" onClick={() => openEdit(s)} title="Edit" aria-label="Edit"><Pencil className="w-4 h-4" /></Button>
-                <Button variant="ghost" size="icon" onClick={() => onDelete(s)} title="Delete" aria-label="Delete" className="hover:text-destructive"><Trash2 className="w-4 h-4" /></Button>
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
+      <DataTable
+        columns={columns}
+        data={rows}
+        loading={isLoading}
+        enableFiltering={false}
+        defaultPageSize={10}
+        emptyMessage={search ? "No skills match your search." : "No skills yet. Create your first skill."}
+        header={
+          <div className="relative max-w-sm">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+            <Input placeholder="Search skills…" value={search} onChange={(e) => setSearch(e.target.value)} className="pl-9" />
+          </div>
+        }
+      />
 
-      <SkillFormDialog open={dialogOpen} onOpenChange={setDialogOpen} skill={editing} />
+      <SkillFormDialog open={dialogOpen} onOpenChange={setDialogOpen} skill={editing} cloneFrom={cloning} />
+      <SkillDetailDialog open={viewOpen} onOpenChange={setViewOpen} skill={viewing} onEdit={openEdit} />
     </div>
   );
 }

--- a/apps/web-ui/components/ui/data-table-faceted-filter.tsx
+++ b/apps/web-ui/components/ui/data-table-faceted-filter.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import * as React from 'react';
+import { Check, PlusCircle } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from '@/components/ui/command';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { Separator } from '@/components/ui/separator';
+
+export interface FacetedFilterOption {
+  label: string;
+  value: string;
+  icon?: React.ComponentType<{ className?: string }>;
+}
+
+interface DataTableFacetedFilterProps {
+  title: string;
+  options: FacetedFilterOption[];
+  selected: string[];
+  onChange: (values: string[]) => void;
+}
+
+export function DataTableFacetedFilter({
+  title,
+  options,
+  selected,
+  onChange,
+}: DataTableFacetedFilterProps) {
+  const selectedSet = new Set(selected);
+
+  const toggle = (value: string) => {
+    const next = new Set(selectedSet);
+    if (next.has(value)) next.delete(value);
+    else next.add(value);
+    onChange(Array.from(next));
+  };
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline" size="sm" className="h-9 border-dashed">
+          <PlusCircle className="mr-2 h-4 w-4" />
+          {title}
+          {selectedSet.size > 0 && (
+            <>
+              <Separator orientation="vertical" className="mx-2 h-4" />
+              <Badge variant="secondary" className="rounded-sm px-1 font-normal lg:hidden">
+                {selectedSet.size}
+              </Badge>
+              <div className="hidden space-x-1 lg:flex">
+                {selectedSet.size > 2 ? (
+                  <Badge variant="secondary" className="rounded-sm px-1 font-normal">
+                    {selectedSet.size} selected
+                  </Badge>
+                ) : (
+                  options
+                    .filter((o) => selectedSet.has(o.value))
+                    .map((o) => (
+                      <Badge
+                        key={o.value}
+                        variant="secondary"
+                        className="rounded-sm px-1 font-normal"
+                      >
+                        {o.label}
+                      </Badge>
+                    ))
+                )}
+              </div>
+            </>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[200px] p-0" align="start">
+        <Command>
+          <CommandInput placeholder={title} />
+          <CommandList>
+            <CommandEmpty>No results found.</CommandEmpty>
+            <CommandGroup>
+              {options.map((option) => {
+                const isSelected = selectedSet.has(option.value);
+                return (
+                  <CommandItem key={option.value} onSelect={() => toggle(option.value)}>
+                    <div
+                      className={cn(
+                        'mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-primary',
+                        isSelected
+                          ? 'bg-primary text-primary-foreground'
+                          : 'opacity-50 [&_svg]:invisible'
+                      )}
+                    >
+                      <Check className="h-4 w-4" />
+                    </div>
+                    {option.icon && (
+                      <option.icon className="mr-2 h-4 w-4 text-muted-foreground" />
+                    )}
+                    <span>{option.label}</span>
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+            {selectedSet.size > 0 && (
+              <>
+                <CommandSeparator />
+                <CommandGroup>
+                  <CommandItem
+                    onSelect={() => onChange([])}
+                    className="justify-center text-center"
+                  >
+                    Clear filters
+                  </CommandItem>
+                </CommandGroup>
+              </>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web-ui/components/ui/data-table.tsx
+++ b/apps/web-ui/components/ui/data-table.tsx
@@ -13,6 +13,7 @@ import {
   getSortedRowModel,
   useReactTable,
   PaginationState,
+  OnChangeFn,
 } from '@tanstack/react-table';
 
 import {
@@ -35,6 +36,10 @@ interface DataTableProps<TData, TValue> {
   enableFiltering?: boolean;
   defaultPageSize?: number;
   pageSizeOptions?: number[];
+  manualPagination?: boolean;
+  rowCount?: number;
+  pagination?: PaginationState;
+  onPaginationChange?: OnChangeFn<PaginationState>;
   emptyMessage?: React.ReactNode;
   header?: React.ReactNode;
   footer?: React.ReactNode;
@@ -49,6 +54,10 @@ export function DataTable<TData, TValue>({
   enableFiltering = true,
   defaultPageSize = 10,
   pageSizeOptions,
+  manualPagination = false,
+  rowCount,
+  pagination: controlledPagination,
+  onPaginationChange,
   emptyMessage = 'No results.',
   header,
   footer,
@@ -57,10 +66,12 @@ export function DataTable<TData, TValue>({
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([]);
   const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>({});
   const [rowSelection, setRowSelection] = React.useState({});
-  const [pagination, setPagination] = React.useState<PaginationState>({
+  const [internalPagination, setInternalPagination] = React.useState<PaginationState>({
     pageIndex: 0,
     pageSize: defaultPageSize,
   });
+  const pagination = controlledPagination ?? internalPagination;
+  const setPagination: OnChangeFn<PaginationState> = onPaginationChange ?? setInternalPagination;
 
   const table = useReactTable({
     data,
@@ -79,8 +90,11 @@ export function DataTable<TData, TValue>({
     onPaginationChange: enablePagination ? setPagination : undefined,
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: enableFiltering ? getFilteredRowModel() : undefined,
-    getPaginationRowModel: enablePagination ? getPaginationRowModel() : undefined,
+    getPaginationRowModel:
+      enablePagination && !manualPagination ? getPaginationRowModel() : undefined,
     getSortedRowModel: enableSorting ? getSortedRowModel() : undefined,
+    manualPagination,
+    rowCount: manualPagination ? rowCount : undefined,
   });
 
   return (

--- a/apps/web-ui/components/ui/data-table.tsx
+++ b/apps/web-ui/components/ui/data-table.tsx
@@ -40,6 +40,10 @@ interface DataTableProps<TData, TValue> {
   rowCount?: number;
   pagination?: PaginationState;
   onPaginationChange?: OnChangeFn<PaginationState>;
+  /** Server-side sorting: the table won't sort rows locally; emit sort state to the caller instead. */
+  manualSorting?: boolean;
+  sorting?: SortingState;
+  onSortingChange?: OnChangeFn<SortingState>;
   emptyMessage?: React.ReactNode;
   header?: React.ReactNode;
   footer?: React.ReactNode;
@@ -58,11 +62,14 @@ export function DataTable<TData, TValue>({
   rowCount,
   pagination: controlledPagination,
   onPaginationChange,
+  manualSorting = false,
+  sorting: controlledSorting,
+  onSortingChange,
   emptyMessage = 'No results.',
   header,
   footer,
 }: DataTableProps<TData, TValue>) {
-  const [sorting, setSorting] = React.useState<SortingState>([]);
+  const [internalSorting, setInternalSorting] = React.useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([]);
   const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>({});
   const [rowSelection, setRowSelection] = React.useState({});
@@ -72,6 +79,8 @@ export function DataTable<TData, TValue>({
   });
   const pagination = controlledPagination ?? internalPagination;
   const setPagination: OnChangeFn<PaginationState> = onPaginationChange ?? setInternalPagination;
+  const sorting = controlledSorting ?? internalSorting;
+  const setSorting: OnChangeFn<SortingState> = onSortingChange ?? setInternalSorting;
 
   const table = useReactTable({
     data,
@@ -92,8 +101,10 @@ export function DataTable<TData, TValue>({
     getFilteredRowModel: enableFiltering ? getFilteredRowModel() : undefined,
     getPaginationRowModel:
       enablePagination && !manualPagination ? getPaginationRowModel() : undefined,
-    getSortedRowModel: enableSorting ? getSortedRowModel() : undefined,
+    getSortedRowModel:
+      enableSorting && !manualSorting ? getSortedRowModel() : undefined,
     manualPagination,
+    manualSorting,
     rowCount: manualPagination ? rowCount : undefined,
   });
 

--- a/apps/web-ui/lib/agent/build-chat-transcript.test.ts
+++ b/apps/web-ui/lib/agent/build-chat-transcript.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import { buildChatTranscript, TOOL_RESULT_CHAR_CAP, type ChatMessageLike } from './build-chat-transcript';
+
+describe('buildChatTranscript', () => {
+    it('includes text parts verbatim and untruncated', () => {
+        const longText = 'a'.repeat(50_000);
+        const messages: ChatMessageLike[] = [
+            { role: 'user', parts: [{ type: 'text', text: longText }] },
+        ];
+        const result = buildChatTranscript(messages);
+        expect(result).toBe(`USER: ${longText}`);
+    });
+
+    it('serializes a tool-invocation part with name, args, and result', () => {
+        const messages: ChatMessageLike[] = [
+            {
+                role: 'assistant',
+                parts: [
+                    {
+                        type: 'tool-invocation',
+                        toolCallId: 'call_1',
+                        toolName: 'execute_command',
+                        args: { command: 'aws ce get-cost-and-usage' },
+                        result: 'ok',
+                    },
+                ],
+            },
+        ];
+        const result = buildChatTranscript(messages);
+        expect(result).toBe(
+            'ASSISTANT: TOOL_CALL: execute_command({"command":"aws ce get-cost-and-usage"})\nTOOL_RESULT: ok',
+        );
+    });
+
+    it('caps a large tool result but keeps args in full', () => {
+        const bigArgValue = 'x'.repeat(4_500);
+        const bigResult = 'y'.repeat(5_000);
+        const messages: ChatMessageLike[] = [
+            {
+                role: 'assistant',
+                parts: [
+                    {
+                        type: 'tool-invocation',
+                        toolCallId: 'call_2',
+                        toolName: 'list_instances',
+                        args: { note: bigArgValue },
+                        result: bigResult,
+                    },
+                ],
+            },
+        ];
+        const result = buildChatTranscript(messages);
+        // args untouched, full length present
+        expect(result).toContain(JSON.stringify({ note: bigArgValue }));
+        // result capped at TOOL_RESULT_CHAR_CAP with a truncation marker
+        expect(result).toContain('y'.repeat(TOOL_RESULT_CHAR_CAP));
+        expect(result).not.toContain('y'.repeat(TOOL_RESULT_CHAR_CAP + 1));
+        expect(result).toContain('[...truncated 1000 more chars]');
+    });
+
+    it('leaves a small tool result untouched', () => {
+        const messages: ChatMessageLike[] = [
+            {
+                role: 'assistant',
+                parts: [
+                    {
+                        type: 'tool-invocation',
+                        toolCallId: 'call_3',
+                        toolName: 'get_status',
+                        args: {},
+                        result: 'all good',
+                    },
+                ],
+            },
+        ];
+        const result = buildChatTranscript(messages);
+        expect(result).toContain('TOOL_RESULT: all good');
+        expect(result).not.toContain('truncated');
+    });
+
+    it('interleaves text and tool parts in original order', () => {
+        const messages: ChatMessageLike[] = [
+            {
+                role: 'assistant',
+                parts: [
+                    { type: 'text', text: 'Checking costs now.' },
+                    {
+                        type: 'tool-invocation',
+                        toolCallId: 'call_4',
+                        toolName: 'get_cost',
+                        args: {},
+                        result: '$100',
+                    },
+                    { type: 'text', text: 'Total spend is $100.' },
+                ],
+            },
+        ];
+        const result = buildChatTranscript(messages);
+        const idxA = result.indexOf('Checking costs now.');
+        const idxTool = result.indexOf('TOOL_CALL: get_cost');
+        const idxB = result.indexOf('Total spend is $100.');
+        expect(idxA).toBeGreaterThanOrEqual(0);
+        expect(idxTool).toBeGreaterThan(idxA);
+        expect(idxB).toBeGreaterThan(idxTool);
+    });
+
+    it('falls back to message.content when parts is empty or absent', () => {
+        const messages: ChatMessageLike[] = [{ role: 'user', content: 'hello there' }];
+        const result = buildChatTranscript(messages);
+        expect(result).toBe('USER: hello there');
+    });
+
+    it('derives tool name from a "tool-<name>" part type when toolName/name are absent', () => {
+        const messages: ChatMessageLike[] = [
+            {
+                role: 'assistant',
+                parts: [
+                    {
+                        type: 'tool-execute_command',
+                        toolCallId: 'call_5',
+                        args: { command: 'ls' },
+                        result: 'file.txt',
+                    },
+                ],
+            },
+        ];
+        const result = buildChatTranscript(messages);
+        expect(result).toContain('TOOL_CALL: execute command({"command":"ls"})');
+    });
+
+    it('joins multiple messages with a blank line between them', () => {
+        const messages: ChatMessageLike[] = [
+            { role: 'user', parts: [{ type: 'text', text: 'Hi' }] },
+            { role: 'assistant', parts: [{ type: 'text', text: 'Hello' }] },
+        ];
+        const result = buildChatTranscript(messages);
+        expect(result).toBe('USER: Hi\n\nASSISTANT: Hello');
+    });
+});

--- a/apps/web-ui/lib/agent/build-chat-transcript.ts
+++ b/apps/web-ui/lib/agent/build-chat-transcript.ts
@@ -1,0 +1,83 @@
+/**
+ * build-chat-transcript.ts
+ *
+ * Pure function that flattens chat messages (text + tool-invocation parts) into
+ * a single transcript string for skill distillation. Text is never truncated;
+ * only oversized individual tool *results* are capped (args and all prose are
+ * kept in full — see docs/superpowers/specs/2026-07-01-skill-distillation-redesign-design.md).
+ */
+
+/** Cap for a single tool result payload, in characters. Never applied to args or chat text. */
+export const TOOL_RESULT_CHAR_CAP = 4000;
+
+export interface ChatMessagePart {
+    type: string;
+    text?: string;
+    toolName?: string;
+    name?: string;
+    toolCallId?: string;
+    args?: unknown;
+    input?: unknown;
+    result?: unknown;
+    output?: unknown;
+}
+
+export interface ChatMessageLike {
+    role: string;
+    parts?: ChatMessagePart[];
+    content?: unknown;
+}
+
+function isToolPart(part: ChatMessagePart): boolean {
+    return part.type === 'tool-invocation' || Boolean(part.toolCallId);
+}
+
+function stringifyValue(value: unknown): string {
+    return typeof value === 'string' ? value : JSON.stringify(value);
+}
+
+function serializeToolPart(part: ChatMessagePart): string {
+    let toolName = part.toolName || part.name;
+    if (!toolName && part.type?.startsWith('tool-')) {
+        toolName = part.type.replace('tool-', '').replace(/_/g, ' ');
+    }
+    toolName = toolName || 'tool';
+
+    const args = part.args || part.input;
+    const result = part.result || part.output;
+
+    const argsStr = args === undefined ? '' : stringifyValue(args);
+    let block = `TOOL_CALL: ${toolName}(${argsStr})`;
+
+    if (result !== undefined) {
+        let resultStr = stringifyValue(result);
+        if (resultStr.length > TOOL_RESULT_CHAR_CAP) {
+            const truncatedCount = resultStr.length - TOOL_RESULT_CHAR_CAP;
+            resultStr = `${resultStr.slice(0, TOOL_RESULT_CHAR_CAP)}  [...truncated ${truncatedCount} more chars]`;
+        }
+        block += `\nTOOL_RESULT: ${resultStr}`;
+    }
+
+    return block;
+}
+
+/** Flattens messages into "ROLE: body" blocks joined by blank lines, preserving part order. */
+export function buildChatTranscript(messages: ChatMessageLike[]): string {
+    return messages
+        .map((m) => {
+            const segments: string[] = [];
+            for (const part of m.parts ?? []) {
+                if (part.type === 'text') {
+                    if (part.text && part.text.trim().length > 0) {
+                        segments.push(part.text);
+                    }
+                } else if (isToolPart(part)) {
+                    segments.push(serializeToolPart(part));
+                }
+            }
+            const body =
+                segments.length > 0 ? segments.join('\n') : typeof m.content === 'string' ? m.content : '';
+            return `${m.role.toUpperCase()}: ${body}`;
+        })
+        .join('\n\n');
+}

--- a/apps/web-ui/lib/client-skill-service.ts
+++ b/apps/web-ui/lib/client-skill-service.ts
@@ -1,6 +1,6 @@
 export interface SkillDTO {
     id: string; name: string; description: string; tier: string;
-    source: string; isEnabled: boolean; createdBy: string | null; updatedAt: string; content?: string;
+    source: string; isEnabled: boolean; createdBy: string | null; createdAt: string; updatedAt: string; content?: string;
 }
 export interface SkillInput {
     name: string; description: string; tier: string; content: string;

--- a/apps/web-ui/lib/db/repositories/agent-memory/interface.ts
+++ b/apps/web-ui/lib/db/repositories/agent-memory/interface.ts
@@ -20,6 +20,8 @@ export interface AgentMemoryRecord {
 export interface AgentMemoryFilters {
     tenantId: string;
     category?: MemoryCategory;
+    /** Multi-select category filter; takes precedence over `category` when non-empty. */
+    categories?: MemoryCategory[];
     search?: string;
     page?: number;
     limit?: number;

--- a/apps/web-ui/lib/db/repositories/agent-memory/interface.ts
+++ b/apps/web-ui/lib/db/repositories/agent-memory/interface.ts
@@ -17,6 +17,10 @@ export interface AgentMemoryRecord {
     expiresAt: string;
 }
 
+/** Columns the list view can be sorted by (server-side). */
+export type AgentMemorySortField = 'category' | 'key' | 'createdAt' | 'expiresAt';
+export type SortDirection = 'asc' | 'desc';
+
 export interface AgentMemoryFilters {
     tenantId: string;
     category?: MemoryCategory;
@@ -25,6 +29,9 @@ export interface AgentMemoryFilters {
     search?: string;
     page?: number;
     limit?: number;
+    /** Sort column; defaults to most-recently-updated first when omitted. */
+    sortBy?: AgentMemorySortField;
+    sortDir?: SortDirection;
 }
 
 export interface AgentMemoryPage {

--- a/apps/web-ui/lib/db/repositories/agent-memory/postgres.test.ts
+++ b/apps/web-ui/lib/db/repositories/agent-memory/postgres.test.ts
@@ -116,4 +116,40 @@ describe('AgentMemoryPostgresRepository', () => {
             where: { id: 'mem-1', tenantId: 't1' },
         });
     });
+
+    it('listByTenant builds an OR of per-category predicates for multiple categories', async () => {
+        const repo = new AgentMemoryPostgresRepository();
+        await repo.listByTenant({ tenantId: 't1', categories: ['infra', 'user'] });
+
+        const arg = mockPrisma.agentMemory.findMany.mock.calls[0][0];
+        expect(arg.where.AND).toEqual([
+            {
+                OR: [
+                    { OR: [{ namespace: { startsWith: 'infra/' } }, { namespace: 'infra' }] },
+                    { OR: [{ namespace: { startsWith: 'user/' } }, { namespace: 'user' }] },
+                ],
+            },
+        ]);
+    });
+
+    it('listByTenant with a single-element categories array keeps the bare per-category shape', async () => {
+        const repo = new AgentMemoryPostgresRepository();
+        await repo.listByTenant({ tenantId: 't1', categories: ['patterns'] });
+
+        const arg = mockPrisma.agentMemory.findMany.mock.calls[0][0];
+        expect(arg.where.AND).toEqual([
+            { OR: [{ namespace: { startsWith: 'patterns/' } }, { namespace: 'patterns' }] },
+        ]);
+    });
+
+    it('listByTenant paginates via skip/take and returns count as total', async () => {
+        mockPrisma.agentMemory.count.mockResolvedValue(42);
+        const repo = new AgentMemoryPostgresRepository();
+        const result = await repo.listByTenant({ tenantId: 't1', page: 3, limit: 10 });
+
+        const arg = mockPrisma.agentMemory.findMany.mock.calls[0][0];
+        expect(arg.skip).toBe(20);
+        expect(arg.take).toBe(10);
+        expect(result.total).toBe(42);
+    });
 });

--- a/apps/web-ui/lib/db/repositories/agent-memory/postgres.test.ts
+++ b/apps/web-ui/lib/db/repositories/agent-memory/postgres.test.ts
@@ -142,6 +142,30 @@ describe('AgentMemoryPostgresRepository', () => {
         ]);
     });
 
+    it('listByTenant defaults to updatedAt desc when no sort is requested', async () => {
+        const repo = new AgentMemoryPostgresRepository();
+        await repo.listByTenant({ tenantId: 't1' });
+
+        const arg = mockPrisma.agentMemory.findMany.mock.calls[0][0];
+        expect(arg.orderBy).toEqual({ updatedAt: 'desc' });
+    });
+
+    it('listByTenant maps a sort field + direction to orderBy', async () => {
+        const repo = new AgentMemoryPostgresRepository();
+        await repo.listByTenant({ tenantId: 't1', sortBy: 'createdAt', sortDir: 'asc' });
+
+        const arg = mockPrisma.agentMemory.findMany.mock.calls[0][0];
+        expect(arg.orderBy).toEqual({ createdAt: 'asc' });
+    });
+
+    it('listByTenant sorts category by the derived namespace column', async () => {
+        const repo = new AgentMemoryPostgresRepository();
+        await repo.listByTenant({ tenantId: 't1', sortBy: 'category', sortDir: 'desc' });
+
+        const arg = mockPrisma.agentMemory.findMany.mock.calls[0][0];
+        expect(arg.orderBy).toEqual({ namespace: 'desc' });
+    });
+
     it('listByTenant paginates via skip/take and returns count as total', async () => {
         mockPrisma.agentMemory.count.mockResolvedValue(42);
         const repo = new AgentMemoryPostgresRepository();

--- a/apps/web-ui/lib/db/repositories/agent-memory/postgres.ts
+++ b/apps/web-ui/lib/db/repositories/agent-memory/postgres.ts
@@ -1,5 +1,6 @@
 import { getTenantClient } from '@/lib/db/pg-config';
 import { categoryFromNamespace, KNOWN_CATEGORIES } from '@/lib/agent-memory/category';
+import type { MemoryCategory } from '@/lib/agent-memory/category';
 import type {
     IAgentMemoryRepository,
     AgentMemoryRecord,
@@ -45,6 +46,21 @@ function toRecord(row: MemoryRow): AgentMemoryRecord {
     };
 }
 
+/** Prisma `where` predicate matching a single derived category via its namespace prefix. */
+function categoryClause(c: MemoryCategory): Record<string, unknown> {
+    if (c === 'other') {
+        return {
+            NOT: {
+                OR: KNOWN_CATEGORIES.flatMap((k) => [
+                    { namespace: { startsWith: `${k}/` } },
+                    { namespace: k },
+                ]),
+            },
+        };
+    }
+    return { OR: [{ namespace: { startsWith: `${c}/` } }, { namespace: c }] };
+}
+
 export class AgentMemoryPostgresRepository implements IAgentMemoryRepository {
     async listByTenant(filters: AgentMemoryFilters): Promise<AgentMemoryPage> {
         const db = getTenantClient(filters.tenantId);
@@ -55,18 +71,12 @@ export class AgentMemoryPostgresRepository implements IAgentMemoryRepository {
         const where: Record<string, unknown> = { tenantId: filters.tenantId };
         const and: unknown[] = [];
 
-        if (filters.category && filters.category !== 'other') {
-            const c = filters.category;
-            and.push({ OR: [{ namespace: { startsWith: `${c}/` } }, { namespace: c }] });
-        } else if (filters.category === 'other') {
-            and.push({
-                NOT: {
-                    OR: KNOWN_CATEGORIES.flatMap((c) => [
-                        { namespace: { startsWith: `${c}/` } },
-                        { namespace: c },
-                    ]),
-                },
-            });
+        const categories =
+            filters.categories?.length ? filters.categories : filters.category ? [filters.category] : [];
+        if (categories.length === 1) {
+            and.push(categoryClause(categories[0]));
+        } else if (categories.length > 1) {
+            and.push({ OR: categories.map(categoryClause) });
         }
 
         if (filters.search) {

--- a/apps/web-ui/lib/db/repositories/agent-memory/postgres.ts
+++ b/apps/web-ui/lib/db/repositories/agent-memory/postgres.ts
@@ -6,6 +6,7 @@ import type {
     AgentMemoryRecord,
     AgentMemoryFilters,
     AgentMemoryPage,
+    AgentMemorySortField,
 } from './interface';
 
 type MemoryRow = {
@@ -61,6 +62,21 @@ function categoryClause(c: MemoryCategory): Record<string, unknown> {
     return { OR: [{ namespace: { startsWith: `${c}/` } }, { namespace: c }] };
 }
 
+/**
+ * Maps a sort field to a Prisma `orderBy`. `category` is derived from the
+ * namespace prefix, so it sorts on `namespace` (close enough to alphabetical
+ * category order). Defaults to newest-updated first when no sort is requested.
+ */
+function orderByClause(
+    sortBy: AgentMemorySortField | undefined,
+    sortDir: 'asc' | 'desc' | undefined
+): Record<string, 'asc' | 'desc'> {
+    if (!sortBy) return { updatedAt: 'desc' };
+    const dir = sortDir ?? 'asc';
+    const column = sortBy === 'category' ? 'namespace' : sortBy;
+    return { [column]: dir };
+}
+
 export class AgentMemoryPostgresRepository implements IAgentMemoryRepository {
     async listByTenant(filters: AgentMemoryFilters): Promise<AgentMemoryPage> {
         const db = getTenantClient(filters.tenantId);
@@ -95,7 +111,7 @@ export class AgentMemoryPostgresRepository implements IAgentMemoryRepository {
         const [rows, total] = await Promise.all([
             db.agentMemory.findMany({
                 where,
-                orderBy: { updatedAt: 'desc' },
+                orderBy: orderByClause(filters.sortBy, filters.sortDir),
                 skip,
                 take: limit,
             }),

--- a/apps/web-ui/lib/nav-config.ts
+++ b/apps/web-ui/lib/nav-config.ts
@@ -36,6 +36,7 @@ export const navMenus: NavItem[] = [
       { title: "Knowledge Base", href: "/app/knowledge-base" },
       { title: "Ask", href: "/app/knowledge-base/ask" },
       { title: "Skills", href: "/app/skills" },
+      { title: "MCP Servers", href: "/app/agent-ops/mcp-settings" },
       // LLM providers power the agents — grouped with Agentic Ops, not Settings.
       { title: "Providers", href: "/app/settings/providers" },
     ],
@@ -67,7 +68,6 @@ export const navMenus: NavItem[] = [
       { title: "Channels", href: "/app/channels" },
       { title: "Jira", href: "/app/agent-ops/jira-settings" },
       { title: "Slack", href: "/app/agent-ops/slack-settings" },
-      { title: "MCP Servers", href: "/app/agent-ops/mcp-settings" },
     ],
   },
   {

--- a/apps/web-ui/lib/queries/agent-memories.ts
+++ b/apps/web-ui/lib/queries/agent-memories.ts
@@ -25,12 +25,16 @@ export interface MemoryRow {
     expiresAt: string;
 }
 
+export type MemorySortField = 'category' | 'key' | 'createdAt' | 'expiresAt';
+
 export interface MemoryFilters {
     category?: MemoryCategory;
     categories?: MemoryCategory[];
     search?: string;
     page?: number;
     limit?: number;
+    sortBy?: MemorySortField;
+    sortDir?: 'asc' | 'desc';
 }
 
 export function useAgentMemories(filters?: MemoryFilters) {
@@ -42,6 +46,10 @@ export function useAgentMemories(filters?: MemoryFilters) {
             if (filters?.category) params.set('category', filters.category);
             if (filters?.categories?.length) params.set('category', filters.categories.join(','));
             if (filters?.search?.trim()) params.set('search', filters.search.trim());
+            if (filters?.sortBy) {
+                params.set('sort', filters.sortBy);
+                params.set('dir', filters.sortDir ?? 'asc');
+            }
             params.set('limit', String(filters?.limit ?? 100));
             params.set('page', String(filters?.page ?? 1));
 

--- a/apps/web-ui/lib/queries/agent-memories.ts
+++ b/apps/web-ui/lib/queries/agent-memories.ts
@@ -27,6 +27,7 @@ export interface MemoryRow {
 
 export interface MemoryFilters {
     category?: MemoryCategory;
+    categories?: MemoryCategory[];
     search?: string;
     page?: number;
     limit?: number;
@@ -39,6 +40,7 @@ export function useAgentMemories(filters?: MemoryFilters) {
             const params = new URLSearchParams();
             // The UI passes `undefined` for the All tab, so only real categories arrive here.
             if (filters?.category) params.set('category', filters.category);
+            if (filters?.categories?.length) params.set('category', filters.categories.join(','));
             if (filters?.search?.trim()) params.set('search', filters.search.trim());
             params.set('limit', String(filters?.limit ?? 100));
             params.set('page', String(filters?.page ?? 1));

--- a/docs/superpowers/plans/2026-07-01-memory-datatable.md
+++ b/docs/superpowers/plans/2026-07-01-memory-datatable.md
@@ -1,0 +1,888 @@
+# Memory Module shadcn Data-Table Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert the Memory module list view into the standard shadcn data-table (server-side pagination, debounced search, faceted multi-select category filter, per-row action dropdown).
+
+**Architecture:** Backend gains multi-category filtering (repo + API) on top of its existing `page`/`limit`/`total` support. The shared `DataTable` primitive gets opt-in manual (server) pagination props. A new shadcn faceted-filter primitive is added. `memory-client-component.tsx` is rewritten to render the `DataTable` in manual-pagination mode with a search + faceted-category toolbar and a per-row `DropdownMenu` (View / Delete). Existing detail + delete dialogs and the delete API route are reused unchanged.
+
+**Tech Stack:** Next.js 15 / React 19, TanStack Query v5, TanStack Table v8, shadcn/ui (Radix), Tailwind, Prisma (repository pattern), Vitest.
+
+## Global Constraints
+
+- Data access only via the repository factory (`@/lib/db/repository-factory`) — never Prisma directly in routes. (Repo internals use `getTenantClient`.)
+- Every query is tenant-scoped; mutating routes call `authorize(action, Subject)`. (No new routes here — reuse existing.)
+- UI: TanStack Query hooks in `lib/queries/<domain>.ts` (keys via `lib/queries/query-keys.ts`); toasts via `import { toast } from "sonner"`; `cn()` from `@/lib/utils`; `@/` import alias.
+- Do NOT modify `components/ui/*` primitives except the two explicitly named here (`data-table.tsx` — additive props; new `data-table-faceted-filter.tsx`).
+- Indentation: 4 spaces in `lib/`/service/api files; 2 spaces in `components/ui/*`. Match the file you edit.
+- web-ui tests: `cd apps/web-ui && bun run test` (Vitest, `vitest run`). Lint: `cd apps/web-ui && bun run lint`.
+- The single-row delete endpoint (`DELETE /api/agent-memories/[id]`) and RBAC (`read`/`delete` on `Memory`) are unchanged. No bulk actions.
+
+---
+
+### Task 1: Repository — multi-category filter
+
+**Files:**
+- Modify: `apps/web-ui/lib/db/repositories/agent-memory/interface.ts`
+- Modify: `apps/web-ui/lib/db/repositories/agent-memory/postgres.ts`
+- Test: `apps/web-ui/lib/db/repositories/agent-memory/postgres.test.ts`
+
+**Interfaces:**
+- Consumes: existing `AgentMemoryFilters`, `KNOWN_CATEGORIES`, `categoryFromNamespace`, `MemoryCategory`.
+- Produces: `AgentMemoryFilters.categories?: MemoryCategory[]`. When `categories` is non-empty it takes precedence over the single `category`; the `where.AND` gets `[{ OR: [<per-category clause>, …] }]` for >1 category, or the bare per-category clause for exactly 1 (preserving current single-category shape). Single-category clause = `{ OR: [{ namespace: { startsWith: `${c}/` } }, { namespace: c }] }`; `other` = `{ NOT: { OR: <all known prefix clauses> } }`.
+
+- [ ] **Step 1: Add the `categories` field to the filter interface**
+
+In `interface.ts`, add one line inside `AgentMemoryFilters`:
+
+```typescript
+export interface AgentMemoryFilters {
+    tenantId: string;
+    category?: MemoryCategory;
+    /** Multi-select category filter; takes precedence over `category` when non-empty. */
+    categories?: MemoryCategory[];
+    search?: string;
+    page?: number;
+    limit?: number;
+}
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Append these tests inside the `describe('AgentMemoryPostgresRepository', …)` block in `postgres.test.ts`:
+
+```typescript
+    it('listByTenant builds an OR of per-category predicates for multiple categories', async () => {
+        const repo = new AgentMemoryPostgresRepository();
+        await repo.listByTenant({ tenantId: 't1', categories: ['infra', 'user'] });
+
+        const arg = mockPrisma.agentMemory.findMany.mock.calls[0][0];
+        expect(arg.where.AND).toEqual([
+            {
+                OR: [
+                    { OR: [{ namespace: { startsWith: 'infra/' } }, { namespace: 'infra' }] },
+                    { OR: [{ namespace: { startsWith: 'user/' } }, { namespace: 'user' }] },
+                ],
+            },
+        ]);
+    });
+
+    it('listByTenant with a single-element categories array keeps the bare per-category shape', async () => {
+        const repo = new AgentMemoryPostgresRepository();
+        await repo.listByTenant({ tenantId: 't1', categories: ['patterns'] });
+
+        const arg = mockPrisma.agentMemory.findMany.mock.calls[0][0];
+        expect(arg.where.AND).toEqual([
+            { OR: [{ namespace: { startsWith: 'patterns/' } }, { namespace: 'patterns' }] },
+        ]);
+    });
+
+    it('listByTenant paginates via skip/take and returns count as total', async () => {
+        mockPrisma.agentMemory.count.mockResolvedValue(42);
+        const repo = new AgentMemoryPostgresRepository();
+        const result = await repo.listByTenant({ tenantId: 't1', page: 3, limit: 10 });
+
+        const arg = mockPrisma.agentMemory.findMany.mock.calls[0][0];
+        expect(arg.skip).toBe(20);
+        expect(arg.take).toBe(10);
+        expect(result.total).toBe(42);
+    });
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd apps/web-ui && bunx vitest run lib/db/repositories/agent-memory/postgres.test.ts`
+Expected: the two `categories` tests FAIL (current code ignores `categories`, so `where.AND` is `[]` / `undefined`). The pagination test should PASS already (it documents existing behavior).
+
+- [ ] **Step 4: Implement multi-category filtering**
+
+In `postgres.ts`, add the `MemoryCategory` type import and a `categoryClause` helper, then replace the existing single-category `if/else if` block.
+
+Change the import line at the top:
+
+```typescript
+import { categoryFromNamespace, KNOWN_CATEGORIES } from '@/lib/agent-memory/category';
+import type { MemoryCategory } from '@/lib/agent-memory/category';
+```
+
+Add this helper above the class (after `toRecord`):
+
+```typescript
+/** Prisma `where` predicate matching a single derived category via its namespace prefix. */
+function categoryClause(c: MemoryCategory): Record<string, unknown> {
+    if (c === 'other') {
+        return {
+            NOT: {
+                OR: KNOWN_CATEGORIES.flatMap((k) => [
+                    { namespace: { startsWith: `${k}/` } },
+                    { namespace: k },
+                ]),
+            },
+        };
+    }
+    return { OR: [{ namespace: { startsWith: `${c}/` } }, { namespace: c }] };
+}
+```
+
+Replace this existing block:
+
+```typescript
+        if (filters.category && filters.category !== 'other') {
+            const c = filters.category;
+            and.push({ OR: [{ namespace: { startsWith: `${c}/` } }, { namespace: c }] });
+        } else if (filters.category === 'other') {
+            and.push({
+                NOT: {
+                    OR: KNOWN_CATEGORIES.flatMap((c) => [
+                        { namespace: { startsWith: `${c}/` } },
+                        { namespace: c },
+                    ]),
+                },
+            });
+        }
+```
+
+with:
+
+```typescript
+        const categories =
+            filters.categories?.length ? filters.categories : filters.category ? [filters.category] : [];
+        if (categories.length === 1) {
+            and.push(categoryClause(categories[0]));
+        } else if (categories.length > 1) {
+            and.push({ OR: categories.map(categoryClause) });
+        }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd apps/web-ui && bunx vitest run lib/db/repositories/agent-memory/postgres.test.ts`
+Expected: PASS (all tests, including the pre-existing single-`category` and `other` tests — the refactor preserves their shapes).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web-ui/lib/db/repositories/agent-memory/interface.ts apps/web-ui/lib/db/repositories/agent-memory/postgres.ts apps/web-ui/lib/db/repositories/agent-memory/postgres.test.ts
+git commit -m "feat(memory): repository multi-category namespace filter"
+```
+
+---
+
+### Task 2: API route — comma-separated category parsing
+
+**Files:**
+- Modify: `apps/web-ui/app/api/agent-memories/route.ts`
+- Test: `apps/web-ui/app/api/agent-memories/agent-memories-api.test.ts`
+
+**Interfaces:**
+- Consumes: `AgentMemoryFilters.categories` (Task 1), `VALID_CATEGORIES`, `MemoryCategory`.
+- Produces: `GET` splits the `category` query param on `,`, trims, validates each against `VALID_CATEGORIES`, and passes `categories: MemoryCategory[]` (empty array when none) to `repo.listByTenant`. The single `category` field is no longer passed.
+
+- [ ] **Step 1: Update the existing test + add new CSV tests**
+
+In `agent-memories-api.test.ts`, change the first `GET` test's assertion from `category: 'infra'` to `categories: ['infra']`:
+
+```typescript
+    it('scopes the list query to the session tenant and returns the envelope', async () => {
+        repo.listByTenant.mockResolvedValue({ memories: [{ id: 'mem-1' }], total: 1 });
+        const req = new Request('http://localhost/api/agent-memories?category=infra&search=ecs');
+        const res = await GET(req as any);
+        const body = await res.json();
+
+        expect(repo.listByTenant).toHaveBeenCalledWith(
+            expect.objectContaining({ tenantId: 'tenant-a', categories: ['infra'], search: 'ecs' })
+        );
+        expect(body).toEqual({ success: true, data: [{ id: 'mem-1' }], total: 1 });
+    });
+```
+
+Add two more tests inside the `describe('GET /api/agent-memories', …)` block:
+
+```typescript
+    it('parses a comma-separated category param into a validated categories array', async () => {
+        repo.listByTenant.mockResolvedValue({ memories: [], total: 0 });
+        const req = new Request('http://localhost/api/agent-memories?category=infra,user,bogus');
+        await GET(req as any);
+        expect(repo.listByTenant).toHaveBeenCalledWith(
+            expect.objectContaining({ categories: ['infra', 'user'] })
+        );
+    });
+
+    it('passes an empty categories array when no category param is present', async () => {
+        repo.listByTenant.mockResolvedValue({ memories: [], total: 0 });
+        const req = new Request('http://localhost/api/agent-memories');
+        await GET(req as any);
+        expect(repo.listByTenant).toHaveBeenCalledWith(
+            expect.objectContaining({ categories: [] })
+        );
+    });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/web-ui && bunx vitest run app/api/agent-memories/agent-memories-api.test.ts`
+Expected: the updated + two new tests FAIL (route still passes `category`, not `categories`).
+
+- [ ] **Step 3: Implement CSV parsing in the route**
+
+In `route.ts`, replace this block:
+
+```typescript
+        const { searchParams } = new URL(request.url);
+        const rawCategory = searchParams.get('category');
+        const category =
+            rawCategory && VALID_CATEGORIES.has(rawCategory as MemoryCategory)
+                ? (rawCategory as MemoryCategory)
+                : undefined;
+
+        const repo = getAgentMemoryRepository();
+        const result = await repo.listByTenant({
+            tenantId,
+            category,
+            search: searchParams.get('search') || undefined,
+            limit: parseInt(searchParams.get('limit') || '100', 10),
+            page: parseInt(searchParams.get('page') || '1', 10),
+        });
+```
+
+with:
+
+```typescript
+        const { searchParams } = new URL(request.url);
+        const categories = (searchParams.get('category') ?? '')
+            .split(',')
+            .map((c) => c.trim())
+            .filter((c): c is MemoryCategory => VALID_CATEGORIES.has(c as MemoryCategory));
+
+        const repo = getAgentMemoryRepository();
+        const result = await repo.listByTenant({
+            tenantId,
+            categories,
+            search: searchParams.get('search') || undefined,
+            limit: parseInt(searchParams.get('limit') || '100', 10),
+            page: parseInt(searchParams.get('page') || '1', 10),
+        });
+```
+
+(`VALID_CATEGORIES` and the `MemoryCategory` import already exist in this file.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/web-ui && bunx vitest run app/api/agent-memories/agent-memories-api.test.ts`
+Expected: PASS (all GET + DELETE tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web-ui/app/api/agent-memories/route.ts apps/web-ui/app/api/agent-memories/agent-memories-api.test.ts
+git commit -m "feat(memory): parse comma-separated category filter in list API"
+```
+
+---
+
+### Task 3: Shared DataTable — opt-in manual (server) pagination
+
+**Files:**
+- Modify: `apps/web-ui/components/ui/data-table.tsx`
+
+**Interfaces:**
+- Consumes: `PaginationState`, `OnChangeFn` from `@tanstack/react-table`.
+- Produces: four new optional `DataTableProps` — `manualPagination?: boolean`, `rowCount?: number`, `pagination?: PaginationState`, `onPaginationChange?: OnChangeFn<PaginationState>`. When `manualPagination` is set, the table uses the controlled `pagination`/`onPaginationChange` (or internal state as fallback), sets TanStack `manualPagination: true` + `rowCount`, and omits `getPaginationRowModel`. Consumers passing none of these props get the current client-side behavior unchanged.
+
+- [ ] **Step 1: Extend the import to include `OnChangeFn`**
+
+Add `OnChangeFn` to the existing `@tanstack/react-table` import block (it already imports `PaginationState`):
+
+```typescript
+import {
+  ColumnDef,
+  SortingState,
+  ColumnFiltersState,
+  VisibilityState,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+  PaginationState,
+  OnChangeFn,
+} from '@tanstack/react-table';
+```
+
+- [ ] **Step 2: Add the four props to the interface**
+
+Add to `interface DataTableProps<TData, TValue>` (after `pageSizeOptions?`):
+
+```typescript
+  manualPagination?: boolean;
+  rowCount?: number;
+  pagination?: PaginationState;
+  onPaginationChange?: OnChangeFn<PaginationState>;
+```
+
+- [ ] **Step 3: Destructure the new props with defaults**
+
+Add them to the component's destructured parameter list (after `pageSizeOptions`):
+
+```typescript
+  manualPagination = false,
+  rowCount,
+  pagination: controlledPagination,
+  onPaginationChange,
+```
+
+- [ ] **Step 4: Wire controlled-vs-internal pagination state**
+
+Replace the existing internal pagination `useState`:
+
+```typescript
+  const [pagination, setPagination] = React.useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: defaultPageSize,
+  });
+```
+
+with:
+
+```typescript
+  const [internalPagination, setInternalPagination] = React.useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: defaultPageSize,
+  });
+  const pagination = controlledPagination ?? internalPagination;
+  const setPagination: OnChangeFn<PaginationState> = onPaginationChange ?? setInternalPagination;
+```
+
+- [ ] **Step 5: Pass manual-pagination options to `useReactTable`**
+
+In the `useReactTable({ … })` call, update the pagination-related options. The `state.pagination`, `onPaginationChange` lines already reference `pagination`/`setPagination` (now the resolved values). Change the `getPaginationRowModel` line and add `manualPagination` + `rowCount`:
+
+```typescript
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: enableFiltering ? getFilteredRowModel() : undefined,
+    getPaginationRowModel:
+      enablePagination && !manualPagination ? getPaginationRowModel() : undefined,
+    getSortedRowModel: enableSorting ? getSortedRowModel() : undefined,
+    manualPagination,
+    rowCount: manualPagination ? rowCount : undefined,
+```
+
+- [ ] **Step 6: Verify types compile and Skills is unaffected**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit -p tsconfig.json`
+Expected: no NEW errors introduced by `data-table.tsx` (compare against the pre-existing baseline — this repo carries a known tsc error baseline; the diff must add zero errors in `data-table.tsx`, `skills-client.tsx`, or their imports).
+
+Run: `cd apps/web-ui && bun run lint`
+Expected: no new lint errors in `components/ui/data-table.tsx`.
+
+Manual reasoning check (no code change): `skills-client.tsx` passes none of `manualPagination`/`rowCount`/`pagination`/`onPaginationChange`, so `manualPagination` defaults `false`, `pagination` falls back to internal state, and `getPaginationRowModel` is still applied — identical to before.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web-ui/components/ui/data-table.tsx
+git commit -m "feat(ui): opt-in manual/server pagination for shared DataTable"
+```
+
+---
+
+### Task 4: New primitive — DataTable faceted filter
+
+**Files:**
+- Create: `apps/web-ui/components/ui/data-table-faceted-filter.tsx`
+
+**Interfaces:**
+- Consumes: `Popover*`, `Command*`, `Badge`, `Button`, `Separator`, `cn`, lucide `Check`/`PlusCircle`.
+- Produces: `DataTableFacetedFilter` component + `FacetedFilterOption` type. Props: `title: string`, `options: FacetedFilterOption[]` (`{ label; value; icon? }`), `selected: string[]`, `onChange: (values: string[]) => void`. Multi-select; toggling an option calls `onChange` with the next array; a "Clear filters" footer calls `onChange([])`.
+
+- [ ] **Step 1: Create the faceted filter component**
+
+Create `apps/web-ui/components/ui/data-table-faceted-filter.tsx` with exactly:
+
+```tsx
+'use client';
+
+import * as React from 'react';
+import { Check, PlusCircle } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from '@/components/ui/command';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { Separator } from '@/components/ui/separator';
+
+export interface FacetedFilterOption {
+  label: string;
+  value: string;
+  icon?: React.ComponentType<{ className?: string }>;
+}
+
+interface DataTableFacetedFilterProps {
+  title: string;
+  options: FacetedFilterOption[];
+  selected: string[];
+  onChange: (values: string[]) => void;
+}
+
+export function DataTableFacetedFilter({
+  title,
+  options,
+  selected,
+  onChange,
+}: DataTableFacetedFilterProps) {
+  const selectedSet = new Set(selected);
+
+  const toggle = (value: string) => {
+    const next = new Set(selectedSet);
+    if (next.has(value)) next.delete(value);
+    else next.add(value);
+    onChange(Array.from(next));
+  };
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline" size="sm" className="h-9 border-dashed">
+          <PlusCircle className="mr-2 h-4 w-4" />
+          {title}
+          {selectedSet.size > 0 && (
+            <>
+              <Separator orientation="vertical" className="mx-2 h-4" />
+              <Badge variant="secondary" className="rounded-sm px-1 font-normal lg:hidden">
+                {selectedSet.size}
+              </Badge>
+              <div className="hidden space-x-1 lg:flex">
+                {selectedSet.size > 2 ? (
+                  <Badge variant="secondary" className="rounded-sm px-1 font-normal">
+                    {selectedSet.size} selected
+                  </Badge>
+                ) : (
+                  options
+                    .filter((o) => selectedSet.has(o.value))
+                    .map((o) => (
+                      <Badge
+                        key={o.value}
+                        variant="secondary"
+                        className="rounded-sm px-1 font-normal"
+                      >
+                        {o.label}
+                      </Badge>
+                    ))
+                )}
+              </div>
+            </>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[200px] p-0" align="start">
+        <Command>
+          <CommandInput placeholder={title} />
+          <CommandList>
+            <CommandEmpty>No results found.</CommandEmpty>
+            <CommandGroup>
+              {options.map((option) => {
+                const isSelected = selectedSet.has(option.value);
+                return (
+                  <CommandItem key={option.value} onSelect={() => toggle(option.value)}>
+                    <div
+                      className={cn(
+                        'mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-primary',
+                        isSelected
+                          ? 'bg-primary text-primary-foreground'
+                          : 'opacity-50 [&_svg]:invisible'
+                      )}
+                    >
+                      <Check className="h-4 w-4" />
+                    </div>
+                    {option.icon && (
+                      <option.icon className="mr-2 h-4 w-4 text-muted-foreground" />
+                    )}
+                    <span>{option.label}</span>
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+            {selectedSet.size > 0 && (
+              <>
+                <CommandSeparator />
+                <CommandGroup>
+                  <CommandItem
+                    onSelect={() => onChange([])}
+                    className="justify-center text-center"
+                  >
+                    Clear filters
+                  </CommandItem>
+                </CommandGroup>
+              </>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit -p tsconfig.json`
+Expected: zero new errors attributable to `data-table-faceted-filter.tsx`.
+
+Run: `cd apps/web-ui && bun run lint`
+Expected: no new lint errors in the new file.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web-ui/components/ui/data-table-faceted-filter.tsx
+git commit -m "feat(ui): shadcn faceted multi-select filter primitive"
+```
+
+---
+
+### Task 5: Query hook + rewrite the Memory client component
+
+**Files:**
+- Modify: `apps/web-ui/lib/queries/agent-memories.ts`
+- Modify (full rewrite): `apps/web-ui/components/memory/memory-client-component.tsx`
+
+**Interfaces:**
+- Consumes: `useAgentMemories`/`useDeleteAgentMemory`/`MemoryRow` (hook), `DataTable` with manual pagination (Task 3), `DataTableFacetedFilter` (Task 4), `MemoryDetailDialog`, `DeleteMemoryDialog`, `KNOWN_CATEGORIES`/`MemoryCategory`, `useDebounce`.
+- Produces: `MemoryFilters.categories?: MemoryCategory[]` (serialized to the CSV `category` param); the rewritten `MemoryClientComponent` (same export name).
+
+- [ ] **Step 1: Add `categories` to the query hook**
+
+In `agent-memories.ts`, add the field to `MemoryFilters`:
+
+```typescript
+export interface MemoryFilters {
+    category?: MemoryCategory;
+    categories?: MemoryCategory[];
+    search?: string;
+    page?: number;
+    limit?: number;
+}
+```
+
+In `useAgentMemories`'s `queryFn`, after the existing single-category line, serialize `categories` to the same `category` param (the array form wins when present):
+
+```typescript
+            // The UI passes `undefined` for the All tab, so only real categories arrive here.
+            if (filters?.category) params.set('category', filters.category);
+            if (filters?.categories?.length) params.set('category', filters.categories.join(','));
+```
+
+(Everything else in the hook — return shape, `queryKeys.agentMemories.list(filters)`, `placeholderData: (prev) => prev`, `useDeleteAgentMemory` — stays as-is.)
+
+- [ ] **Step 2: Rewrite `memory-client-component.tsx`**
+
+Replace the entire contents of `apps/web-ui/components/memory/memory-client-component.tsx` with:
+
+```tsx
+"use client";
+
+import { useMemo, useState } from "react";
+import type { ColumnDef, PaginationState } from "@tanstack/react-table";
+import { Brain, MoreHorizontal, Eye, Trash2, Search, X } from "lucide-react";
+import { toast } from "sonner";
+import { PageHeader } from "@/components/shared/page-header";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { DataTable } from "@/components/ui/data-table";
+import { DataTableFacetedFilter } from "@/components/ui/data-table-faceted-filter";
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { KNOWN_CATEGORIES, type MemoryCategory } from "@/lib/agent-memory/category";
+import {
+    useAgentMemories,
+    useDeleteAgentMemory,
+    type MemoryRow,
+} from "@/lib/queries/agent-memories";
+import { useDebounce } from "@/hooks/use-debounce";
+import { MemoryDetailDialog } from "./memory-detail-dialog";
+import { DeleteMemoryDialog } from "./delete-memory-dialog";
+
+const CATEGORY_OPTIONS: { label: string; value: MemoryCategory }[] = [
+    ...KNOWN_CATEGORIES,
+    "other" as const,
+].map((c) => ({ label: c.charAt(0).toUpperCase() + c.slice(1), value: c }));
+
+function confidenceVariant(c: string | null): "default" | "secondary" | "outline" {
+    if (c === "high") return "default";
+    if (c === "medium") return "secondary";
+    return "outline";
+}
+
+export function MemoryClientComponent() {
+    const [pagination, setPagination] = useState<PaginationState>({ pageIndex: 0, pageSize: 10 });
+    const [searchInput, setSearchInput] = useState("");
+    const search = useDebounce(searchInput, 300);
+    const [categories, setCategories] = useState<MemoryCategory[]>([]);
+    const [detail, setDetail] = useState<MemoryRow | null>(null);
+    const [deleteTarget, setDeleteTarget] = useState<MemoryRow | null>(null);
+
+    const { data, isLoading } = useAgentMemories({
+        page: pagination.pageIndex + 1,
+        limit: pagination.pageSize,
+        categories: categories.length ? categories : undefined,
+        search: search || undefined,
+    });
+    const memories = data?.data ?? [];
+    const total = data?.total ?? 0;
+    const del = useDeleteAgentMemory();
+
+    // Any server-side filter change must return to the first page.
+    const resetToFirstPage = () => setPagination((p) => ({ ...p, pageIndex: 0 }));
+    const handleSearchChange = (v: string) => {
+        setSearchInput(v);
+        resetToFirstPage();
+    };
+    const handleCategoriesChange = (values: string[]) => {
+        setCategories(values as MemoryCategory[]);
+        resetToFirstPage();
+    };
+    const clearFilters = () => {
+        setSearchInput("");
+        setCategories([]);
+        resetToFirstPage();
+    };
+
+    const handleDelete = () => {
+        if (!deleteTarget) return;
+        const target = deleteTarget;
+        del.mutate(target.id, {
+            onSuccess: () => {
+                toast.success("Memory deleted", { description: target.key });
+                setDeleteTarget(null);
+            },
+            onError: (e) => {
+                toast.error("Failed to delete memory", {
+                    description: e instanceof Error ? e.message : undefined,
+                });
+            },
+        });
+    };
+
+    const columns = useMemo<ColumnDef<MemoryRow>[]>(
+        () => [
+            {
+                accessorKey: "category",
+                header: "Category",
+                enableSorting: false,
+                cell: ({ row }) => <Badge variant="outline">{row.original.category}</Badge>,
+            },
+            {
+                accessorKey: "key",
+                header: "Key",
+                enableSorting: false,
+                cell: ({ row }) => (
+                    <button
+                        type="button"
+                        onClick={() => setDetail(row.original)}
+                        className="text-left font-medium hover:underline"
+                    >
+                        {row.original.key}
+                    </button>
+                ),
+            },
+            {
+                accessorKey: "fact",
+                header: "Fact",
+                enableSorting: false,
+                cell: ({ row }) => (
+                    <span className="block max-w-md truncate">{row.original.fact}</span>
+                ),
+            },
+            {
+                accessorKey: "confidence",
+                header: "Confidence",
+                enableSorting: false,
+                cell: ({ row }) =>
+                    row.original.confidence ? (
+                        <Badge variant={confidenceVariant(row.original.confidence)}>
+                            {row.original.confidence}
+                        </Badge>
+                    ) : (
+                        <span className="text-muted-foreground">—</span>
+                    ),
+            },
+            {
+                accessorKey: "createdAt",
+                header: "Created",
+                enableSorting: false,
+                cell: ({ row }) => (
+                    <span className="whitespace-nowrap text-sm text-muted-foreground">
+                        {new Date(row.original.createdAt).toLocaleDateString()}
+                    </span>
+                ),
+            },
+            {
+                accessorKey: "expiresAt",
+                header: "Expires",
+                enableSorting: false,
+                cell: ({ row }) => (
+                    <span className="whitespace-nowrap text-sm text-muted-foreground">
+                        {new Date(row.original.expiresAt).toLocaleDateString()}
+                    </span>
+                ),
+            },
+            {
+                id: "actions",
+                header: () => <div className="text-right">Actions</div>,
+                enableSorting: false,
+                cell: ({ row }) => {
+                    const m = row.original;
+                    return (
+                        <div className="flex justify-end">
+                            <DropdownMenu>
+                                <DropdownMenuTrigger asChild>
+                                    <Button variant="ghost" className="h-8 w-8 p-0">
+                                        <span className="sr-only">Open actions</span>
+                                        <MoreHorizontal className="h-4 w-4" />
+                                    </Button>
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent align="end">
+                                    <DropdownMenuItem onClick={() => setDetail(m)}>
+                                        <Eye className="mr-2 h-4 w-4" />
+                                        View details
+                                    </DropdownMenuItem>
+                                    <DropdownMenuItem
+                                        onClick={() => setDeleteTarget(m)}
+                                        className="text-destructive"
+                                    >
+                                        <Trash2 className="mr-2 h-4 w-4" />
+                                        Delete
+                                    </DropdownMenuItem>
+                                </DropdownMenuContent>
+                            </DropdownMenu>
+                        </div>
+                    );
+                },
+            },
+        ],
+        []
+    );
+
+    const hasFilters = search.length > 0 || categories.length > 0;
+
+    return (
+        <div className="space-y-4">
+            <PageHeader
+                icon={Brain}
+                title="Memory"
+                description="What the AI Ops agent has learned across sessions. Review and prune as needed."
+            />
+
+            <DataTable
+                columns={columns}
+                data={memories}
+                loading={isLoading}
+                enableSorting={false}
+                enableFiltering={false}
+                manualPagination
+                rowCount={total}
+                pagination={pagination}
+                onPaginationChange={setPagination}
+                emptyMessage={
+                    hasFilters
+                        ? "No memories match your filters."
+                        : "No memories yet — the AI Ops agent will populate these as it works."
+                }
+                header={
+                    <div className="flex flex-wrap items-center gap-2">
+                        <div className="relative max-w-xs flex-1">
+                            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                            <Input
+                                placeholder="Search key or fact…"
+                                value={searchInput}
+                                onChange={(e) => handleSearchChange(e.target.value)}
+                                className="pl-9"
+                            />
+                        </div>
+                        <DataTableFacetedFilter
+                            title="Category"
+                            options={CATEGORY_OPTIONS}
+                            selected={categories}
+                            onChange={handleCategoriesChange}
+                        />
+                        {hasFilters && (
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={clearFilters}
+                                className="h-9 px-2 lg:px-3"
+                            >
+                                Reset
+                                <X className="ml-2 h-4 w-4" />
+                            </Button>
+                        )}
+                    </div>
+                }
+            />
+
+            <MemoryDetailDialog memory={detail} onClose={() => setDetail(null)} />
+            <DeleteMemoryDialog
+                target={deleteTarget}
+                pending={del.isPending}
+                onCancel={() => setDeleteTarget(null)}
+                onConfirm={handleDelete}
+            />
+        </div>
+    );
+}
+```
+
+- [ ] **Step 3: Typecheck and lint**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit -p tsconfig.json`
+Expected: zero new errors in `memory-client-component.tsx` or `agent-memories.ts`.
+
+Run: `cd apps/web-ui && bun run lint`
+Expected: no new lint errors in the two modified files.
+
+- [ ] **Step 4: Run the full web-ui test suite**
+
+Run: `cd apps/web-ui && bun run test`
+Expected: the memory repo + API tests pass; no previously-passing test regresses (this repo has a known set of pre-existing mock-harness failures — compare against baseline, add zero new failures).
+
+- [ ] **Step 5: Manual/Playwright verification against the running app**
+
+Start the dev server (needs Postgres up: `docker compose up -d postgres`): `cd apps/web-ui && bun run dev` (port 3001). Then, using the Playwright MCP server (or manually in a browser), sign in and navigate to `/app/memory`, and verify:
+
+1. The table renders memories with columns Category / Key / Fact / Confidence / Created / Expires / Actions.
+2. The pagination footer shows "Page 1 of N", the page-size selector changes rows-per-page, and Next/Prev navigate server pages (the row set changes and the request `?page=` increments — check the Network tab / `browser_network_requests`).
+3. Typing in the search box filters after the 300 ms debounce and resets to page 1.
+4. The **Category** faceted filter multi-selects (e.g. select Infra + User), narrows results, shows count badges, and "Clear filters" / "Reset" restores the full list.
+5. A row's **⋯** dropdown opens with **View details** (opens the detail dialog) and **Delete** (opens the confirm dialog); confirming Delete removes the row, fires a success toast, and the list refetches.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web-ui/lib/queries/agent-memories.ts apps/web-ui/components/memory/memory-client-component.tsx
+git commit -m "feat(memory): shadcn data-table with server pagination, faceted category filter, row action menu"
+```
+
+---
+
+## Notes / known cosmetics
+
+- The shared `DataTablePagination` footer shows a "0 of N row(s) selected." line. Memory has no selection column, so it will read "0 of \<page rows\> row(s) selected." — this is the same benign line already shown by the Skills module and is intentionally left unchanged for consistency (not worth a shared-primitive change).
+- Column sorting is intentionally disabled: the server always returns `updatedAt desc`, and TanStack client sorting would only reorder the current page under manual pagination, which would mislead. Server-side sorting is explicitly out of scope.

--- a/docs/superpowers/plans/2026-07-01-skill-distillation-redesign.md
+++ b/docs/superpowers/plans/2026-07-01-skill-distillation-redesign.md
@@ -1,0 +1,677 @@
+# Skill Distillation Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ground "convert chat to skill" distillation in the real tool calls made during a conversation, make the distillation prompt domain-agnostic instead of AWS/CloudOps-locked, and remove the hard 24k-character transcript truncation.
+
+**Architecture:** A new pure function (`buildChatTranscript`) replaces the inline transcript-building code in the chat UI, now interleaving text and tool-invocation parts (capping only oversized individual tool *results*, never chat text). The `/api/skills/distill` route drops its character-slice truncation in favor of a pre-flight size guard that fails fast with a clear error, and its prompt is rewritten to infer domain/tools from the transcript instead of assuming AWS.
+
+**Tech Stack:** Next.js 15 App Router API route, React 19 client component, TypeScript, Vitest (`apps/web-ui` test suite, `environment: 'node'`, `globals: true`, `@/*` alias to `apps/web-ui/`).
+
+## Global Constraints
+
+- No Prisma schema changes, no new UI fields — output contract stays `{ name, description, tier, content }`.
+- The `tier` enum (`"read-only" | "mutation" | "approval-gated"`) is unchanged — it is also hardcoded as a Zod enum in `apps/web-ui/components/skills/skill-form-dialog.tsx:23`, so do not touch that file.
+- `TOOL_RESULT_CHAR_CAP = 4000` — caps only individual tool *result* payloads; tool *args* and all chat text are never capped.
+- `MAX_TRANSCRIPT_CHARS = 600_000` — server-side pre-flight guard in the distill route; returns HTTP 413 before any LLM call.
+- Follow existing test conventions exactly: see `apps/web-ui/app/api/skills/route.test.ts` for the `next/server` mock pattern and `makeRequest` helper style used throughout `apps/web-ui/app/api/**/*.test.ts`.
+- Design spec: `docs/superpowers/specs/2026-07-01-skill-distillation-redesign-design.md`.
+
+---
+
+### Task 1: `buildChatTranscript` pure function
+
+**Files:**
+- Create: `apps/web-ui/lib/agent/build-chat-transcript.ts`
+- Test: `apps/web-ui/lib/agent/build-chat-transcript.test.ts`
+
+**Interfaces:**
+- Produces: `TOOL_RESULT_CHAR_CAP: number`, `ChatMessagePart` interface, `ChatMessageLike` interface, `buildChatTranscript(messages: ChatMessageLike[]): string` — all exported from `apps/web-ui/lib/agent/build-chat-transcript.ts`. Task 2 imports and calls `buildChatTranscript`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/web-ui/lib/agent/build-chat-transcript.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { buildChatTranscript, TOOL_RESULT_CHAR_CAP, type ChatMessageLike } from './build-chat-transcript';
+
+describe('buildChatTranscript', () => {
+    it('includes text parts verbatim and untruncated', () => {
+        const longText = 'a'.repeat(50_000);
+        const messages: ChatMessageLike[] = [
+            { role: 'user', parts: [{ type: 'text', text: longText }] },
+        ];
+        const result = buildChatTranscript(messages);
+        expect(result).toBe(`USER: ${longText}`);
+    });
+
+    it('serializes a tool-invocation part with name, args, and result', () => {
+        const messages: ChatMessageLike[] = [
+            {
+                role: 'assistant',
+                parts: [
+                    {
+                        type: 'tool-invocation',
+                        toolCallId: 'call_1',
+                        toolName: 'execute_command',
+                        args: { command: 'aws ce get-cost-and-usage' },
+                        result: 'ok',
+                    },
+                ],
+            },
+        ];
+        const result = buildChatTranscript(messages);
+        expect(result).toBe(
+            'ASSISTANT: TOOL_CALL: execute_command({"command":"aws ce get-cost-and-usage"})\nTOOL_RESULT: ok',
+        );
+    });
+
+    it('caps a large tool result but keeps args in full', () => {
+        const bigArgValue = 'x'.repeat(4_500);
+        const bigResult = 'y'.repeat(5_000);
+        const messages: ChatMessageLike[] = [
+            {
+                role: 'assistant',
+                parts: [
+                    {
+                        type: 'tool-invocation',
+                        toolCallId: 'call_2',
+                        toolName: 'list_instances',
+                        args: { note: bigArgValue },
+                        result: bigResult,
+                    },
+                ],
+            },
+        ];
+        const result = buildChatTranscript(messages);
+        // args untouched, full length present
+        expect(result).toContain(JSON.stringify({ note: bigArgValue }));
+        // result capped at TOOL_RESULT_CHAR_CAP with a truncation marker
+        expect(result).toContain('y'.repeat(TOOL_RESULT_CHAR_CAP));
+        expect(result).not.toContain('y'.repeat(TOOL_RESULT_CHAR_CAP + 1));
+        expect(result).toContain('[...truncated 1000 more chars]');
+    });
+
+    it('leaves a small tool result untouched', () => {
+        const messages: ChatMessageLike[] = [
+            {
+                role: 'assistant',
+                parts: [
+                    {
+                        type: 'tool-invocation',
+                        toolCallId: 'call_3',
+                        toolName: 'get_status',
+                        args: {},
+                        result: 'all good',
+                    },
+                ],
+            },
+        ];
+        const result = buildChatTranscript(messages);
+        expect(result).toContain('TOOL_RESULT: all good');
+        expect(result).not.toContain('truncated');
+    });
+
+    it('interleaves text and tool parts in original order', () => {
+        const messages: ChatMessageLike[] = [
+            {
+                role: 'assistant',
+                parts: [
+                    { type: 'text', text: 'Checking costs now.' },
+                    {
+                        type: 'tool-invocation',
+                        toolCallId: 'call_4',
+                        toolName: 'get_cost',
+                        args: {},
+                        result: '$100',
+                    },
+                    { type: 'text', text: 'Total spend is $100.' },
+                ],
+            },
+        ];
+        const result = buildChatTranscript(messages);
+        const idxA = result.indexOf('Checking costs now.');
+        const idxTool = result.indexOf('TOOL_CALL: get_cost');
+        const idxB = result.indexOf('Total spend is $100.');
+        expect(idxA).toBeGreaterThanOrEqual(0);
+        expect(idxTool).toBeGreaterThan(idxA);
+        expect(idxB).toBeGreaterThan(idxTool);
+    });
+
+    it('falls back to message.content when parts is empty or absent', () => {
+        const messages: ChatMessageLike[] = [{ role: 'user', content: 'hello there' }];
+        const result = buildChatTranscript(messages);
+        expect(result).toBe('USER: hello there');
+    });
+
+    it('derives tool name from a "tool-<name>" part type when toolName/name are absent', () => {
+        const messages: ChatMessageLike[] = [
+            {
+                role: 'assistant',
+                parts: [
+                    {
+                        type: 'tool-execute_command',
+                        toolCallId: 'call_5',
+                        args: { command: 'ls' },
+                        result: 'file.txt',
+                    },
+                ],
+            },
+        ];
+        const result = buildChatTranscript(messages);
+        expect(result).toContain('TOOL_CALL: execute command({"command":"ls"})');
+    });
+
+    it('joins multiple messages with a blank line between them', () => {
+        const messages: ChatMessageLike[] = [
+            { role: 'user', parts: [{ type: 'text', text: 'Hi' }] },
+            { role: 'assistant', parts: [{ type: 'text', text: 'Hello' }] },
+        ];
+        const result = buildChatTranscript(messages);
+        expect(result).toBe('USER: Hi\n\nASSISTANT: Hello');
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/build-chat-transcript.test.ts`
+Expected: FAIL — `Cannot find module './build-chat-transcript'` (file does not exist yet).
+
+- [ ] **Step 3: Write the implementation**
+
+Create `apps/web-ui/lib/agent/build-chat-transcript.ts`:
+
+```typescript
+/**
+ * build-chat-transcript.ts
+ *
+ * Pure function that flattens chat messages (text + tool-invocation parts) into
+ * a single transcript string for skill distillation. Text is never truncated;
+ * only oversized individual tool *results* are capped (args and all prose are
+ * kept in full — see docs/superpowers/specs/2026-07-01-skill-distillation-redesign-design.md).
+ */
+
+/** Cap for a single tool result payload, in characters. Never applied to args or chat text. */
+export const TOOL_RESULT_CHAR_CAP = 4000;
+
+export interface ChatMessagePart {
+    type: string;
+    text?: string;
+    toolName?: string;
+    name?: string;
+    toolCallId?: string;
+    args?: unknown;
+    input?: unknown;
+    result?: unknown;
+    output?: unknown;
+}
+
+export interface ChatMessageLike {
+    role: string;
+    parts?: ChatMessagePart[];
+    content?: unknown;
+}
+
+function isToolPart(part: ChatMessagePart): boolean {
+    return part.type === 'tool-invocation' || Boolean(part.toolCallId);
+}
+
+function stringifyValue(value: unknown): string {
+    return typeof value === 'string' ? value : JSON.stringify(value);
+}
+
+function serializeToolPart(part: ChatMessagePart): string {
+    let toolName = part.toolName || part.name;
+    if (!toolName && part.type?.startsWith('tool-')) {
+        toolName = part.type.replace('tool-', '').replace(/_/g, ' ');
+    }
+    toolName = toolName || 'tool';
+
+    const args = part.args || part.input;
+    const result = part.result || part.output;
+
+    const argsStr = args === undefined ? '' : stringifyValue(args);
+    let block = `TOOL_CALL: ${toolName}(${argsStr})`;
+
+    if (result !== undefined) {
+        let resultStr = stringifyValue(result);
+        if (resultStr.length > TOOL_RESULT_CHAR_CAP) {
+            const truncatedCount = resultStr.length - TOOL_RESULT_CHAR_CAP;
+            resultStr = `${resultStr.slice(0, TOOL_RESULT_CHAR_CAP)}  [...truncated ${truncatedCount} more chars]`;
+        }
+        block += `\nTOOL_RESULT: ${resultStr}`;
+    }
+
+    return block;
+}
+
+/** Flattens messages into "ROLE: body" blocks joined by blank lines, preserving part order. */
+export function buildChatTranscript(messages: ChatMessageLike[]): string {
+    return messages
+        .map((m) => {
+            const segments: string[] = [];
+            for (const part of m.parts ?? []) {
+                if (part.type === 'text') {
+                    if (part.text && part.text.trim().length > 0) {
+                        segments.push(part.text);
+                    }
+                } else if (isToolPart(part)) {
+                    segments.push(serializeToolPart(part));
+                }
+            }
+            const body =
+                segments.length > 0 ? segments.join('\n') : typeof m.content === 'string' ? m.content : '';
+            return `${m.role.toUpperCase()}: ${body}`;
+        })
+        .join('\n\n');
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/build-chat-transcript.test.ts`
+Expected: PASS — all 8 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web-ui/lib/agent/build-chat-transcript.ts apps/web-ui/lib/agent/build-chat-transcript.test.ts
+git commit -m "$(cat <<'EOF'
+feat(skills): add buildChatTranscript with tool-call grounding
+
+Pure function replacing the text-only transcript builder used for skill
+distillation. Interleaves text and tool-invocation parts in original order
+so distillation sees real tool calls/results, not just narration. Only
+oversized individual tool results are capped (4000 chars) — chat text and
+tool args are never truncated.
+EOF
+)"
+```
+
+---
+
+### Task 2: Wire `buildChatTranscript` into `handleSaveAsSkill`
+
+**Files:**
+- Modify: `apps/web-ui/components/agent/chat-interface.tsx:784-800`
+
+**Interfaces:**
+- Consumes: `buildChatTranscript(messages: ChatMessageLike[]): string` from `apps/web-ui/lib/agent/build-chat-transcript.ts` (Task 1).
+
+- [ ] **Step 1: Add the import**
+
+In `apps/web-ui/components/agent/chat-interface.tsx`, near the other `@/lib` imports (e.g. alongside the existing `import { cn } from "@/lib/utils";` at the top of the file), add:
+
+```typescript
+import { buildChatTranscript } from "@/lib/agent/build-chat-transcript";
+```
+
+- [ ] **Step 2: Replace the inline transcript-building code**
+
+Find the current `handleSaveAsSkill` function:
+
+```typescript
+  const handleSaveAsSkill = async () => {
+    if (messages.length === 0) return;
+    const transcript = messages.map((m: any) => {
+      const text = (m.parts ?? [])
+        .filter((p: { type: string }) => p.type === "text")
+        .map((p: { text?: string }) => p.text ?? "")
+        .join("\n") || (typeof m.content === "string" ? m.content : "");
+      return `${m.role.toUpperCase()}: ${text}`;
+    }).join("\n\n");
+    try {
+      const draft = await distillSkill.mutateAsync({ threadId, transcript });
+      setSkillDraft(draft);
+      setSkillDialogOpen(true);
+    } catch (e) {
+      toast.error("Could not create skill from chat", { description: e instanceof Error ? e.message : "Try again" });
+    }
+  };
+```
+
+Replace it with:
+
+```typescript
+  const handleSaveAsSkill = async () => {
+    if (messages.length === 0) return;
+    const transcript = buildChatTranscript(messages as any);
+    try {
+      const draft = await distillSkill.mutateAsync({ threadId, transcript });
+      setSkillDraft(draft);
+      setSkillDialogOpen(true);
+    } catch (e) {
+      toast.error("Could not create skill from chat", { description: e instanceof Error ? e.message : "Try again" });
+    }
+  };
+```
+
+(`messages` from `useChat` is untyped as `any` throughout this file already — the `as any` cast matches the existing style at this call site and avoids fighting the AI SDK's message type here; `buildChatTranscript`'s own parameter and internals are fully typed.)
+
+- [ ] **Step 3: Type-check**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit`
+Expected: no new errors introduced by this file.
+
+- [ ] **Step 4: Confirm no test regressions**
+
+Run: `cd apps/web-ui && bun run test`
+Expected: PASS — this file has no dedicated test suite today, so there are no direct tests to update; this step just confirms the change didn't break anything else (e.g. the `build-chat-transcript.test.ts` from Task 1 still passes).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web-ui/components/agent/chat-interface.tsx
+git commit -m "$(cat <<'EOF'
+refactor(skills): use buildChatTranscript in handleSaveAsSkill
+
+Replaces the inline text-only transcript builder with the shared pure
+function so tool calls/results are included in skill distillation input.
+EOF
+)"
+```
+
+---
+
+### Task 3: Domain-agnostic prompt, remove truncation, add size guard
+
+**Files:**
+- Modify: `apps/web-ui/app/api/skills/distill/route.ts`
+- Create: `apps/web-ui/app/api/skills/distill/route.test.ts`
+
+**Interfaces:**
+- Consumes: `resolveDefaultModelConfig(tenantId: string): Promise<ResolvedModelConfig>` from `@/lib/agent/model-resolver`; `createAgentModels(config: ResolvedModelConfig): AgentModels` (where `AgentModels = { main: BaseChatModel; reflector: BaseChatModel }`) from `@/lib/agent/model-factory`; `isProviderConfigError(err: unknown): boolean` and `ProviderConfigError` from `@/lib/agent/provider-errors`.
+- Produces: unchanged route contract — `POST` handler at `apps/web-ui/app/api/skills/distill/route.ts`, response shape `{ success: true, data: { name, description, tier, content } }` or `{ success: false, error }`. New behavior: 413 response when `transcript.length > MAX_TRANSCRIPT_CHARS`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/web-ui/app/api/skills/distill/route.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('next/server', () => ({
+    NextRequest: vi.fn(),
+    NextResponse: {
+        json: vi.fn((data: unknown, init?: { status?: number }) => ({
+            _data: data,
+            _status: init?.status ?? 200,
+            status: init?.status ?? 200,
+            json: async () => data,
+        })),
+    },
+}));
+
+vi.mock('@/lib/rbac/authorize', () => ({ authorize: vi.fn() }));
+vi.mock('@/lib/auth-session', () => ({ getSessionTenantId: vi.fn() }));
+vi.mock('@/lib/agent/model-resolver', () => ({ resolveDefaultModelConfig: vi.fn() }));
+vi.mock('@/lib/agent/model-factory', () => ({ createAgentModels: vi.fn() }));
+
+import { POST } from './route';
+import { authorize } from '@/lib/rbac/authorize';
+import { getSessionTenantId } from '@/lib/auth-session';
+import { resolveDefaultModelConfig } from '@/lib/agent/model-resolver';
+import { createAgentModels } from '@/lib/agent/model-factory';
+import { ProviderConfigError } from '@/lib/agent/provider-errors';
+
+const makeRequest = (body?: unknown) => ({ json: vi.fn().mockResolvedValue(body ?? {}) }) as any;
+
+const validDraftJson = JSON.stringify({
+    name: 'Review Cost Trends',
+    description: 'Use when asked to review AWS cost trends.',
+    tier: 'read-only',
+    content: '# Review Cost Trends\n1. Run `aws ce get-cost-and-usage`.',
+});
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authorize).mockResolvedValue(null);
+    vi.mocked(getSessionTenantId).mockResolvedValue('t1');
+    vi.mocked(resolveDefaultModelConfig).mockResolvedValue({ provider: 'anthropic', modelId: 'm1' } as any);
+});
+
+describe('POST /api/skills/distill', () => {
+    it('403s when authorize denies', async () => {
+        vi.mocked(authorize).mockResolvedValue({ status: 403, _data: { error: 'Forbidden' }, _status: 403 } as any);
+        const res = await POST(makeRequest({ transcript: 'USER: hi' }));
+        expect(res).toEqual({ status: 403, _data: { error: 'Forbidden' }, _status: 403 });
+    });
+
+    it('400s on missing transcript', async () => {
+        const res = await POST(makeRequest({}));
+        expect((res as any)._status).toBe(400);
+        expect((res as any)._data.success).toBe(false);
+    });
+
+    it('413s when transcript exceeds the size guard, without calling the model', async () => {
+        const hugeTranscript = 'a'.repeat(600_001);
+        const invoke = vi.fn();
+        vi.mocked(createAgentModels).mockReturnValue({ main: { invoke }, reflector: {} } as any);
+        const res = await POST(makeRequest({ transcript: hugeTranscript }));
+        expect((res as any)._status).toBe(413);
+        expect((res as any)._data.success).toBe(false);
+        expect(invoke).not.toHaveBeenCalled();
+    });
+
+    it('sends the full transcript to the model with no truncation', async () => {
+        const longTranscript = `USER: ${'b'.repeat(100_000)}`;
+        const invoke = vi.fn().mockResolvedValue({ content: validDraftJson });
+        vi.mocked(createAgentModels).mockReturnValue({ main: { invoke }, reflector: {} } as any);
+        await POST(makeRequest({ transcript: longTranscript }));
+        expect(invoke).toHaveBeenCalledOnce();
+        const promptSent = invoke.mock.calls[0][0] as string;
+        expect(promptSent).toContain(longTranscript);
+    });
+
+    it('returns the parsed draft on success', async () => {
+        const invoke = vi.fn().mockResolvedValue({ content: validDraftJson });
+        vi.mocked(createAgentModels).mockReturnValue({ main: { invoke }, reflector: {} } as any);
+        const res = await POST(makeRequest({ transcript: 'USER: check my costs' }));
+        expect((res as any)._status).toBe(200);
+        expect((res as any)._data).toEqual({
+            success: true,
+            data: {
+                name: 'Review Cost Trends',
+                description: 'Use when asked to review AWS cost trends.',
+                tier: 'read-only',
+                content: '# Review Cost Trends\n1. Run `aws ce get-cost-and-usage`.',
+            },
+        });
+    });
+
+    it('502s when the model does not return valid JSON', async () => {
+        const invoke = vi.fn().mockResolvedValue({ content: 'not json' });
+        vi.mocked(createAgentModels).mockReturnValue({ main: { invoke }, reflector: {} } as any);
+        const res = await POST(makeRequest({ transcript: 'USER: hi' }));
+        expect((res as any)._status).toBe(502);
+        expect((res as any)._data.success).toBe(false);
+    });
+
+    it('falls back to read-only when the model returns an invalid tier', async () => {
+        const invoke = vi.fn().mockResolvedValue({
+            content: JSON.stringify({ name: 'X', description: 'd', tier: 'nonsense', content: 'c' }),
+        });
+        vi.mocked(createAgentModels).mockReturnValue({ main: { invoke }, reflector: {} } as any);
+        const res = await POST(makeRequest({ transcript: 'USER: hi' }));
+        expect((res as any)._data.data.tier).toBe('read-only');
+    });
+
+    it('400s with the provider message when no default provider is configured', async () => {
+        vi.mocked(resolveDefaultModelConfig).mockRejectedValue(new ProviderConfigError('No LLM provider is configured.'));
+        const res = await POST(makeRequest({ transcript: 'USER: hi' }));
+        expect((res as any)._status).toBe(400);
+        expect((res as any)._data.error).toBe('No LLM provider is configured.');
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/web-ui && bunx vitest run app/api/skills/distill/route.test.ts`
+Expected: FAIL — the 413 guard test and the no-truncation test fail against the current implementation (current code truncates to 24,000 chars and has no size guard), e.g. `expected 200 to be 413` and `expected [Function] to have been called with arguments matching ...`.
+
+- [ ] **Step 3: Update the route implementation**
+
+Replace the full contents of `apps/web-ui/app/api/skills/distill/route.ts` with:
+
+```typescript
+/**
+ * POST /api/skills/distill — distil a chat transcript into a reusable skill draft (no persistence)
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { authorize } from '@/lib/rbac/authorize';
+import { getSessionTenantId } from '@/lib/auth-session';
+import { resolveDefaultModelConfig } from '@/lib/agent/model-resolver';
+import { createAgentModels } from '@/lib/agent/model-factory';
+import { isProviderConfigError } from '@/lib/agent/provider-errors';
+
+/**
+ * No per-model context-window figure is tracked anywhere in this codebase (the
+ * `maxTokens` field on provider records is the output completion cap, not input
+ * size). This is a conservative, provider-agnostic backstop against pathological
+ * input (~150k tokens at ~4 chars/token) — comfortably under mainstream
+ * 128k-200k-token context windows — not a routine limiter.
+ */
+const MAX_TRANSCRIPT_CHARS = 600_000;
+
+const DISTILL_PROMPT = `You are distilling an AI agent's chat transcript into a reusable "skill" — a
+generalized procedure the same agent can follow again for similar future requests.
+
+The transcript may include TOOL_CALL / TOOL_RESULT blocks showing the exact
+tools, commands, or API calls the agent actually used (AWS CLI, AWS SDK calls,
+Slack/Jira/other MCP tool calls, file operations, etc.) — this platform is not
+limited to any one domain. Infer the actual domain and tools from the
+transcript itself; do not assume AWS or any other specific system.
+
+Return ONLY a JSON object (no markdown fences) with keys:
+- "name": short Title Case name (max 5 words)
+- "description": one sentence describing when to use this skill
+- "tier": one of "read-only" | "mutation" | "approval-gated" — pick based on
+  what the actual tool calls did:
+  - "read-only": every tool call only queried/read/listed state, nothing was
+    changed anywhere
+  - "mutation": at least one tool call created, updated, deleted, sent, or
+    posted something in any external system (cloud resources, tickets,
+    messages, files, etc.)
+  - "approval-gated": the transcript shows a destructive/irreversible action,
+    or the agent explicitly asked for human confirmation before proceeding
+- "content": a markdown SKILL body with a one-line intro and a numbered,
+  generalized step-by-step procedure GROUNDED in the actual tool calls made
+  (name the real commands/API calls/tool names used, not generic UI
+  navigation). Strip one-off identifiers (specific account/resource IDs,
+  ticket numbers, usernames) and replace with placeholders — describe the
+  repeatable method, not the one-off answer.
+
+Transcript:
+`;
+
+export async function POST(request: NextRequest) {
+    const authError = await authorize('create', 'Skill');
+    if (authError) return authError;
+    try {
+        const tenantId = await getSessionTenantId();
+        const body = await request.json();
+        const { transcript } = body;
+        if (!transcript || typeof transcript !== 'string') {
+            return NextResponse.json(
+                { success: false, error: 'Missing transcript' },
+                { status: 400 }
+            );
+        }
+        if (transcript.length > MAX_TRANSCRIPT_CHARS) {
+            return NextResponse.json(
+                {
+                    success: false,
+                    error: `This conversation is too long to distill in a single pass (~${Math.round(transcript.length / 1000)}k chars, limit ~${Math.round(MAX_TRANSCRIPT_CHARS / 1000)}k). Try a shorter portion of the chat, or configure a larger-context model as your tenant default.`,
+                },
+                { status: 413 }
+            );
+        }
+        const modelConfig = await resolveDefaultModelConfig(tenantId);
+        const { main } = createAgentModels(modelConfig);
+        const resp = await main.invoke(`${DISTILL_PROMPT}\n${transcript}`);
+        const raw = typeof resp.content === 'string' ? resp.content : JSON.stringify(resp.content);
+        const jsonText = raw.replace(/^```(?:json)?/i, '').replace(/```$/i, '').trim();
+        let draft: { name?: string; description?: string; tier?: string; content?: string };
+        try {
+            draft = JSON.parse(jsonText);
+        } catch {
+            return NextResponse.json(
+                { success: false, error: 'Model did not return valid JSON' },
+                { status: 502 }
+            );
+        }
+        const validTiers = ['read-only', 'mutation', 'approval-gated'];
+        const tier = validTiers.includes(draft.tier ?? '') ? draft.tier : 'read-only';
+        return NextResponse.json({
+            success: true,
+            data: {
+                name: draft.name ?? 'Untitled Skill',
+                description: draft.description ?? '',
+                tier,
+                content: draft.content ?? '',
+            },
+        });
+    } catch (error) {
+        if (isProviderConfigError(error)) {
+            return NextResponse.json(
+                { success: false, error: (error as Error).message },
+                { status: 400 }
+            );
+        }
+        console.error('[SkillsAPI] distill error:', error);
+        return NextResponse.json(
+            { success: false, error: error instanceof Error ? error.message : 'Failed to distill' },
+            { status: 500 }
+        );
+    }
+}
+```
+
+(Only three things changed from the original: `DISTILL_PROMPT`'s text, the removal of `.slice(0, 24000)` in the `main.invoke` call, and the new `MAX_TRANSCRIPT_CHARS` guard block. Everything else — imports, auth, JSON parsing, tier fallback, error handling — is untouched.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/web-ui && bunx vitest run app/api/skills/distill/route.test.ts`
+Expected: PASS — all 8 tests green.
+
+- [ ] **Step 5: Run the full web-ui test suite**
+
+Run: `cd apps/web-ui && bun run test`
+Expected: PASS — no regressions in `app/api/skills/route.test.ts`, `app/api/skills/[id]/route.test.ts`, or elsewhere.
+
+- [ ] **Step 6: Type-check**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit`
+Expected: no new errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web-ui/app/api/skills/distill/route.ts apps/web-ui/app/api/skills/distill/route.test.ts
+git commit -m "$(cat <<'EOF'
+feat(skills): make distillation domain-agnostic, drop hard truncation
+
+- DISTILL_PROMPT no longer assumes AWS/CloudOps; it infers domain and
+  tools from the transcript's TOOL_CALL/TOOL_RESULT blocks (AWS, Slack,
+  Jira, or any MCP tool).
+- Removes transcript.slice(0, 24000) — the full transcript is sent to
+  the model, so a long conversation's resolution is no longer silently
+  dropped.
+- Adds a MAX_TRANSCRIPT_CHARS=600_000 pre-flight guard returning HTTP
+  413 before any LLM call, since no per-model context-window figure is
+  tracked in this codebase.
+EOF
+)"
+```
+
+---
+
+## Post-Implementation Verification
+
+- [ ] Run `cd apps/web-ui && bun run test` once more from a clean state — full suite green.
+- [ ] Run `cd apps/web-ui && bun run lint` — no new lint errors in the three touched/created files.
+- [ ] Manually exercise the flow: open a chat with at least one tool call (e.g. an `execute_command` AWS CLI call), click the Sparkles "Save as skill" button, and confirm the resulting draft's `content` references the actual command/tool used rather than generic console navigation.

--- a/docs/superpowers/specs/2026-07-01-memory-datatable-design.md
+++ b/docs/superpowers/specs/2026-07-01-memory-datatable-design.md
@@ -1,0 +1,146 @@
+# Memory module → shadcn data-table
+
+**Date:** 2026-07-01
+**Status:** Approved (design)
+**Scope:** Convert the Memory module list view (`components/memory/`) into the standard
+shadcn data-table used elsewhere in the app, with server-side pagination, a debounced
+search filter, a faceted category filter, and a per-row collapsible action dropdown.
+
+## Motivation
+
+The current Memory view (`memory-client-component.tsx`) renders a plain `<Table>` with
+category tab-buttons and a debounced search. It fetches up to 200 rows in one request and
+has no pagination UI and only a single inline "Delete" button per row. Agent memories grow
+unbounded over time, so the view needs true server-side pagination and a table shape
+consistent with the rest of the app (Accounts, Skills).
+
+## Decisions (from brainstorming)
+
+- **Pagination:** server-side. The repo already returns `page`/`limit`/`total`.
+- **Bulk actions:** none. Delete stays a single, per-row action. No selection checkboxes.
+- **Row actions:** aggregated into one collapsible `DropdownMenu` per row, mirroring the
+  Accounts module (`accounts-table.tsx`).
+- **Categorization:** a shadcn **faceted column filter** (multi-select) replaces the tab
+  buttons.
+
+## Current state (grounding)
+
+- `components/memory/memory-client-component.tsx` — plain table + tabs + search, `limit: 200`.
+- `components/memory/memory-detail-dialog.tsx`, `delete-memory-dialog.tsx` — reused as-is.
+- `components/ui/data-table.tsx` — shared shadcn DataTable. Client-side sort/filter/pagination.
+  Already tracks `rowSelection` internally. Used by `skills/skills-client.tsx` (client mode).
+- `components/ui/{popover,command,checkbox,dropdown-menu,badge}.tsx` — all present.
+  No faceted-filter component exists yet.
+- `lib/queries/agent-memories.ts` — `useAgentMemories(filters)` returns `{ data, total }`,
+  `placeholderData: keepPrevious`. `useDeleteAgentMemory()` invalidates
+  `queryKeys.agentMemories.all`.
+- `app/api/agent-memories/route.ts` — `GET` with `authorize('read','Memory')`; parses a single
+  `category`, plus `search`/`limit`/`page`; returns `{ success, data, total }`.
+- `app/api/agent-memories/[id]/route.ts` — `DELETE` with `authorize('delete','Memory')` + audit.
+- `lib/db/repositories/agent-memory/{interface,postgres}.ts` — `category` is **derived from the
+  `namespace` prefix**, not a column; filtering is by `namespace` prefix match. `other` =
+  `NOT (any known prefix)`. `listByTenant` returns `{ memories, total }`.
+
+## Architecture
+
+### 1. Repository — multi-category filter
+
+`interface.ts`: add optional `categories?: MemoryCategory[]` to `AgentMemoryFilters`
+(keep the single `category` for back-compat; `categories` takes precedence when non-empty).
+
+`postgres.ts` `listByTenant`: when `categories` is non-empty, push a single `OR` clause built
+from the per-category namespace conditions:
+
+- For each known category `c` (infra/user/patterns/errors): `{ OR: [{ namespace: { startsWith: `${c}/` } }, { namespace: c }] }`.
+- For `other`: `{ NOT: { OR: <all known prefix clauses> } }`.
+
+The combined clause is `{ OR: [<one entry per selected category>] }`, pushed onto the same
+`AND` array the search clause already uses. Single-`category` behavior is unchanged.
+
+### 2. API route — CSV category parsing
+
+`GET /api/agent-memories`: read the `category` query param, split on `,`, trim, and validate
+each against `VALID_CATEGORIES`. Pass the resulting `categories: MemoryCategory[]` to the repo
+(empty array → no category filter → all). `limit`/`page`/`search` unchanged; response
+`{ success, data, total }` unchanged. RBAC unchanged.
+
+No new endpoints. Delete remains `DELETE /api/agent-memories/[id]`.
+
+### 3. Shared `DataTable` — opt-in server pagination (non-breaking)
+
+Add optional props:
+
+- `manualPagination?: boolean`
+- `rowCount?: number` — total server-side row count
+- `pagination?: PaginationState` — controlled state
+- `onPaginationChange?: OnChangeFn<PaginationState>`
+
+When `manualPagination` is set: use the controlled `pagination`/`onPaginationChange` (falling
+back to internal state if absent), set the table options `manualPagination: true` + `rowCount`,
+and omit `getPaginationRowModel` (the `data` prop is already one server page). The existing
+`DataTablePagination` footer works unchanged because it drives `table.getPageCount()` /
+`nextPage()` / `previousPage()`, which honor `manualPagination` + `rowCount`.
+
+Skills passes none of these props → its client-side behavior is completely unchanged. This is
+the "improve the code you're working in" change: the new props are additive and default off.
+
+### 4. New primitive — `components/ui/data-table-faceted-filter.tsx`
+
+Standard shadcn faceted filter: a `Popover` triggered by an outline `Button` (dashed, with a
+`PlusCircle` icon and selected-count badges), containing a `Command` list of options with a
+`Checkbox`/check indicator per option and a "Clear filters" footer. Generic over an
+`options: { label; value; icon? }[]` + controlled `selected: string[]` + `onChange`. Multi-select.
+
+### 5. `memory-client-component.tsx` — rewrite as data table
+
+State: `pagination` (`{ pageIndex, pageSize }`, default `pageSize: 10`), `searchInput` +
+debounced `search`, `categories: MemoryCategory[]`, `detail`, `deleteTarget`.
+
+Data: `useAgentMemories({ page: pageIndex + 1, limit: pageSize, categories, search })`.
+Changing `search` or `categories` resets `pageIndex` to 0.
+
+Columns (`ColumnDef<MemoryRow>`):
+
+| Column     | Cell |
+|------------|------|
+| Category   | `<Badge variant="outline">` of `m.category` |
+| Key        | clickable button → opens `MemoryDetailDialog` (like Skills' name cell) |
+| Fact       | truncated (`max-w-md truncate`) |
+| Confidence | small badge (`high`/`medium`/`low` → variant/tint), `—` when null |
+| Created    | `toLocaleDateString()` |
+| Expires    | `toLocaleDateString()` |
+| Actions    | `DropdownMenu` (`MoreHorizontal` ghost trigger, `align="end"`): **View details** (→ detail dialog), **Delete** (`text-destructive` → delete dialog) |
+
+Sorting toggles disabled (`enableSorting={false}`) — the server always orders newest-first
+(`updatedAt desc`); page-local client sorting would be misleading under server pagination.
+`enableFiltering={false}` (filtering is server-side).
+
+Toolbar via the DataTable `header` slot: debounced search `Input` + the faceted **Category**
+filter + a "Reset" button shown only when `search` or `categories` is active.
+
+Rendered with the shared `DataTable` in manual-pagination mode:
+`manualPagination`, `rowCount={total}`, controlled `pagination`/`onPaginationChange`,
+`loading={isLoading}`, `emptyMessage` (search/filter-aware).
+
+Dialogs: reuse `MemoryDetailDialog` and `DeleteMemoryDialog` unchanged; delete flow keeps the
+existing `useDeleteAgentMemory` mutation + sonner toasts.
+
+### 6. Query hook — `lib/queries/agent-memories.ts`
+
+Add `categories?: MemoryCategory[]` to `MemoryFilters`. In `useAgentMemories`, serialize
+`categories` to the CSV `category` param (`categories.join(',')`) when non-empty. Return shape,
+query key factory, and `useDeleteAgentMemory` unchanged.
+
+## Testing (TDD)
+
+- `lib/db/repositories/agent-memory/postgres.test.ts`: multi-category `OR` filtering (e.g.
+  `['infra','user']` returns both; `['other']` excludes known prefixes) and correct `total`
+  under pagination (`skip`/`take` + `count` on the same `where`).
+- `app/api/agent-memories/agent-memories-api.test.ts`: CSV `category` param parses to the
+  expected `categories[]`, invalid values are dropped, empty → no filter.
+
+## Out of scope
+
+- Bulk/multi-select actions.
+- Server-side sorting.
+- Creating or editing memories (agent-written only).

--- a/docs/superpowers/specs/2026-07-01-skill-distillation-redesign-design.md
+++ b/docs/superpowers/specs/2026-07-01-skill-distillation-redesign-design.md
@@ -1,0 +1,174 @@
+# Skill Distillation Redesign — Design Spec
+
+Date: 2026-07-01
+Status: Approved (pending write-up review)
+
+## Problem
+
+The "convert chat to skill" feature (Sparkles button in the chat UI → `/api/skills/distill`)
+produces low-quality skills. Investigation found three root causes:
+
+1. **Tool calls are stripped before distillation.** `handleSaveAsSkill` in
+   `apps/web-ui/components/agent/chat-interface.tsx` builds the transcript sent to the
+   distillation LLM by filtering message `parts` to `type === "text"` only. Every
+   `tool-invocation` part — the actual AWS CLI/SDK calls, MCP tool calls (Slack, Jira,
+   etc.), their arguments, and their results — is discarded. The LLM only ever sees the
+   human-readable narration around the work, never the concrete actions taken. This is
+   the primary reason generated skills read like generic "open the console and click
+   around" prose instead of grounded, executable procedures.
+2. **The prompt is domain-locked to "CloudOps."** `DISTILL_PROMPT` in
+   `apps/web-ui/app/api/skills/distill/route.ts` opens with "You are distilling a CloudOps
+   chat transcript…", but the agent can connect to arbitrary MCP servers (Slack, Jira,
+   Discord, Telegram, webhooks are already wired as channels) — chats are not
+   AWS-only. The prompt should infer the domain from the transcript, not assume one.
+3. **Hard truncation drops the end of the conversation.** `transcript.slice(0, 24000)`
+   keeps only the first 24,000 characters. Conclusions/resolutions in a troubleshooting
+   chat are usually near the end, so long chats can lose exactly the part that matters,
+   silently, with no user-visible warning.
+
+## Goals
+
+- Ground generated skills in the real tool calls made during the conversation, not just
+  the prose narration.
+- Make the distillation prompt and pipeline domain-agnostic — chats about AWS, Slack,
+  Jira, or anything else the agent can reach via MCP should distill equally well.
+- Remove the hard character-count truncation of the human-readable transcript.
+- Keep the change contained: no Prisma schema changes, no new UI fields, same output
+  contract (`name`, `description`, `tier`, `content`).
+
+## Non-goals
+
+- A multi-stage "extract then draft" pipeline (two LLM calls). Explicitly rejected in
+  favor of a single smart pass — same latency/cost as today, fewer failure modes (one
+  JSON parse instead of two), sufficient for the problems found.
+- Per-model context-window-aware truncation/chunking. No per-model context-window data
+  exists in this codebase today (`maxTokens` on provider records is the output
+  completion cap, not input context size); building a lookup table is out of scope.
+- Adding a "domain" or "category" field to the `Skill` model or its UI. The model
+  infers domain implicitly through better prompting; no new metadata is persisted.
+
+## Design
+
+### 1. Transcript construction (client-side)
+
+Extract the transcript-building logic out of `handleSaveAsSkill` (currently inline,
+`apps/web-ui/components/agent/chat-interface.tsx`) into a new pure, exported function —
+e.g. `apps/web-ui/lib/agent/build-chat-transcript.ts` — so it is unit-testable in
+isolation from the chat component. `handleSaveAsSkill` calls this function instead of
+building the string inline.
+
+Behavior:
+
+- Parts are processed **in their original order within each message** — text and
+  `tool-invocation` parts are interleaved exactly as they occur, not grouped (all text
+  first, all tools after). This preserves the actual sequence of reasoning → action →
+  reasoning that the transcript already reflects.
+- Every text part is included **verbatim, in full — no truncation**.
+- Every `tool-invocation` part (identified by `part.type === "tool-invocation"` or the
+  presence of `part.toolCallId`, matching the existing `renderToolInvocation` logic in
+  the same file) is serialized as a `TOOL_CALL` / `TOOL_RESULT` block:
+  - Tool name: `part.toolName || part.name`, falling back to deriving it from
+    `part.type` (e.g. `"tool-execute_command"` → `execute_command`) — same precedence
+    `renderToolInvocation` already uses.
+  - Args: `part.args || part.input`, included **in full, never capped** (arguments are
+    small — they represent a decision the agent made, not a data payload).
+  - Result: `part.result || part.output`, included in full **unless it exceeds
+    `TOOL_RESULT_CHAR_CAP = 4000` characters**, in which case it is truncated to that
+    length with a trailing marker, e.g. `[...truncated N more chars]` where N is the
+    number of characters removed. This is not a truncation of the *chat* — it is a cap
+    on a single large machine-generated data payload (e.g. a big `describe-instances`
+    JSON dump) so it does not dominate the prompt with information that adds no
+    procedural value beyond "this API returned a list of things."
+- Output format is flat, readable text (not JSON) since it is prose context for an LLM:
+
+  ```
+  ASSISTANT: I'll check EC2 costs for the last 3 months.
+  TOOL_CALL: execute_command({"command":"aws ce get-cost-and-usage ..."})
+  TOOL_RESULT: {"ResultsByTime":[...]}  [...truncated 3120 more chars]
+  ASSISTANT: Top driver is EC2 at $4,200/mo, up 18% from last month...
+  ```
+
+### 2. API route (`apps/web-ui/app/api/skills/distill/route.ts`)
+
+- Remove `transcript.slice(0, 24000)` entirely. The full assembled transcript is sent
+  to `main.invoke(...)`.
+- Add a pre-flight size guard **before** calling the LLM (see Error Handling below).
+- Replace `DISTILL_PROMPT` with a domain-agnostic version:
+
+  ```
+  You are distilling an AI agent's chat transcript into a reusable "skill" — a
+  generalized procedure the same agent can follow again for similar future requests.
+
+  The transcript may include TOOL_CALL / TOOL_RESULT blocks showing the exact
+  tools, commands, or API calls the agent actually used (AWS CLI, AWS SDK calls,
+  Slack/Jira/other MCP tool calls, file operations, etc.) — this platform is not
+  limited to any one domain. Infer the actual domain and tools from the
+  transcript itself; do not assume AWS or any other specific system.
+
+  Return ONLY a JSON object (no markdown fences) with keys:
+  - "name": short Title Case name (max 5 words)
+  - "description": one sentence describing when to use this skill
+  - "tier": one of "read-only" | "mutation" | "approval-gated" — pick based on
+    what the actual tool calls did:
+    - "read-only": every tool call only queried/read/listed state, nothing was
+      changed anywhere
+    - "mutation": at least one tool call created, updated, deleted, sent, or
+      posted something in any external system (cloud resources, tickets,
+      messages, files, etc.)
+    - "approval-gated": the transcript shows a destructive/irreversible action,
+      or the agent explicitly asked for human confirmation before proceeding
+  - "content": a markdown SKILL body with a one-line intro and a numbered,
+    generalized step-by-step procedure GROUNDED in the actual tool calls made
+    (name the real commands/API calls/tool names used, not generic UI
+    navigation). Strip one-off identifiers (specific account/resource IDs,
+    ticket numbers, usernames) and replace with placeholders — describe the
+    repeatable method, not the one-off answer.
+
+  Transcript:
+  ```
+
+- The `tier` value set (`read-only` | `mutation` | `approval-gated`) is unchanged — it
+  is also hardcoded as a Zod enum in `components/skills/skill-form-dialog.tsx`, so
+  keeping the same three values avoids touching the form/schema. Only the
+  classification *guidance* in the prompt changes, generalized away from
+  "creates/updates/deletes resources" to "changed something in any external system."
+
+### 3. Error handling
+
+- **Size guard:** no per-model context-window data exists in this codebase (`maxTokens`
+  on provider records is the output completion cap, not input size — confirmed in
+  `model-resolver.ts` / `model-factory.ts`). Rather than build a fragile per-model
+  lookup table, use one conservative constant:
+  `MAX_TRANSCRIPT_CHARS = 600_000` (~150k tokens at a rough 4 chars/token — comfortably
+  under mainstream 128k–200k-token context windows, high enough that no realistic chat
+  hits it; a backstop against pathological input, not a routine limiter).
+- If the assembled transcript exceeds this, return **HTTP 413** before calling the LLM:
+  `{ success: false, error: "This conversation is too long to distill in a single pass
+  (~Nk chars, limit ~600k). Try a shorter portion of the chat, or configure a
+  larger-context model as your tenant default." }`.
+- All other error handling (provider config errors, JSON-parse failures, tier
+  validation fallback) is unchanged.
+
+### 4. Testing (Vitest, `apps/web-ui`)
+
+- New `build-chat-transcript.test.ts`:
+  - Text parts are preserved verbatim and untruncated, including long text.
+  - `tool-invocation` parts are serialized with tool name, full args, and result.
+  - A tool result over ~4000 chars is capped with a truncation marker; args are never
+    capped regardless of size.
+  - A tool result under the cap is included in full, unmodified.
+- Updated/new `distill/route.test.ts` (or equivalent):
+  - A long transcript (under the size guard) reaches `main.invoke` with no truncation
+    applied (mock the model, assert the full string is present in the call).
+  - A transcript over `MAX_TRANSCRIPT_CHARS` returns 413 and `main.invoke` is never
+    called.
+  - Existing behavior unchanged: invalid/non-JSON model response → 502; unrecognized
+    `tier` value → falls back to `read-only`.
+
+## Out of scope / explicitly deferred
+
+- Two-stage (extract-then-draft) distillation pipeline.
+- Per-model/provider context-window lookup for precise overflow detection.
+- New `Skill` schema fields (e.g. a persisted "domain"/"category").
+- Client-side pre-flight size check before the POST is sent (the 600k-char case is rare
+  enough that a server-side-only check is sufficient for now).


### PR DESCRIPTION
## Summary
- **Memory module**: shadcn data-table for agent memories with server-side pagination, multi-category faceted filter, search, row actions, and now server-side column sorting (Category/Key/Created/Expires).
- **Skill distillation redesign**: domain-agnostic transcript building (`buildChatTranscript` with tool-call grounding) wired into "Save as Skill", dropped hard truncation, and blocked the chat UI with a spinner overlay while a skill is generating.
- **MCP Server settings**: replaced the stacked expanded-card list with a Table + Sheet slide-over pattern; moved "MCP Servers" under the Agent Config nav group.
- **Skills UI**: added a skill detail dialog and surfaced `createdAt` on skill DTOs.

## Test plan
- [x] `bun run test` (web-ui) — all tests touching changed files pass (52/52); 51 pre-existing failures in unrelated `audit-log`/`inventory`/`rbac` repo tests confirmed present before this branch (untouched since commit `d5c69fcb`)
- [x] `tsc --noEmit` — no new errors introduced; remaining errors are pre-existing and unrelated to changed files
- [x] MCP Server Table+Sheet redesign manually verified live in browser
- [x] Skill-generation spinner overlay manually verified (all interactive controls gated on `distillSkill.isPending`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)