### PR TITLE
feat(memory): multi-layer agent memory — the full cognitive stack (Phases 0–4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -109,6 +109,10 @@ WORKING_MEMORY_KEEP_RECENT=8
 # LLM judge before writing. Set false to restore blind upserts (legacy behavior).
 MEMORY_RECONCILE_ENABLED=true
 
+# Episodic memory (Phase 3) — capture one distilled episode per tool-using run and
+# replay similar past episodes as few-shot experience at task start.
+EPISODIC_MEMORY_ENABLED=true
+
 # ============================================================================
 # Optional integrations
 # ============================================================================

--- a/.env.example
+++ b/.env.example
@@ -105,6 +105,10 @@ WORKING_MEMORY_ENABLED=true
 WORKING_MEMORY_TOKEN_BUDGET=60000
 WORKING_MEMORY_KEEP_RECENT=8
 
+# Save-time memory reconciliation (Phase 2) — dedup/contradiction resolution via an
+# LLM judge before writing. Set false to restore blind upserts (legacy behavior).
+MEMORY_RECONCILE_ENABLED=true
+
 # ============================================================================
 # Optional integrations
 # ============================================================================

--- a/.env.example
+++ b/.env.example
@@ -97,6 +97,14 @@ DEFAULT_TENANT_ID=org-default
 RIGHT_SIZING_ENABLED=true
 NEXT_PUBLIC_RIGHT_SIZING_ENABLED=true
 
+# Working memory (Phase 1) — in-session context compaction for long-running agents.
+# When over WORKING_MEMORY_TOKEN_BUDGET estimated tokens, older turns are folded into
+# a rolling summary + scratchpad (via the reflector model) so multi-hour runs survive
+# the context window. Set WORKING_MEMORY_ENABLED=false for identical legacy behavior.
+WORKING_MEMORY_ENABLED=true
+WORKING_MEMORY_TOKEN_BUDGET=60000
+WORKING_MEMORY_KEEP_RECENT=8
+
 # ============================================================================
 # Optional integrations
 # ============================================================================

--- a/.env.example
+++ b/.env.example
@@ -113,6 +113,10 @@ MEMORY_RECONCILE_ENABLED=true
 # replay similar past episodes as few-shot experience at task start.
 EPISODIC_MEMORY_ENABLED=true
 
+# Procedural memory (Phase 4) — learn operating rules from corrections/failures and
+# inject them as '### Operating rules (learned)'; promote matured rules to Skills (human-approved).
+PROCEDURAL_MEMORY_ENABLED=true
+
 # ============================================================================
 # Optional integrations
 # ============================================================================

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,6 +185,7 @@ Key shared modules:
 | `persistence.ts`    | LangGraph checkpointer + chat history (PostgreSQL-backed)                  |
 | `memory/memory-service.ts` | Typed long-term memory: `recall`/`remember` (kind-discriminated `AgentMemory` + pgvector HNSW) + working-memory get/put. `saveMemory`/`searchMemory` in `persistence.ts` delegate here. |
 | `memory/working-memory.ts` | In-session compaction for long runs: `prepareContext` (budget-aware window + reflector-model summary folding) + `AgentWorkingMemory` snapshot. Gated by `WORKING_MEMORY_ENABLED`. |
+| `memory/reconcile.ts` | Save-time conflict resolution: batched LLM judge (ADD/UPDATE/SUPERSEDE/REINFORCE/NOOP) applied via MemoryService with an auditable supersede trail. Gated by `MEMORY_RECONCILE_ENABLED`. |
 
 Tool definition pattern:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,8 @@ Key shared modules:
 | `prompt-templates.ts` | Reusable prompt fragments (`CORE_PRINCIPLES`, `buildBaseIdentity`, etc.) |
 | `mcp-manager.ts`    | MCP server lifecycle (connect/disconnect, credential injection)            |
 | `persistence.ts`    | LangGraph checkpointer + chat history (PostgreSQL-backed)                  |
+| `memory/memory-service.ts` | Typed long-term memory: `recall`/`remember` (kind-discriminated `AgentMemory` + pgvector HNSW) + working-memory get/put. `saveMemory`/`searchMemory` in `persistence.ts` delegate here. |
+| `memory/working-memory.ts` | In-session compaction for long runs: `prepareContext` (budget-aware window + reflector-model summary folding) + `AgentWorkingMemory` snapshot. Gated by `WORKING_MEMORY_ENABLED`. |
 
 Tool definition pattern:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,7 @@ Key shared modules:
 | `memory/working-memory.ts` | In-session compaction for long runs: `prepareContext` (budget-aware window + reflector-model summary folding) + `AgentWorkingMemory` snapshot. Gated by `WORKING_MEMORY_ENABLED`. |
 | `memory/reconcile.ts` | Save-time conflict resolution: batched LLM judge (ADD/UPDATE/SUPERSEDE/REINFORCE/NOOP) applied via MemoryService with an auditable supersede trail. Gated by `MEMORY_RECONCILE_ENABLED`. |
 | `memory/episode.ts` | Episodic memory: one distilled episode (context/reasoning/action/outcome) per tool-using run, replayed as few-shot experience via memoryContext. Gated by `EPISODIC_MEMORY_ENABLED`. |
+| `memory/procedural.ts` | Procedural memory: operating rules learned from corrections/failures, injected as "Operating rules (learned)"; matured rules promote to Skills via SkillFormDialog (human-approved). Gated by `PROCEDURAL_MEMORY_ENABLED`. |
 
 Tool definition pattern:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,7 @@ Key shared modules:
 | `memory/memory-service.ts` | Typed long-term memory: `recall`/`remember` (kind-discriminated `AgentMemory` + pgvector HNSW) + working-memory get/put. `saveMemory`/`searchMemory` in `persistence.ts` delegate here. |
 | `memory/working-memory.ts` | In-session compaction for long runs: `prepareContext` (budget-aware window + reflector-model summary folding) + `AgentWorkingMemory` snapshot. Gated by `WORKING_MEMORY_ENABLED`. |
 | `memory/reconcile.ts` | Save-time conflict resolution: batched LLM judge (ADD/UPDATE/SUPERSEDE/REINFORCE/NOOP) applied via MemoryService with an auditable supersede trail. Gated by `MEMORY_RECONCILE_ENABLED`. |
+| `memory/episode.ts` | Episodic memory: one distilled episode (context/reasoning/action/outcome) per tool-using run, replayed as few-shot experience via memoryContext. Gated by `EPISODIC_MEMORY_ENABLED`. |
 
 Tool definition pattern:
 

--- a/apps/web-ui/components/memory/memory-client-component.tsx
+++ b/apps/web-ui/components/memory/memory-client-component.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 import type { ColumnDef, PaginationState, SortingState } from "@tanstack/react-table";
-import { Brain, MoreHorizontal, Eye, Trash2, Search, X } from "lucide-react";
+import { Brain, MoreHorizontal, Eye, Trash2, Search, X, Sparkles } from "lucide-react";
 import { toast } from "sonner";
 import { PageHeader } from "@/components/shared/page-header";
 import { Input } from "@/components/ui/input";
@@ -27,6 +27,8 @@ import {
 import { useDebounce } from "@/hooks/use-debounce";
 import { MemoryDetailDialog } from "./memory-detail-dialog";
 import { DeleteMemoryDialog } from "./delete-memory-dialog";
+import { SkillFormDialog } from "@/components/skills/skill-form-dialog";
+import { buildSkillDraftFromMemory, type SkillDraft } from "@/lib/agent-memory/promote";
 
 const CATEGORY_OPTIONS: { label: string; value: MemoryCategory }[] = [
     ...KNOWN_CATEGORIES,
@@ -47,6 +49,7 @@ export function MemoryClientComponent() {
     const [categories, setCategories] = useState<MemoryCategory[]>([]);
     const [detail, setDetail] = useState<MemoryRow | null>(null);
     const [deleteTarget, setDeleteTarget] = useState<MemoryRow | null>(null);
+    const [promote, setPromote] = useState<{ draft: SkillDraft; sourceRunId: string | null } | null>(null);
 
     const sort = sorting[0];
     const { data, isLoading } = useAgentMemories({
@@ -177,6 +180,21 @@ export function MemoryClientComponent() {
                                         <Eye className="mr-2 h-4 w-4" />
                                         View details
                                     </DropdownMenuItem>
+                                    {m.kind === "PROCEDURAL" ? (
+                                        <DropdownMenuItem
+                                            onClick={() => {
+                                                const draft = buildSkillDraftFromMemory(m);
+                                                if (draft) {
+                                                    setPromote({ draft, sourceRunId: m.sourceThreadId ?? null });
+                                                } else {
+                                                    toast.error("This memory is missing rule fields and can't be promoted");
+                                                }
+                                            }}
+                                        >
+                                            <Sparkles className="mr-2 h-4 w-4" />
+                                            Promote to skill
+                                        </DropdownMenuItem>
+                                    ) : null}
                                     <DropdownMenuItem
                                         onClick={() => setDeleteTarget(m)}
                                         className="text-destructive"
@@ -259,6 +277,12 @@ export function MemoryClientComponent() {
                 pending={del.isPending}
                 onCancel={() => setDeleteTarget(null)}
                 onConfirm={handleDelete}
+            />
+            <SkillFormDialog
+                open={!!promote}
+                onOpenChange={(v) => { if (!v) setPromote(null); }}
+                initialDraft={promote?.draft ?? null}
+                sourceRunId={promote?.sourceRunId ?? null}
             />
         </div>
     );

--- a/apps/web-ui/components/memory/memory-detail-dialog.tsx
+++ b/apps/web-ui/components/memory/memory-detail-dialog.tsx
@@ -45,6 +45,16 @@ export function MemoryDetailDialog({
                         <Row label="Created" value={new Date(memory.createdAt).toLocaleString()} />
                         <Row label="Updated" value={new Date(memory.updatedAt).toLocaleString()} />
                         <Row label="Expires" value={new Date(memory.expiresAt).toLocaleString()} />
+                        {memory.supersededAt ? (
+                          <Row
+                            label="Superseded"
+                            value={
+                              <span className="text-destructive">
+                                {new Date(memory.supersededAt).toLocaleString()} — replaced by a newer memory
+                              </span>
+                            }
+                          />
+                        ) : null}
                         <div className="space-y-1">
                             <span className="text-sm text-muted-foreground">Raw value</span>
                             <pre className="max-h-64 min-w-0 overflow-auto whitespace-pre-wrap break-all rounded-md bg-muted p-3 text-xs">

--- a/apps/web-ui/env.ts
+++ b/apps/web-ui/env.ts
@@ -84,6 +84,7 @@ export const env = createEnv({
         WORKING_MEMORY_ENABLED: z.string().optional(),
         WORKING_MEMORY_TOKEN_BUDGET: z.string().optional(),
         WORKING_MEMORY_KEEP_RECENT: z.string().optional(),
+        MEMORY_RECONCILE_ENABLED: z.string().optional(),
         USE_PG_SCHEDULES: z.string().optional(),
         DUAL_WRITE_SCHEDULES: z.string().optional(),
         INTERNAL_API_KEY: z.string().optional(),

--- a/apps/web-ui/env.ts
+++ b/apps/web-ui/env.ts
@@ -81,6 +81,9 @@ export const env = createEnv({
 
         // Feature flags / misc
         RIGHT_SIZING_ENABLED: z.string().optional(),
+        WORKING_MEMORY_ENABLED: z.string().optional(),
+        WORKING_MEMORY_TOKEN_BUDGET: z.string().optional(),
+        WORKING_MEMORY_KEEP_RECENT: z.string().optional(),
         USE_PG_SCHEDULES: z.string().optional(),
         DUAL_WRITE_SCHEDULES: z.string().optional(),
         INTERNAL_API_KEY: z.string().optional(),

--- a/apps/web-ui/env.ts
+++ b/apps/web-ui/env.ts
@@ -85,6 +85,7 @@ export const env = createEnv({
         WORKING_MEMORY_TOKEN_BUDGET: z.string().optional(),
         WORKING_MEMORY_KEEP_RECENT: z.string().optional(),
         MEMORY_RECONCILE_ENABLED: z.string().optional(),
+        EPISODIC_MEMORY_ENABLED: z.string().optional(),
         USE_PG_SCHEDULES: z.string().optional(),
         DUAL_WRITE_SCHEDULES: z.string().optional(),
         INTERNAL_API_KEY: z.string().optional(),

--- a/apps/web-ui/env.ts
+++ b/apps/web-ui/env.ts
@@ -86,6 +86,7 @@ export const env = createEnv({
         WORKING_MEMORY_KEEP_RECENT: z.string().optional(),
         MEMORY_RECONCILE_ENABLED: z.string().optional(),
         EPISODIC_MEMORY_ENABLED: z.string().optional(),
+        PROCEDURAL_MEMORY_ENABLED: z.string().optional(),
         USE_PG_SCHEDULES: z.string().optional(),
         DUAL_WRITE_SCHEDULES: z.string().optional(),
         INTERNAL_API_KEY: z.string().optional(),

--- a/apps/web-ui/lib/agent-memory/category.test.ts
+++ b/apps/web-ui/lib/agent-memory/category.test.ts
@@ -7,6 +7,7 @@ describe('categoryFromNamespace', () => {
         expect(categoryFromNamespace('user/preferences')).toBe('user');
         expect(categoryFromNamespace('patterns/ecs')).toBe('patterns');
         expect(categoryFromNamespace('errors/rds')).toBe('errors');
+        expect(categoryFromNamespace('episodes')).toBe('episodes');
     });
 
     it('is case-insensitive on the first segment', () => {
@@ -22,7 +23,7 @@ describe('categoryFromNamespace', () => {
         expect(categoryFromNamespace('')).toBe('other');
     });
 
-    it('exposes the four known categories in display order', () => {
-        expect(KNOWN_CATEGORIES).toEqual(['infra', 'user', 'patterns', 'errors']);
+    it('exposes the known categories in display order', () => {
+        expect(KNOWN_CATEGORIES).toEqual(['infra', 'user', 'patterns', 'errors', 'episodes']);
     });
 });

--- a/apps/web-ui/lib/agent-memory/category.test.ts
+++ b/apps/web-ui/lib/agent-memory/category.test.ts
@@ -8,6 +8,7 @@ describe('categoryFromNamespace', () => {
         expect(categoryFromNamespace('patterns/ecs')).toBe('patterns');
         expect(categoryFromNamespace('errors/rds')).toBe('errors');
         expect(categoryFromNamespace('episodes')).toBe('episodes');
+        expect(categoryFromNamespace('procedures/aws-cli')).toBe('procedures');
     });
 
     it('is case-insensitive on the first segment', () => {
@@ -24,6 +25,6 @@ describe('categoryFromNamespace', () => {
     });
 
     it('exposes the known categories in display order', () => {
-        expect(KNOWN_CATEGORIES).toEqual(['infra', 'user', 'patterns', 'errors', 'episodes']);
+        expect(KNOWN_CATEGORIES).toEqual(['infra', 'user', 'patterns', 'errors', 'episodes', 'procedures']);
     });
 });

--- a/apps/web-ui/lib/agent-memory/category.ts
+++ b/apps/web-ui/lib/agent-memory/category.ts
@@ -1,8 +1,8 @@
 /** UI bucket derived from an AgentMemory namespace's first path segment. */
-export type MemoryCategory = 'infra' | 'user' | 'patterns' | 'errors' | 'episodes' | 'other';
+export type MemoryCategory = 'infra' | 'user' | 'patterns' | 'errors' | 'episodes' | 'procedures' | 'other';
 
 /** The agent-written namespace prefixes, in the order the UI shows them. */
-export const KNOWN_CATEGORIES: MemoryCategory[] = ['infra', 'user', 'patterns', 'errors', 'episodes'];
+export const KNOWN_CATEGORIES: MemoryCategory[] = ['infra', 'user', 'patterns', 'errors', 'episodes', 'procedures'];
 
 /**
  * Memories store `namespace` as a slash-joined string (e.g. "infra/<account-id>",

--- a/apps/web-ui/lib/agent-memory/category.ts
+++ b/apps/web-ui/lib/agent-memory/category.ts
@@ -1,8 +1,8 @@
 /** UI bucket derived from an AgentMemory namespace's first path segment. */
-export type MemoryCategory = 'infra' | 'user' | 'patterns' | 'errors' | 'other';
+export type MemoryCategory = 'infra' | 'user' | 'patterns' | 'errors' | 'episodes' | 'other';
 
-/** The four agent-written namespace prefixes, in the order the UI shows them. */
-export const KNOWN_CATEGORIES: MemoryCategory[] = ['infra', 'user', 'patterns', 'errors'];
+/** The agent-written namespace prefixes, in the order the UI shows them. */
+export const KNOWN_CATEGORIES: MemoryCategory[] = ['infra', 'user', 'patterns', 'errors', 'episodes'];
 
 /**
  * Memories store `namespace` as a slash-joined string (e.g. "infra/<account-id>",

--- a/apps/web-ui/lib/agent-memory/promote.test.ts
+++ b/apps/web-ui/lib/agent-memory/promote.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { buildSkillDraftFromMemory } from './promote';
+import type { MemoryRow } from '@/lib/queries/agent-memories';
+
+const row = (overrides: Partial<MemoryRow> = {}): MemoryRow => ({
+    id: 'm1', userId: 'u1', namespace: 'procedures/aws-cli', category: 'other' as any,
+    key: 'paginate-list-calls', fact: '', source: null, confidence: null,
+    value: { instruction: 'Always paginate list/describe calls', trigger: 'any AWS CLI list operation', evidence: 'missed a resource once' },
+    kind: 'PROCEDURAL', sourceThreadId: 'th-42',
+    supersededById: null, supersededAt: null,
+    createdAt: '2026-07-02T00:00:00Z', updatedAt: '2026-07-02T00:00:00Z', expiresAt: '2026-10-01T00:00:00Z',
+    ...overrides,
+});
+
+describe('buildSkillDraftFromMemory', () => {
+    it('builds a draft from a procedural row', () => {
+        const d = buildSkillDraftFromMemory(row());
+        expect(d).not.toBeNull();
+        expect(d!.name).toBe('Paginate List Calls');
+        expect(d!.description).toBe('any AWS CLI list operation');
+        expect(d!.tier).toBe('read-only');
+        expect(d!.content).toContain('## Rule\nAlways paginate list/describe calls');
+        expect(d!.content).toContain('## When it applies\nany AWS CLI list operation');
+        expect(d!.content).toContain('## Why (evidence)\nmissed a resource once');
+    });
+    it('returns null for non-procedural rows', () => {
+        expect(buildSkillDraftFromMemory(row({ kind: 'SEMANTIC' }))).toBeNull();
+        expect(buildSkillDraftFromMemory(row({ kind: 'EPISODIC' }))).toBeNull();
+    });
+    it('returns null when instruction or trigger missing', () => {
+        expect(buildSkillDraftFromMemory(row({ value: { trigger: 't' } }))).toBeNull();
+        expect(buildSkillDraftFromMemory(row({ value: { instruction: 'i' } }))).toBeNull();
+    });
+    it('evidence missing → placeholder, still promotable', () => {
+        const d = buildSkillDraftFromMemory(row({ value: { instruction: 'i', trigger: 't' } }));
+        expect(d!.content).toContain('## Why (evidence)\n(not recorded)');
+    });
+});

--- a/apps/web-ui/lib/agent-memory/promote.ts
+++ b/apps/web-ui/lib/agent-memory/promote.ts
@@ -1,0 +1,38 @@
+/**
+ * promote.ts — procedural memory → Skill draft mapping (Phase 4 bridge).
+ * Pure and client-safe; persistence happens only through the existing
+ * SkillFormDialog → useCreateSkill → POST /api/skills path (human-approved).
+ */
+
+import type { MemoryRow } from '@/lib/queries/agent-memories';
+
+export interface SkillDraft {
+    name: string;
+    description: string;
+    tier: string;
+    content: string;
+}
+
+function humanize(key: string): string {
+    return key
+        .split(/[-_]+/)
+        .filter(Boolean)
+        .map((w) => (w[0]?.toUpperCase() ?? '') + w.slice(1))
+        .join(' ');
+}
+
+export function buildSkillDraftFromMemory(row: MemoryRow): SkillDraft | null {
+    if (row.kind !== 'PROCEDURAL') return null;
+    const v = row.value as { instruction?: string; trigger?: string; evidence?: string };
+    if (!v?.instruction || !v?.trigger) return null;
+    return {
+        name: humanize(row.key),
+        description: v.trigger,
+        tier: 'read-only',
+        content:
+            `## Rule\n${v.instruction}\n\n` +
+            `## When it applies\n${v.trigger}\n\n` +
+            `## Why (evidence)\n${v.evidence || '(not recorded)'}\n\n` +
+            `_Learned by the agent; promoted from procedural memory._`,
+    };
+}

--- a/apps/web-ui/lib/agent/agent-shared.ts
+++ b/apps/web-ui/lib/agent/agent-shared.ts
@@ -2,6 +2,7 @@ import { BaseMessage, AIMessage, HumanMessage, ToolMessage } from "@langchain/co
 import { StateGraphArgs } from "@langchain/langgraph";
 import { getCheckpointer as getPersistenceCheckpointer, getMemoryStore as getPersistenceMemoryStore } from "./persistence";
 import { env } from "@/env";
+import type { Scratchpad } from "./memory/types";
 
 /** Resolved model configuration — provider-agnostic. */
 export interface ResolvedModelConfig {
@@ -73,6 +74,8 @@ export interface ReflectionState {
     isComplete: boolean;
     toolResults: ToolResultEntry[]; // Structured tool results for reflection/summary
     memoryContext: string; // Formatted relevant memories from recall node
+    runningSummary: string; // Phase 1: rolling summary of compacted turns
+    scratchpad: Scratchpad; // Phase 1: structured working-memory scratchpad
 }
 
 // --- Schema for StateGraph ---
@@ -129,6 +132,14 @@ export const graphState: StateGraphArgs<ReflectionState>["channels"] = {
     memoryContext: {
         reducer: (x: string, y: string) => y || x,
         default: () => "",
+    },
+    runningSummary: {
+        reducer: (x: string, y: string) => y || x,
+        default: () => "",
+    },
+    scratchpad: {
+        reducer: (x: Scratchpad, y: Scratchpad) => y || x,
+        default: () => ({ openGoals: [], keyFindings: [], resourceIds: [], pendingSteps: [] }),
     },
 };
 

--- a/apps/web-ui/lib/agent/fast-agent.ts
+++ b/apps/web-ui/lib/agent/fast-agent.ts
@@ -9,7 +9,6 @@ import {
     graphState,
     MAX_ITERATIONS,
     truncateOutput,
-    getRecentMessages,
     sanitizeMessagesForBedrock,
     tagMessagePhase,
     getCheckpointer,
@@ -30,6 +29,7 @@ import {
 } from "./prompt-templates";
 import { createAgentModels, assembleTools } from "./model-factory";
 import { createMemoryRecallNode, createMemorySaveNode } from "./memory-nodes";
+import { prepareContext, buildWorkingMemorySection } from "./memory/working-memory";
 
 // --- FAST GRAPH (Reflection Agent Mode) ---
 export async function createFastGraph(config: GraphConfig) {
@@ -66,10 +66,13 @@ export async function createFastGraph(config: GraphConfig) {
     const memoryRecallNode = createMemoryRecallNode(memoryDeps);
     const memorySaveNode = createMemorySaveNode(memoryDeps);
 
+    // Working-memory deps — threadId is read per-node from the runtime config.
+    const wmDeps = { reflectorModel, tenantId, userId: config.userId };
+
     // ---------------------------------------------------------------------------
     // AGENT NODE
     // ---------------------------------------------------------------------------
-    async function agentNode(state: ReflectionState): Promise<Partial<ReflectionState>> {
+    async function agentNode(state: ReflectionState, runtimeConfig?: any): Promise<Partial<ReflectionState>> {
         const { messages, iterationCount, memoryContext } = state;
 
         console.log(`\n================================================================================`);
@@ -83,6 +86,10 @@ export async function createFastGraph(config: GraphConfig) {
             ? `\n## Relevant Context from Memory\n${memoryContext}\n`
             : '';
 
+        const threadId = runtimeConfig?.configurable?.thread_id as string | undefined;
+        const { windowMessages, workingMemorySection, stateUpdate } =
+            await prepareContext(state, { ...wmDeps, threadId }, 20);
+
         const systemPrompt = new SystemMessage(`${baseIdentity}
 ${effectiveSkillSection}
 ${CORE_PRINCIPLES}
@@ -91,6 +98,7 @@ ${autoApproveGuidance}
 ${operationalWorkflows}
 ${accountContext}
 ${memorySection}
+${workingMemorySection}
 ## Conversation Continuity
 
 Review the full conversation history before responding:
@@ -105,8 +113,7 @@ Review the full conversation history before responding:
 - If you receive a critique from the Reflector, address each identified issue specifically — do not restate the original answer unchanged.
 - Be precise: include resource IDs, command flags, numeric values, and account names in your responses where available.`);
 
-        const recentMessages = getRecentMessages(messages, 20);
-        const safeMessages = sanitizeMessagesForBedrock(recentMessages);
+        const safeMessages = sanitizeMessagesForBedrock(windowMessages);
         const response = await modelWithTools.invoke([systemPrompt, ...safeMessages]);
 
         if ('tool_calls' in response && response.tool_calls && response.tool_calls.length > 0) {
@@ -121,7 +128,8 @@ Review the full conversation history before responding:
 
         return {
             messages: [tagMessagePhase(response, 'execution')],
-            iterationCount: iterationCount + 1
+            iterationCount: iterationCount + 1,
+            ...stateUpdate,
         };
     }
 
@@ -291,6 +299,11 @@ Please provide your critique.`
     // user would receive an empty ("placeholder") response.
     async function finalizeNode(state: ReflectionState): Promise<Partial<ReflectionState>> {
         const { messages, memoryContext, toolResults } = state;
+        const workingMemorySection = buildWorkingMemorySection(
+            state.runningSummary || (state.scratchpad?.openGoals?.length ?? 0) > 0
+                ? { runningSummary: state.runningSummary ?? '', scratchpad: state.scratchpad ?? { openGoals: [], keyFindings: [], resourceIds: [], pendingSteps: [] }, tokenCount: 0, turnCount: 0 }
+                : null,
+        );
 
         console.log(`\n================================================================================`);
         console.log(`🏁 [FAST AGENT] Iteration cap reached — synthesizing final answer (no tools)`);
@@ -323,6 +336,7 @@ Please provide your critique.`
 ${effectiveSkillSection}
 ${accountContext}
 ${memorySection}
+${workingMemorySection}
 ## Final Answer (iteration cap reached)
 
 You have reached the maximum number of tool-call iterations, so you can NOT run any more tools.

--- a/apps/web-ui/lib/agent/memory-nodes.ts
+++ b/apps/web-ui/lib/agent/memory-nodes.ts
@@ -10,6 +10,8 @@ import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { ReflectionState, truncateOutput } from "./agent-shared";
 import { searchMemory, saveMemory } from "./persistence";
+import { reconcileMemories, reconcileEnabled } from "./memory/reconcile";
+import type { ExtractedFact } from "./memory/types";
 
 interface MemoryNodeDeps {
     reflectorModel: BaseChatModel;
@@ -108,7 +110,7 @@ Return only the relevant memories.`
 export function createMemorySaveNode(deps: MemoryNodeDeps) {
     const { reflectorModel, tenantId, userId, store } = deps;
 
-    return async function memorySaveNode(state: ReflectionState): Promise<Partial<ReflectionState>> {
+    return async function memorySaveNode(state: ReflectionState, runtimeConfig?: any): Promise<Partial<ReflectionState>> {
         if (!store || !tenantId || !userId) {
             console.log("[MemorySave] Skipped — store, tenantId, or userId not available");
             return {};
@@ -197,14 +199,25 @@ Extract memories to save.`
                 return {};
             }
 
-            console.log(`🧠 [MEMORY SAVE] Saving ${toSave.length} memories...`);
-
-            for (const mem of toSave) {
-                try {
-                    await saveMemory(tenantId, userId, mem.namespace, mem.key, mem.value as Record<string, unknown>);
-                    console.log(`   ✅ Saved: ${mem.namespace.join("/")}/${mem.key}`);
-                } catch (err: any) {
-                    console.warn(`   ⚠️ Failed to save ${mem.key}: ${err?.message ?? err}`);
+            if (reconcileEnabled()) {
+                console.log(`🧠 [MEMORY SAVE] Reconciling ${toSave.length} extracted facts...`);
+                const threadId = runtimeConfig?.configurable?.thread_id as string | undefined;
+                const summary = await reconcileMemories({
+                    tenantId, userId,
+                    facts: toSave.map(m => ({ namespace: m.namespace, key: m.key, value: m.value })) as ExtractedFact[],
+                    judgeModel: reflectorModel,
+                    sourceThreadId: threadId,
+                });
+                console.log(`🧠 [MEMORY SAVE] Reconcile: ${summary.added} added, ${summary.updated} updated, ${summary.superseded} superseded, ${summary.reinforced} reinforced, ${summary.noop} noop, ${summary.failed} failed`);
+            } else {
+                console.log(`🧠 [MEMORY SAVE] Saving ${toSave.length} memories (reconcile disabled)...`);
+                for (const mem of toSave) {
+                    try {
+                        await saveMemory(tenantId, userId, mem.namespace, mem.key, mem.value as Record<string, unknown>);
+                        console.log(`   ✅ Saved: ${mem.namespace.join("/")}/${mem.key}`);
+                    } catch (err: any) {
+                        console.warn(`   ⚠️ Failed to save ${mem.key}: ${err?.message ?? err}`);
+                    }
                 }
             }
         } catch (err: any) {

--- a/apps/web-ui/lib/agent/memory-nodes.ts
+++ b/apps/web-ui/lib/agent/memory-nodes.ts
@@ -16,7 +16,11 @@ import {
     EPISODE_RECALL_LIMIT, EPISODE_DISTANCE_THRESHOLD,
 } from "./memory/episode";
 import { reconcileMemories, reconcileEnabled } from "./memory/reconcile";
-import type { ExtractedFact, EpisodicValue } from "./memory/types";
+import {
+    proceduralMemoryEnabled, formatProceduresSection, isValidExtractedItem,
+    PROCEDURE_RECALL_LIMIT, PROCEDURE_DISTANCE_THRESHOLD,
+} from "./memory/procedural";
+import type { ExtractedFact, EpisodicValue, ProceduralValue } from "./memory/types";
 
 interface MemoryNodeDeps {
     reflectorModel: BaseChatModel;
@@ -91,6 +95,26 @@ Return only the relevant memories.`
             console.warn(`[MemoryRecall] Semantic search failed: ${err?.message ?? err}`);
         }
 
+        // ── Learned operating rules — distance-gated, no LLM filter ─────────
+        let proceduresSection = "";
+        if (proceduralMemoryEnabled()) {
+            try {
+                const rules = await getMemoryService().recall({
+                    tenantId, userId, query, kinds: ["PROCEDURAL"], limit: PROCEDURE_RECALL_LIMIT,
+                });
+                const near = rules
+                    .filter(r => r.distance !== undefined && r.distance <= PROCEDURE_DISTANCE_THRESHOLD)
+                    .map(r => r.value as unknown as ProceduralValue)
+                    .filter(v => !!v?.instruction && !!v?.trigger);
+                if (near.length > 0) {
+                    console.log(`🧠 [MEMORY RECALL] Applying ${near.length} learned operating rule(s)`);
+                    proceduresSection = formatProceduresSection(near);
+                }
+            } catch (err: any) {
+                console.warn(`[MemoryRecall] Procedural search failed: ${err?.message ?? err}`);
+            }
+        }
+
         // ── Episodic few-shot replay — distance-gated, no LLM filter ────────
         let episodesSection = "";
         if (episodicMemoryEnabled()) {
@@ -108,7 +132,7 @@ Return only the relevant memories.`
             }
         }
 
-        const memoryContext = composeMemoryContext(factsSection, episodesSection);
+        const memoryContext = composeMemoryContext(factsSection, episodesSection, proceduresSection);
         if (memoryContext) {
             console.log(`🧠 [MEMORY RECALL] Injecting relevant memories into context`);
         } else {
@@ -156,7 +180,11 @@ export function createMemorySaveNode(deps: MemoryNodeDeps) {
   Examples: how a scaling issue was resolved, successful deployment patterns
 - Error resolutions → namespace: ["errors", "<service-type>"]
   Examples: how an OOM was fixed, what caused a timeout, permission error workarounds
-
+` + (proceduralMemoryEnabled() ? `- Operating rules → add "kind": "PROCEDURAL", namespace: ["procedures", "<domain>"]
+  A rule for HOW the agent should behave in this environment, learned from this run.
+  Extract a rule ONLY from a correction, a failure the run recovered from, or an explicit user preference about behavior.
+  Shape: { "kind": "PROCEDURAL", "namespace": ["procedures", "aws-cli"], "key": "paginate-list-calls", "value": { "instruction": "Always paginate list/describe calls", "trigger": "any AWS CLI list operation", "evidence": "run truncated results and missed the target resource", "confidence": "high" } }
+` : '') + `
 **Rules:**
 - Only extract facts that would be useful in a FUTURE session — skip ephemeral details
 - Each memory must have confidence "high" or "medium" — skip anything uncertain
@@ -196,14 +224,16 @@ Extract memories to save.`
             }
 
             const memories: Array<{
+                kind?: string;
                 namespace: string[];
                 key: string;
-                value: { fact: string; source: string; confidence: string };
+                value: Record<string, unknown>;
             }> = JSON.parse(jsonMatch[0]);
 
-            const toSave = memories.filter(m =>
-                m.value?.confidence === "high" || m.value?.confidence === "medium"
-            );
+            const toSave = memories.filter(isValidExtractedItem);
+            if (toSave.length < memories.length) {
+                console.log(`[MemorySave] Dropped ${memories.length - toSave.length} invalid/low-confidence item(s)`);
+            }
 
             if (toSave.length === 0) {
                 console.log("[MemorySave] No high/medium confidence memories to save");
@@ -215,7 +245,10 @@ Extract memories to save.`
                 const threadId = runtimeConfig?.configurable?.thread_id as string | undefined;
                 const summary = await reconcileMemories({
                     tenantId, userId,
-                    facts: toSave.map(m => ({ namespace: m.namespace, key: m.key, value: m.value })) as ExtractedFact[],
+                    facts: toSave.map(m => ({
+                        kind: m.kind === 'PROCEDURAL' ? 'PROCEDURAL' as const : undefined,
+                        namespace: m.namespace, key: m.key, value: m.value,
+                    })) as unknown as ExtractedFact[],
                     judgeModel: reflectorModel,
                     sourceThreadId: threadId,
                 });
@@ -223,6 +256,10 @@ Extract memories to save.`
             } else {
                 console.log(`🧠 [MEMORY SAVE] Saving ${toSave.length} memories (reconcile disabled)...`);
                 for (const mem of toSave) {
+                    if (mem.kind === 'PROCEDURAL') {
+                        console.log(`   ⏭️ Skipped procedural rule ${mem.key} (reconcile disabled)`);
+                        continue;
+                    }
                     try {
                         await saveMemory(tenantId, userId, mem.namespace, mem.key, mem.value as Record<string, unknown>);
                         console.log(`   ✅ Saved: ${mem.namespace.join("/")}/${mem.key}`);

--- a/apps/web-ui/lib/agent/memory-nodes.ts
+++ b/apps/web-ui/lib/agent/memory-nodes.ts
@@ -9,9 +9,14 @@
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { ReflectionState, truncateOutput } from "./agent-shared";
-import { searchMemory, saveMemory } from "./persistence";
+import { saveMemory } from "./persistence";
+import { getMemoryService } from "./memory/memory-service";
+import {
+    captureEpisode, episodicMemoryEnabled, formatEpisodesSection, composeMemoryContext,
+    EPISODE_RECALL_LIMIT, EPISODE_DISTANCE_THRESHOLD,
+} from "./memory/episode";
 import { reconcileMemories, reconcileEnabled } from "./memory/reconcile";
-import type { ExtractedFact } from "./memory/types";
+import type { ExtractedFact, EpisodicValue } from "./memory/types";
 
 interface MemoryNodeDeps {
     reflectorModel: BaseChatModel;
@@ -42,68 +47,74 @@ export function createMemoryRecallNode(deps: MemoryNodeDeps) {
 
         console.log(`\n🧠 [MEMORY RECALL] Searching memories for: "${truncateOutput(query, 100)}"`);
 
-        let rawResults: Array<{ key: string; value: unknown; namespace: string }>;
+        // ── Semantic facts → existing LLM relevance filter ──────────────────
+        let factsSection = "";
         try {
-            // Recall spans all memory kinds (SEMANTIC today; EPISODIC/PROCEDURAL in later phases).
-            const results = await searchMemory(tenantId, userId, [], query, 10);
-            rawResults = (results as Array<{ key: string; value: unknown; namespace: string }>) ?? [];
-        } catch (err: any) {
-            console.warn(`[MemoryRecall] Search failed: ${err?.message ?? err}`);
-            return { memoryContext: "" };
-        }
-
-        if (rawResults.length === 0) {
-            console.log("[MemoryRecall] No memories found");
-            return { memoryContext: "" };
-        }
-
-        console.log(`[MemoryRecall] Found ${rawResults.length} raw memories, filtering for relevance...`);
-
-        const memorySummary = rawResults.map((m, i) =>
-            `${i + 1}. [${m.namespace}/${m.key}] ${JSON.stringify(m.value)}`
-        ).join("\n");
-
-        let relevantMemories: string;
-        try {
-            const filterPrompt = new SystemMessage(
-                `You are a relevance filter. Given a user task and a list of memories from previous sessions, return ONLY the memories that are directly relevant to the current task.
+            const hits = await getMemoryService().recall({
+                tenantId, userId, query, kinds: ["SEMANTIC"], limit: 10,
+            });
+            if (hits.length > 0) {
+                console.log(`[MemoryRecall] Found ${hits.length} raw facts, filtering for relevance...`);
+                const memorySummary = hits.map((m, i) =>
+                    `${i + 1}. [${m.namespace}/${m.key}] ${JSON.stringify(m.value)}`
+                ).join("\n");
+                try {
+                    const filterPrompt = new SystemMessage(
+                        `You are a relevance filter. Given a user task and a list of memories from previous sessions, return ONLY the memories that are directly relevant to the current task.
 
 Return a markdown list of relevant memories, each on its own line with the format:
 - [namespace/key] One-line summary of the relevant fact
 
 If no memories are relevant, return exactly: NONE`
-            );
-
-            const filterInput = new HumanMessage({
-                content: `**User Task:** ${truncateOutput(query, 2000)}
+                    );
+                    const filterInput = new HumanMessage({
+                        content: `**User Task:** ${truncateOutput(query, 2000)}
 
 **Available Memories:**
 ${memorySummary}
 
 Return only the relevant memories.`
-            });
-
-            const response = await reflectorModel.invoke([filterPrompt, filterInput]);
-            const content = typeof response.content === "string"
-                ? response.content
-                : JSON.stringify(response.content);
-
-            if (content.trim() === "NONE" || !content.trim()) {
-                console.log("[MemoryRecall] No relevant memories after filtering");
-                return { memoryContext: "" };
+                    });
+                    const response = await reflectorModel.invoke([filterPrompt, filterInput]);
+                    const content = typeof response.content === "string"
+                        ? response.content
+                        : JSON.stringify(response.content);
+                    factsSection = (content.trim() === "NONE") ? "" : content.trim();
+                } catch (err: any) {
+                    console.warn(`[MemoryRecall] Relevance filter failed: ${err?.message ?? err}`);
+                    factsSection = hits.slice(0, 5).map(m =>
+                        `- [${m.namespace}/${m.key}] ${JSON.stringify(m.value)}`
+                    ).join("\n");
+                }
             }
-
-            relevantMemories = content.trim();
         } catch (err: any) {
-            console.warn(`[MemoryRecall] Relevance filter failed: ${err?.message ?? err}`);
-            relevantMemories = rawResults.slice(0, 5).map(m =>
-                `- [${m.namespace}/${m.key}] ${JSON.stringify(m.value)}`
-            ).join("\n");
+            console.warn(`[MemoryRecall] Semantic search failed: ${err?.message ?? err}`);
         }
 
-        console.log(`🧠 [MEMORY RECALL] Injecting relevant memories into context`);
+        // ── Episodic few-shot replay — distance-gated, no LLM filter ────────
+        let episodesSection = "";
+        if (episodicMemoryEnabled()) {
+            try {
+                const eps = await getMemoryService().recall({
+                    tenantId, userId, query, kinds: ["EPISODIC"], limit: EPISODE_RECALL_LIMIT,
+                });
+                const near = eps.filter(e => e.distance !== undefined && e.distance <= EPISODE_DISTANCE_THRESHOLD);
+                if (near.length > 0) {
+                    console.log(`🧠 [MEMORY RECALL] Replaying ${near.length} past episode(s)`);
+                    episodesSection = formatEpisodesSection(near.map(e => e.value as unknown as EpisodicValue));
+                }
+            } catch (err: any) {
+                console.warn(`[MemoryRecall] Episodic search failed: ${err?.message ?? err}`);
+            }
+        }
 
-        return { memoryContext: relevantMemories };
+        const memoryContext = composeMemoryContext(factsSection, episodesSection);
+        if (memoryContext) {
+            console.log(`🧠 [MEMORY RECALL] Injecting relevant memories into context`);
+        } else {
+            console.log("[MemoryRecall] Nothing relevant found");
+        }
+        return { memoryContext };
     };
 }
 
@@ -222,6 +233,17 @@ Extract memories to save.`
             }
         } catch (err: any) {
             console.warn(`[MemorySave] Extraction failed: ${err?.message ?? err}`);
+        }
+
+        // ── Episodic capture — independent of fact extraction; never blocks END ──
+        const { plan, toolResults, errors, reflection, isComplete, iterationCount } = state;
+        const threadIdForEpisode = runtimeConfig?.configurable?.thread_id as string | undefined;
+        if (episodicMemoryEnabled() && threadIdForEpisode && toolResults.length > 0) {
+            await captureEpisode({
+                tenantId, userId, threadId: threadIdForEpisode,
+                distillerModel: reflectorModel,
+                taskDescription, plan, toolResults, errors, reflection, isComplete, iterationCount,
+            });
         }
 
         return {};

--- a/apps/web-ui/lib/agent/memory-nodes.ts
+++ b/apps/web-ui/lib/agent/memory-nodes.ts
@@ -42,6 +42,7 @@ export function createMemoryRecallNode(deps: MemoryNodeDeps) {
 
         let rawResults: Array<{ key: string; value: unknown; namespace: string }>;
         try {
+            // Recall spans all memory kinds (SEMANTIC today; EPISODIC/PROCEDURAL in later phases).
             const results = await searchMemory(tenantId, userId, [], query, 10);
             rawResults = (results as Array<{ key: string; value: unknown; namespace: string }>) ?? [];
         } catch (err: any) {

--- a/apps/web-ui/lib/agent/memory/episode.test.ts
+++ b/apps/web-ui/lib/agent/memory/episode.test.ts
@@ -127,3 +127,24 @@ describe('composeMemoryContext', () => {
         expect(composeMemoryContext('', '')).toBe('');
     });
 });
+
+describe('composeMemoryContext with procedures (third arg)', () => {
+    it('third arg defaults empty — two-arg behavior unchanged', () => {
+        expect(composeMemoryContext('- [a/b] fact', '')).toBe('- [a/b] fact');
+    });
+    it('all three → facts header, procedures, episodes in order', () => {
+        const s = composeMemoryContext('- [a/b] fact', '### Past experience\nE', '### Operating rules (learned)\nR');
+        expect(s).toBe('### Known facts\n- [a/b] fact\n\n### Operating rules (learned)\nR\n\n### Past experience\nE');
+    });
+    it('procedures only → section as-is', () => {
+        expect(composeMemoryContext('', '', '### Operating rules (learned)\nR')).toBe('### Operating rules (learned)\nR');
+    });
+    it('procedures + episodes (no facts) → joined, no facts header', () => {
+        expect(composeMemoryContext('', '### Past experience\nE', '### Operating rules (learned)\nR'))
+            .toBe('### Operating rules (learned)\nR\n\n### Past experience\nE');
+    });
+    it('facts + procedures (no episodes) → facts header + procedures', () => {
+        expect(composeMemoryContext('- f', '', '### Operating rules (learned)\nR'))
+            .toBe('### Known facts\n- f\n\n### Operating rules (learned)\nR');
+    });
+});

--- a/apps/web-ui/lib/agent/memory/episode.test.ts
+++ b/apps/web-ui/lib/agent/memory/episode.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('./memory-service', () => ({ getMemoryService: vi.fn() }));
+
+import { getMemoryService } from './memory-service';
+import {
+    captureEpisode, formatEpisodesSection, composeMemoryContext, episodicMemoryEnabled,
+} from './episode';
+import type { EpisodicValue } from './types';
+
+const mockSvc = { remember: vi.fn() };
+
+const goodEpisode: EpisodicValue = {
+    context: 'ECS service stuck in DRAINING',
+    reasoning: 'cycle the tasks via force-new-deployment',
+    action: 'aws ecs update-service --force-new-deployment',
+    outcome: 'SUCCEEDED — service returned to steady state',
+};
+
+const distillerReturning = (content: string) =>
+    ({ invoke: vi.fn().mockResolvedValue({ content }) }) as any;
+
+const baseParams = (overrides: Record<string, unknown> = {}) => ({
+    tenantId: 't1', userId: 'u1', threadId: 'th-9',
+    distillerModel: distillerReturning(JSON.stringify(goodEpisode)),
+    taskDescription: 'restart stuck ECS service',
+    plan: [{ step: 'find service', status: 'completed' }],
+    toolResults: [{ toolName: 'execute_command', output: 'service restarted', isError: false }],
+    errors: [], reflection: 'looks good', isComplete: true, iterationCount: 3,
+    ...overrides,
+});
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mockSvc.remember.mockResolvedValue('ep-row-id');
+    vi.mocked(getMemoryService).mockReturnValue(mockSvc as any);
+});
+afterEach(() => { delete process.env.EPISODIC_MEMORY_ENABLED; });
+
+describe('episodicMemoryEnabled', () => {
+    it('defaults true; false/0 disable', () => {
+        expect(episodicMemoryEnabled()).toBe(true);
+        process.env.EPISODIC_MEMORY_ENABLED = 'false';
+        expect(episodicMemoryEnabled()).toBe(false);
+    });
+});
+
+describe('captureEpisode', () => {
+    it('distills and saves an EPISODIC memory keyed by thread', async () => {
+        const saved = await captureEpisode(baseParams() as any);
+        expect(saved).toBe(true);
+        expect(mockSvc.remember).toHaveBeenCalledWith(expect.objectContaining({
+            tenantId: 't1', userId: 'u1', kind: 'EPISODIC',
+            namespace: ['episodes'], key: 'thread-th-9', sourceThreadId: 'th-9',
+            value: expect.objectContaining({ outcome: goodEpisode.outcome }),
+        }));
+    });
+
+    it('SKIP → no save, returns false', async () => {
+        const saved = await captureEpisode(baseParams({ distillerModel: distillerReturning('SKIP') }) as any);
+        expect(saved).toBe(false);
+        expect(mockSvc.remember).not.toHaveBeenCalled();
+    });
+
+    it('invalid distiller output (missing outcome) → no save, false', async () => {
+        const bad = JSON.stringify({ context: 'c', reasoning: 'r', action: 'a' });
+        const saved = await captureEpisode(baseParams({ distillerModel: distillerReturning(bad) }) as any);
+        expect(saved).toBe(false);
+        expect(mockSvc.remember).not.toHaveBeenCalled();
+    });
+
+    it('distiller throwing → false, does not throw', async () => {
+        const boom = { invoke: vi.fn().mockRejectedValue(new Error('llm down')) } as any;
+        const saved = await captureEpisode(baseParams({ distillerModel: boom }) as any);
+        expect(saved).toBe(false);
+    });
+
+    it('flag off → short-circuits before invoking the distiller', async () => {
+        process.env.EPISODIC_MEMORY_ENABLED = 'false';
+        const distiller = distillerReturning(JSON.stringify(goodEpisode));
+        const saved = await captureEpisode(baseParams({ distillerModel: distiller }) as any);
+        expect(saved).toBe(false);
+        expect(distiller.invoke).not.toHaveBeenCalled();
+    });
+});
+
+describe('formatEpisodesSection', () => {
+    it("returns '' for empty input", () => {
+        expect(formatEpisodesSection([])).toBe('');
+    });
+    it('renders all four labeled fields', () => {
+        const s = formatEpisodesSection([goodEpisode]);
+        expect(s).toContain('### Past experience');
+        expect(s).toContain(`**Situation:** ${goodEpisode.context}`);
+        expect(s).toContain(`**Approach:** ${goodEpisode.reasoning}`);
+        expect(s).toContain(`**Actions taken:** ${goodEpisode.action}`);
+        expect(s).toContain(`**Outcome:** ${goodEpisode.outcome}`);
+    });
+});
+
+describe('composeMemoryContext', () => {
+    it('facts only → bare facts (legacy shape, no headers added)', () => {
+        expect(composeMemoryContext('- [a/b] fact', '')).toBe('- [a/b] fact');
+    });
+    it('episodes only → episodes section as-is', () => {
+        expect(composeMemoryContext('', '### Past experience\nX')).toBe('### Past experience\nX');
+    });
+    it('both → facts under a Known facts header, then episodes', () => {
+        const s = composeMemoryContext('- [a/b] fact', '### Past experience\nX');
+        expect(s).toBe('### Known facts\n- [a/b] fact\n\n### Past experience\nX');
+    });
+    it("both empty → ''", () => {
+        expect(composeMemoryContext('', '')).toBe('');
+    });
+});

--- a/apps/web-ui/lib/agent/memory/episode.test.ts
+++ b/apps/web-ui/lib/agent/memory/episode.test.ts
@@ -82,6 +82,20 @@ describe('captureEpisode', () => {
         expect(saved).toBe(false);
         expect(distiller.invoke).not.toHaveBeenCalled();
     });
+
+    it('distiller returns prose with no JSON object → no save, false', async () => {
+        const saved = await captureEpisode(baseParams({
+            distillerModel: distillerReturning('I could not distill this run into an episode.'),
+        }) as any);
+        expect(saved).toBe(false);
+        expect(mockSvc.remember).not.toHaveBeenCalled();
+    });
+
+    it('remember/save throwing → false, does not throw', async () => {
+        mockSvc.remember.mockRejectedValue(new Error('db down'));
+        const saved = await captureEpisode(baseParams() as any);
+        expect(saved).toBe(false);
+    });
 });
 
 describe('formatEpisodesSection', () => {

--- a/apps/web-ui/lib/agent/memory/episode.ts
+++ b/apps/web-ui/lib/agent/memory/episode.ts
@@ -120,15 +120,17 @@ export function formatEpisodesSection(episodes: EpisodicValue[]): string {
 }
 
 /**
- * Compose memoryContext from facts + episodes. Facts-only returns the bare
- * facts string (byte-identical to pre-Phase-3 behavior); the "Known facts"
- * header appears only when episodes are also present.
+ * Compose memoryContext from facts + episodes + learned rules. Facts-only returns
+ * the bare facts string (byte-identical to pre-Phase-3 behavior); the "Known facts"
+ * header appears only when facts coexist with another section. Output order:
+ * facts → operating rules → past experience (imperatives before illustrations).
  */
-export function composeMemoryContext(factsSection: string, episodesSection: string): string {
+export function composeMemoryContext(factsSection: string, episodesSection: string, proceduresSection = ''): string {
     const facts = factsSection.trim();
     const episodes = episodesSection.trim();
-    if (facts && episodes) return `### Known facts\n${facts}\n\n${episodes}`;
+    const procedures = proceduresSection.trim();
+    const others = [procedures, episodes].filter(Boolean);
+    if (facts && others.length) return [`### Known facts\n${facts}`, ...others].join('\n\n');
     if (facts) return facts;
-    if (episodes) return episodes;
-    return '';
+    return others.join('\n\n');
 }

--- a/apps/web-ui/lib/agent/memory/episode.ts
+++ b/apps/web-ui/lib/agent/memory/episode.ts
@@ -1,0 +1,134 @@
+/**
+ * episode.ts — episodic memory: capture + replay formatting (Phase 3).
+ *
+ * Capture: distill one cognitive snapshot (context/reasoning/action/outcome)
+ * per tool-using run; the distiller may SKIP routine runs; failures are
+ * first-class ("what didn't work" is the most valuable experience). One
+ * episode per thread (key `thread-<threadId>`), refreshed via the live-unique
+ * upsert. Episodes bypass the reconcile judge — they are historical records.
+ * Replay: pure formatters that compose episodes into the memoryContext string.
+ * Never throws.
+ */
+
+import { SystemMessage, HumanMessage } from '@langchain/core/messages';
+import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
+import { getMemoryService } from './memory-service';
+import { compressToolOutput } from './working-memory';
+import type { EpisodicValue } from './types';
+
+export const EPISODE_RECALL_LIMIT = 2;
+// Looser than reconcile's 0.55 — an ANALOGOUS past experience is useful even
+// when not near-identical. Initial guess — tune from recall logs.
+export const EPISODE_DISTANCE_THRESHOLD = 0.65;
+
+export function episodicMemoryEnabled(): boolean {
+    const v = process.env.EPISODIC_MEMORY_ENABLED?.toLowerCase();
+    return !(v === 'false' || v === '0');
+}
+
+export interface CaptureEpisodeParams {
+    tenantId: string;
+    userId: string;
+    threadId: string;
+    distillerModel: BaseChatModel;
+    taskDescription: string;
+    plan: Array<{ step: string; status: string }>;
+    toolResults: Array<{ toolName: string; output: string; isError: boolean }>;
+    errors: string[];
+    reflection: string;
+    isComplete: boolean;
+    iterationCount: number;
+}
+
+function isNonEmptyString(v: unknown): v is string {
+    return typeof v === 'string' && v.trim().length > 0;
+}
+
+const DISTILLER_SYSTEM = new SystemMessage(
+    `You distill a completed agent run into ONE reusable episode for future few-shot recall.
+Return ONLY a JSON object with exactly these four non-empty string fields:
+{"context": "...", "reasoning": "...", "action": "...", "outcome": "..."}
+- context: the task/situation the agent faced (generalized; drop ephemeral IDs unless essential).
+- reasoning: the approach taken and why.
+- action: the key tool calls / steps actually executed.
+- outcome: whether it SUCCEEDED or FAILED, and why. Failures are valuable — capture what didn't work.
+If the run was routine or unremarkable (simple lookups, trivial queries), return exactly: SKIP`,
+);
+
+export async function captureEpisode(p: CaptureEpisodeParams): Promise<boolean> {
+    if (!episodicMemoryEnabled()) return false;
+    try {
+        const toolSummary = p.toolResults
+            .map((t) => `- ${t.toolName} [${t.isError ? 'ERROR' : 'OK'}]: ${compressToolOutput(t.output, 400)}`)
+            .join('\n');
+        const planSummary = p.plan.length
+            ? p.plan.map((s, i) => `${i + 1}. [${s.status}] ${s.step}`).join('\n')
+            : '(no explicit plan)';
+
+        const input = new HumanMessage(
+            `**Task:** ${compressToolOutput(p.taskDescription || '(unknown)', 1000)}\n\n` +
+            `**Plan:**\n${planSummary}\n\n` +
+            `**Tool executions:**\n${compressToolOutput(toolSummary, 4000)}\n\n` +
+            `**Errors:** ${p.errors.length ? p.errors.join('; ') : '(none)'}\n\n` +
+            `**Reviewer reflection:** ${compressToolOutput(p.reflection || '(none)', 800)}\n\n` +
+            `**Completed:** ${p.isComplete} after ${p.iterationCount} iterations.\n\n` +
+            `Distill the episode now.`,
+        );
+
+        const resp = await p.distillerModel.invoke([DISTILLER_SYSTEM, input]);
+        const content = typeof resp.content === 'string' ? resp.content : JSON.stringify(resp.content);
+        if (content.trim() === 'SKIP') {
+            console.log('🧠 [EPISODE] Distiller skipped — routine run');
+            return false;
+        }
+        const match = content.match(/\{[\s\S]*\}/);
+        if (!match) {
+            console.warn('🧠 [EPISODE] No JSON object in distiller output — not saved');
+            return false;
+        }
+        const parsed = JSON.parse(match[0]) as Partial<EpisodicValue>;
+        if (!isNonEmptyString(parsed.context) || !isNonEmptyString(parsed.reasoning)
+            || !isNonEmptyString(parsed.action) || !isNonEmptyString(parsed.outcome)) {
+            console.warn('🧠 [EPISODE] Distiller output invalid — not saved');
+            return false;
+        }
+        const value: EpisodicValue = {
+            context: parsed.context, reasoning: parsed.reasoning,
+            action: parsed.action, outcome: parsed.outcome,
+        };
+        await getMemoryService().remember({
+            tenantId: p.tenantId, userId: p.userId, kind: 'EPISODIC',
+            namespace: ['episodes'], key: `thread-${p.threadId}`,
+            value: value as unknown as Record<string, unknown>,
+            sourceThreadId: p.threadId,
+        });
+        console.log(`🧠 [EPISODE] Captured episode for thread ${p.threadId}`);
+        return true;
+    } catch (err: any) {
+        console.warn(`🧠 [EPISODE] Capture failed (non-fatal): ${err?.message ?? err}`);
+        return false;
+    }
+}
+
+/** Render episodes as few-shot experience blocks; '' for empty input. */
+export function formatEpisodesSection(episodes: EpisodicValue[]): string {
+    if (!episodes.length) return '';
+    const blocks = episodes.map((e) =>
+        `**Situation:** ${e.context}\n**Approach:** ${e.reasoning}\n**Actions taken:** ${e.action}\n**Outcome:** ${e.outcome}`,
+    ).join('\n\n---\n\n');
+    return `### Past experience (similar previous sessions)\n${blocks}`;
+}
+
+/**
+ * Compose memoryContext from facts + episodes. Facts-only returns the bare
+ * facts string (byte-identical to pre-Phase-3 behavior); the "Known facts"
+ * header appears only when episodes are also present.
+ */
+export function composeMemoryContext(factsSection: string, episodesSection: string): string {
+    const facts = factsSection.trim();
+    const episodes = episodesSection.trim();
+    if (facts && episodes) return `### Known facts\n${facts}\n\n${episodes}`;
+    if (facts) return facts;
+    if (episodes) return episodes;
+    return '';
+}

--- a/apps/web-ui/lib/agent/memory/memory-service.test.ts
+++ b/apps/web-ui/lib/agent/memory/memory-service.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the prisma client + embeddings BEFORE importing the service.
+const mockExecuteRaw = vi.fn().mockResolvedValue(1);
+const mockQueryRaw = vi.fn().mockResolvedValue([]);
+const mockUpsert = vi.fn().mockResolvedValue({});
+const mockFindUnique = vi.fn().mockResolvedValue(null);
+
+vi.mock('@/lib/db/pg-config', () => ({
+    getPrismaClient: () => ({
+        $executeRaw: mockExecuteRaw,
+        $queryRaw: mockQueryRaw,
+        agentMemory: { upsert: mockUpsert },
+        agentWorkingMemory: { upsert: mockUpsert, findUnique: mockFindUnique },
+    }),
+}));
+
+vi.mock('../embeddings-factory', () => ({
+    getTenantEmbeddings: vi.fn().mockResolvedValue({
+        embedQuery: vi.fn().mockResolvedValue(new Array(1024).fill(0.1)),
+    }),
+}));
+
+import { getMemoryService } from './memory-service';
+
+describe('MemoryService.recall', () => {
+    beforeEach(() => {
+        mockQueryRaw.mockClear();
+        mockQueryRaw.mockResolvedValue([
+            { namespace: 'infra/123', key: 'region', value: { fact: 'us-east-1' }, kind: 'SEMANTIC' },
+        ]);
+    });
+
+    it('returns typed MemoryHit[] and filters by kind', async () => {
+        const svc = getMemoryService();
+        const hits = await svc.recall({
+            tenantId: 't1', userId: 'u1', query: 'where is prod', kinds: ['SEMANTIC'], limit: 5,
+        });
+        expect(hits).toHaveLength(1);
+        expect(hits[0]).toMatchObject({ namespace: 'infra/123', key: 'region', kind: 'SEMANTIC' });
+        // vector search path was used (embedding available)
+        expect(mockQueryRaw).toHaveBeenCalled();
+    });
+});
+
+describe('MemoryService.remember', () => {
+    it('upserts with an embedding vector', async () => {
+        mockExecuteRaw.mockClear();
+        const svc = getMemoryService();
+        await svc.remember({
+            tenantId: 't1', userId: 'u1', kind: 'SEMANTIC',
+            namespace: ['infra', '123'], key: 'region',
+            value: { fact: 'us-east-1', source: 'cli', confidence: 'high' },
+        });
+        expect(mockExecuteRaw).toHaveBeenCalledTimes(1);
+    });
+});

--- a/apps/web-ui/lib/agent/memory/memory-service.test.ts
+++ b/apps/web-ui/lib/agent/memory/memory-service.test.ts
@@ -44,14 +44,16 @@ describe('MemoryService.recall', () => {
 });
 
 describe('MemoryService.remember', () => {
-    it('upserts with an embedding vector', async () => {
-        mockExecuteRaw.mockClear();
+    it('upserts with an embedding vector and returns the row id', async () => {
+        mockQueryRaw.mockClear();
+        mockQueryRaw.mockResolvedValueOnce([{ id: 'row-1' }]);
         const svc = getMemoryService();
-        await svc.remember({
+        const id = await svc.remember({
             tenantId: 't1', userId: 'u1', kind: 'SEMANTIC',
             namespace: ['infra', '123'], key: 'region',
             value: { fact: 'us-east-1', source: 'cli', confidence: 'high' },
         });
-        expect(mockExecuteRaw).toHaveBeenCalledTimes(1);
+        expect(id).toBe('row-1');
+        expect(mockQueryRaw).toHaveBeenCalledTimes(1);
     });
 });

--- a/apps/web-ui/lib/agent/memory/memory-service.test.ts
+++ b/apps/web-ui/lib/agent/memory/memory-service.test.ts
@@ -5,12 +5,13 @@ const mockExecuteRaw = vi.fn().mockResolvedValue(1);
 const mockQueryRaw = vi.fn().mockResolvedValue([]);
 const mockUpsert = vi.fn().mockResolvedValue({});
 const mockFindUnique = vi.fn().mockResolvedValue(null);
+const mockUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
 
 vi.mock('@/lib/db/pg-config', () => ({
     getPrismaClient: () => ({
         $executeRaw: mockExecuteRaw,
         $queryRaw: mockQueryRaw,
-        agentMemory: { upsert: mockUpsert },
+        agentMemory: { upsert: mockUpsert, findFirst: mockFindUnique, create: mockUpsert, updateMany: mockUpdateMany },
         agentWorkingMemory: { upsert: mockUpsert, findUnique: mockFindUnique },
     }),
 }));
@@ -55,5 +56,48 @@ describe('MemoryService.remember', () => {
         });
         expect(id).toBe('row-1');
         expect(mockQueryRaw).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('MemoryService.recall hit shape', () => {
+    it('returns id and distance on vector hits', async () => {
+        mockQueryRaw.mockClear();
+        mockQueryRaw.mockResolvedValueOnce([
+            { id: 'm-1', namespace: 'infra/123', key: 'region', value: { fact: 'us-east-1' }, kind: 'SEMANTIC', distance: 0.12 },
+        ]);
+        const svc = getMemoryService();
+        const hits = await svc.recall({ tenantId: 't1', userId: 'u1', query: 'region', limit: 5 });
+        expect(hits[0]).toMatchObject({ id: 'm-1', kind: 'SEMANTIC', distance: 0.12 });
+    });
+});
+
+describe('MemoryService.supersede', () => {
+    it('marks the old row tenant-scoped', async () => {
+        const svc = getMemoryService();
+        await svc.supersede('t1', 'old-1', 'new-1');
+        expect(mockUpdateMany).toHaveBeenCalledWith(expect.objectContaining({
+            where: { id: 'old-1', tenantId: 't1' },
+            data: expect.objectContaining({ supersededById: 'new-1' }),
+        }));
+    });
+});
+
+describe('MemoryService.reinforce', () => {
+    it('refreshes TTL and bumps accessCount tenant-scoped', async () => {
+        const svc = getMemoryService();
+        await svc.reinforce('t1', 'm-1');
+        const arg = mockUpdateMany.mock.calls.at(-1)![0];
+        expect(arg.where).toEqual({ id: 'm-1', tenantId: 't1' });
+        expect(arg.data.accessCount).toEqual({ increment: 1 });
+        expect(arg.data.expiresAt).toBeInstanceOf(Date);
+    });
+});
+
+describe('MemoryService.update', () => {
+    it('updates value + embedding via raw SQL when embedding succeeds', async () => {
+        mockExecuteRaw.mockClear();
+        const svc = getMemoryService();
+        await svc.update('t1', 'm-1', { fact: 'refined' });
+        expect(mockExecuteRaw).toHaveBeenCalledTimes(1);
     });
 });

--- a/apps/web-ui/lib/agent/memory/memory-service.ts
+++ b/apps/web-ui/lib/agent/memory/memory-service.ts
@@ -42,7 +42,7 @@ export class MemoryService {
         return cached;
     }
 
-    async remember(m: RememberParams): Promise<void> {
+    async remember(m: RememberParams): Promise<string> {
         const prisma = getPrismaClient();
         const namespace = m.namespace.join('/');
         const expiresAt = new Date(Date.now() + TTL_MS);
@@ -57,19 +57,54 @@ export class MemoryService {
 
         if (vec) {
             const vecStr = `[${vec.join(',')}]`;
-            // $executeRaw is NOT tenant-intercepted — tenantId is bound explicitly.
-            await prisma.$executeRaw`
+            // $queryRaw is NOT tenant-intercepted — tenantId is bound explicitly.
+            // The conflict target names the PARTIAL unique index (live rows only), so a
+            // superseded row with the same key never blocks inserting its successor.
+            const rows = await prisma.$queryRaw<Array<{ id: string }>>`
                 INSERT INTO agent_memories ("id","tenantId","userId","namespace","key","value","kind","embedding","sourceThreadId","createdAt","updatedAt","expiresAt")
                 VALUES (gen_random_uuid()::text, ${m.tenantId}, ${m.userId}, ${namespace}, ${m.key}, ${JSON.stringify(m.value)}::jsonb, ${m.kind}::"MemoryKind", ${vecStr}::vector, ${m.sourceThreadId ?? null}, NOW(), NOW(), ${expiresAt})
-                ON CONFLICT ("tenantId","namespace","key") DO UPDATE
+                ON CONFLICT ("tenantId","namespace","key") WHERE "supersededById" IS NULL DO UPDATE
                 SET "value" = EXCLUDED."value", "kind" = EXCLUDED."kind", "embedding" = EXCLUDED."embedding", "updatedAt" = NOW(), "expiresAt" = EXCLUDED."expiresAt"
+                RETURNING "id"
             `;
-        } else {
-            await prisma.agentMemory.upsert({
-                where: { tenantId_namespace_key: { tenantId: m.tenantId, namespace, key: m.key } },
-                create: { tenantId: m.tenantId, userId: m.userId, namespace, key: m.key, value: m.value as Prisma.InputJsonValue, kind: m.kind, sourceThreadId: m.sourceThreadId ?? null, expiresAt },
-                update: { value: m.value as Prisma.InputJsonValue, kind: m.kind, expiresAt, updatedAt: new Date() },
+            return rows[0].id;
+        }
+
+        // No embedding — ORM fallback. The compound unique no longer exists in the Prisma
+        // schema (the partial unique index is SQL-only), so upsert is replaced by
+        // find-live-then-update/create, with a one-shot retry if a concurrent create wins
+        // the race (the partial unique index is the backstop; Prisma maps 23505 → P2002).
+        const live = await prisma.agentMemory.findFirst({
+            where: { tenantId: m.tenantId, namespace, key: m.key, supersededById: null },
+            select: { id: true },
+        });
+        if (live) {
+            await prisma.agentMemory.updateMany({
+                where: { id: live.id, tenantId: m.tenantId },
+                data: { value: m.value as Prisma.InputJsonValue, kind: m.kind, expiresAt, updatedAt: new Date() },
             });
+            return live.id;
+        }
+        try {
+            const created = await prisma.agentMemory.create({
+                data: { tenantId: m.tenantId, userId: m.userId, namespace, key: m.key, value: m.value as Prisma.InputJsonValue, kind: m.kind, sourceThreadId: m.sourceThreadId ?? null, expiresAt },
+            });
+            return created.id;
+        } catch (err) {
+            if ((err as { code?: string })?.code === 'P2002') {
+                const winner = await prisma.agentMemory.findFirst({
+                    where: { tenantId: m.tenantId, namespace, key: m.key, supersededById: null },
+                    select: { id: true },
+                });
+                if (winner) {
+                    await prisma.agentMemory.updateMany({
+                        where: { id: winner.id, tenantId: m.tenantId },
+                        data: { value: m.value as Prisma.InputJsonValue, kind: m.kind, expiresAt, updatedAt: new Date() },
+                    });
+                    return winner.id;
+                }
+            }
+            throw err;
         }
     }
 

--- a/apps/web-ui/lib/agent/memory/memory-service.ts
+++ b/apps/web-ui/lib/agent/memory/memory-service.ts
@@ -1,0 +1,175 @@
+import type { Embeddings } from '@langchain/core/embeddings';
+import { Prisma } from '@prisma/client';
+import { getPrismaClient } from '@/lib/db/pg-config';
+import { getTenantEmbeddings } from '../embeddings-factory';
+import type { MemoryHit, MemoryKind, WorkingMemory, Scratchpad } from './types';
+
+export interface RecallParams {
+    tenantId: string;
+    userId: string;
+    query: string;
+    kinds?: MemoryKind[];
+    namespacePrefix?: string[];
+    limit?: number;
+}
+export interface RememberParams {
+    tenantId: string;
+    userId: string;
+    kind: MemoryKind;
+    namespace: string[];
+    key: string;
+    value: Record<string, unknown>;
+    sourceThreadId?: string;
+}
+export interface PutWorkingMemoryParams {
+    tenantId: string;
+    threadId: string;
+    wm: WorkingMemory;
+}
+
+const TTL_MS = 90 * 24 * 60 * 60 * 1000; // 90 days, matches existing memory TTL
+
+export class MemoryService {
+    private embeddingsCache = new Map<string, Promise<Embeddings>>();
+
+    private getEmbeddings(tenantId: string): Promise<Embeddings> {
+        let cached = this.embeddingsCache.get(tenantId);
+        if (!cached) {
+            cached = getTenantEmbeddings(tenantId);
+            cached.catch(() => this.embeddingsCache.delete(tenantId));
+            this.embeddingsCache.set(tenantId, cached);
+        }
+        return cached;
+    }
+
+    async remember(m: RememberParams): Promise<void> {
+        const prisma = getPrismaClient();
+        const namespace = m.namespace.join('/');
+        const expiresAt = new Date(Date.now() + TTL_MS);
+
+        let vec: number[] | null = null;
+        try {
+            const emb = await this.getEmbeddings(m.tenantId);
+            vec = await emb.embedQuery(JSON.stringify(m.value));
+        } catch {
+            // provider missing / embedding failure is non-fatal
+        }
+
+        if (vec) {
+            const vecStr = `[${vec.join(',')}]`;
+            // $executeRaw is NOT tenant-intercepted — tenantId is bound explicitly.
+            await prisma.$executeRaw`
+                INSERT INTO agent_memories ("id","tenantId","userId","namespace","key","value","kind","embedding","sourceThreadId","createdAt","updatedAt","expiresAt")
+                VALUES (gen_random_uuid()::text, ${m.tenantId}, ${m.userId}, ${namespace}, ${m.key}, ${JSON.stringify(m.value)}::jsonb, ${m.kind}::"MemoryKind", ${vecStr}::vector, ${m.sourceThreadId ?? null}, NOW(), NOW(), ${expiresAt})
+                ON CONFLICT ("tenantId","namespace","key") DO UPDATE
+                SET "value" = EXCLUDED."value", "kind" = EXCLUDED."kind", "embedding" = EXCLUDED."embedding", "updatedAt" = NOW(), "expiresAt" = EXCLUDED."expiresAt"
+            `;
+        } else {
+            await prisma.agentMemory.upsert({
+                where: { tenantId_namespace_key: { tenantId: m.tenantId, namespace, key: m.key } },
+                create: { tenantId: m.tenantId, userId: m.userId, namespace, key: m.key, value: m.value as Prisma.InputJsonValue, kind: m.kind, sourceThreadId: m.sourceThreadId ?? null, expiresAt },
+                update: { value: m.value as Prisma.InputJsonValue, kind: m.kind, expiresAt, updatedAt: new Date() },
+            });
+        }
+    }
+
+    async recall(p: RecallParams): Promise<MemoryHit[]> {
+        const prisma = getPrismaClient();
+        const limit = p.limit ?? 5;
+        const nsPrefix = (p.namespacePrefix ?? []).join('/');
+        const kinds = p.kinds ?? [];
+
+        let queryVec: number[] | null = null;
+        try {
+            const emb = await this.getEmbeddings(p.tenantId);
+            queryVec = await emb.embedQuery(p.query);
+        } catch {
+            // fall through to recency search
+        }
+
+        // Build the kind filter as a parameter list; empty => all kinds.
+        const kindList = kinds.length ? kinds : null;
+
+        let rows: Array<{ namespace: string; key: string; value: unknown; kind: MemoryKind }>;
+        if (queryVec) {
+            const vecStr = `[${queryVec.join(',')}]`;
+            rows = await prisma.$queryRaw<Array<{ namespace: string; key: string; value: unknown; kind: MemoryKind }>>`
+                SELECT "namespace","key","value","kind"
+                FROM agent_memories
+                WHERE "tenantId" = ${p.tenantId}
+                  AND "supersededById" IS NULL
+                  AND (${nsPrefix} = '' OR "namespace" LIKE ${nsPrefix + '%'})
+                  AND (${kindList}::text[] IS NULL OR "kind"::text = ANY(${kindList}::text[]))
+                ORDER BY embedding <=> ${vecStr}::vector
+                LIMIT ${limit}
+            `;
+        } else {
+            rows = await prisma.$queryRaw<Array<{ namespace: string; key: string; value: unknown; kind: MemoryKind }>>`
+                SELECT "namespace","key","value","kind"
+                FROM agent_memories
+                WHERE "tenantId" = ${p.tenantId}
+                  AND "supersededById" IS NULL
+                  AND (${nsPrefix} = '' OR "namespace" LIKE ${nsPrefix + '%'})
+                  AND (${kindList}::text[] IS NULL OR "kind"::text = ANY(${kindList}::text[]))
+                ORDER BY "createdAt" DESC
+                LIMIT ${limit}
+            `;
+        }
+
+        // Reinforcement signal — best-effort, non-blocking.
+        const keys = rows.map((r) => r.key);
+        if (keys.length) {
+            prisma.$executeRaw`
+                UPDATE agent_memories SET "lastAccessedAt" = NOW(), "accessCount" = "accessCount" + 1
+                WHERE "tenantId" = ${p.tenantId} AND "key" = ANY(${keys}::text[])
+            `.catch(() => {});
+        }
+
+        return rows.map((r) => ({
+            namespace: r.namespace,
+            key: r.key,
+            value: (r.value ?? {}) as Record<string, unknown>,
+            kind: r.kind,
+        }));
+    }
+
+    async getWorkingMemory(tenantId: string, threadId: string): Promise<WorkingMemory | null> {
+        const prisma = getPrismaClient();
+        const row = await prisma.agentWorkingMemory.findUnique({
+            where: { tenantId_threadId: { tenantId, threadId } },
+        });
+        if (!row) return null;
+        return {
+            runningSummary: row.runningSummary,
+            scratchpad: (row.scratchpad ?? {}) as unknown as Scratchpad,
+            tokenCount: row.tokenCount,
+            turnCount: row.turnCount,
+        };
+    }
+
+    async putWorkingMemory(p: PutWorkingMemoryParams): Promise<void> {
+        const prisma = getPrismaClient();
+        const expiresAt = new Date(Date.now() + TTL_MS);
+        await prisma.agentWorkingMemory.upsert({
+            where: { tenantId_threadId: { tenantId: p.tenantId, threadId: p.threadId } },
+            create: {
+                tenantId: p.tenantId, threadId: p.threadId,
+                runningSummary: p.wm.runningSummary,
+                scratchpad: p.wm.scratchpad as unknown as object,
+                tokenCount: p.wm.tokenCount, turnCount: p.wm.turnCount, expiresAt,
+            },
+            update: {
+                runningSummary: p.wm.runningSummary,
+                scratchpad: p.wm.scratchpad as unknown as object,
+                tokenCount: p.wm.tokenCount, turnCount: p.wm.turnCount,
+                expiresAt, updatedAt: new Date(),
+            },
+        });
+    }
+}
+
+let _service: MemoryService | undefined;
+export function getMemoryService(): MemoryService {
+    if (!_service) _service = new MemoryService();
+    return _service;
+}

--- a/apps/web-ui/lib/agent/memory/memory-service.ts
+++ b/apps/web-ui/lib/agent/memory/memory-service.ts
@@ -125,11 +125,11 @@ export class MemoryService {
         // Build the kind filter as a parameter list; empty => all kinds.
         const kindList = kinds.length ? kinds : null;
 
-        let rows: Array<{ namespace: string; key: string; value: unknown; kind: MemoryKind }>;
+        let rows: Array<{ id: string; namespace: string; key: string; value: unknown; kind: MemoryKind; distance: number | null }>;
         if (queryVec) {
             const vecStr = `[${queryVec.join(',')}]`;
-            rows = await prisma.$queryRaw<Array<{ namespace: string; key: string; value: unknown; kind: MemoryKind }>>`
-                SELECT "namespace","key","value","kind"
+            rows = await prisma.$queryRaw<Array<{ id: string; namespace: string; key: string; value: unknown; kind: MemoryKind; distance: number | null }>>`
+                SELECT "id","namespace","key","value","kind", (embedding <=> ${vecStr}::vector) AS distance
                 FROM agent_memories
                 WHERE "tenantId" = ${p.tenantId}
                   AND "supersededById" IS NULL
@@ -139,8 +139,8 @@ export class MemoryService {
                 LIMIT ${limit}
             `;
         } else {
-            rows = await prisma.$queryRaw<Array<{ namespace: string; key: string; value: unknown; kind: MemoryKind }>>`
-                SELECT "namespace","key","value","kind"
+            rows = await prisma.$queryRaw<Array<{ id: string; namespace: string; key: string; value: unknown; kind: MemoryKind; distance: number | null }>>`
+                SELECT "id","namespace","key","value","kind", NULL::float8 AS distance
                 FROM agent_memories
                 WHERE "tenantId" = ${p.tenantId}
                   AND "supersededById" IS NULL
@@ -161,11 +161,57 @@ export class MemoryService {
         }
 
         return rows.map((r) => ({
+            id: r.id,
             namespace: r.namespace,
             key: r.key,
             value: (r.value ?? {}) as Record<string, unknown>,
             kind: r.kind,
+            ...(r.distance !== null && r.distance !== undefined ? { distance: Number(r.distance) } : {}),
         }));
+    }
+
+    /** Replace a memory's value in place (judge UPDATE). Re-embeds; embed failure keeps the old vector. */
+    async update(tenantId: string, id: string, value: Record<string, unknown>): Promise<void> {
+        const prisma = getPrismaClient();
+        const expiresAt = new Date(Date.now() + TTL_MS);
+        let vec: number[] | null = null;
+        try {
+            const emb = await this.getEmbeddings(tenantId);
+            vec = await emb.embedQuery(JSON.stringify(value));
+        } catch {
+            // keep the old embedding
+        }
+        if (vec) {
+            const vecStr = `[${vec.join(',')}]`;
+            await prisma.$executeRaw`
+                UPDATE agent_memories
+                SET "value" = ${JSON.stringify(value)}::jsonb, "embedding" = ${vecStr}::vector, "updatedAt" = NOW(), "expiresAt" = ${expiresAt}
+                WHERE "id" = ${id} AND "tenantId" = ${tenantId}
+            `;
+        } else {
+            await prisma.agentMemory.updateMany({
+                where: { id, tenantId },
+                data: { value: value as Prisma.InputJsonValue, expiresAt, updatedAt: new Date() },
+            });
+        }
+    }
+
+    /** Mark `oldId` as displaced by `newId` (judge SUPERSEDE). Old row is never deleted. */
+    async supersede(tenantId: string, oldId: string, newId: string): Promise<void> {
+        const prisma = getPrismaClient();
+        await prisma.agentMemory.updateMany({
+            where: { id: oldId, tenantId },
+            data: { supersededById: newId, supersededAt: new Date(), updatedAt: new Date() },
+        });
+    }
+
+    /** A duplicate re-confirmed this memory (judge REINFORCE): refresh TTL, bump the signal. */
+    async reinforce(tenantId: string, id: string): Promise<void> {
+        const prisma = getPrismaClient();
+        await prisma.agentMemory.updateMany({
+            where: { id, tenantId },
+            data: { expiresAt: new Date(Date.now() + TTL_MS), accessCount: { increment: 1 }, lastAccessedAt: new Date(), updatedAt: new Date() },
+        });
     }
 
     async getWorkingMemory(tenantId: string, threadId: string): Promise<WorkingMemory | null> {

--- a/apps/web-ui/lib/agent/memory/procedural.test.ts
+++ b/apps/web-ui/lib/agent/memory/procedural.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+    proceduralMemoryEnabled, formatProceduresSection, isValidExtractedItem,
+    PROCEDURE_RECALL_LIMIT, PROCEDURE_DISTANCE_THRESHOLD,
+} from './procedural';
+
+afterEach(() => { delete process.env.PROCEDURAL_MEMORY_ENABLED; });
+
+describe('proceduralMemoryEnabled', () => {
+    it('defaults true; false/0 disable', () => {
+        expect(proceduralMemoryEnabled()).toBe(true);
+        process.env.PROCEDURAL_MEMORY_ENABLED = 'false';
+        expect(proceduralMemoryEnabled()).toBe(false);
+    });
+});
+
+describe('constants', () => {
+    it('locked values', () => {
+        expect(PROCEDURE_RECALL_LIMIT).toBe(3);
+        expect(PROCEDURE_DISTANCE_THRESHOLD).toBe(0.65);
+    });
+});
+
+describe('formatProceduresSection', () => {
+    it("returns '' for empty input", () => {
+        expect(formatProceduresSection([])).toBe('');
+    });
+    it('renders one "- When <trigger>: <instruction>" line per rule under the header', () => {
+        const s = formatProceduresSection([
+            { instruction: 'Always paginate list calls', trigger: 'any AWS CLI list operation', evidence: 'e1' },
+            { instruction: 'Verify state before mutation', trigger: 'any resource mutation', evidence: 'e2' },
+        ]);
+        expect(s).toBe(
+            '### Operating rules (learned)\n' +
+            '- When any AWS CLI list operation: Always paginate list calls\n' +
+            '- When any resource mutation: Verify state before mutation',
+        );
+    });
+});
+
+describe('isValidExtractedItem', () => {
+    const semantic = (v: Record<string, unknown>) => ({ value: v });
+    const procedural = (v: Record<string, unknown>) => ({ kind: 'PROCEDURAL', value: v });
+
+    it('semantic: requires non-empty fact + high/medium confidence', () => {
+        expect(isValidExtractedItem(semantic({ fact: 'x', confidence: 'high' }))).toBe(true);
+        expect(isValidExtractedItem(semantic({ fact: 'x', confidence: 'low' }))).toBe(false);
+        expect(isValidExtractedItem(semantic({ fact: '  ', confidence: 'high' }))).toBe(false);
+        expect(isValidExtractedItem(semantic({ confidence: 'high' }))).toBe(false);
+    });
+
+    it('procedural: requires non-empty instruction/trigger/evidence + high/medium confidence', () => {
+        expect(isValidExtractedItem(procedural({ instruction: 'i', trigger: 't', evidence: 'e', confidence: 'medium' }))).toBe(true);
+        expect(isValidExtractedItem(procedural({ instruction: 'i', trigger: 't', confidence: 'high' }))).toBe(false);
+        expect(isValidExtractedItem(procedural({ instruction: 'i', trigger: 't', evidence: '', confidence: 'high' }))).toBe(false);
+        expect(isValidExtractedItem(procedural({ instruction: 'i', trigger: 't', evidence: 'e', confidence: 'low' }))).toBe(false);
+    });
+
+    it('rejects missing/non-object value', () => {
+        expect(isValidExtractedItem({} as any)).toBe(false);
+        expect(isValidExtractedItem({ value: undefined } as any)).toBe(false);
+    });
+});

--- a/apps/web-ui/lib/agent/memory/procedural.ts
+++ b/apps/web-ui/lib/agent/memory/procedural.ts
@@ -1,0 +1,44 @@
+/**
+ * procedural.ts — procedural memory (Phase 4): learned operating rules.
+ *
+ * Capture rides the memory-save extraction (kind: 'PROCEDURAL' items) and the
+ * kind-aware reconcile pipeline. This module holds the flag, recall constants,
+ * the prompt-section formatter, and the shape-aware extraction-item validator.
+ */
+
+import type { ProceduralValue } from './types';
+
+export const PROCEDURE_RECALL_LIMIT = 3;
+// Shared value with EPISODE_DISTANCE_THRESHOLD — one knob until logs say otherwise.
+export const PROCEDURE_DISTANCE_THRESHOLD = 0.65;
+
+export function proceduralMemoryEnabled(): boolean {
+    const v = process.env.PROCEDURAL_MEMORY_ENABLED?.toLowerCase();
+    return !(v === 'false' || v === '0');
+}
+
+function isNonEmptyString(v: unknown): v is string {
+    return typeof v === 'string' && v.trim().length > 0;
+}
+
+/** Render learned rules as an imperative prompt section; '' for empty input. */
+export function formatProceduresSection(rules: ProceduralValue[]): string {
+    if (!rules.length) return '';
+    const lines = rules.map((r) => `- When ${r.trigger}: ${r.instruction}`);
+    return `### Operating rules (learned)\n${lines.join('\n')}`;
+}
+
+/**
+ * Shape-aware validity check for raw extracted items (semantic or procedural).
+ * Both shapes require high/medium confidence; procedural items additionally
+ * require instruction/trigger/evidence, semantic items require fact.
+ */
+export function isValidExtractedItem(item: { kind?: string; value?: Record<string, unknown> }): boolean {
+    const v = item?.value;
+    if (!v || typeof v !== 'object') return false;
+    if (v.confidence !== 'high' && v.confidence !== 'medium') return false;
+    if (item.kind === 'PROCEDURAL') {
+        return isNonEmptyString(v.instruction) && isNonEmptyString(v.trigger) && isNonEmptyString(v.evidence);
+    }
+    return isNonEmptyString(v.fact);
+}

--- a/apps/web-ui/lib/agent/memory/reconcile.test.ts
+++ b/apps/web-ui/lib/agent/memory/reconcile.test.ts
@@ -153,4 +153,33 @@ describe('reconcileMemories', () => {
         expect(mockSvc.update).not.toHaveBeenCalled();
         expect(summary.added).toBe(1);
     });
+
+    const proceduralFact = (key: string): ExtractedFact => ({
+        kind: 'PROCEDURAL', namespace: ['procedures', 'aws-cli'], key,
+        value: { instruction: 'always paginate', trigger: 'list ops', evidence: 'missed items', confidence: 'high' } as any,
+    });
+
+    it('procedural fact → neighbors fetched with kinds PROCEDURAL and ADD saves kind PROCEDURAL', async () => {
+        mockSvc.recall.mockResolvedValue([]); // no neighbors → fast-path ADD
+        const judge = judgeReturning([]);
+        await reconcileMemories({ ...base, facts: [proceduralFact('paginate')], judgeModel: judge });
+        expect(mockSvc.recall).toHaveBeenCalledWith(expect.objectContaining({ kinds: ['PROCEDURAL'] }));
+        expect(mockSvc.remember).toHaveBeenCalledWith(expect.objectContaining({ kind: 'PROCEDURAL' }));
+    });
+
+    it('procedural SUPERSEDE → new row saved with kind PROCEDURAL', async () => {
+        mockSvc.recall.mockResolvedValue([neighbor('old-rule')]);
+        const judge = judgeReturning([{ factIndex: 0, action: 'SUPERSEDE', targetId: 'old-rule' }]);
+        await reconcileMemories({ ...base, facts: [proceduralFact('paginate')], judgeModel: judge });
+        expect(mockSvc.remember).toHaveBeenCalledWith(expect.objectContaining({ kind: 'PROCEDURAL' }));
+        expect(mockSvc.supersede).toHaveBeenCalledWith('t1', 'old-rule', 'new-id');
+    });
+
+    it('kind absent → SEMANTIC everywhere (legacy default)', async () => {
+        mockSvc.recall.mockResolvedValue([]);
+        const judge = judgeReturning([]);
+        await reconcileMemories({ ...base, facts: [fact('k1')], judgeModel: judge });
+        expect(mockSvc.recall).toHaveBeenCalledWith(expect.objectContaining({ kinds: ['SEMANTIC'] }));
+        expect(mockSvc.remember).toHaveBeenCalledWith(expect.objectContaining({ kind: 'SEMANTIC' }));
+    });
 });

--- a/apps/web-ui/lib/agent/memory/reconcile.test.ts
+++ b/apps/web-ui/lib/agent/memory/reconcile.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('./memory-service', () => ({ getMemoryService: vi.fn() }));
+
+import { getMemoryService } from './memory-service';
+import { reconcileMemories, reconcileEnabled } from './reconcile';
+import type { ExtractedFact } from './types';
+
+const mockSvc = {
+    recall: vi.fn(),
+    remember: vi.fn(),
+    update: vi.fn(),
+    supersede: vi.fn(),
+    reinforce: vi.fn(),
+};
+
+const fact = (key: string): ExtractedFact => ({
+    namespace: ['infra', 'a1'], key,
+    value: { fact: `${key} fact`, source: 's', confidence: 'high' },
+});
+const neighbor = (id: string, distance = 0.1) => ({
+    id, namespace: 'infra/a1', key: 'existing', value: { fact: 'old' }, kind: 'SEMANTIC', distance,
+});
+const judgeReturning = (json: unknown) => ({
+    invoke: vi.fn().mockResolvedValue({ content: JSON.stringify(json) }),
+}) as any;
+const base = { tenantId: 't1', userId: 'u1', sourceThreadId: 'th-1' };
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mockSvc.recall.mockResolvedValue([]);
+    mockSvc.remember.mockResolvedValue('new-id');
+    mockSvc.update.mockResolvedValue(undefined);
+    mockSvc.supersede.mockResolvedValue(undefined);
+    mockSvc.reinforce.mockResolvedValue(undefined);
+    vi.mocked(getMemoryService).mockReturnValue(mockSvc as any);
+});
+afterEach(() => { delete process.env.MEMORY_RECONCILE_ENABLED; });
+
+describe('reconcileEnabled', () => {
+    it('defaults true; false/0 disable', () => {
+        expect(reconcileEnabled()).toBe(true);
+        process.env.MEMORY_RECONCILE_ENABLED = 'false';
+        expect(reconcileEnabled()).toBe(false);
+    });
+});
+
+describe('reconcileMemories', () => {
+    it('no near neighbors → ADD without calling the judge', async () => {
+        mockSvc.recall.mockResolvedValue([neighbor('far-1', 0.9)]); // beyond threshold
+        const judge = judgeReturning([]);
+        const summary = await reconcileMemories({ ...base, facts: [fact('k1')], judgeModel: judge });
+        expect(judge.invoke).not.toHaveBeenCalled();
+        expect(mockSvc.remember).toHaveBeenCalledTimes(1);
+        expect(summary.added).toBe(1);
+    });
+
+    it('SUPERSEDE → remember new then supersede old with the new id', async () => {
+        mockSvc.recall.mockResolvedValue([neighbor('old-1')]);
+        const judge = judgeReturning([{ factIndex: 0, action: 'SUPERSEDE', targetId: 'old-1' }]);
+        const summary = await reconcileMemories({ ...base, facts: [fact('k1')], judgeModel: judge });
+        expect(mockSvc.remember).toHaveBeenCalledTimes(1);
+        expect(mockSvc.supersede).toHaveBeenCalledWith('t1', 'old-1', 'new-id');
+        expect(summary.superseded).toBe(1);
+    });
+
+    it('REINFORCE → reinforce only, no new row', async () => {
+        mockSvc.recall.mockResolvedValue([neighbor('old-1')]);
+        const judge = judgeReturning([{ factIndex: 0, action: 'REINFORCE', targetId: 'old-1' }]);
+        const summary = await reconcileMemories({ ...base, facts: [fact('k1')], judgeModel: judge });
+        expect(mockSvc.reinforce).toHaveBeenCalledWith('t1', 'old-1');
+        expect(mockSvc.remember).not.toHaveBeenCalled();
+        expect(summary.reinforced).toBe(1);
+    });
+
+    it('UPDATE → update target with mergedValue', async () => {
+        mockSvc.recall.mockResolvedValue([neighbor('old-1')]);
+        const merged = { fact: 'merged', source: 's', confidence: 'high' };
+        const judge = judgeReturning([{ factIndex: 0, action: 'UPDATE', targetId: 'old-1', mergedValue: merged }]);
+        const summary = await reconcileMemories({ ...base, facts: [fact('k1')], judgeModel: judge });
+        expect(mockSvc.update).toHaveBeenCalledWith('t1', 'old-1', merged);
+        expect(summary.updated).toBe(1);
+    });
+
+    it('NOOP → nothing written', async () => {
+        mockSvc.recall.mockResolvedValue([neighbor('old-1')]);
+        const judge = judgeReturning([{ factIndex: 0, action: 'NOOP' }]);
+        const summary = await reconcileMemories({ ...base, facts: [fact('k1')], judgeModel: judge });
+        expect(mockSvc.remember).not.toHaveBeenCalled();
+        expect(summary.noop).toBe(1);
+    });
+
+    it('judge throws → ADD fallback', async () => {
+        mockSvc.recall.mockResolvedValue([neighbor('old-1')]);
+        const judge = { invoke: vi.fn().mockRejectedValue(new Error('boom')) } as any;
+        const summary = await reconcileMemories({ ...base, facts: [fact('k1')], judgeModel: judge });
+        expect(mockSvc.remember).toHaveBeenCalledTimes(1);
+        expect(summary.added).toBe(1);
+    });
+
+    it('invalid targetId → ADD fallback', async () => {
+        mockSvc.recall.mockResolvedValue([neighbor('old-1')]);
+        const judge = judgeReturning([{ factIndex: 0, action: 'SUPERSEDE', targetId: 'not-a-neighbor' }]);
+        const summary = await reconcileMemories({ ...base, facts: [fact('k1')], judgeModel: judge });
+        expect(mockSvc.supersede).not.toHaveBeenCalled();
+        expect(summary.added).toBe(1);
+    });
+
+    it('one fact failing does not block its sibling', async () => {
+        mockSvc.recall.mockResolvedValue([neighbor('old-1')]);
+        mockSvc.reinforce.mockRejectedValueOnce(new Error('db down'));
+        const judge = judgeReturning([
+            { factIndex: 0, action: 'REINFORCE', targetId: 'old-1' },
+            { factIndex: 1, action: 'NOOP' },
+        ]);
+        const summary = await reconcileMemories({ ...base, facts: [fact('k1'), fact('k2')], judgeModel: judge });
+        expect(summary.failed).toBe(1);
+        expect(summary.noop).toBe(1);
+    });
+});

--- a/apps/web-ui/lib/agent/memory/reconcile.test.ts
+++ b/apps/web-ui/lib/agent/memory/reconcile.test.ts
@@ -117,4 +117,40 @@ describe('reconcileMemories', () => {
         expect(summary.failed).toBe(1);
         expect(summary.noop).toBe(1);
     });
+
+    it('recall throwing → fact treated as no-neighbors → ADD, judge not called', async () => {
+        mockSvc.recall.mockRejectedValue(new Error('pgvector down'));
+        const judge = judgeReturning([]);
+        const summary = await reconcileMemories({ ...base, facts: [fact('k1')], judgeModel: judge });
+        expect(judge.invoke).not.toHaveBeenCalled();
+        expect(mockSvc.remember).toHaveBeenCalledTimes(1);
+        expect(summary.added).toBe(1);
+    });
+
+    it('judge returning decisions for only some facts → missing ones fall back to ADD', async () => {
+        mockSvc.recall.mockResolvedValue([neighbor('old-1')]);
+        const judge = judgeReturning([{ factIndex: 0, action: 'NOOP' }]); // nothing for factIndex 1
+        const summary = await reconcileMemories({ ...base, facts: [fact('k1'), fact('k2')], judgeModel: judge });
+        expect(summary.noop).toBe(1);
+        expect(summary.added).toBe(1);
+        expect(mockSvc.remember).toHaveBeenCalledTimes(1);
+    });
+
+    it('judge invoked exactly once for multiple neighbor-bearing facts', async () => {
+        mockSvc.recall.mockResolvedValue([neighbor('old-1')]);
+        const judge = judgeReturning([
+            { factIndex: 0, action: 'NOOP' },
+            { factIndex: 1, action: 'NOOP' },
+        ]);
+        await reconcileMemories({ ...base, facts: [fact('k1'), fact('k2')], judgeModel: judge });
+        expect(judge.invoke).toHaveBeenCalledTimes(1);
+    });
+
+    it('UPDATE with array mergedValue is rejected → ADD fallback', async () => {
+        mockSvc.recall.mockResolvedValue([neighbor('old-1')]);
+        const judge = judgeReturning([{ factIndex: 0, action: 'UPDATE', targetId: 'old-1', mergedValue: ['not-an-object'] }]);
+        const summary = await reconcileMemories({ ...base, facts: [fact('k1')], judgeModel: judge });
+        expect(mockSvc.update).not.toHaveBeenCalled();
+        expect(summary.added).toBe(1);
+    });
 });

--- a/apps/web-ui/lib/agent/memory/reconcile.ts
+++ b/apps/web-ui/lib/agent/memory/reconcile.ts
@@ -36,6 +36,7 @@ For each new fact, choose exactly one action:
 - "SUPERSEDE": the new fact EXPLICITLY CONTRADICTS one neighbor — both cannot be true (e.g. a resource moved region). The new fact wins. Provide "targetId".
 - "REINFORCE": semantically the same fact as one neighbor; nothing new. Provide "targetId".
 - "NOOP": ephemeral or not worth remembering.
+Items may be facts or operating rules; the same actions apply (a rule that changed = SUPERSEDE; the same rule re-learned = REINFORCE).
 Rules:
 - SUPERSEDE only on mutual exclusivity, NEVER on similarity or partial overlap.
 - Uncertain between UPDATE and REINFORCE → choose REINFORCE.
@@ -86,7 +87,7 @@ export async function reconcileMemories(params: {
 
     const add = async (fact: ExtractedFact): Promise<void> => {
         await svc.remember({
-            tenantId, userId, kind: 'SEMANTIC',
+            tenantId, userId, kind: fact.kind ?? 'SEMANTIC',
             namespace: fact.namespace, key: fact.key,
             value: fact.value as unknown as Record<string, unknown>,
             sourceThreadId,
@@ -102,7 +103,7 @@ export async function reconcileMemories(params: {
             // Query by the value JSON — the same text remember() embeds, so distances are comparable.
             const hits = await svc.recall({
                 tenantId, userId, query: JSON.stringify(fact.value),
-                kinds: ['SEMANTIC'], limit: RECONCILE_TOP_K,
+                kinds: [fact.kind ?? 'SEMANTIC'], limit: RECONCILE_TOP_K,
             });
             neighbors = hits.filter((h) => h.distance !== undefined && h.distance <= RECONCILE_DISTANCE_THRESHOLD);
         } catch {
@@ -157,7 +158,7 @@ export async function reconcileMemories(params: {
                     break;
                 case 'SUPERSEDE': {
                     const newId = await svc.remember({
-                        tenantId, userId, kind: 'SEMANTIC',
+                        tenantId, userId, kind: item.fact.kind ?? 'SEMANTIC',
                         namespace: item.fact.namespace, key: item.fact.key,
                         value: item.fact.value as unknown as Record<string, unknown>,
                         sourceThreadId,

--- a/apps/web-ui/lib/agent/memory/reconcile.ts
+++ b/apps/web-ui/lib/agent/memory/reconcile.ts
@@ -67,7 +67,7 @@ function isValidDecision(d: ReconcileDecision, item: FactWithNeighbors): boolean
             return !!d.targetId && neighborIds.has(d.targetId);
         case 'UPDATE':
             return !!d.targetId && neighborIds.has(d.targetId)
-                && !!d.mergedValue && typeof d.mergedValue === 'object';
+                && !!d.mergedValue && typeof d.mergedValue === 'object' && !Array.isArray(d.mergedValue);
         default:
             return false;
     }

--- a/apps/web-ui/lib/agent/memory/reconcile.ts
+++ b/apps/web-ui/lib/agent/memory/reconcile.ts
@@ -1,0 +1,185 @@
+/**
+ * reconcile.ts — save-time semantic conflict resolution (Phase 2).
+ *
+ * extract → neighbor fetch (pgvector) → one batched LLM judge call →
+ * apply (ADD / UPDATE / SUPERSEDE / REINFORCE / NOOP) via MemoryService.
+ * Policy layer only — MemoryService stays a pure data layer.
+ * Never throws; every failure degrades to ADD (legacy behavior).
+ */
+
+import { SystemMessage, HumanMessage } from '@langchain/core/messages';
+import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
+import { getMemoryService } from './memory-service';
+import type { ExtractedFact, MemoryHit, ReconcileDecision, ReconcileSummary } from './types';
+
+export const RECONCILE_TOP_K = 5;
+// Cosine distance (0 = identical). Neighbors farther than this are treated as
+// unrelated and the fact goes straight to ADD. Initial guess — tune from logs.
+export const RECONCILE_DISTANCE_THRESHOLD = 0.55;
+
+export function reconcileEnabled(): boolean {
+    const v = process.env.MEMORY_RECONCILE_ENABLED?.toLowerCase();
+    return !(v === 'false' || v === '0');
+}
+
+interface FactWithNeighbors {
+    factIndex: number;
+    fact: ExtractedFact;
+    neighbors: MemoryHit[];
+}
+
+const JUDGE_SYSTEM = new SystemMessage(
+    `You reconcile newly extracted agent memories against similar existing memories.
+For each new fact, choose exactly one action:
+- "ADD": genuinely new information not covered by any neighbor.
+- "UPDATE": same fact as one neighbor but with more or refined detail. Provide "mergedValue": the neighbor's value enriched with the new detail (same JSON shape as the new fact's value).
+- "SUPERSEDE": the new fact EXPLICITLY CONTRADICTS one neighbor — both cannot be true (e.g. a resource moved region). The new fact wins. Provide "targetId".
+- "REINFORCE": semantically the same fact as one neighbor; nothing new. Provide "targetId".
+- "NOOP": ephemeral or not worth remembering.
+Rules:
+- SUPERSEDE only on mutual exclusivity, NEVER on similarity or partial overlap.
+- Uncertain between UPDATE and REINFORCE → choose REINFORCE.
+- Uncertain whether facts contradict → choose ADD (keep both).
+Return ONLY a JSON array with one object per fact:
+[{"factIndex": 0, "action": "SUPERSEDE", "targetId": "..."}]
+"targetId" must be an id from that fact's own neighbors. Include "mergedValue" only for UPDATE.`,
+);
+
+function parseDecisions(content: string): ReconcileDecision[] {
+    const match = content.match(/\[[\s\S]*\]/);
+    if (!match) return [];
+    try {
+        const parsed = JSON.parse(match[0]);
+        return Array.isArray(parsed) ? (parsed as ReconcileDecision[]) : [];
+    } catch {
+        return [];
+    }
+}
+
+function isValidDecision(d: ReconcileDecision, item: FactWithNeighbors): boolean {
+    const neighborIds = new Set(item.neighbors.map((n) => n.id));
+    switch (d.action) {
+        case 'ADD':
+        case 'NOOP':
+            return true;
+        case 'REINFORCE':
+        case 'SUPERSEDE':
+            return !!d.targetId && neighborIds.has(d.targetId);
+        case 'UPDATE':
+            return !!d.targetId && neighborIds.has(d.targetId)
+                && !!d.mergedValue && typeof d.mergedValue === 'object';
+        default:
+            return false;
+    }
+}
+
+export async function reconcileMemories(params: {
+    tenantId: string;
+    userId: string;
+    facts: ExtractedFact[];
+    judgeModel: BaseChatModel;
+    sourceThreadId?: string;
+}): Promise<ReconcileSummary> {
+    const { tenantId, userId, facts, judgeModel, sourceThreadId } = params;
+    const summary: ReconcileSummary = { added: 0, updated: 0, superseded: 0, reinforced: 0, noop: 0, failed: 0 };
+    const svc = getMemoryService();
+
+    const add = async (fact: ExtractedFact): Promise<void> => {
+        await svc.remember({
+            tenantId, userId, kind: 'SEMANTIC',
+            namespace: fact.namespace, key: fact.key,
+            value: fact.value as unknown as Record<string, unknown>,
+            sourceThreadId,
+        });
+        summary.added++;
+    };
+
+    // 1. Neighbor fetch — facts with no near neighbor skip the judge entirely.
+    const withNeighbors: FactWithNeighbors[] = [];
+    for (const [factIndex, fact] of facts.entries()) {
+        let neighbors: MemoryHit[] = [];
+        try {
+            // Query by the value JSON — the same text remember() embeds, so distances are comparable.
+            const hits = await svc.recall({
+                tenantId, userId, query: JSON.stringify(fact.value),
+                kinds: ['SEMANTIC'], limit: RECONCILE_TOP_K,
+            });
+            neighbors = hits.filter((h) => h.distance !== undefined && h.distance <= RECONCILE_DISTANCE_THRESHOLD);
+        } catch {
+            // recall failure → treat as no neighbors
+        }
+        if (neighbors.length === 0) {
+            try { await add(fact); } catch (err: any) {
+                console.warn(`[Reconcile] ADD failed for ${fact.key}: ${err?.message ?? err}`);
+                summary.failed++;
+            }
+        } else {
+            withNeighbors.push({ factIndex, fact, neighbors });
+        }
+    }
+    if (withNeighbors.length === 0) return summary;
+
+    // 2. One batched judge call for every fact that has neighbors.
+    const decisions = new Map<number, ReconcileDecision>();
+    try {
+        const input = new HumanMessage(JSON.stringify(
+            withNeighbors.map((w) => ({
+                factIndex: w.factIndex,
+                newFact: { namespace: w.fact.namespace.join('/'), key: w.fact.key, value: w.fact.value },
+                neighbors: w.neighbors.map((n) => ({ id: n.id, namespace: n.namespace, key: n.key, value: n.value })),
+            })), null, 2,
+        ));
+        const resp = await judgeModel.invoke([JUDGE_SYSTEM, input]);
+        const content = typeof resp.content === 'string' ? resp.content : JSON.stringify(resp.content);
+        for (const d of parseDecisions(content)) {
+            if (typeof d?.factIndex === 'number') decisions.set(d.factIndex, d);
+        }
+    } catch (err: any) {
+        console.warn(`[Reconcile] Judge failed, falling back to ADD: ${err?.message ?? err}`);
+        // decisions stays empty → every fact falls back to ADD below
+    }
+
+    // 3. Apply — anything missing/invalid degrades to ADD; one failure never blocks siblings.
+    for (const item of withNeighbors) {
+        const d = decisions.get(item.factIndex);
+        try {
+            if (!d || !isValidDecision(d, item)) {
+                await add(item.fact);
+                continue;
+            }
+            switch (d.action) {
+                case 'ADD':
+                    await add(item.fact);
+                    break;
+                case 'UPDATE':
+                    await svc.update(tenantId, d.targetId!, d.mergedValue!);
+                    summary.updated++;
+                    break;
+                case 'SUPERSEDE': {
+                    const newId = await svc.remember({
+                        tenantId, userId, kind: 'SEMANTIC',
+                        namespace: item.fact.namespace, key: item.fact.key,
+                        value: item.fact.value as unknown as Record<string, unknown>,
+                        sourceThreadId,
+                    });
+                    await svc.supersede(tenantId, d.targetId!, newId);
+                    summary.superseded++;
+                    summary.added++;
+                    break;
+                }
+                case 'REINFORCE':
+                    await svc.reinforce(tenantId, d.targetId!);
+                    summary.reinforced++;
+                    break;
+                case 'NOOP':
+                    summary.noop++;
+                    break;
+            }
+        } catch (err: any) {
+            console.warn(`[Reconcile] Apply failed for ${item.fact.key}: ${err?.message ?? err}`);
+            summary.failed++;
+        }
+    }
+
+    return summary;
+}

--- a/apps/web-ui/lib/agent/memory/types.ts
+++ b/apps/web-ui/lib/agent/memory/types.ts
@@ -27,3 +27,27 @@ export interface WorkingMemory {
     tokenCount: number;
     turnCount: number;
 }
+
+export interface ExtractedFact {
+    namespace: string[];
+    key: string;
+    value: SemanticValue;
+}
+
+export type ReconcileAction = 'ADD' | 'UPDATE' | 'SUPERSEDE' | 'REINFORCE' | 'NOOP';
+
+export interface ReconcileDecision {
+    factIndex: number;
+    action: ReconcileAction;
+    targetId?: string;                     // UPDATE / SUPERSEDE / REINFORCE
+    mergedValue?: Record<string, unknown>; // UPDATE only
+}
+
+export interface ReconcileSummary {
+    added: number;
+    updated: number;
+    superseded: number;
+    reinforced: number;
+    noop: number;
+    failed: number;
+}

--- a/apps/web-ui/lib/agent/memory/types.ts
+++ b/apps/web-ui/lib/agent/memory/types.ts
@@ -5,10 +5,13 @@ export interface EpisodicValue { context: string; reasoning: string; action: str
 export interface ProceduralValue { instruction: string; trigger: string; evidence: string; }
 
 export interface MemoryHit {
+    id: string;
     namespace: string;
     key: string;
     value: Record<string, unknown>;
     kind: MemoryKind;
+    /** Cosine distance to the query (0 = identical); present only on vector-search hits. */
+    distance?: number;
 }
 
 export interface Scratchpad {

--- a/apps/web-ui/lib/agent/memory/types.ts
+++ b/apps/web-ui/lib/agent/memory/types.ts
@@ -2,7 +2,7 @@ export type MemoryKind = 'SEMANTIC' | 'EPISODIC' | 'PROCEDURAL';
 
 export interface SemanticValue { fact: string; source: string; confidence: 'high' | 'medium'; }
 export interface EpisodicValue { context: string; reasoning: string; action: string; outcome: string; }
-export interface ProceduralValue { instruction: string; trigger: string; evidence: string; }
+export interface ProceduralValue { instruction: string; trigger: string; evidence: string; confidence?: 'high' | 'medium'; }
 
 export interface MemoryHit {
     id: string;
@@ -29,9 +29,11 @@ export interface WorkingMemory {
 }
 
 export interface ExtractedFact {
+    /** Memory layer this item belongs to; absent = 'SEMANTIC'. */
+    kind?: MemoryKind;
     namespace: string[];
     key: string;
-    value: SemanticValue;
+    value: SemanticValue | ProceduralValue;
 }
 
 export type ReconcileAction = 'ADD' | 'UPDATE' | 'SUPERSEDE' | 'REINFORCE' | 'NOOP';

--- a/apps/web-ui/lib/agent/memory/types.ts
+++ b/apps/web-ui/lib/agent/memory/types.ts
@@ -1,0 +1,26 @@
+export type MemoryKind = 'SEMANTIC' | 'EPISODIC' | 'PROCEDURAL';
+
+export interface SemanticValue { fact: string; source: string; confidence: 'high' | 'medium'; }
+export interface EpisodicValue { context: string; reasoning: string; action: string; outcome: string; }
+export interface ProceduralValue { instruction: string; trigger: string; evidence: string; }
+
+export interface MemoryHit {
+    namespace: string;
+    key: string;
+    value: Record<string, unknown>;
+    kind: MemoryKind;
+}
+
+export interface Scratchpad {
+    openGoals: string[];
+    keyFindings: string[];
+    resourceIds: string[];
+    pendingSteps: string[];
+}
+
+export interface WorkingMemory {
+    runningSummary: string;
+    scratchpad: Scratchpad;
+    tokenCount: number;
+    turnCount: number;
+}

--- a/apps/web-ui/lib/agent/memory/working-memory.test.ts
+++ b/apps/web-ui/lib/agent/memory/working-memory.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { workingMemoryEnabled, tokenBudget, keepRecent } from './working-memory';
+
+describe('working-memory config', () => {
+    const saved = { ...process.env };
+    afterEach(() => { process.env = { ...saved }; });
+
+    it('defaults: enabled=true, budget=60000, keep=8', () => {
+        delete process.env.WORKING_MEMORY_ENABLED;
+        delete process.env.WORKING_MEMORY_TOKEN_BUDGET;
+        delete process.env.WORKING_MEMORY_KEEP_RECENT;
+        expect(workingMemoryEnabled()).toBe(true);
+        expect(tokenBudget()).toBe(60000);
+        expect(keepRecent()).toBe(8);
+    });
+
+    it('WORKING_MEMORY_ENABLED=false disables', () => {
+        process.env.WORKING_MEMORY_ENABLED = 'false';
+        expect(workingMemoryEnabled()).toBe(false);
+    });
+
+    it('reads numeric overrides', () => {
+        process.env.WORKING_MEMORY_TOKEN_BUDGET = '30000';
+        process.env.WORKING_MEMORY_KEEP_RECENT = '4';
+        expect(tokenBudget()).toBe(30000);
+        expect(keepRecent()).toBe(4);
+    });
+});

--- a/apps/web-ui/lib/agent/memory/working-memory.test.ts
+++ b/apps/web-ui/lib/agent/memory/working-memory.test.ts
@@ -114,3 +114,80 @@ describe('buildWorkingMemorySection', () => {
         expect(sec).toContain('cluster-1');
     });
 });
+
+import { prepareContext, foldWorkingMemory } from './working-memory';
+import { getRecentMessages } from '../agent-shared';
+import type { ReflectionState } from '../agent-shared';
+
+function baseState(messages: any[]): ReflectionState {
+    return {
+        messages, taskDescription: 't', plan: [], code: '', executionOutput: '',
+        errors: [], reflection: '', iterationCount: 0, nextAction: 'plan',
+        isComplete: false, toolResults: [], memoryContext: '',
+        runningSummary: '', scratchpad: { openGoals: [], keyFindings: [], resourceIds: [], pendingSteps: [] },
+    };
+}
+
+const fakeReflector = {
+    invoke: async () => ({
+        content: JSON.stringify({
+            summary: 'Restarted the stuck ECS task.',
+            scratchpad: { openGoals: ['verify health'], keyFindings: ['task was OOM'], resourceIds: ['svc-1'], pendingSteps: [] },
+        }),
+    }),
+} as any;
+
+describe('prepareContext', () => {
+    afterEach(() => { delete process.env.WORKING_MEMORY_ENABLED; delete process.env.WORKING_MEMORY_TOKEN_BUDGET; });
+
+    it('disabled → falls back to getRecentMessages(fallbackWindow), no WM section, no LLM call', async () => {
+        process.env.WORKING_MEMORY_ENABLED = 'false';
+        // Alternate roles so getRecentMessages passes the window through unchanged
+        // (adjacent same-role messages make it inject synthetic "Acknowledged." AIMessages,
+        // which would push the returned length above the fallbackWindow — a getRecentMessages
+        // concern, not prepareContext's). Same convention as the selectWindow property test.
+        const msgs = Array.from({ length: 30 }, (_, i) =>
+            i % 2 === 0 ? new HumanMessage(`m${i}`) : new AIMessage(`m${i}`),
+        );
+        const res = await prepareContext(baseState(msgs), { reflectorModel: fakeReflector }, 20);
+        expect(res.workingMemorySection).toBe('');
+        expect(res.stateUpdate).toEqual({});
+        // Disabled path returns EXACTLY the legacy getRecentMessages(fallbackWindow) window
+        // (identical to today's behavior). Asserting a length bound is wrong: getRecentMessages
+        // does not hard-cap at maxMessages — it can add leading/adjacency fixups — so compare to it directly.
+        expect(res.windowMessages).toEqual(getRecentMessages(msgs, 20));
+    });
+
+    it('enabled + under budget → no compaction, no LLM call, empty stateUpdate', async () => {
+        process.env.WORKING_MEMORY_TOKEN_BUDGET = '100000';
+        const msgs = [new HumanMessage('hi'), new AIMessage('hello')];
+        const res = await prepareContext(baseState(msgs), { reflectorModel: fakeReflector }, 20);
+        expect(res.stateUpdate).toEqual({});
+        expect(res.windowMessages.length).toBe(2);
+    });
+
+    it('enabled + over budget → folds evicted turns into summary + scratchpad', async () => {
+        process.env.WORKING_MEMORY_TOKEN_BUDGET = '10'; // force compaction
+        const msgs = Array.from({ length: 12 }, (_, i) =>
+            i % 2 === 0 ? new HumanMessage('X'.repeat(80) + i) : new AIMessage('X'.repeat(80) + i),
+        );
+        const res = await prepareContext(baseState(msgs), { reflectorModel: fakeReflector }, 20);
+        expect(res.workingMemorySection).toContain('## Working Memory');
+        expect(res.workingMemorySection).toContain('Restarted the stuck ECS task.');
+        expect(res.stateUpdate.runningSummary).toContain('Restarted');
+        expect(res.stateUpdate.scratchpad?.openGoals).toContain('verify health');
+    });
+});
+
+describe('foldWorkingMemory monotonicity', () => {
+    it('never drops a pre-existing open goal', async () => {
+        const prev = {
+            runningSummary: 'prior', tokenCount: 0, turnCount: 1,
+            scratchpad: { openGoals: ['KEEP ME'], keyFindings: [], resourceIds: [], pendingSteps: [] },
+        };
+        const next = await foldWorkingMemory(prev, [new HumanMessage('did stuff')], fakeReflector);
+        expect(next.scratchpad.openGoals).toContain('KEEP ME');   // merged, not replaced
+        expect(next.scratchpad.openGoals).toContain('verify health'); // plus the new one
+        expect(next.turnCount).toBe(2);
+    });
+});

--- a/apps/web-ui/lib/agent/memory/working-memory.test.ts
+++ b/apps/web-ui/lib/agent/memory/working-memory.test.ts
@@ -26,3 +26,91 @@ describe('working-memory config', () => {
         expect(keepRecent()).toBe(4);
     });
 });
+
+import { HumanMessage, AIMessage } from '@langchain/core/messages';
+import fc from 'fast-check';
+import {
+    estimateTokens, estimateMessagesTokens, compressToolOutput,
+    selectWindow, buildWorkingMemorySection, emptyScratchpad,
+} from './working-memory';
+
+describe('estimateTokens', () => {
+    it('is ceil(len/4)', () => {
+        expect(estimateTokens('12345678')).toBe(2);
+        expect(estimateTokens('123')).toBe(1);
+        expect(estimateTokens('')).toBe(0);
+    });
+});
+
+describe('compressToolOutput', () => {
+    it('keeps head+tail with an elision marker when over the cap', () => {
+        const big = 'A'.repeat(500) + 'B'.repeat(500);
+        const out = compressToolOutput(big, 200);
+        expect(out.length).toBeLessThan(big.length);
+        expect(out).toContain('elided');
+        expect(out.startsWith('A')).toBe(true);
+        expect(out.endsWith('B')).toBe(true);
+    });
+    it('returns short content unchanged', () => {
+        expect(compressToolOutput('short', 200)).toBe('short');
+    });
+});
+
+describe('selectWindow', () => {
+    it('always keeps at least the last `keep` messages', () => {
+        const msgs = Array.from({ length: 20 }, (_, i) => new HumanMessage(`m${i}`));
+        const win = selectWindow(msgs, 1, 5); // tiny budget
+        expect(win.length).toBeGreaterThanOrEqual(5);
+    });
+
+    it('property: window is a recency-preserving suffix, keeps >= min(keep,n), and stays within budget once the keep-floor fits', () => {
+        fc.assert(fc.property(
+            fc.array(fc.string({ minLength: 1, maxLength: 400 }), { minLength: 1, maxLength: 60 }),
+            fc.integer({ min: 1, max: 10 }),
+            (contents, keep) => {
+                // Alternate Human/AI roles + non-empty content so getRecentMessages
+                // passes the slice through UNCHANGED. (Two same-role messages adjacent
+                // make getRecentMessages inject a synthetic "Acknowledged." AIMessage to
+                // satisfy Bedrock adjacency — that repair is getRecentMessages' concern,
+                // not selectWindow's, and would grow the array out from under a suffix check.)
+                const msgs = contents.map((c, i) =>
+                    i % 2 === 0 ? new HumanMessage(`${i}:${c}`) : new AIMessage(`${i}:${c}`),
+                );
+                const budget = 5000;
+                const win = selectWindow(msgs, budget, keep);
+
+                // (1) Floor: never drops below min(keep, n) messages.
+                expect(win.length).toBeGreaterThanOrEqual(Math.min(keep, msgs.length));
+
+                // (2) Suffix: the window is exactly the last win.length messages, in order
+                //     (getRecentMessages preserves order and, for these non-empty human
+                //     messages, does not drop any). This is what "recency-preserving" means.
+                const tail = msgs.slice(msgs.length - win.length);
+                expect(win.map((m) => m.content)).toEqual(tail.map((m) => m.content));
+
+                // (3) Budget: any message ADDED beyond the keep-floor stays within budget.
+                //     (The keep-floor itself may exceed budget by design — that is allowed.)
+                if (win.length > keep) {
+                    expect(estimateMessagesTokens(win)).toBeLessThanOrEqual(budget);
+                }
+            },
+        ));
+    });
+});
+
+describe('buildWorkingMemorySection', () => {
+    it('returns empty string for null WM', () => {
+        expect(buildWorkingMemorySection(null)).toBe('');
+    });
+    it('renders summary + scratchpad goals', () => {
+        const sec = buildWorkingMemorySection({
+            runningSummary: 'Investigated ECS.',
+            scratchpad: { ...emptyScratchpad(), openGoals: ['restart task'], resourceIds: ['cluster-1'] },
+            tokenCount: 100, turnCount: 3,
+        });
+        expect(sec).toContain('## Working Memory');
+        expect(sec).toContain('Investigated ECS.');
+        expect(sec).toContain('restart task');
+        expect(sec).toContain('cluster-1');
+    });
+});

--- a/apps/web-ui/lib/agent/memory/working-memory.ts
+++ b/apps/web-ui/lib/agent/memory/working-memory.ts
@@ -1,0 +1,17 @@
+// Working-memory configuration. Read process.env directly (not the typed `env`
+// object) so Vitest can mutate values per-test — env.ts skips validation under
+// NODE_ENV==='test' but caches at import time.
+export function workingMemoryEnabled(): boolean {
+    const v = process.env.WORKING_MEMORY_ENABLED?.toLowerCase();
+    return !(v === 'false' || v === '0');
+}
+
+export function tokenBudget(): number {
+    const n = Number(process.env.WORKING_MEMORY_TOKEN_BUDGET);
+    return Number.isFinite(n) && n > 0 ? n : 60000;
+}
+
+export function keepRecent(): number {
+    const n = Number(process.env.WORKING_MEMORY_KEEP_RECENT);
+    return Number.isFinite(n) && n > 0 ? n : 8;
+}

--- a/apps/web-ui/lib/agent/memory/working-memory.ts
+++ b/apps/web-ui/lib/agent/memory/working-memory.ts
@@ -1,3 +1,7 @@
+import type { BaseMessage } from '@langchain/core/messages';
+import { getRecentMessages } from '../agent-shared';
+import type { Scratchpad, WorkingMemory } from './types';
+
 // Working-memory configuration. Read process.env directly (not the typed `env`
 // object) so Vitest can mutate values per-test — env.ts skips validation under
 // NODE_ENV==='test' but caches at import time.
@@ -14,4 +18,61 @@ export function tokenBudget(): number {
 export function keepRecent(): number {
     const n = Number(process.env.WORKING_MEMORY_KEEP_RECENT);
     return Number.isFinite(n) && n > 0 ? n : 8;
+}
+
+export function emptyScratchpad(): Scratchpad {
+    return { openGoals: [], keyFindings: [], resourceIds: [], pendingSteps: [] };
+}
+
+export function estimateTokens(text: string): number {
+    return Math.ceil(text.length / 4);
+}
+
+function messageText(m: BaseMessage): string {
+    return typeof m.content === 'string' ? m.content : JSON.stringify(m.content);
+}
+
+export function estimateMessagesTokens(messages: BaseMessage[]): number {
+    return messages.reduce((sum, m) => sum + estimateTokens(messageText(m)), 0);
+}
+
+export function compressToolOutput(content: string, maxChars = 2000): string {
+    if (content.length <= maxChars) return content;
+    const half = Math.floor(maxChars / 2);
+    const head = content.slice(0, half);
+    const tail = content.slice(content.length - half);
+    return `${head}\n… [${content.length - maxChars} chars elided] …\n${tail}`;
+}
+
+// Pick the most-recent messages that fit `budget` tokens, always keeping at least
+// `keep` of them, then run getRecentMessages() to preserve tool_call/tool_result
+// pairing and drop empties (Bedrock adjacency rules).
+export function selectWindow(messages: BaseMessage[], budget: number, keep: number): BaseMessage[] {
+    if (messages.length === 0) return [];
+    let count = Math.min(keep, messages.length);
+    let used = estimateMessagesTokens(messages.slice(messages.length - count));
+    for (let i = messages.length - count - 1; i >= 0; i--) {
+        const t = estimateTokens(messageText(messages[i]));
+        if (used + t > budget) break;
+        used += t;
+        count++;
+    }
+    const slice = messages.slice(messages.length - count);
+    return getRecentMessages(slice, slice.length);
+}
+
+export function buildWorkingMemorySection(wm: WorkingMemory | null): string {
+    if (!wm) return '';
+    const s = wm.scratchpad ?? emptyScratchpad();
+    const list = (label: string, items: string[]) =>
+        items && items.length ? `\n**${label}:**\n${items.map((i) => `- ${i}`).join('\n')}` : '';
+    const body = [
+        wm.runningSummary ? `\n${wm.runningSummary}` : '',
+        list('Open goals', s.openGoals),
+        list('Key findings', s.keyFindings),
+        list('Resource IDs', s.resourceIds),
+        list('Pending steps', s.pendingSteps),
+    ].join('');
+    if (!body.trim()) return '';
+    return `\n## Working Memory\nA compacted record of this long-running session so far:${body}\n`;
 }

--- a/apps/web-ui/lib/agent/memory/working-memory.ts
+++ b/apps/web-ui/lib/agent/memory/working-memory.ts
@@ -1,6 +1,10 @@
 import type { BaseMessage } from '@langchain/core/messages';
+import { SystemMessage, HumanMessage } from '@langchain/core/messages';
+import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { getRecentMessages } from '../agent-shared';
+import type { ReflectionState } from '../agent-shared';
 import type { Scratchpad, WorkingMemory } from './types';
+import { getMemoryService } from './memory-service';
 
 // Working-memory configuration. Read process.env directly (not the typed `env`
 // object) so Vitest can mutate values per-test — env.ts skips validation under
@@ -75,4 +79,134 @@ export function buildWorkingMemorySection(wm: WorkingMemory | null): string {
     ].join('');
     if (!body.trim()) return '';
     return `\n## Working Memory\nA compacted record of this long-running session so far:${body}\n`;
+}
+
+function uniq(a: string[]): string[] { return Array.from(new Set(a.filter(Boolean))); }
+
+function mergeScratchpad(prev: Scratchpad, next: Partial<Scratchpad>): Scratchpad {
+    return {
+        openGoals: uniq([...(prev.openGoals ?? []), ...(next.openGoals ?? [])]),
+        keyFindings: uniq([...(prev.keyFindings ?? []), ...(next.keyFindings ?? [])]),
+        resourceIds: uniq([...(prev.resourceIds ?? []), ...(next.resourceIds ?? [])]),
+        pendingSteps: uniq([...(prev.pendingSteps ?? []), ...(next.pendingSteps ?? [])]),
+    };
+}
+
+// Fold evicted turns into the running summary + scratchpad using the reflector
+// model. Monotonicity (never lose a recorded goal/finding) is enforced in code by
+// MERGING the LLM output with the prior scratchpad — we do not trust the LLM to
+// carry everything forward.
+export async function foldWorkingMemory(
+    prev: WorkingMemory,
+    evicted: BaseMessage[],
+    reflectorModel: BaseChatModel,
+): Promise<WorkingMemory> {
+    const transcript = evicted
+        .map((m) => `[${m._getType()}] ${compressToolOutput(messageText(m), 1200)}`)
+        .join('\n\n');
+
+    const sys = new SystemMessage(
+        `You compress a long-running agent session into durable working memory. ` +
+        `Given the prior summary/scratchpad and newly-evicted turns, return ONLY a JSON object:\n` +
+        `{"summary": string, "scratchpad": {"openGoals": string[], "keyFindings": string[], "resourceIds": string[], "pendingSteps": string[]}}\n` +
+        `- summary: a concise cumulative narrative (fold the new turns into the prior summary).\n` +
+        `- scratchpad: only NEW items discovered in the evicted turns (prior items are preserved automatically).\n` +
+        `Never fabricate. Return the JSON object and nothing else.`,
+    );
+    const input = new HumanMessage(
+        `**Prior summary:**\n${prev.runningSummary || '(none)'}\n\n` +
+        `**Prior open goals:** ${JSON.stringify(prev.scratchpad?.openGoals ?? [])}\n\n` +
+        `**Newly evicted turns:**\n${compressToolOutput(transcript, 8000)}`,
+    );
+
+    let summary = prev.runningSummary;
+    let newSp: Partial<Scratchpad> = {};
+    try {
+        const resp = await reflectorModel.invoke([sys, input]);
+        const content = typeof resp.content === 'string' ? resp.content : JSON.stringify(resp.content);
+        const match = content.match(/\{[\s\S]*\}/);
+        if (match) {
+            const parsed = JSON.parse(match[0]) as { summary?: string; scratchpad?: Partial<Scratchpad> };
+            if (parsed.summary) summary = parsed.summary;
+            if (parsed.scratchpad) newSp = parsed.scratchpad;
+        }
+    } catch {
+        // Folding failure is non-fatal — keep the prior summary, still advance turnCount.
+    }
+
+    return {
+        runningSummary: summary,
+        scratchpad: mergeScratchpad(prev.scratchpad ?? emptyScratchpad(), newSp),
+        tokenCount: 0,
+        turnCount: (prev.turnCount ?? 0) + 1,
+    };
+}
+
+export interface PrepareContextDeps {
+    reflectorModel: BaseChatModel;
+    tenantId?: string;
+    threadId?: string;
+}
+export interface PreparedContext {
+    windowMessages: BaseMessage[];
+    workingMemorySection: string;
+    stateUpdate: Partial<Pick<ReflectionState, 'runningSummary' | 'scratchpad'>>;
+}
+
+export async function prepareContext(
+    state: ReflectionState,
+    deps: PrepareContextDeps,
+    fallbackWindow: number,
+): Promise<PreparedContext> {
+    const { messages } = state;
+
+    // Disabled → identical to legacy behavior.
+    if (!workingMemoryEnabled()) {
+        return {
+            windowMessages: getRecentMessages(messages, fallbackWindow),
+            workingMemorySection: '',
+            stateUpdate: {},
+        };
+    }
+
+    const budget = tokenBudget();
+    const keep = keepRecent();
+    const total = estimateMessagesTokens(messages);
+
+    const currentWm: WorkingMemory = {
+        runningSummary: state.runningSummary ?? '',
+        scratchpad: state.scratchpad ?? emptyScratchpad(),
+        tokenCount: total,
+        turnCount: 0,
+    };
+
+    // Under budget → no compaction; surface any existing WM from state.
+    if (total <= budget) {
+        const hasWm = currentWm.runningSummary || (currentWm.scratchpad.openGoals?.length ?? 0) > 0;
+        return {
+            windowMessages: selectWindow(messages, budget, keep),
+            workingMemorySection: hasWm ? buildWorkingMemorySection(currentWm) : '',
+            stateUpdate: {},
+        };
+    }
+
+    // Over budget → fold the evicted prefix into working memory.
+    const window = selectWindow(messages, budget, keep);
+    const evicted = messages.slice(0, Math.max(0, messages.length - window.length));
+    const folded = evicted.length
+        ? await foldWorkingMemory(currentWm, evicted, deps.reflectorModel)
+        : currentWm;
+
+    // Durable mirror (best-effort; checkpoint state is the source of truth).
+    if (deps.tenantId && deps.threadId) {
+        getMemoryService()
+            .putWorkingMemory({ tenantId: deps.tenantId, threadId: deps.threadId, wm: folded })
+            .catch(() => {});
+    }
+
+    return {
+        windowMessages: window,
+        workingMemorySection: buildWorkingMemorySection(folded),
+        stateUpdate: { runningSummary: folded.runningSummary, scratchpad: folded.scratchpad },
+    };
 }

--- a/apps/web-ui/lib/agent/persistence.ts
+++ b/apps/web-ui/lib/agent/persistence.ts
@@ -11,6 +11,7 @@
  */
 
 import type { Embeddings } from "@langchain/core/embeddings";
+import { Prisma } from "@prisma/client";
 import { PostgresSaver } from "@langchain/langgraph-checkpoint-postgres";
 import { getPrismaClient } from "@/lib/db/pg-config";
 import { getTenantEmbeddings } from "./embeddings-factory";
@@ -141,11 +142,45 @@ class PostgresMemoryStore implements MemoryStoreInterface {
                         SET "value" = EXCLUDED."value", "embedding" = EXCLUDED."embedding", "updatedAt" = NOW(), "expiresAt" = EXCLUDED."expiresAt"
                     `;
                 } else {
-                    await prisma.agentMemory.upsert({
-                        where: { tenantId_namespace_key: { tenantId: tenantId, namespace, key } },
-                        create: { tenantId: tenantId, userId, namespace, key, value, expiresAt },
-                        update: { value, expiresAt, updatedAt: new Date() },
+                    // The compound unique no longer exists in the Prisma schema (Phase 2:
+                    // uniqueness moved to a partial index on live rows, SQL-only), so upsert
+                    // is replaced by find-live-then-update/create. Same blind-upsert
+                    // semantics as before for the deep-agent path.
+                    const live = await prisma.agentMemory.findFirst({
+                        where: { tenantId, namespace, key, supersededById: null },
+                        select: { id: true },
                     });
+                    if (live) {
+                        await prisma.agentMemory.updateMany({
+                            where: { id: live.id, tenantId },
+                            data: { value: value as Prisma.InputJsonValue, expiresAt, updatedAt: new Date() },
+                        });
+                    } else {
+                        try {
+                            await prisma.agentMemory.create({
+                                data: { tenantId, userId, namespace, key, value: value as Prisma.InputJsonValue, expiresAt },
+                            });
+                        } catch (err) {
+                            // Concurrent create of the same live key — partial unique index is
+                            // the backstop; retry once as an update of the winner.
+                            if ((err as { code?: string })?.code === 'P2002') {
+                                const winner = await prisma.agentMemory.findFirst({
+                                    where: { tenantId, namespace, key, supersededById: null },
+                                    select: { id: true },
+                                });
+                                if (winner) {
+                                    await prisma.agentMemory.updateMany({
+                                        where: { id: winner.id, tenantId },
+                                        data: { value: value as Prisma.InputJsonValue, expiresAt, updatedAt: new Date() },
+                                    });
+                                } else {
+                                    throw err;
+                                }
+                            } else {
+                                throw err;
+                            }
+                        }
+                    }
                 }
                 results.push(null);
             } else if (op.namespacePrefix !== undefined && op.query !== undefined) {

--- a/apps/web-ui/lib/agent/persistence.ts
+++ b/apps/web-ui/lib/agent/persistence.ts
@@ -14,6 +14,7 @@ import type { Embeddings } from "@langchain/core/embeddings";
 import { PostgresSaver } from "@langchain/langgraph-checkpoint-postgres";
 import { getPrismaClient } from "@/lib/db/pg-config";
 import { getTenantEmbeddings } from "./embeddings-factory";
+import { getMemoryService } from "./memory/memory-service";
 import { env } from "@/env";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -264,11 +265,7 @@ export async function saveMemory(
     key: string,
     value: Record<string, unknown>
 ): Promise<void> {
-    const store = await getMemoryStore();
-    await store.batch(
-        [{ namespace, key, value }],
-        { configurable: { tenant_id: tenantId, user_id: userId } }
-    );
+    await getMemoryService().remember({ tenantId, userId, kind: 'SEMANTIC', namespace, key, value });
 }
 
 export async function searchMemory(
@@ -278,10 +275,6 @@ export async function searchMemory(
     query: string,
     limit = 5
 ): Promise<unknown[]> {
-    const store = await getMemoryStore();
-    const [results] = await store.batch(
-        [{ namespacePrefix, query, limit }],
-        { configurable: { tenant_id: tenantId, user_id: userId } }
-    );
-    return (results as unknown[]) ?? [];
+    const hits = await getMemoryService().recall({ tenantId, userId, query, namespacePrefix, limit });
+    return hits.map((h) => ({ key: h.key, value: h.value, namespace: h.namespace }));
 }

--- a/apps/web-ui/lib/agent/persistence.ts
+++ b/apps/web-ui/lib/agent/persistence.ts
@@ -137,7 +137,7 @@ class PostgresMemoryStore implements MemoryStoreInterface {
                     await prisma.$executeRaw`
                         INSERT INTO agent_memories ("id", "tenantId", "userId", "namespace", "key", "value", "embedding", "createdAt", "updatedAt", "expiresAt")
                         VALUES (gen_random_uuid()::text, ${tenantId}, ${userId}, ${namespace}, ${key}, ${JSON.stringify(value)}::jsonb, ${embeddingStr}::vector, NOW(), NOW(), ${expiresAt})
-                        ON CONFLICT ("tenantId", "namespace", "key") DO UPDATE
+                        ON CONFLICT ("tenantId", "namespace", "key") WHERE "supersededById" IS NULL DO UPDATE
                         SET "value" = EXCLUDED."value", "embedding" = EXCLUDED."embedding", "updatedAt" = NOW(), "expiresAt" = EXCLUDED."expiresAt"
                     `;
                 } else {

--- a/apps/web-ui/lib/agent/planning-agent.ts
+++ b/apps/web-ui/lib/agent/planning-agent.ts
@@ -10,7 +10,6 @@ import {
     graphState,
     MAX_ITERATIONS,
     truncateOutput,
-    getRecentMessages,
     sanitizeMessagesForBedrock,
     tagMessagePhase,
     llmAuditLog,
@@ -29,6 +28,7 @@ import {
 } from "./prompt-templates";
 import { createAgentModels, assembleTools } from "./model-factory";
 import { createMemoryRecallNode, createMemorySaveNode } from "./memory-nodes";
+import { prepareContext, buildWorkingMemorySection } from "./memory/working-memory";
 
 // Factory function to create a configured reflection graph
 export async function createReflectionGraph(config: GraphConfig) {
@@ -66,11 +66,19 @@ export async function createReflectionGraph(config: GraphConfig) {
     const memoryRecallNode = createMemoryRecallNode(memoryDeps);
     const memorySaveNode = createMemorySaveNode(memoryDeps);
 
+    // Working-memory deps — threadId is read per-node from the runtime config.
+    const wmDeps = { reflectorModel, tenantId, userId: config.userId };
+
     // ---------------------------------------------------------------------------
     // PLANNER NODE
     // ---------------------------------------------------------------------------
     async function planNode(state: ReflectionState): Promise<Partial<ReflectionState>> {
         const { messages, memoryContext } = state;
+        const workingMemorySection = buildWorkingMemorySection(
+            state.runningSummary || (state.scratchpad?.openGoals?.length ?? 0) > 0
+                ? { runningSummary: state.runningSummary ?? '', scratchpad: state.scratchpad ?? { openGoals: [], keyFindings: [], resourceIds: [], pendingSteps: [] }, tokenCount: 0, turnCount: 0 }
+                : null,
+        );
         const lastMessage = messages[messages.length - 1];
         const taskDescription = typeof lastMessage.content === 'string'
             ? lastMessage.content
@@ -87,6 +95,7 @@ Your role is to decompose the user's task into a precise, dependency-ordered exe
 ${effectiveSkillSection}
 ${CORE_PRINCIPLES}
 ${memoryContext ? `\n## Relevant Context from Memory\n${memoryContext}\n` : ''}
+${workingMemorySection}
 ## Planning Methodology
 
 Work through three phases when building the plan:
@@ -162,7 +171,7 @@ Only return the JSON array, nothing else.`);
     // ---------------------------------------------------------------------------
     // GENERATOR (EXECUTOR) NODE
     // ---------------------------------------------------------------------------
-    async function generateNode(state: ReflectionState): Promise<Partial<ReflectionState>> {
+    async function generateNode(state: ReflectionState, runtimeConfig?: any): Promise<Partial<ReflectionState>> {
         const { messages, plan, iterationCount, memoryContext } = state;
 
         console.log(`\n================================================================================`);
@@ -174,11 +183,16 @@ Only return the JSON array, nothing else.`);
         const pendingSteps = plan.filter(s => s.status === 'pending' || s.status === 'in_progress');
         const currentStep = pendingSteps[0]?.step || "Complete the task";
 
+        const threadId = runtimeConfig?.configurable?.thread_id as string | undefined;
+        const { windowMessages, workingMemorySection, stateUpdate } =
+            await prepareContext(state, { ...wmDeps, threadId }, 15);
+
         const executorSystemPrompt = new SystemMessage(`${baseIdentity}
 Your role is to execute the current plan step precisely and completely using available tools.
 ${effectiveSkillSection}
 ${CORE_PRINCIPLES}
 ${memoryContext ? `\n## Relevant Context from Memory\n${memoryContext}\n` : ''}
+${workingMemorySection}
 ## Current Execution Context
 
 Current Step: ${currentStep}
@@ -202,7 +216,7 @@ ${accountContext}
 
 ⚠️ **Tool Parameter Validation**: Always ensure tool calls include all required parameters. If a tool call fails with a parameter validation error, check that you provided all required fields.`);
 
-        const recentMessages = getRecentMessages(messages, 15);
+        const recentMessages = windowMessages;
         if (recentMessages.length > 0 && recentMessages[recentMessages.length - 1]._getType() === 'ai') {
             recentMessages.push(new HumanMessage({ content: "Please execute the next step of the plan based on the tools available." }));
         }
@@ -232,7 +246,8 @@ ${accountContext}
         return {
             messages: [tagMessagePhase(response, 'execution')],
             iterationCount: iterationCount + 1,
-            plan: updatedPlan
+            plan: updatedPlan,
+            ...stateUpdate,
         };
     }
 
@@ -460,8 +475,12 @@ ${suggestions !== "None" ? `💡 **Suggestions:** ${suggestions}` : ""}
     // ---------------------------------------------------------------------------
     // REVISER NODE
     // ---------------------------------------------------------------------------
-    async function reviseNode(state: ReflectionState): Promise<Partial<ReflectionState>> {
+    async function reviseNode(state: ReflectionState, runtimeConfig?: any): Promise<Partial<ReflectionState>> {
         const { messages, reflection, errors } = state;
+
+        const threadId = runtimeConfig?.configurable?.thread_id as string | undefined;
+        const { windowMessages, workingMemorySection, stateUpdate } =
+            await prepareContext(state, { ...wmDeps, threadId }, 10);
 
         console.log(`\n================================================================================`);
         console.log(`📝 [REVISER] Applying fixes and improvements`);
@@ -472,6 +491,7 @@ ${suggestions !== "None" ? `💡 **Suggestions:** ${suggestions}` : ""}
 Your role is to address the specific issues identified by the reviewer and advance the plan toward completion.
 ${effectiveSkillSection}
 ${CORE_PRINCIPLES}
+${workingMemorySection}
 ## Reviewer Feedback
 
 Analysis: ${reflection}
@@ -490,7 +510,7 @@ Issues to Address: ${errors.join(', ') || 'None'}
 8. After fixing all issues, provide a brief summary of what was corrected and what the result now shows.
 ${accountContext}`);
 
-        const recentMessages = getRecentMessages(messages, 10);
+        const recentMessages = windowMessages;
         if (recentMessages.length > 0 && recentMessages[recentMessages.length - 1]._getType() === 'ai') {
             recentMessages.push(new HumanMessage({ content: "Please fix the issues mentioned in the reflection." }));
         }
@@ -509,7 +529,8 @@ ${accountContext}`);
 
         return {
             messages: [tagMessagePhase(response, 'revision')],
-            nextAction: "generate"
+            nextAction: "generate",
+            ...stateUpdate,
         };
     }
 

--- a/apps/web-ui/lib/db/repositories/agent-memory/interface.ts
+++ b/apps/web-ui/lib/db/repositories/agent-memory/interface.ts
@@ -19,6 +19,7 @@ export interface AgentMemoryRecord {
     expiresAt: string;
     supersededById: string | null;
     supersededAt: string | null;
+    sourceThreadId: string | null;
 }
 
 /** Columns the list view can be sorted by (server-side). */

--- a/apps/web-ui/lib/db/repositories/agent-memory/interface.ts
+++ b/apps/web-ui/lib/db/repositories/agent-memory/interface.ts
@@ -1,4 +1,5 @@
 import type { MemoryCategory } from '@/lib/agent-memory/category';
+import type { MemoryKind } from '@/lib/agent/memory/types';
 
 export interface AgentMemoryRecord {
     id: string;
@@ -6,6 +7,7 @@ export interface AgentMemoryRecord {
     userId: string;
     namespace: string;
     category: MemoryCategory;
+    kind: MemoryKind;
     key: string;
     fact: string;
     source: string | null;

--- a/apps/web-ui/lib/db/repositories/agent-memory/interface.ts
+++ b/apps/web-ui/lib/db/repositories/agent-memory/interface.ts
@@ -17,6 +17,8 @@ export interface AgentMemoryRecord {
     createdAt: string;
     updatedAt: string;
     expiresAt: string;
+    supersededById: string | null;
+    supersededAt: string | null;
 }
 
 /** Columns the list view can be sorted by (server-side). */

--- a/apps/web-ui/lib/db/repositories/agent-memory/postgres.test.ts
+++ b/apps/web-ui/lib/db/repositories/agent-memory/postgres.test.ts
@@ -16,6 +16,7 @@ const makeRow = (overrides: Record<string, unknown> = {}) => ({
     namespace: 'infra/acct-123',
     key: 'prod-ecs-region',
     value: { fact: 'prod ECS runs in us-east-1', source: 'discovery scan', confidence: 'high' },
+    kind: 'SEMANTIC' as const,
     createdAt: new Date('2026-06-01T00:00:00Z'),
     updatedAt: new Date('2026-06-02T00:00:00Z'),
     expiresAt: new Date('2026-09-01T00:00:00Z'),

--- a/apps/web-ui/lib/db/repositories/agent-memory/postgres.test.ts
+++ b/apps/web-ui/lib/db/repositories/agent-memory/postgres.test.ts
@@ -20,6 +20,8 @@ const makeRow = (overrides: Record<string, unknown> = {}) => ({
     createdAt: new Date('2026-06-01T00:00:00Z'),
     updatedAt: new Date('2026-06-02T00:00:00Z'),
     expiresAt: new Date('2026-09-01T00:00:00Z'),
+    supersededById: null,
+    supersededAt: null,
     ...overrides,
 });
 
@@ -176,5 +178,22 @@ describe('AgentMemoryPostgresRepository', () => {
         expect(arg.skip).toBe(20);
         expect(arg.take).toBe(10);
         expect(result.total).toBe(42);
+    });
+
+    it('listByTenant excludes superseded rows', async () => {
+        const repo = new AgentMemoryPostgresRepository();
+        await repo.listByTenant({ tenantId: 't1' });
+        const arg = mockPrisma.agentMemory.findMany.mock.calls[0][0];
+        expect(arg.where.supersededById).toBeNull();
+    });
+
+    it('getById still returns superseded rows with provenance fields', async () => {
+        mockPrisma.agentMemory.findFirst.mockResolvedValueOnce(
+            makeRow({ supersededById: 'mem-2', supersededAt: new Date('2026-07-01T00:00:00Z') }),
+        );
+        const repo = new AgentMemoryPostgresRepository();
+        const rec = await repo.getById('t1', 'mem-1');
+        expect(rec?.supersededById).toBe('mem-2');
+        expect(rec?.supersededAt).toBe('2026-07-01T00:00:00.000Z');
     });
 });

--- a/apps/web-ui/lib/db/repositories/agent-memory/postgres.test.ts
+++ b/apps/web-ui/lib/db/repositories/agent-memory/postgres.test.ts
@@ -22,6 +22,7 @@ const makeRow = (overrides: Record<string, unknown> = {}) => ({
     expiresAt: new Date('2026-09-01T00:00:00Z'),
     supersededById: null,
     supersededAt: null,
+    sourceThreadId: null,
     ...overrides,
 });
 
@@ -208,5 +209,12 @@ describe('AgentMemoryPostgresRepository', () => {
         const rec = await repo.getById('t1', 'mem-1');
         expect(rec?.category).toBe('episodes');
         expect(rec?.fact).toBe('SUCCEEDED — cycled tasks');
+    });
+
+    it('maps sourceThreadId through', async () => {
+        mockPrisma.agentMemory.findFirst.mockResolvedValueOnce(makeRow({ sourceThreadId: 'th-42' }));
+        const repo = new AgentMemoryPostgresRepository();
+        const rec = await repo.getById('t1', 'mem-1');
+        expect(rec?.sourceThreadId).toBe('th-42');
     });
 });

--- a/apps/web-ui/lib/db/repositories/agent-memory/postgres.test.ts
+++ b/apps/web-ui/lib/db/repositories/agent-memory/postgres.test.ts
@@ -217,4 +217,17 @@ describe('AgentMemoryPostgresRepository', () => {
         const rec = await repo.getById('t1', 'mem-1');
         expect(rec?.sourceThreadId).toBe('th-42');
     });
+
+    it('maps procedural rows: category from namespace, fact falls back to instruction', async () => {
+        mockPrisma.agentMemory.findFirst.mockResolvedValueOnce(makeRow({
+            namespace: 'procedures/aws-cli',
+            key: 'paginate-list-calls',
+            kind: 'PROCEDURAL',
+            value: { instruction: 'Always paginate list calls', trigger: 'any list op', evidence: 'missed items', confidence: 'high' },
+        }));
+        const repo = new AgentMemoryPostgresRepository();
+        const rec = await repo.getById('t1', 'mem-1');
+        expect(rec?.category).toBe('procedures');
+        expect(rec?.fact).toBe('Always paginate list calls');
+    });
 });

--- a/apps/web-ui/lib/db/repositories/agent-memory/postgres.test.ts
+++ b/apps/web-ui/lib/db/repositories/agent-memory/postgres.test.ts
@@ -196,4 +196,17 @@ describe('AgentMemoryPostgresRepository', () => {
         expect(rec?.supersededById).toBe('mem-2');
         expect(rec?.supersededAt).toBe('2026-07-01T00:00:00.000Z');
     });
+
+    it('maps episodic rows: category from namespace, fact falls back to outcome', async () => {
+        mockPrisma.agentMemory.findFirst.mockResolvedValueOnce(makeRow({
+            namespace: 'episodes',
+            key: 'thread-th-9',
+            kind: 'EPISODIC',
+            value: { context: 'c', reasoning: 'r', action: 'a', outcome: 'SUCCEEDED — cycled tasks' },
+        }));
+        const repo = new AgentMemoryPostgresRepository();
+        const rec = await repo.getById('t1', 'mem-1');
+        expect(rec?.category).toBe('episodes');
+        expect(rec?.fact).toBe('SUCCEEDED — cycled tasks');
+    });
 });

--- a/apps/web-ui/lib/db/repositories/agent-memory/postgres.ts
+++ b/apps/web-ui/lib/db/repositories/agent-memory/postgres.ts
@@ -1,6 +1,7 @@
 import { getTenantClient } from '@/lib/db/pg-config';
 import { categoryFromNamespace, KNOWN_CATEGORIES } from '@/lib/agent-memory/category';
 import type { MemoryCategory } from '@/lib/agent-memory/category';
+import type { MemoryKind } from '@/lib/agent/memory/types';
 import type {
     IAgentMemoryRepository,
     AgentMemoryRecord,
@@ -16,6 +17,7 @@ type MemoryRow = {
     namespace: string;
     key: string;
     value: unknown;
+    kind: MemoryKind;
     createdAt: Date;
     updatedAt: Date;
     expiresAt: Date;
@@ -36,6 +38,7 @@ function toRecord(row: MemoryRow): AgentMemoryRecord {
         userId: row.userId,
         namespace: row.namespace,
         category: categoryFromNamespace(row.namespace),
+        kind: row.kind,
         key: row.key,
         fact: asString(value.fact) ?? '',
         source: asString(value.source),

--- a/apps/web-ui/lib/db/repositories/agent-memory/postgres.ts
+++ b/apps/web-ui/lib/db/repositories/agent-memory/postgres.ts
@@ -43,7 +43,7 @@ function toRecord(row: MemoryRow): AgentMemoryRecord {
         category: categoryFromNamespace(row.namespace),
         kind: row.kind,
         key: row.key,
-        fact: asString(value.fact) ?? asString(value.outcome) ?? '',
+        fact: asString(value.fact) ?? asString(value.outcome) ?? asString(value.instruction) ?? '',
         source: asString(value.source),
         confidence: asString(value.confidence),
         value,

--- a/apps/web-ui/lib/db/repositories/agent-memory/postgres.ts
+++ b/apps/web-ui/lib/db/repositories/agent-memory/postgres.ts
@@ -42,7 +42,7 @@ function toRecord(row: MemoryRow): AgentMemoryRecord {
         category: categoryFromNamespace(row.namespace),
         kind: row.kind,
         key: row.key,
-        fact: asString(value.fact) ?? '',
+        fact: asString(value.fact) ?? asString(value.outcome) ?? '',
         source: asString(value.source),
         confidence: asString(value.confidence),
         value,

--- a/apps/web-ui/lib/db/repositories/agent-memory/postgres.ts
+++ b/apps/web-ui/lib/db/repositories/agent-memory/postgres.ts
@@ -23,6 +23,7 @@ type MemoryRow = {
     expiresAt: Date;
     supersededById: string | null;
     supersededAt: Date | null;
+    sourceThreadId: string | null;
 };
 
 function asString(v: unknown): string | null {
@@ -51,6 +52,7 @@ function toRecord(row: MemoryRow): AgentMemoryRecord {
         expiresAt: row.expiresAt.toISOString(),
         supersededById: row.supersededById,
         supersededAt: row.supersededAt ? row.supersededAt.toISOString() : null,
+        sourceThreadId: row.sourceThreadId,
     };
 }
 

--- a/apps/web-ui/lib/db/repositories/agent-memory/postgres.ts
+++ b/apps/web-ui/lib/db/repositories/agent-memory/postgres.ts
@@ -21,6 +21,8 @@ type MemoryRow = {
     createdAt: Date;
     updatedAt: Date;
     expiresAt: Date;
+    supersededById: string | null;
+    supersededAt: Date | null;
 };
 
 function asString(v: unknown): string | null {
@@ -47,6 +49,8 @@ function toRecord(row: MemoryRow): AgentMemoryRecord {
         createdAt: row.createdAt.toISOString(),
         updatedAt: row.updatedAt.toISOString(),
         expiresAt: row.expiresAt.toISOString(),
+        supersededById: row.supersededById,
+        supersededAt: row.supersededAt ? row.supersededAt.toISOString() : null,
     };
 }
 
@@ -87,7 +91,7 @@ export class AgentMemoryPostgresRepository implements IAgentMemoryRepository {
         const limit = filters.limit ?? 50;
         const skip = (page - 1) * limit;
 
-        const where: Record<string, unknown> = { tenantId: filters.tenantId };
+        const where: Record<string, unknown> = { tenantId: filters.tenantId, supersededById: null };
         const and: unknown[] = [];
 
         const categories =

--- a/apps/web-ui/lib/queries/agent-memories.ts
+++ b/apps/web-ui/lib/queries/agent-memories.ts
@@ -23,6 +23,8 @@ export interface MemoryRow {
     createdAt: string;
     updatedAt: string;
     expiresAt: string;
+    supersededById: string | null;
+    supersededAt: string | null;
 }
 
 export type MemorySortField = 'category' | 'key' | 'createdAt' | 'expiresAt';

--- a/apps/web-ui/lib/queries/agent-memories.ts
+++ b/apps/web-ui/lib/queries/agent-memories.ts
@@ -9,6 +9,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from '@/lib/queries/query-keys';
 import type { MemoryCategory } from '@/lib/agent-memory/category';
+import type { MemoryKind } from '@/lib/agent/memory/types';
 
 export interface MemoryRow {
     id: string;
@@ -20,6 +21,8 @@ export interface MemoryRow {
     source: string | null;
     confidence: string | null;
     value: Record<string, unknown>;
+    kind: MemoryKind;
+    sourceThreadId: string | null;
     createdAt: string;
     updatedAt: string;
     expiresAt: string;

--- a/docs/superpowers/plans/2026-07-01-agent-memory-foundation-working-memory.md
+++ b/docs/superpowers/plans/2026-07-01-agent-memory-foundation-working-memory.md
@@ -227,7 +227,8 @@ model AgentWorkingMemory {
 
 - [ ] **Step 5: Generate the migration SQL (do NOT apply yet)**
 
-Run: `cd apps/web-ui && bunx prisma migrate dev --create-only --name agent_memory_foundation --schema ../../libs/prisma/schema.prisma`
+Run: `cd apps/web-ui && bun run db:migrate -- --create-only --name agent_memory_foundation`
+(The `db:migrate` script is `cd ../.. && prisma migrate dev --schema=./libs/prisma/schema.prisma`; args after `--` are forwarded.)
 Expected: a new folder `libs/prisma/migrations/<timestamp>_agent_memory_foundation/migration.sql` is created; nothing applied to the DB yet.
 
 - [ ] **Step 6: Append the raw HNSW index to the generated migration**
@@ -244,7 +245,7 @@ CREATE INDEX IF NOT EXISTS "agent_memories_embedding_hnsw"
 
 - [ ] **Step 7: Apply the migration**
 
-Run: `cd apps/web-ui && bunx prisma migrate dev --schema ../../libs/prisma/schema.prisma`
+Run: `cd apps/web-ui && bun run db:migrate`
 Expected: `The following migration(s) have been applied` including `agent_memory_foundation`; ends `Your database is now in sync with your schema.`
 
 - [ ] **Step 8: Regenerate BOTH Prisma clients**
@@ -254,15 +255,15 @@ Expected: both print `Generated Prisma Client`.
 
 - [ ] **Step 9: Verify the schema changes in the DB**
 
-Run:
+Run (local `DATABASE_URL` is `postgresql://nucleus:...@localhost:5432/nucleus` → user `nucleus`, db `nucleus`):
 ```bash
-docker compose exec -T postgres psql -U postgres -d nucleus -c "SELECT indexname FROM pg_indexes WHERE tablename='agent_memories' AND indexname='agent_memories_embedding_hnsw';"
-docker compose exec -T postgres psql -U postgres -d nucleus -c "SELECT count(*) AS null_kind FROM agent_memories WHERE kind IS NULL;"
-docker compose exec -T postgres psql -U postgres -d nucleus -c "\d agent_working_memory"
+docker compose exec -T postgres psql -U nucleus -d nucleus -c "SELECT indexname FROM pg_indexes WHERE tablename='agent_memories' AND indexname='agent_memories_embedding_hnsw';"
+docker compose exec -T postgres psql -U nucleus -d nucleus -c "SELECT count(*) AS null_kind FROM agent_memories WHERE kind IS NULL;"
+docker compose exec -T postgres psql -U nucleus -d nucleus -c "\d agent_working_memory"
 ```
 Expected: first prints `agent_memories_embedding_hnsw` (1 row); second prints `null_kind = 0`; third shows the `agent_working_memory` table with a unique index on `(tenantId, threadId)`.
 
-> If the DB/user/name differs locally, read the credentials from the root `.env` `DATABASE_URL` and substitute `-U`/`-d` accordingly.
+> If the credentials differ, re-read them from the root `.env` `DATABASE_URL` and substitute `-U`/`-d` accordingly.
 
 - [ ] **Step 10: Commit**
 
@@ -722,15 +723,29 @@ describe('selectWindow', () => {
         expect(win.length).toBeGreaterThanOrEqual(5);
     });
 
-    it('property: window token estimate stays near budget for large budgets', () => {
+    it('property: window is a recency-preserving suffix, keeps >= min(keep,n), and stays within budget once the keep-floor fits', () => {
         fc.assert(fc.property(
             fc.array(fc.string({ minLength: 1, maxLength: 400 }), { minLength: 1, maxLength: 60 }),
-            (contents) => {
-                const msgs = contents.map((c) => new HumanMessage(c));
-                const budget = 10000;
-                const win = selectWindow(msgs, budget, 4);
-                // Never returns more messages than input; keeps recency ordering.
-                expect(win.length).toBeLessThanOrEqual(msgs.length);
+            fc.integer({ min: 1, max: 10 }),
+            (contents, keep) => {
+                const msgs = contents.map((c, i) => new HumanMessage(`${i}:${c}`)); // unique, non-empty
+                const budget = 5000;
+                const win = selectWindow(msgs, budget, keep);
+
+                // (1) Floor: never drops below min(keep, n) messages.
+                expect(win.length).toBeGreaterThanOrEqual(Math.min(keep, msgs.length));
+
+                // (2) Suffix: the window is exactly the last win.length messages, in order
+                //     (getRecentMessages preserves order and, for these non-empty human
+                //     messages, does not drop any). This is what "recency-preserving" means.
+                const tail = msgs.slice(msgs.length - win.length);
+                expect(win.map((m) => m.content)).toEqual(tail.map((m) => m.content));
+
+                // (3) Budget: any message ADDED beyond the keep-floor stays within budget.
+                //     (The keep-floor itself may exceed budget by design — that is allowed.)
+                if (win.length > keep) {
+                    expect(estimateMessagesTokens(win)).toBeLessThanOrEqual(budget);
+                }
             },
         ));
     });

--- a/docs/superpowers/plans/2026-07-01-agent-memory-foundation-working-memory.md
+++ b/docs/superpowers/plans/2026-07-01-agent-memory-foundation-working-memory.md
@@ -958,7 +958,13 @@ describe('prepareContext', () => {
 
     it('disabled → falls back to getRecentMessages(fallbackWindow), no WM section, no LLM call', async () => {
         process.env.WORKING_MEMORY_ENABLED = 'false';
-        const msgs = Array.from({ length: 30 }, (_, i) => new HumanMessage(`m${i}`));
+        // Alternate roles so getRecentMessages passes the window through unchanged
+        // (adjacent same-role messages make it inject synthetic "Acknowledged." AIMessages,
+        // which would push the returned length above the fallbackWindow — a getRecentMessages
+        // concern, not prepareContext's). Same convention as the selectWindow property test.
+        const msgs = Array.from({ length: 30 }, (_, i) =>
+            i % 2 === 0 ? new HumanMessage(`m${i}`) : new AIMessage(`m${i}`),
+        );
         const res = await prepareContext(baseState(msgs), { reflectorModel: fakeReflector }, 20);
         expect(res.workingMemorySection).toBe('');
         expect(res.stateUpdate).toEqual({});
@@ -975,7 +981,9 @@ describe('prepareContext', () => {
 
     it('enabled + over budget → folds evicted turns into summary + scratchpad', async () => {
         process.env.WORKING_MEMORY_TOKEN_BUDGET = '10'; // force compaction
-        const msgs = Array.from({ length: 12 }, (_, i) => new HumanMessage('X'.repeat(80) + i));
+        const msgs = Array.from({ length: 12 }, (_, i) =>
+            i % 2 === 0 ? new HumanMessage('X'.repeat(80) + i) : new AIMessage('X'.repeat(80) + i),
+        );
         const res = await prepareContext(baseState(msgs), { reflectorModel: fakeReflector }, 20);
         expect(res.workingMemorySection).toContain('## Working Memory');
         expect(res.workingMemorySection).toContain('Restarted the stuck ECS task.');

--- a/docs/superpowers/plans/2026-07-01-agent-memory-foundation-working-memory.md
+++ b/docs/superpowers/plans/2026-07-01-agent-memory-foundation-working-memory.md
@@ -255,11 +255,11 @@ Expected: both print `Generated Prisma Client`.
 
 - [ ] **Step 9: Verify the schema changes in the DB**
 
-Run (local `DATABASE_URL` is `postgresql://nucleus:...@localhost:5432/nucleus` → user `nucleus`, db `nucleus`):
+Run (local container is `nucleus-postgres`, user `nucleus`, db `nucleus`):
 ```bash
-docker compose exec -T postgres psql -U nucleus -d nucleus -c "SELECT indexname FROM pg_indexes WHERE tablename='agent_memories' AND indexname='agent_memories_embedding_hnsw';"
-docker compose exec -T postgres psql -U nucleus -d nucleus -c "SELECT count(*) AS null_kind FROM agent_memories WHERE kind IS NULL;"
-docker compose exec -T postgres psql -U nucleus -d nucleus -c "\d agent_working_memory"
+docker exec -i nucleus-postgres psql -U nucleus -d nucleus -c "SELECT indexname FROM pg_indexes WHERE tablename='agent_memories' AND indexname='agent_memories_embedding_hnsw';"
+docker exec -i nucleus-postgres psql -U nucleus -d nucleus -c "SELECT count(*) AS null_kind FROM agent_memories WHERE kind IS NULL;"
+docker exec -i nucleus-postgres psql -U nucleus -d nucleus -c "\d agent_working_memory"
 ```
 Expected: first prints `agent_memories_embedding_hnsw` (1 row); second prints `null_kind = 0`; third shows the `agent_working_memory` table with a unique index on `(tenantId, threadId)`.
 

--- a/docs/superpowers/plans/2026-07-01-agent-memory-foundation-working-memory.md
+++ b/docs/superpowers/plans/2026-07-01-agent-memory-foundation-working-memory.md
@@ -1,0 +1,1490 @@
+# Agent Memory Refactor — Phase 0 + Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the foundation of a native-TS multi-layer memory system (typed kind-discriminated schema + HNSW index + a typed `MemoryService`) and Phase 1 working memory (in-session compaction + budget-aware context assembly) so autonomous agents survive long runs.
+
+**Architecture:** Evolve the existing `AgentMemory` table with a `kind` discriminator and scaffolding columns (one table, one vector index, one retrieval path). A new `MemoryService` becomes the single typed entry point; `PostgresMemoryStore.batch()` stays as a thin delegating shim so the deep-agent's tools are untouched. Working memory lives in the checkpointed `ReflectionState` (source of truth during a run) and is mirrored to a durable `AgentWorkingMemory` table on each compaction. A pure `prepareContext()` helper replaces the naive `getRecentMessages()` slice at each agent-node call site — folding evicted turns into a running summary and assembling a budget-bounded window.
+
+**Tech Stack:** TypeScript 5, Next.js 15, Prisma (dual client: `@prisma/client@5` web-ui root + `@6` workers), PostgreSQL + pgvector (`pgvector/pgvector:pg16`), LangGraph JS, `@t3-oss/env-nextjs`, Vitest + fast-check.
+
+## Global Constraints
+
+- **Prisma dual-client:** after any `schema.prisma` change, regenerate BOTH clients — `cd apps/web-ui && bun run db:generate` AND `cd apps/workers && bun run db:generate`.
+- **Schema is the single source of truth:** `libs/prisma/schema.prisma` (shared by web-ui + workers).
+- **Multi-tenant safety:** every query scoped by `tenantId`. Use `getTenantClient(tenantId)` for ORM calls; for `$executeRaw`/`$queryRaw` (NOT intercepted by the tenant extension) add `WHERE "tenantId" = ...` manually.
+- **Embeddings:** provider-only via `getTenantEmbeddings(tenantId)`; fixed **1024-dim**; embedding failure is non-fatal (degrade to recency/text search). No Bedrock fallback.
+- **Additive migrations only:** no dropped columns; existing `agent_memories` rows must keep working.
+- **Feature-flag gating:** new behavior gated by `WORKING_MEMORY_ENABLED` (pattern: `RIGHT_SIZING_ENABLED`); when off, behavior is identical to today.
+- **Style:** 4-space indent in `lib/` service files; named exports (no default); functional code; `@/` path alias for cross-dir imports in web-ui.
+- **Deep-agent is out of scope** — do not modify `apps/web-ui/lib/deep-agent/**`.
+- **Provider-only LLM:** memory summarization uses the agent's existing `reflectorModel` — never instantiate a hardcoded model.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `libs/prisma/schema.prisma` | `MemoryKind` enum, new `AgentMemory` columns, `AgentWorkingMemory` model |
+| `libs/prisma/migrations/<ts>_agent_memory_foundation/migration.sql` | additive DDL + raw HNSW index |
+| `apps/web-ui/lib/agent/memory/types.ts` | `MemoryKind`, per-kind value unions, `MemoryHit`, `Scratchpad`, `WorkingMemory` |
+| `apps/web-ui/lib/agent/memory/memory-service.ts` | typed `recall`/`remember`/`getWorkingMemory`/`putWorkingMemory` + `getMemoryService()` singleton |
+| `apps/web-ui/lib/agent/memory/memory-service.test.ts` | unit tests for MemoryService (mocked prisma) |
+| `apps/web-ui/lib/agent/memory/working-memory.ts` | config accessors, token estimation, tool-log compression, `selectWindow`, `foldWorkingMemory`, `prepareContext` |
+| `apps/web-ui/lib/agent/memory/working-memory.test.ts` | unit + fast-check tests for working memory (mocked reflector) |
+| `apps/web-ui/env.ts` | `WORKING_MEMORY_*` env vars |
+| `apps/web-ui/lib/agent/persistence.ts` | `PostgresMemoryStore.batch()` delegates to `MemoryService` |
+| `apps/web-ui/lib/agent/memory-nodes.ts` | recall/save call `MemoryService` (typed, kind-aware) |
+| `apps/web-ui/lib/agent/agent-shared.ts` | `ReflectionState` + `graphState` gain `runningSummary`/`scratchpad` |
+| `apps/web-ui/lib/agent/fast-agent.ts` | wire `prepareContext` into `agentNode` + `finalizeNode` |
+| `apps/web-ui/lib/agent/planning-agent.ts` | wire `prepareContext` into its 3 window call sites |
+| `apps/web-ui/lib/db/repositories/agent-memory/{interface,postgres}.ts` | expose `kind` on `AgentMemoryRecord` (keeps Memory UI working, enables later filtering) |
+
+---
+
+## Interfaces (locked — every task must match these names/types)
+
+`apps/web-ui/lib/agent/memory/types.ts`:
+
+```typescript
+export type MemoryKind = 'SEMANTIC' | 'EPISODIC' | 'PROCEDURAL';
+
+export interface SemanticValue { fact: string; source: string; confidence: 'high' | 'medium'; }
+export interface EpisodicValue { context: string; reasoning: string; action: string; outcome: string; }
+export interface ProceduralValue { instruction: string; trigger: string; evidence: string; }
+
+export interface MemoryHit {
+    namespace: string;
+    key: string;
+    value: Record<string, unknown>;
+    kind: MemoryKind;
+}
+
+export interface Scratchpad {
+    openGoals: string[];
+    keyFindings: string[];
+    resourceIds: string[];
+    pendingSteps: string[];
+}
+
+export interface WorkingMemory {
+    runningSummary: string;
+    scratchpad: Scratchpad;
+    tokenCount: number;
+    turnCount: number;
+}
+```
+
+`apps/web-ui/lib/agent/memory/memory-service.ts`:
+
+```typescript
+export interface RecallParams {
+    tenantId: string;
+    userId: string;
+    query: string;
+    kinds?: MemoryKind[];
+    namespacePrefix?: string[];
+    limit?: number;
+}
+export interface RememberParams {
+    tenantId: string;
+    userId: string;
+    kind: MemoryKind;
+    namespace: string[];
+    key: string;
+    value: Record<string, unknown>;
+    sourceThreadId?: string;
+}
+export interface PutWorkingMemoryParams {
+    tenantId: string;
+    threadId: string;
+    wm: WorkingMemory;
+}
+// methods: recall(RecallParams) => Promise<MemoryHit[]>
+//          remember(RememberParams) => Promise<void>
+//          getWorkingMemory(tenantId, threadId) => Promise<WorkingMemory | null>
+//          putWorkingMemory(PutWorkingMemoryParams) => Promise<void>
+export function getMemoryService(): MemoryService;
+```
+
+`apps/web-ui/lib/agent/memory/working-memory.ts`:
+
+```typescript
+export function workingMemoryEnabled(): boolean;
+export function tokenBudget(): number;      // WORKING_MEMORY_TOKEN_BUDGET, default 60000
+export function keepRecent(): number;        // WORKING_MEMORY_KEEP_RECENT, default 8
+export function estimateTokens(text: string): number;                 // ceil(len/4)
+export function estimateMessagesTokens(messages: BaseMessage[]): number;
+export function compressToolOutput(content: string, maxChars?: number): string;  // head+tail
+export function emptyScratchpad(): Scratchpad;
+export function selectWindow(messages: BaseMessage[], budget: number, keep: number): BaseMessage[];
+export function buildWorkingMemorySection(wm: WorkingMemory | null): string; // '' or "## Working Memory\n..."
+
+export interface PrepareContextDeps {
+    reflectorModel: BaseChatModel;
+    tenantId?: string;
+    threadId?: string;
+}
+export interface PreparedContext {
+    windowMessages: BaseMessage[];
+    workingMemorySection: string;
+    stateUpdate: Partial<Pick<ReflectionState, 'runningSummary' | 'scratchpad'>>;
+}
+export async function prepareContext(
+    state: ReflectionState,
+    deps: PrepareContextDeps,
+    fallbackWindow: number,
+): Promise<PreparedContext>;
+```
+
+`ReflectionState` gains (in `agent-shared.ts`): `runningSummary: string;` and `scratchpad: Scratchpad;`.
+
+---
+
+## Task 1: Schema + migration (Phase 0-A, 0-B)
+
+**Files:**
+- Modify: `libs/prisma/schema.prisma:498-514` (AgentMemory) + add `MemoryKind` enum + `AgentWorkingMemory` model
+- Create: `libs/prisma/migrations/<timestamp>_agent_memory_foundation/migration.sql`
+
+**Interfaces:**
+- Produces: DB columns `agent_memories.kind|sourceThreadId|supersededById|supersededAt|lastAccessedAt|accessCount`; table `agent_working_memory`; HNSW index `agent_memories_embedding_hnsw`. Prisma models `AgentMemory` (extended) + `AgentWorkingMemory` + enum `MemoryKind`.
+
+- [ ] **Step 1: Start Postgres (if not running)**
+
+Run: `cd /Users/kartik/.superset/worktrees/nucleus-cloud-ops/agent-memory && docker compose up -d postgres`
+Expected: container `postgres` is `Up`/healthy.
+
+- [ ] **Step 2: Edit the schema — add the enum**
+
+In `libs/prisma/schema.prisma`, directly above `model AgentMemory {` (line ~498), add:
+
+```prisma
+enum MemoryKind {
+  SEMANTIC
+  EPISODIC
+  PROCEDURAL
+}
+```
+
+- [ ] **Step 3: Edit the schema — extend `AgentMemory`**
+
+Replace the `AgentMemory` model body with (additive fields + index; existing fields unchanged):
+
+```prisma
+model AgentMemory {
+  id             String                       @id @default(cuid())
+  tenantId       String
+  userId         String
+  namespace      String
+  key            String
+  value          Json
+  kind           MemoryKind                   @default(SEMANTIC)
+  embedding      Unsupported("vector(1024)")?
+  sourceThreadId String?
+  supersededById String?
+  supersededAt   DateTime?
+  lastAccessedAt DateTime?
+  accessCount    Int                          @default(0)
+  createdAt      DateTime                     @default(now())
+  updatedAt      DateTime                     @updatedAt
+  expiresAt      DateTime // 90-day TTL
+
+  @@unique([tenantId, namespace, key])
+  @@index([tenantId, userId])
+  @@index([tenantId, kind])
+  @@index([expiresAt])
+  @@map("agent_memories")
+}
+```
+
+- [ ] **Step 4: Edit the schema — add `AgentWorkingMemory`**
+
+Immediately after the `AgentMemory` model, add:
+
+```prisma
+// AgentWorkingMemory — per-thread in-session scratchpad + rolling summary (Phase 1).
+// Live source of truth is the LangGraph checkpoint; this table is a durable mirror
+// written on each compaction. No embedding (this is live context, not searched).
+model AgentWorkingMemory {
+  id             String   @id @default(cuid())
+  tenantId       String
+  threadId       String
+  runningSummary String   @db.Text
+  scratchpad     Json
+  tokenCount     Int      @default(0)
+  turnCount      Int      @default(0)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+  expiresAt      DateTime
+
+  @@unique([tenantId, threadId])
+  @@index([expiresAt])
+  @@map("agent_working_memory")
+}
+```
+
+- [ ] **Step 5: Generate the migration SQL (do NOT apply yet)**
+
+Run: `cd apps/web-ui && bunx prisma migrate dev --create-only --name agent_memory_foundation --schema ../../libs/prisma/schema.prisma`
+Expected: a new folder `libs/prisma/migrations/<timestamp>_agent_memory_foundation/migration.sql` is created; nothing applied to the DB yet.
+
+- [ ] **Step 6: Append the raw HNSW index to the generated migration**
+
+Open the generated `migration.sql` and append at the very end (Prisma cannot emit an index on an `Unsupported` column):
+
+```sql
+-- pgvector HNSW index for cosine similarity (matches the <=> queries in persistence.ts)
+CREATE INDEX IF NOT EXISTS "agent_memories_embedding_hnsw"
+  ON "agent_memories" USING hnsw ("embedding" vector_cosine_ops);
+```
+
+(Note: the `kind` column is added with `DEFAULT 'SEMANTIC'`, so existing rows backfill automatically — no manual `UPDATE` needed.)
+
+- [ ] **Step 7: Apply the migration**
+
+Run: `cd apps/web-ui && bunx prisma migrate dev --schema ../../libs/prisma/schema.prisma`
+Expected: `The following migration(s) have been applied` including `agent_memory_foundation`; ends `Your database is now in sync with your schema.`
+
+- [ ] **Step 8: Regenerate BOTH Prisma clients**
+
+Run: `cd apps/web-ui && bun run db:generate && cd ../workers && bun run db:generate`
+Expected: both print `Generated Prisma Client`.
+
+- [ ] **Step 9: Verify the schema changes in the DB**
+
+Run:
+```bash
+docker compose exec -T postgres psql -U postgres -d nucleus -c "SELECT indexname FROM pg_indexes WHERE tablename='agent_memories' AND indexname='agent_memories_embedding_hnsw';"
+docker compose exec -T postgres psql -U postgres -d nucleus -c "SELECT count(*) AS null_kind FROM agent_memories WHERE kind IS NULL;"
+docker compose exec -T postgres psql -U postgres -d nucleus -c "\d agent_working_memory"
+```
+Expected: first prints `agent_memories_embedding_hnsw` (1 row); second prints `null_kind = 0`; third shows the `agent_working_memory` table with a unique index on `(tenantId, threadId)`.
+
+> If the DB/user/name differs locally, read the credentials from the root `.env` `DATABASE_URL` and substitute `-U`/`-d` accordingly.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add libs/prisma/schema.prisma libs/prisma/migrations/
+git commit -m "feat(memory): schema foundation — MemoryKind, scaffolding columns, working-memory table, HNSW index"
+```
+
+---
+
+## Task 2: Memory types (Phase 0-C)
+
+**Files:**
+- Create: `apps/web-ui/lib/agent/memory/types.ts`
+
+**Interfaces:**
+- Produces: `MemoryKind`, `SemanticValue`, `EpisodicValue`, `ProceduralValue`, `MemoryHit`, `Scratchpad`, `WorkingMemory` (exact shapes in the "Interfaces" section above).
+
+- [ ] **Step 1: Write the file**
+
+Create `apps/web-ui/lib/agent/memory/types.ts` with exactly the contents of the `types.ts` block in the "Interfaces" section above.
+
+- [ ] **Step 2: Verify it typechecks**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep "memory/types.ts" || echo "no errors in types.ts"`
+Expected: `no errors in types.ts`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web-ui/lib/agent/memory/types.ts
+git commit -m "feat(memory): typed value unions and working-memory types"
+```
+
+---
+
+## Task 3: MemoryService (Phase 0-C)
+
+**Files:**
+- Create: `apps/web-ui/lib/agent/memory/memory-service.ts`
+- Create: `apps/web-ui/lib/agent/memory/memory-service.test.ts`
+
+**Interfaces:**
+- Consumes: `types.ts` (Task 2); `getPrismaClient` from `@/lib/db/pg-config`; `getTenantEmbeddings` from `../embeddings-factory`.
+- Produces: `MemoryService` class, `getMemoryService()` singleton, `RecallParams`, `RememberParams`, `PutWorkingMemoryParams` (signatures in "Interfaces" section).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web-ui/lib/agent/memory/memory-service.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the prisma client + embeddings BEFORE importing the service.
+const mockExecuteRaw = vi.fn().mockResolvedValue(1);
+const mockQueryRaw = vi.fn().mockResolvedValue([]);
+const mockUpsert = vi.fn().mockResolvedValue({});
+const mockFindUnique = vi.fn().mockResolvedValue(null);
+
+vi.mock('@/lib/db/pg-config', () => ({
+    getPrismaClient: () => ({
+        $executeRaw: mockExecuteRaw,
+        $queryRaw: mockQueryRaw,
+        agentMemory: { upsert: mockUpsert },
+        agentWorkingMemory: { upsert: mockUpsert, findUnique: mockFindUnique },
+    }),
+}));
+
+vi.mock('../embeddings-factory', () => ({
+    getTenantEmbeddings: vi.fn().mockResolvedValue({
+        embedQuery: vi.fn().mockResolvedValue(new Array(1024).fill(0.1)),
+    }),
+}));
+
+import { getMemoryService } from './memory-service';
+
+describe('MemoryService.recall', () => {
+    beforeEach(() => {
+        mockQueryRaw.mockClear();
+        mockQueryRaw.mockResolvedValue([
+            { namespace: 'infra/123', key: 'region', value: { fact: 'us-east-1' }, kind: 'SEMANTIC' },
+        ]);
+    });
+
+    it('returns typed MemoryHit[] and filters by kind', async () => {
+        const svc = getMemoryService();
+        const hits = await svc.recall({
+            tenantId: 't1', userId: 'u1', query: 'where is prod', kinds: ['SEMANTIC'], limit: 5,
+        });
+        expect(hits).toHaveLength(1);
+        expect(hits[0]).toMatchObject({ namespace: 'infra/123', key: 'region', kind: 'SEMANTIC' });
+        // vector search path was used (embedding available)
+        expect(mockQueryRaw).toHaveBeenCalled();
+    });
+});
+
+describe('MemoryService.remember', () => {
+    it('upserts with an embedding vector', async () => {
+        mockExecuteRaw.mockClear();
+        const svc = getMemoryService();
+        await svc.remember({
+            tenantId: 't1', userId: 'u1', kind: 'SEMANTIC',
+            namespace: ['infra', '123'], key: 'region',
+            value: { fact: 'us-east-1', source: 'cli', confidence: 'high' },
+        });
+        expect(mockExecuteRaw).toHaveBeenCalledTimes(1);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/memory/memory-service.test.ts`
+Expected: FAIL — `Cannot find module './memory-service'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `apps/web-ui/lib/agent/memory/memory-service.ts`:
+
+```typescript
+import type { Embeddings } from '@langchain/core/embeddings';
+import { getPrismaClient } from '@/lib/db/pg-config';
+import { getTenantEmbeddings } from '../embeddings-factory';
+import type { MemoryHit, MemoryKind, WorkingMemory, Scratchpad } from './types';
+
+export interface RecallParams {
+    tenantId: string;
+    userId: string;
+    query: string;
+    kinds?: MemoryKind[];
+    namespacePrefix?: string[];
+    limit?: number;
+}
+export interface RememberParams {
+    tenantId: string;
+    userId: string;
+    kind: MemoryKind;
+    namespace: string[];
+    key: string;
+    value: Record<string, unknown>;
+    sourceThreadId?: string;
+}
+export interface PutWorkingMemoryParams {
+    tenantId: string;
+    threadId: string;
+    wm: WorkingMemory;
+}
+
+const TTL_MS = 90 * 24 * 60 * 60 * 1000; // 90 days, matches existing memory TTL
+
+export class MemoryService {
+    private embeddingsCache = new Map<string, Promise<Embeddings>>();
+
+    private getEmbeddings(tenantId: string): Promise<Embeddings> {
+        let cached = this.embeddingsCache.get(tenantId);
+        if (!cached) {
+            cached = getTenantEmbeddings(tenantId);
+            cached.catch(() => this.embeddingsCache.delete(tenantId));
+            this.embeddingsCache.set(tenantId, cached);
+        }
+        return cached;
+    }
+
+    async remember(m: RememberParams): Promise<void> {
+        const prisma = getPrismaClient();
+        const namespace = m.namespace.join('/');
+        const expiresAt = new Date(Date.now() + TTL_MS);
+
+        let vec: number[] | null = null;
+        try {
+            const emb = await this.getEmbeddings(m.tenantId);
+            vec = await emb.embedQuery(JSON.stringify(m.value));
+        } catch {
+            // provider missing / embedding failure is non-fatal
+        }
+
+        if (vec) {
+            const vecStr = `[${vec.join(',')}]`;
+            // $executeRaw is NOT tenant-intercepted — tenantId is bound explicitly.
+            await prisma.$executeRaw`
+                INSERT INTO agent_memories ("id","tenantId","userId","namespace","key","value","kind","embedding","sourceThreadId","createdAt","updatedAt","expiresAt")
+                VALUES (gen_random_uuid()::text, ${m.tenantId}, ${m.userId}, ${namespace}, ${m.key}, ${JSON.stringify(m.value)}::jsonb, ${m.kind}::"MemoryKind", ${vecStr}::vector, ${m.sourceThreadId ?? null}, NOW(), NOW(), ${expiresAt})
+                ON CONFLICT ("tenantId","namespace","key") DO UPDATE
+                SET "value" = EXCLUDED."value", "kind" = EXCLUDED."kind", "embedding" = EXCLUDED."embedding", "updatedAt" = NOW(), "expiresAt" = EXCLUDED."expiresAt"
+            `;
+        } else {
+            await prisma.agentMemory.upsert({
+                where: { tenantId_namespace_key: { tenantId: m.tenantId, namespace, key: m.key } },
+                create: { tenantId: m.tenantId, userId: m.userId, namespace, key: m.key, value: m.value, kind: m.kind, sourceThreadId: m.sourceThreadId ?? null, expiresAt },
+                update: { value: m.value, kind: m.kind, expiresAt, updatedAt: new Date() },
+            });
+        }
+    }
+
+    async recall(p: RecallParams): Promise<MemoryHit[]> {
+        const prisma = getPrismaClient();
+        const limit = p.limit ?? 5;
+        const nsPrefix = (p.namespacePrefix ?? []).join('/');
+        const kinds = p.kinds ?? [];
+
+        let queryVec: number[] | null = null;
+        try {
+            const emb = await this.getEmbeddings(p.tenantId);
+            queryVec = await emb.embedQuery(p.query);
+        } catch {
+            // fall through to recency search
+        }
+
+        // Build the kind filter as a parameter list; empty => all kinds.
+        const kindList = kinds.length ? kinds : null;
+
+        let rows: Array<{ namespace: string; key: string; value: unknown; kind: MemoryKind }>;
+        if (queryVec) {
+            const vecStr = `[${queryVec.join(',')}]`;
+            rows = await prisma.$queryRaw<Array<{ namespace: string; key: string; value: unknown; kind: MemoryKind }>>`
+                SELECT "namespace","key","value","kind"
+                FROM agent_memories
+                WHERE "tenantId" = ${p.tenantId}
+                  AND "supersededById" IS NULL
+                  AND (${nsPrefix} = '' OR "namespace" LIKE ${nsPrefix + '%'})
+                  AND (${kindList}::text[] IS NULL OR "kind"::text = ANY(${kindList}::text[]))
+                ORDER BY embedding <=> ${vecStr}::vector
+                LIMIT ${limit}
+            `;
+        } else {
+            rows = await prisma.$queryRaw<Array<{ namespace: string; key: string; value: unknown; kind: MemoryKind }>>`
+                SELECT "namespace","key","value","kind"
+                FROM agent_memories
+                WHERE "tenantId" = ${p.tenantId}
+                  AND "supersededById" IS NULL
+                  AND (${nsPrefix} = '' OR "namespace" LIKE ${nsPrefix + '%'})
+                  AND (${kindList}::text[] IS NULL OR "kind"::text = ANY(${kindList}::text[]))
+                ORDER BY "createdAt" DESC
+                LIMIT ${limit}
+            `;
+        }
+
+        // Reinforcement signal — best-effort, non-blocking.
+        const keys = rows.map((r) => r.key);
+        if (keys.length) {
+            prisma.$executeRaw`
+                UPDATE agent_memories SET "lastAccessedAt" = NOW(), "accessCount" = "accessCount" + 1
+                WHERE "tenantId" = ${p.tenantId} AND "key" = ANY(${keys}::text[])
+            `.catch(() => {});
+        }
+
+        return rows.map((r) => ({
+            namespace: r.namespace,
+            key: r.key,
+            value: (r.value ?? {}) as Record<string, unknown>,
+            kind: r.kind,
+        }));
+    }
+
+    async getWorkingMemory(tenantId: string, threadId: string): Promise<WorkingMemory | null> {
+        const prisma = getPrismaClient();
+        const row = await prisma.agentWorkingMemory.findUnique({
+            where: { tenantId_threadId: { tenantId, threadId } },
+        });
+        if (!row) return null;
+        return {
+            runningSummary: row.runningSummary,
+            scratchpad: (row.scratchpad ?? {}) as unknown as Scratchpad,
+            tokenCount: row.tokenCount,
+            turnCount: row.turnCount,
+        };
+    }
+
+    async putWorkingMemory(p: PutWorkingMemoryParams): Promise<void> {
+        const prisma = getPrismaClient();
+        const expiresAt = new Date(Date.now() + TTL_MS);
+        await prisma.agentWorkingMemory.upsert({
+            where: { tenantId_threadId: { tenantId: p.tenantId, threadId: p.threadId } },
+            create: {
+                tenantId: p.tenantId, threadId: p.threadId,
+                runningSummary: p.wm.runningSummary,
+                scratchpad: p.wm.scratchpad as unknown as object,
+                tokenCount: p.wm.tokenCount, turnCount: p.wm.turnCount, expiresAt,
+            },
+            update: {
+                runningSummary: p.wm.runningSummary,
+                scratchpad: p.wm.scratchpad as unknown as object,
+                tokenCount: p.wm.tokenCount, turnCount: p.wm.turnCount,
+                expiresAt, updatedAt: new Date(),
+            },
+        });
+    }
+}
+
+let _service: MemoryService | undefined;
+export function getMemoryService(): MemoryService {
+    if (!_service) _service = new MemoryService();
+    return _service;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/memory/memory-service.test.ts`
+Expected: PASS (both `recall` and `remember` tests green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web-ui/lib/agent/memory/memory-service.ts apps/web-ui/lib/agent/memory/memory-service.test.ts
+git commit -m "feat(memory): typed MemoryService (recall/remember + working-memory get/put)"
+```
+
+---
+
+## Task 4: Config + env vars (Phase 1-G)
+
+**Files:**
+- Modify: `apps/web-ui/env.ts:82-88` (feature-flags block)
+- Create: `apps/web-ui/lib/agent/memory/working-memory.ts` (config accessors only — grows in Task 5)
+- Create: `apps/web-ui/lib/agent/memory/working-memory.test.ts`
+
+**Interfaces:**
+- Produces: `workingMemoryEnabled()`, `tokenBudget()`, `keepRecent()`.
+
+- [ ] **Step 1: Add env vars**
+
+In `apps/web-ui/env.ts`, inside the `server:` object's "Feature flags / misc" block (after `RIGHT_SIZING_ENABLED` at line ~83), add:
+
+```typescript
+        WORKING_MEMORY_ENABLED: z.string().optional(),
+        WORKING_MEMORY_TOKEN_BUDGET: z.string().optional(),
+        WORKING_MEMORY_KEEP_RECENT: z.string().optional(),
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `apps/web-ui/lib/agent/memory/working-memory.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { workingMemoryEnabled, tokenBudget, keepRecent } from './working-memory';
+
+describe('working-memory config', () => {
+    const saved = { ...process.env };
+    afterEach(() => { process.env = { ...saved }; });
+
+    it('defaults: enabled=true, budget=60000, keep=8', () => {
+        delete process.env.WORKING_MEMORY_ENABLED;
+        delete process.env.WORKING_MEMORY_TOKEN_BUDGET;
+        delete process.env.WORKING_MEMORY_KEEP_RECENT;
+        expect(workingMemoryEnabled()).toBe(true);
+        expect(tokenBudget()).toBe(60000);
+        expect(keepRecent()).toBe(8);
+    });
+
+    it('WORKING_MEMORY_ENABLED=false disables', () => {
+        process.env.WORKING_MEMORY_ENABLED = 'false';
+        expect(workingMemoryEnabled()).toBe(false);
+    });
+
+    it('reads numeric overrides', () => {
+        process.env.WORKING_MEMORY_TOKEN_BUDGET = '30000';
+        process.env.WORKING_MEMORY_KEEP_RECENT = '4';
+        expect(tokenBudget()).toBe(30000);
+        expect(keepRecent()).toBe(4);
+    });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/memory/working-memory.test.ts`
+Expected: FAIL — `Cannot find module './working-memory'`.
+
+- [ ] **Step 4: Write the config accessors**
+
+Create `apps/web-ui/lib/agent/memory/working-memory.ts`:
+
+```typescript
+// Working-memory configuration. Read process.env directly (not the typed `env`
+// object) so Vitest can mutate values per-test — env.ts skips validation under
+// NODE_ENV==='test' but caches at import time.
+export function workingMemoryEnabled(): boolean {
+    const v = process.env.WORKING_MEMORY_ENABLED?.toLowerCase();
+    return !(v === 'false' || v === '0');
+}
+
+export function tokenBudget(): number {
+    const n = Number(process.env.WORKING_MEMORY_TOKEN_BUDGET);
+    return Number.isFinite(n) && n > 0 ? n : 60000;
+}
+
+export function keepRecent(): number {
+    const n = Number(process.env.WORKING_MEMORY_KEEP_RECENT);
+    return Number.isFinite(n) && n > 0 ? n : 8;
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/memory/working-memory.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web-ui/env.ts apps/web-ui/lib/agent/memory/working-memory.ts apps/web-ui/lib/agent/memory/working-memory.test.ts
+git commit -m "feat(memory): working-memory feature flags + config accessors"
+```
+
+---
+
+## Task 5: Working-memory core — estimation, compression, windowing (Phase 1-D/E)
+
+**Files:**
+- Modify: `apps/web-ui/lib/agent/memory/working-memory.ts` (add estimation/compression/windowing/section)
+- Modify: `apps/web-ui/lib/agent/memory/working-memory.test.ts` (add tests incl. fast-check)
+
+**Interfaces:**
+- Consumes: `types.ts` (Task 2); `BaseMessage` from `@langchain/core/messages`; `getRecentMessages` from `../agent-shared`.
+- Produces: `estimateTokens`, `estimateMessagesTokens`, `compressToolOutput`, `emptyScratchpad`, `selectWindow`, `buildWorkingMemorySection`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `apps/web-ui/lib/agent/memory/working-memory.test.ts`:
+
+```typescript
+import { HumanMessage, AIMessage } from '@langchain/core/messages';
+import fc from 'fast-check';
+import {
+    estimateTokens, estimateMessagesTokens, compressToolOutput,
+    selectWindow, buildWorkingMemorySection, emptyScratchpad,
+} from './working-memory';
+
+describe('estimateTokens', () => {
+    it('is ceil(len/4)', () => {
+        expect(estimateTokens('12345678')).toBe(2);
+        expect(estimateTokens('123')).toBe(1);
+        expect(estimateTokens('')).toBe(0);
+    });
+});
+
+describe('compressToolOutput', () => {
+    it('keeps head+tail with an elision marker when over the cap', () => {
+        const big = 'A'.repeat(500) + 'B'.repeat(500);
+        const out = compressToolOutput(big, 200);
+        expect(out.length).toBeLessThan(big.length);
+        expect(out).toContain('elided');
+        expect(out.startsWith('A')).toBe(true);
+        expect(out.endsWith('B')).toBe(true);
+    });
+    it('returns short content unchanged', () => {
+        expect(compressToolOutput('short', 200)).toBe('short');
+    });
+});
+
+describe('selectWindow', () => {
+    it('always keeps at least the last `keep` messages', () => {
+        const msgs = Array.from({ length: 20 }, (_, i) => new HumanMessage(`m${i}`));
+        const win = selectWindow(msgs, 1, 5); // tiny budget
+        expect(win.length).toBeGreaterThanOrEqual(5);
+    });
+
+    it('property: window token estimate stays near budget for large budgets', () => {
+        fc.assert(fc.property(
+            fc.array(fc.string({ minLength: 1, maxLength: 400 }), { minLength: 1, maxLength: 60 }),
+            (contents) => {
+                const msgs = contents.map((c) => new HumanMessage(c));
+                const budget = 10000;
+                const win = selectWindow(msgs, budget, 4);
+                // Never returns more messages than input; keeps recency ordering.
+                expect(win.length).toBeLessThanOrEqual(msgs.length);
+            },
+        ));
+    });
+});
+
+describe('buildWorkingMemorySection', () => {
+    it('returns empty string for null WM', () => {
+        expect(buildWorkingMemorySection(null)).toBe('');
+    });
+    it('renders summary + scratchpad goals', () => {
+        const sec = buildWorkingMemorySection({
+            runningSummary: 'Investigated ECS.',
+            scratchpad: { ...emptyScratchpad(), openGoals: ['restart task'], resourceIds: ['cluster-1'] },
+            tokenCount: 100, turnCount: 3,
+        });
+        expect(sec).toContain('## Working Memory');
+        expect(sec).toContain('Investigated ECS.');
+        expect(sec).toContain('restart task');
+        expect(sec).toContain('cluster-1');
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/memory/working-memory.test.ts`
+Expected: FAIL — the new named exports do not exist yet.
+
+- [ ] **Step 3: Implement the functions**
+
+Append to `apps/web-ui/lib/agent/memory/working-memory.ts` (add imports at top):
+
+```typescript
+import type { BaseMessage } from '@langchain/core/messages';
+import { getRecentMessages } from '../agent-shared';
+import type { Scratchpad, WorkingMemory } from './types';
+
+export function emptyScratchpad(): Scratchpad {
+    return { openGoals: [], keyFindings: [], resourceIds: [], pendingSteps: [] };
+}
+
+export function estimateTokens(text: string): number {
+    return Math.ceil(text.length / 4);
+}
+
+function messageText(m: BaseMessage): string {
+    return typeof m.content === 'string' ? m.content : JSON.stringify(m.content);
+}
+
+export function estimateMessagesTokens(messages: BaseMessage[]): number {
+    return messages.reduce((sum, m) => sum + estimateTokens(messageText(m)), 0);
+}
+
+export function compressToolOutput(content: string, maxChars = 2000): string {
+    if (content.length <= maxChars) return content;
+    const half = Math.floor(maxChars / 2);
+    const head = content.slice(0, half);
+    const tail = content.slice(content.length - half);
+    return `${head}\n… [${content.length - maxChars} chars elided] …\n${tail}`;
+}
+
+// Pick the most-recent messages that fit `budget` tokens, always keeping at least
+// `keep` of them, then run getRecentMessages() to preserve tool_call/tool_result
+// pairing and drop empties (Bedrock adjacency rules).
+export function selectWindow(messages: BaseMessage[], budget: number, keep: number): BaseMessage[] {
+    if (messages.length === 0) return [];
+    let count = Math.min(keep, messages.length);
+    let used = estimateMessagesTokens(messages.slice(messages.length - count));
+    for (let i = messages.length - count - 1; i >= 0; i--) {
+        const t = estimateTokens(messageText(messages[i]));
+        if (used + t > budget) break;
+        used += t;
+        count++;
+    }
+    const slice = messages.slice(messages.length - count);
+    return getRecentMessages(slice, slice.length);
+}
+
+export function buildWorkingMemorySection(wm: WorkingMemory | null): string {
+    if (!wm) return '';
+    const s = wm.scratchpad ?? emptyScratchpad();
+    const list = (label: string, items: string[]) =>
+        items && items.length ? `\n**${label}:**\n${items.map((i) => `- ${i}`).join('\n')}` : '';
+    const body = [
+        wm.runningSummary ? `\n${wm.runningSummary}` : '',
+        list('Open goals', s.openGoals),
+        list('Key findings', s.keyFindings),
+        list('Resource IDs', s.resourceIds),
+        list('Pending steps', s.pendingSteps),
+    ].join('');
+    if (!body.trim()) return '';
+    return `\n## Working Memory\nA compacted record of this long-running session so far:${body}\n`;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/memory/working-memory.test.ts`
+Expected: PASS (all config + core tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web-ui/lib/agent/memory/working-memory.ts apps/web-ui/lib/agent/memory/working-memory.test.ts
+git commit -m "feat(memory): token estimation, tool-log compression, budget windowing, WM section"
+```
+
+---
+
+## Task 6: `ReflectionState` + graph channels (Phase 1-F)
+
+**Files:**
+- Modify: `apps/web-ui/lib/agent/agent-shared.ts:63-76` (ReflectionState) and `:79-133` (graphState channels)
+
+**Interfaces:**
+- Consumes: `Scratchpad` from `./memory/types`.
+- Produces: `ReflectionState.runningSummary: string`, `ReflectionState.scratchpad: Scratchpad`; matching channels.
+
+- [ ] **Step 1: Import the Scratchpad type**
+
+At the top of `apps/web-ui/lib/agent/agent-shared.ts`, add:
+
+```typescript
+import type { Scratchpad } from "./memory/types";
+```
+
+- [ ] **Step 2: Extend `ReflectionState`**
+
+In the `ReflectionState` interface (ends at line ~76), add two fields after `memoryContext: string;`:
+
+```typescript
+    runningSummary: string; // Phase 1: rolling summary of compacted turns
+    scratchpad: Scratchpad; // Phase 1: structured working-memory scratchpad
+```
+
+- [ ] **Step 3: Add channel reducers**
+
+In `graphState` (after the `memoryContext` channel, before the closing `};` at line ~133), add:
+
+```typescript
+    runningSummary: {
+        reducer: (x: string, y: string) => y || x,
+        default: () => "",
+    },
+    scratchpad: {
+        reducer: (x: Scratchpad, y: Scratchpad) => y || x,
+        default: () => ({ openGoals: [], keyFindings: [], resourceIds: [], pendingSteps: [] }),
+    },
+```
+
+- [ ] **Step 4: Verify typecheck (agent-shared has no isolated unit test)**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep "agent-shared.ts" || echo "no errors in agent-shared.ts"`
+Expected: `no errors in agent-shared.ts`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web-ui/lib/agent/agent-shared.ts
+git commit -m "feat(memory): add runningSummary + scratchpad to agent state"
+```
+
+---
+
+## Task 7: `prepareContext` — compaction orchestrator (Phase 1-D/E/F)
+
+**Files:**
+- Modify: `apps/web-ui/lib/agent/memory/working-memory.ts` (add `foldWorkingMemory` + `prepareContext`)
+- Modify: `apps/web-ui/lib/agent/memory/working-memory.test.ts` (add orchestrator tests)
+
+**Interfaces:**
+- Consumes: `ReflectionState` from `../agent-shared` (Task 6); `getMemoryService` from `./memory-service` (Task 3); `BaseChatModel` from `@langchain/core/language_models/chat_models`; `SystemMessage`/`HumanMessage`.
+- Produces: `PrepareContextDeps`, `PreparedContext`, `prepareContext(state, deps, fallbackWindow)`, `foldWorkingMemory(prev, evicted, reflectorModel)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `apps/web-ui/lib/agent/memory/working-memory.test.ts`:
+
+```typescript
+import { prepareContext, foldWorkingMemory } from './working-memory';
+import type { ReflectionState } from '../agent-shared';
+
+function baseState(messages: any[]): ReflectionState {
+    return {
+        messages, taskDescription: 't', plan: [], code: '', executionOutput: '',
+        errors: [], reflection: '', iterationCount: 0, nextAction: 'plan',
+        isComplete: false, toolResults: [], memoryContext: '',
+        runningSummary: '', scratchpad: { openGoals: [], keyFindings: [], resourceIds: [], pendingSteps: [] },
+    };
+}
+
+const fakeReflector = {
+    invoke: async () => ({
+        content: JSON.stringify({
+            summary: 'Restarted the stuck ECS task.',
+            scratchpad: { openGoals: ['verify health'], keyFindings: ['task was OOM'], resourceIds: ['svc-1'], pendingSteps: [] },
+        }),
+    }),
+} as any;
+
+describe('prepareContext', () => {
+    afterEach(() => { delete process.env.WORKING_MEMORY_ENABLED; delete process.env.WORKING_MEMORY_TOKEN_BUDGET; });
+
+    it('disabled → falls back to getRecentMessages(fallbackWindow), no WM section, no LLM call', async () => {
+        process.env.WORKING_MEMORY_ENABLED = 'false';
+        const msgs = Array.from({ length: 30 }, (_, i) => new HumanMessage(`m${i}`));
+        const res = await prepareContext(baseState(msgs), { reflectorModel: fakeReflector }, 20);
+        expect(res.workingMemorySection).toBe('');
+        expect(res.stateUpdate).toEqual({});
+        expect(res.windowMessages.length).toBeLessThanOrEqual(20);
+    });
+
+    it('enabled + under budget → no compaction, no LLM call, empty stateUpdate', async () => {
+        process.env.WORKING_MEMORY_TOKEN_BUDGET = '100000';
+        const msgs = [new HumanMessage('hi'), new AIMessage('hello')];
+        const res = await prepareContext(baseState(msgs), { reflectorModel: fakeReflector }, 20);
+        expect(res.stateUpdate).toEqual({});
+        expect(res.windowMessages.length).toBe(2);
+    });
+
+    it('enabled + over budget → folds evicted turns into summary + scratchpad', async () => {
+        process.env.WORKING_MEMORY_TOKEN_BUDGET = '10'; // force compaction
+        const msgs = Array.from({ length: 12 }, (_, i) => new HumanMessage('X'.repeat(80) + i));
+        const res = await prepareContext(baseState(msgs), { reflectorModel: fakeReflector }, 20);
+        expect(res.workingMemorySection).toContain('## Working Memory');
+        expect(res.workingMemorySection).toContain('Restarted the stuck ECS task.');
+        expect(res.stateUpdate.runningSummary).toContain('Restarted');
+        expect(res.stateUpdate.scratchpad?.openGoals).toContain('verify health');
+    });
+});
+
+describe('foldWorkingMemory monotonicity', () => {
+    it('never drops a pre-existing open goal', async () => {
+        const prev = {
+            runningSummary: 'prior', tokenCount: 0, turnCount: 1,
+            scratchpad: { openGoals: ['KEEP ME'], keyFindings: [], resourceIds: [], pendingSteps: [] },
+        };
+        const next = await foldWorkingMemory(prev, [new HumanMessage('did stuff')], fakeReflector);
+        expect(next.scratchpad.openGoals).toContain('KEEP ME');   // merged, not replaced
+        expect(next.scratchpad.openGoals).toContain('verify health'); // plus the new one
+        expect(next.turnCount).toBe(2);
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/memory/working-memory.test.ts`
+Expected: FAIL — `prepareContext`/`foldWorkingMemory` not exported.
+
+- [ ] **Step 3: Implement `foldWorkingMemory` + `prepareContext`**
+
+Append to `apps/web-ui/lib/agent/memory/working-memory.ts` (add imports at top):
+
+```typescript
+import { SystemMessage, HumanMessage } from "@langchain/core/messages";
+import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
+import type { ReflectionState } from "../agent-shared";
+import { getMemoryService } from "./memory-service";
+
+function uniq(a: string[]): string[] { return Array.from(new Set(a.filter(Boolean))); }
+
+function mergeScratchpad(prev: Scratchpad, next: Partial<Scratchpad>): Scratchpad {
+    return {
+        openGoals: uniq([...(prev.openGoals ?? []), ...(next.openGoals ?? [])]),
+        keyFindings: uniq([...(prev.keyFindings ?? []), ...(next.keyFindings ?? [])]),
+        resourceIds: uniq([...(prev.resourceIds ?? []), ...(next.resourceIds ?? [])]),
+        pendingSteps: uniq([...(prev.pendingSteps ?? []), ...(next.pendingSteps ?? [])]),
+    };
+}
+
+// Fold evicted turns into the running summary + scratchpad using the reflector
+// model. Monotonicity (never lose a recorded goal/finding) is enforced in code by
+// MERGING the LLM output with the prior scratchpad — we do not trust the LLM to
+// carry everything forward.
+export async function foldWorkingMemory(
+    prev: WorkingMemory,
+    evicted: BaseMessage[],
+    reflectorModel: BaseChatModel,
+): Promise<WorkingMemory> {
+    const transcript = evicted
+        .map((m) => `[${m._getType()}] ${compressToolOutput(messageText(m), 1200)}`)
+        .join('\n\n');
+
+    const sys = new SystemMessage(
+        `You compress a long-running agent session into durable working memory. ` +
+        `Given the prior summary/scratchpad and newly-evicted turns, return ONLY a JSON object:\n` +
+        `{"summary": string, "scratchpad": {"openGoals": string[], "keyFindings": string[], "resourceIds": string[], "pendingSteps": string[]}}\n` +
+        `- summary: a concise cumulative narrative (fold the new turns into the prior summary).\n` +
+        `- scratchpad: only NEW items discovered in the evicted turns (prior items are preserved automatically).\n` +
+        `Never fabricate. Return the JSON object and nothing else.`,
+    );
+    const input = new HumanMessage(
+        `**Prior summary:**\n${prev.runningSummary || '(none)'}\n\n` +
+        `**Prior open goals:** ${JSON.stringify(prev.scratchpad?.openGoals ?? [])}\n\n` +
+        `**Newly evicted turns:**\n${compressToolOutput(transcript, 8000)}`,
+    );
+
+    let summary = prev.runningSummary;
+    let newSp: Partial<Scratchpad> = {};
+    try {
+        const resp = await reflectorModel.invoke([sys, input]);
+        const content = typeof resp.content === 'string' ? resp.content : JSON.stringify(resp.content);
+        const match = content.match(/\{[\s\S]*\}/);
+        if (match) {
+            const parsed = JSON.parse(match[0]) as { summary?: string; scratchpad?: Partial<Scratchpad> };
+            if (parsed.summary) summary = parsed.summary;
+            if (parsed.scratchpad) newSp = parsed.scratchpad;
+        }
+    } catch {
+        // Folding failure is non-fatal — keep the prior summary, still advance turnCount.
+    }
+
+    return {
+        runningSummary: summary,
+        scratchpad: mergeScratchpad(prev.scratchpad ?? emptyScratchpad(), newSp),
+        tokenCount: 0,
+        turnCount: (prev.turnCount ?? 0) + 1,
+    };
+}
+
+export interface PrepareContextDeps {
+    reflectorModel: BaseChatModel;
+    tenantId?: string;
+    threadId?: string;
+}
+export interface PreparedContext {
+    windowMessages: BaseMessage[];
+    workingMemorySection: string;
+    stateUpdate: Partial<Pick<ReflectionState, 'runningSummary' | 'scratchpad'>>;
+}
+
+export async function prepareContext(
+    state: ReflectionState,
+    deps: PrepareContextDeps,
+    fallbackWindow: number,
+): Promise<PreparedContext> {
+    const { messages } = state;
+
+    // Disabled → identical to legacy behavior.
+    if (!workingMemoryEnabled()) {
+        return {
+            windowMessages: getRecentMessages(messages, fallbackWindow),
+            workingMemorySection: '',
+            stateUpdate: {},
+        };
+    }
+
+    const budget = tokenBudget();
+    const keep = keepRecent();
+    const total = estimateMessagesTokens(messages);
+
+    const currentWm: WorkingMemory = {
+        runningSummary: state.runningSummary ?? '',
+        scratchpad: state.scratchpad ?? emptyScratchpad(),
+        tokenCount: total,
+        turnCount: 0,
+    };
+
+    // Under budget → no compaction; surface any existing WM from state.
+    if (total <= budget) {
+        const hasWm = currentWm.runningSummary || (currentWm.scratchpad.openGoals?.length ?? 0) > 0;
+        return {
+            windowMessages: selectWindow(messages, budget, keep),
+            workingMemorySection: hasWm ? buildWorkingMemorySection(currentWm) : '',
+            stateUpdate: {},
+        };
+    }
+
+    // Over budget → fold the evicted prefix into working memory.
+    const window = selectWindow(messages, budget, keep);
+    const evicted = messages.slice(0, Math.max(0, messages.length - window.length));
+    const folded = evicted.length
+        ? await foldWorkingMemory(currentWm, evicted, deps.reflectorModel)
+        : currentWm;
+
+    // Durable mirror (best-effort; checkpoint state is the source of truth).
+    if (deps.tenantId && deps.threadId) {
+        getMemoryService()
+            .putWorkingMemory({ tenantId: deps.tenantId, threadId: deps.threadId, wm: folded })
+            .catch(() => {});
+    }
+
+    return {
+        windowMessages: window,
+        workingMemorySection: buildWorkingMemorySection(folded),
+        stateUpdate: { runningSummary: folded.runningSummary, scratchpad: folded.scratchpad },
+    };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/memory/working-memory.test.ts`
+Expected: PASS (config + core + orchestrator + monotonicity).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web-ui/lib/agent/memory/working-memory.ts apps/web-ui/lib/agent/memory/working-memory.test.ts
+git commit -m "feat(memory): prepareContext compaction orchestrator + monotonic summary folding"
+```
+
+---
+
+## Task 8: Wire working memory into the fast agent (Phase 1)
+
+**Files:**
+- Modify: `apps/web-ui/lib/agent/fast-agent.ts:72-126` (agentNode) and `:292-350` (finalizeNode)
+
+**Interfaces:**
+- Consumes: `prepareContext`, `PrepareContextDeps` from `./memory/working-memory` (Task 7).
+
+- [ ] **Step 1: Import and build WM deps**
+
+In `apps/web-ui/lib/agent/fast-agent.ts`, add to the imports:
+
+```typescript
+import { prepareContext } from "./memory/working-memory";
+```
+
+After the memory-nodes wiring (around line 67, after `memorySaveNode`), add:
+
+```typescript
+    // Working-memory deps — threadId is read per-node from the runtime config.
+    const wmDeps = { reflectorModel, tenantId, userId: config.userId };
+```
+
+- [ ] **Step 2: Change `agentNode` to accept runtime config and use `prepareContext`**
+
+Change the signature at line ~72 from `async function agentNode(state: ReflectionState)` to:
+
+```typescript
+    async function agentNode(state: ReflectionState, runtimeConfig?: any): Promise<Partial<ReflectionState>> {
+```
+
+Replace the `const recentMessages = getRecentMessages(messages, 20);` line (~108) and the two lines around it with:
+
+```typescript
+        const threadId = runtimeConfig?.configurable?.thread_id as string | undefined;
+        const { windowMessages, workingMemorySection, stateUpdate } =
+            await prepareContext(state, { ...wmDeps, threadId }, 20);
+
+        const safeMessages = sanitizeMessagesForBedrock(windowMessages);
+```
+
+In the `systemPrompt` template (the `new SystemMessage(...)` at ~86), insert `${workingMemorySection}` on the line directly after `${memorySection}`:
+
+```typescript
+${memorySection}
+${workingMemorySection}
+## Conversation Continuity
+```
+
+Change the node's return (line ~122) to merge the WM state update:
+
+```typescript
+        return {
+            messages: [tagMessagePhase(response, 'execution')],
+            iterationCount: iterationCount + 1,
+            ...stateUpdate,
+        };
+```
+
+- [ ] **Step 3: Inject the WM section into `finalizeNode` too**
+
+`finalizeNode` builds its own system prompt from plain text (no message window), so it only needs the WM section for continuity. At the top of `finalizeNode` (~293), after destructuring state, add:
+
+```typescript
+        const { runningSummary, scratchpad } = state;
+        const workingMemorySection = buildWorkingMemorySection(
+            runningSummary || (scratchpad?.openGoals?.length ?? 0) > 0
+                ? { runningSummary: runningSummary ?? '', scratchpad: scratchpad ?? { openGoals: [], keyFindings: [], resourceIds: [], pendingSteps: [] }, tokenCount: 0, turnCount: 0 }
+                : null,
+        );
+```
+
+Add `buildWorkingMemorySection` to the import from `./memory/working-memory`:
+
+```typescript
+import { prepareContext, buildWorkingMemorySection } from "./memory/working-memory";
+```
+
+In the `finalizeSystemPrompt` template (~322), insert `${workingMemorySection}` after `${memorySection}`.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep "fast-agent.ts" || echo "no errors in fast-agent.ts"`
+Expected: `no errors in fast-agent.ts`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web-ui/lib/agent/fast-agent.ts
+git commit -m "feat(memory): wire working-memory compaction into the fast agent"
+```
+
+---
+
+## Task 9: Wire working memory into the planning agent (Phase 1)
+
+**Files:**
+- Modify: `apps/web-ui/lib/agent/planning-agent.ts` (imports; 3 window call sites at ~205, ~493, and the planner prompt at ~73/166)
+
+**Interfaces:**
+- Consumes: `prepareContext`, `buildWorkingMemorySection` from `./memory/working-memory`.
+
+- [ ] **Step 1: Import + WM deps**
+
+Add to imports:
+
+```typescript
+import { prepareContext, buildWorkingMemorySection } from "./memory/working-memory";
+```
+
+After the memory-nodes wiring (~67), add:
+
+```typescript
+    const wmDeps = { reflectorModel, tenantId, userId: config.userId };
+```
+
+- [ ] **Step 2: Executor node — replace the window at ~205**
+
+Locate the node whose body contains `const recentMessages = getRecentMessages(messages, 15);`. Change its signature to accept `runtimeConfig?: any` as the 2nd arg, and replace that line with:
+
+```typescript
+        const threadId = runtimeConfig?.configurable?.thread_id as string | undefined;
+        const { windowMessages, workingMemorySection, stateUpdate } =
+            await prepareContext(state, { ...wmDeps, threadId }, 15);
+        const recentMessages = windowMessages;
+```
+
+Insert `${workingMemorySection}` into that node's system-prompt template (right after the existing `${memoryContext ? ... : ''}` fragment), and merge `...stateUpdate` into the node's returned object.
+
+- [ ] **Step 3: Second window call site at ~493**
+
+Locate the node containing `const recentMessages = getRecentMessages(messages, 10);`. Change its signature to accept `runtimeConfig?: any`, and replace that line with:
+
+```typescript
+        const threadId = runtimeConfig?.configurable?.thread_id as string | undefined;
+        const { windowMessages, workingMemorySection, stateUpdate } =
+            await prepareContext(state, { ...wmDeps, threadId }, 10);
+        const recentMessages = windowMessages;
+```
+
+Insert `${workingMemorySection}` into that node's system-prompt template after the memory fragment, and merge `...stateUpdate` into its return.
+
+- [ ] **Step 4: Planner node — surface WM (no window there)**
+
+In the planner node (~73) and any node that builds a prompt from `memoryContext` but does NOT call `getRecentMessages` (~166), add near the top after destructuring:
+
+```typescript
+        const workingMemorySection = buildWorkingMemorySection(
+            state.runningSummary || (state.scratchpad?.openGoals?.length ?? 0) > 0
+                ? { runningSummary: state.runningSummary ?? '', scratchpad: state.scratchpad ?? { openGoals: [], keyFindings: [], resourceIds: [], pendingSteps: [] }, tokenCount: 0, turnCount: 0 }
+                : null,
+        );
+```
+
+and insert `${workingMemorySection}` into that node's system-prompt template after the `${memoryContext ? ... : ''}` fragment.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep "planning-agent.ts" || echo "no errors in planning-agent.ts"`
+Expected: `no errors in planning-agent.ts`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web-ui/lib/agent/planning-agent.ts
+git commit -m "feat(memory): wire working-memory compaction into the planning agent"
+```
+
+---
+
+## Task 10: MemoryService delegation shim + typed recall/save (Phase 0-C)
+
+**Files:**
+- Modify: `apps/web-ui/lib/agent/persistence.ts:109-206` (`PostgresMemoryStore.batch` delegates) + helper functions
+- Modify: `apps/web-ui/lib/agent/memory-nodes.ts:21-215` (recall/save via MemoryService, kind-aware)
+
+**Interfaces:**
+- Consumes: `getMemoryService`, `MemoryHit` from `./memory/memory-service` + `./memory/types`.
+
+- [ ] **Step 1: Route `saveMemory`/`searchMemory` helpers through `MemoryService`**
+
+In `apps/web-ui/lib/agent/persistence.ts`, add import at top:
+
+```typescript
+import { getMemoryService } from "./memory/memory-service";
+```
+
+Replace the body of `saveMemory` (~260) so it delegates (default kind SEMANTIC preserves current behavior):
+
+```typescript
+export async function saveMemory(
+    tenantId: string,
+    userId: string,
+    namespace: string[],
+    key: string,
+    value: Record<string, unknown>
+): Promise<void> {
+    await getMemoryService().remember({ tenantId, userId, kind: 'SEMANTIC', namespace, key, value });
+}
+```
+
+Replace the body of `searchMemory` (~274) so it delegates and preserves the `{ key, value, namespace }[]` return shape existing callers expect:
+
+```typescript
+export async function searchMemory(
+    tenantId: string,
+    userId: string,
+    namespacePrefix: string[],
+    query: string,
+    limit = 5
+): Promise<unknown[]> {
+    const hits = await getMemoryService().recall({ tenantId, userId, query, namespacePrefix, limit });
+    return hits.map((h) => ({ key: h.key, value: h.value, namespace: h.namespace }));
+}
+```
+
+Leave `PostgresMemoryStore` (used as the LangGraph `store` for the deep-agent tools) intact — it still works. This keeps deep-agent untouched while unifying the app-facing helpers on `MemoryService`.
+
+- [ ] **Step 2: Make `memory-nodes.ts` recall kind-aware (optional filter, same default behavior)**
+
+In `apps/web-ui/lib/agent/memory-nodes.ts`, the recall node already calls `searchMemory(tenantId, userId, [], query, 10)`, which now flows through `MemoryService` — no change needed for behavior. Add a clarifying comment above that call (~45):
+
+```typescript
+        // Recall spans all memory kinds (SEMANTIC today; EPISODIC/PROCEDURAL in later phases).
+```
+
+The save node keeps writing SEMANTIC facts via `saveMemory` (now delegating). No behavioral change — this task is the plumbing swap that later phases build on.
+
+- [ ] **Step 3: Run the existing agent tests to confirm no regressions**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/memory/ 2>&1 | tail -20`
+Expected: all memory-module tests PASS. (Pre-existing unrelated failures elsewhere in the suite, per project notes, are out of scope — do not fix here.)
+
+- [ ] **Step 4: Typecheck**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep -E "persistence.ts|memory-nodes.ts" || echo "no errors"`
+Expected: `no errors`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web-ui/lib/agent/persistence.ts apps/web-ui/lib/agent/memory-nodes.ts
+git commit -m "refactor(memory): route saveMemory/searchMemory through MemoryService"
+```
+
+---
+
+## Task 11: Expose `kind` on the Memory-module record (Phase 0-A)
+
+**Files:**
+- Modify: `apps/web-ui/lib/db/repositories/agent-memory/interface.ts:3-18` (add `kind`)
+- Modify: `apps/web-ui/lib/db/repositories/agent-memory/postgres.ts:12-48` (map `kind`)
+
+**Interfaces:**
+- Consumes: `MemoryKind` from `@/lib/agent/memory/types`.
+- Produces: `AgentMemoryRecord.kind: MemoryKind`.
+
+- [ ] **Step 1: Add `kind` to the record type**
+
+In `interface.ts`, add the import and field:
+
+```typescript
+import type { MemoryKind } from '@/lib/agent/memory/types';
+```
+
+In `AgentMemoryRecord`, after `category: MemoryCategory;` add:
+
+```typescript
+    kind: MemoryKind;
+```
+
+- [ ] **Step 2: Map `kind` in the repository**
+
+In `postgres.ts`, extend the `MemoryRow` type with `kind: MemoryKind;` (add the import `import type { MemoryKind } from '@/lib/agent/memory/types';`), and in `toRecord` add `kind: row.kind,` to the returned object.
+
+- [ ] **Step 3: Verify the Memory-module repo test still passes**
+
+Run: `cd apps/web-ui && bunx vitest run lib/db/repositories/agent-memory/postgres.test.ts`
+Expected: PASS (existing tests still green; `kind` now present on records).
+
+- [ ] **Step 4: Typecheck**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep "agent-memory" || echo "no errors"`
+Expected: `no errors`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web-ui/lib/db/repositories/agent-memory/interface.ts apps/web-ui/lib/db/repositories/agent-memory/postgres.ts
+git commit -m "feat(memory): surface memory kind on Memory-module records"
+```
+
+---
+
+## Task 12: Full verification + docs
+
+**Files:**
+- Modify: `CLAUDE.md` (Agent Architecture section — one line on working memory) — only if it does not conflict with the GSD-generated lower half.
+
+- [ ] **Step 1: Run the whole web-ui memory test suite**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/memory/ lib/db/repositories/agent-memory/`
+Expected: all PASS.
+
+- [ ] **Step 2: Full typecheck**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep -E "lib/agent/memory|working-memory|memory-service|fast-agent|planning-agent|persistence|memory-nodes|agent-shared" || echo "no errors in touched files"`
+Expected: `no errors in touched files`.
+
+- [ ] **Step 3: Lint the touched files**
+
+Run: `cd apps/web-ui && bun run lint 2>&1 | grep -E "memory|agent" || echo "no lint errors in touched files"`
+Expected: `no lint errors in touched files`.
+
+- [ ] **Step 4: Manual long-run smoke (dev server)**
+
+Run: `cd apps/web-ui && WORKING_MEMORY_TOKEN_BUDGET=2000 bun run dev` then start a fast-agent chat that produces a long tool-heavy transcript.
+Expected in server logs: after the transcript grows past the budget, the agent still responds coherently, references earlier findings, and no context-overflow error occurs. (Set the budget low to force compaction quickly.)
+
+- [ ] **Step 5: Note the new env vars in `.env.example`**
+
+Add to the root `.env.example` under a "Working memory (Phase 1)" comment:
+
+```
+# Working memory — in-session compaction for long-running agents
+WORKING_MEMORY_ENABLED=true
+WORKING_MEMORY_TOKEN_BUDGET=60000
+WORKING_MEMORY_KEEP_RECENT=8
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .env.example CLAUDE.md
+git commit -m "docs(memory): document working-memory env vars"
+```
+
+---
+
+## Self-Review (completed against the spec)
+
+- **Spec A (schema evolution):** Task 1 (enum, columns, WM table) + Task 11 (expose `kind`). ✅
+- **Spec B (HNSW index):** Task 1 Step 6. ✅
+- **Spec C (MemoryService + delegation shim):** Tasks 2, 3, 10. ✅
+- **Spec D (compaction):** Task 7 (`foldWorkingMemory`) + Task 5 (compression). ✅
+- **Spec E (budget-aware assembly):** Task 5 (`selectWindow`) + Tasks 8, 9 (wiring). ✅
+- **Spec F (checkpoint-live + table snapshot):** Task 6 (state fields) + Task 7 (`putWorkingMemory` mirror). ✅
+- **Spec G (config/env):** Task 4. ✅
+- **Testing (Vitest + fast-check budget/monotonicity):** Tasks 3, 4, 5, 7. ✅
+- **Migration verify:** Task 1 Step 9. ✅
+- **Non-goals honored:** deep-agent untouched (Task 10 explicitly leaves `PostgresMemoryStore` intact); no conflict-resolution/episodic/procedural *logic* — only scaffolding columns. ✅
+- **Type consistency:** `MemoryKind`, `Scratchpad`, `WorkingMemory`, `PreparedContext`, `prepareContext(state, deps, fallbackWindow)`, `getMemoryService()` used identically across Tasks 2–11. ✅

--- a/docs/superpowers/plans/2026-07-01-agent-memory-foundation-working-memory.md
+++ b/docs/superpowers/plans/2026-07-01-agent-memory-foundation-working-memory.md
@@ -728,7 +728,14 @@ describe('selectWindow', () => {
             fc.array(fc.string({ minLength: 1, maxLength: 400 }), { minLength: 1, maxLength: 60 }),
             fc.integer({ min: 1, max: 10 }),
             (contents, keep) => {
-                const msgs = contents.map((c, i) => new HumanMessage(`${i}:${c}`)); // unique, non-empty
+                // Alternate Human/AI roles + non-empty content so getRecentMessages
+                // passes the slice through UNCHANGED. (Two same-role messages adjacent
+                // make getRecentMessages inject a synthetic "Acknowledged." AIMessage to
+                // satisfy Bedrock adjacency — that repair is getRecentMessages' concern,
+                // not selectWindow's, and would grow the array out from under a suffix check.)
+                const msgs = contents.map((c, i) =>
+                    i % 2 === 0 ? new HumanMessage(`${i}:${c}`) : new AIMessage(`${i}:${c}`),
+                );
                 const budget = 5000;
                 const win = selectWindow(msgs, budget, keep);
 

--- a/docs/superpowers/plans/2026-07-01-agent-memory-foundation-working-memory.md
+++ b/docs/superpowers/plans/2026-07-01-agent-memory-foundation-working-memory.md
@@ -968,7 +968,11 @@ describe('prepareContext', () => {
         const res = await prepareContext(baseState(msgs), { reflectorModel: fakeReflector }, 20);
         expect(res.workingMemorySection).toBe('');
         expect(res.stateUpdate).toEqual({});
-        expect(res.windowMessages.length).toBeLessThanOrEqual(20);
+        // Disabled path returns EXACTLY the legacy getRecentMessages(fallbackWindow) window
+        // (identical to today's behavior). getRecentMessages does NOT hard-cap at maxMessages
+        // (it can add leading/adjacency fixups), so compare to it directly rather than a length bound.
+        // Requires `import { getRecentMessages } from '../agent-shared';` in the test.
+        expect(res.windowMessages).toEqual(getRecentMessages(msgs, 20));
     });
 
     it('enabled + under budget → no compaction, no LLM call, empty stateUpdate', async () => {

--- a/docs/superpowers/plans/2026-07-02-agent-memory-phase2-conflict-resolution.md
+++ b/docs/superpowers/plans/2026-07-02-agent-memory-phase2-conflict-resolution.md
@@ -1,0 +1,1100 @@
+# Agent Memory Phase 2 — Semantic Conflict Resolution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Inline Mem0-style reconciliation at memory-save time — extract → neighbor fetch → batched LLM judge (ADD/UPDATE/SUPERSEDE/REINFORCE/NOOP) → apply with an auditable supersede trail — so the memory store stays accurate as it grows.
+
+**Architecture:** A partial unique index (live rows only) replaces the full `(tenantId, namespace, key)` unique constraint so a superseded row and its same-key successor coexist. `MemoryService` stays a pure data layer and gains primitives (`remember` returns id; `recall` returns id+distance; new `update`/`supersede`/`reinforce`). A new `reconcile.ts` holds the policy: per-fact neighbor fetch with a distance threshold, one batched judge call on the reflector model, per-fact apply with ADD fallback on any failure. `memorySaveNode` routes through it behind `MEMORY_RECONCILE_ENABLED` (default true; off = today's direct-save loop).
+
+**Tech Stack:** TypeScript 5, Prisma (dual client), PostgreSQL + pgvector, LangGraph JS, Vitest.
+
+## Global Constraints
+
+- **Prisma dual-client:** after any `schema.prisma` change, regenerate BOTH clients — `cd apps/web-ui && bun run db:generate` AND `cd apps/workers && bun run db:generate`.
+- **Multi-tenant safety:** every query scoped by `tenantId`. Raw `$queryRaw`/`$executeRaw` are NOT tenant-intercepted — bind `tenantId` explicitly. ORM writes by id use `updateMany({ where: { id, tenantId } })` (same pattern as the repo's `deleteById`).
+- **Embeddings:** provider-only via `getTenantEmbeddings(tenantId)`; embedding failure is NON-FATAL everywhere (store/update without vector; recall falls back to recency).
+- **Non-fatal reconciliation:** `reconcileMemories` never throws; judge/parse/validation failure degrades to ADD (today's behavior); one bad fact never blocks siblings.
+- **Feature gate:** `MEMORY_RECONCILE_ENABLED` read from `process.env` (accessor pattern of `working-memory.ts`); default true; `'false'`/`'0'` disables. Off = byte-for-byte legacy save loop.
+- **Judge model:** the agent's existing `reflectorModel`, passed in as a param — never instantiate a model.
+- **SUPERSEDE policy:** explicit contradiction only; never delete the old row (set `supersededById`/`supersededAt`).
+- **Deep-agent untouched behaviorally:** `PostgresMemoryStore.batch()` gets ONLY the conflict-target SQL edit (required by the index change); no reconcile there.
+- **Migrations:** `prisma migrate dev` is unusable non-interactively in this environment (known) — hand-author `migration.sql` and apply with `prisma migrate deploy`. Local DB: container `nucleus-postgres`, user `nucleus`, db `nucleus`.
+- **Style:** named exports, 4-space indent in `lib/` files, `@/` alias for cross-dir imports.
+- **Known tsc baseline (do not fix, do not count as new):** `fast-agent.ts`/`planning-agent.ts` store→BaseStore compile errors; `agent-shared.ts:530-531`; `persistence.ts` PostgresChatHistory/PostgresMemoryStore JSON errors.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `libs/prisma/schema.prisma` + new migration | drop compound unique → regular index + raw-SQL partial unique (live rows) |
+| `apps/web-ui/lib/agent/memory/types.ts` | `MemoryHit` gains `id`/`distance?`; new `ExtractedFact`, `ReconcileAction`, `ReconcileDecision`, `ReconcileSummary` |
+| `apps/web-ui/lib/agent/memory/memory-service.ts` | `remember` returns id + new conflict target + ORM-fallback rework; `recall` returns id+distance; new `update`/`supersede`/`reinforce` |
+| `apps/web-ui/lib/agent/memory/memory-service.test.ts` | updated + new primitive tests |
+| `apps/web-ui/lib/agent/memory/reconcile.ts` | **new** — constants, `reconcileEnabled`, judge prompt, `reconcileMemories` |
+| `apps/web-ui/lib/agent/memory/reconcile.test.ts` | **new** — fake judge + mocked service tests |
+| `apps/web-ui/lib/agent/memory-nodes.ts` | `memorySaveNode` routes through reconcile behind the flag; gains `runtimeConfig` for threadId |
+| `apps/web-ui/lib/agent/persistence.ts` | `PostgresMemoryStore.batch()` conflict-target edit (1 line) |
+| `apps/web-ui/env.ts` | `MEMORY_RECONCILE_ENABLED` |
+| `.env.example` | document the flag |
+| `apps/web-ui/lib/db/repositories/agent-memory/{interface,postgres}.ts` (+test) | hide superseded in list; expose supersede fields |
+| `apps/web-ui/lib/queries/agent-memories.ts` | `MemoryRow` gains supersede fields |
+| `apps/web-ui/components/memory/memory-detail-dialog.tsx` | provenance row |
+| `CLAUDE.md` | one table row for reconcile.ts |
+
+## Interfaces (locked — every task must match)
+
+```typescript
+// types.ts additions
+export interface MemoryHit {
+    id: string;                        // NEW
+    namespace: string;
+    key: string;
+    value: Record<string, unknown>;
+    kind: MemoryKind;
+    distance?: number;                 // NEW — cosine distance, only on vector-search hits
+}
+export interface ExtractedFact { namespace: string[]; key: string; value: SemanticValue; }
+export type ReconcileAction = 'ADD' | 'UPDATE' | 'SUPERSEDE' | 'REINFORCE' | 'NOOP';
+export interface ReconcileDecision {
+    factIndex: number;
+    action: ReconcileAction;
+    targetId?: string;                 // UPDATE / SUPERSEDE / REINFORCE
+    mergedValue?: Record<string, unknown>; // UPDATE only
+}
+export interface ReconcileSummary { added: number; updated: number; superseded: number; reinforced: number; noop: number; failed: number; }
+
+// memory-service.ts
+remember(m: RememberParams): Promise<string>;                                   // now returns row id
+update(tenantId: string, id: string, value: Record<string, unknown>): Promise<void>;
+supersede(tenantId: string, oldId: string, newId: string): Promise<void>;
+reinforce(tenantId: string, id: string): Promise<void>;
+
+// reconcile.ts
+export const RECONCILE_TOP_K = 5;
+export const RECONCILE_DISTANCE_THRESHOLD = 0.55;
+export function reconcileEnabled(): boolean;
+export async function reconcileMemories(params: {
+    tenantId: string; userId: string; facts: ExtractedFact[];
+    judgeModel: BaseChatModel; sourceThreadId?: string;
+}): Promise<ReconcileSummary>;
+```
+
+---
+
+## Task 1: Partial unique index migration + upsert-site compatibility
+
+All three upsert sites and the migration land in ONE commit — old conflict-target SQL fails at runtime against the new index ("no unique or exclusion constraint matching the ON CONFLICT specification"), so they must move together.
+
+**Files:**
+- Modify: `libs/prisma/schema.prisma` (AgentMemory `@@unique` → `@@index`)
+- Create: `libs/prisma/migrations/<timestamp>_agent_memory_partial_unique/migration.sql`
+- Modify: `apps/web-ui/lib/agent/memory/memory-service.ts:45-74` (remember)
+- Modify: `apps/web-ui/lib/agent/persistence.ts:136-141` (batch conflict target)
+- Modify: `apps/web-ui/lib/agent/memory/memory-service.test.ts` (remember test)
+
+**Interfaces:**
+- Produces: partial unique index `agent_memories_live_tenant_ns_key`; `remember(): Promise<string>` (returns row id).
+
+- [ ] **Step 1: Schema edit**
+
+In `libs/prisma/schema.prisma`, in `model AgentMemory`, replace the line
+`  @@unique([tenantId, namespace, key])` with:
+
+```prisma
+  @@index([tenantId, namespace, key])
+```
+
+(The uniqueness guarantee moves to a partial index that Prisma cannot express — created in Step 2.)
+
+- [ ] **Step 2: Hand-author the migration**
+
+```bash
+cd /Users/kartik/.superset/worktrees/nucleus-cloud-ops/agent-memory
+MIG="libs/prisma/migrations/$(date +%Y%m%d%H%M%S)_agent_memory_partial_unique"
+mkdir -p "$MIG"
+```
+
+Write `$MIG/migration.sql` with exactly:
+
+```sql
+-- Replace the full unique constraint with a live-rows-only partial unique index so a
+-- superseded row and its same-key successor can coexist (supersede audit trail).
+-- Index name verified in DB: agent_memories_tenantId_namespace_key_key
+DROP INDEX "agent_memories_tenantId_namespace_key_key";
+
+-- Plain index for lookup performance (mirrors the schema's @@index).
+CREATE INDEX "agent_memories_tenantId_namespace_key_idx"
+  ON "agent_memories"("tenantId", "namespace", "key");
+
+-- Uniqueness applies to LIVE rows only.
+CREATE UNIQUE INDEX "agent_memories_live_tenant_ns_key"
+  ON "agent_memories" ("tenantId", "namespace", "key")
+  WHERE "supersededById" IS NULL;
+```
+
+- [ ] **Step 3: Rewrite `MemoryService.remember` (new conflict target + returns id + ORM fallback rework)**
+
+Replace the entire `remember` method with:
+
+```typescript
+    async remember(m: RememberParams): Promise<string> {
+        const prisma = getPrismaClient();
+        const namespace = m.namespace.join('/');
+        const expiresAt = new Date(Date.now() + TTL_MS);
+
+        let vec: number[] | null = null;
+        try {
+            const emb = await this.getEmbeddings(m.tenantId);
+            vec = await emb.embedQuery(JSON.stringify(m.value));
+        } catch {
+            // provider missing / embedding failure is non-fatal
+        }
+
+        if (vec) {
+            const vecStr = `[${vec.join(',')}]`;
+            // $queryRaw is NOT tenant-intercepted — tenantId is bound explicitly.
+            // The conflict target names the PARTIAL unique index (live rows only), so a
+            // superseded row with the same key never blocks inserting its successor.
+            const rows = await prisma.$queryRaw<Array<{ id: string }>>`
+                INSERT INTO agent_memories ("id","tenantId","userId","namespace","key","value","kind","embedding","sourceThreadId","createdAt","updatedAt","expiresAt")
+                VALUES (gen_random_uuid()::text, ${m.tenantId}, ${m.userId}, ${namespace}, ${m.key}, ${JSON.stringify(m.value)}::jsonb, ${m.kind}::"MemoryKind", ${vecStr}::vector, ${m.sourceThreadId ?? null}, NOW(), NOW(), ${expiresAt})
+                ON CONFLICT ("tenantId","namespace","key") WHERE "supersededById" IS NULL DO UPDATE
+                SET "value" = EXCLUDED."value", "kind" = EXCLUDED."kind", "embedding" = EXCLUDED."embedding", "updatedAt" = NOW(), "expiresAt" = EXCLUDED."expiresAt"
+                RETURNING "id"
+            `;
+            return rows[0].id;
+        }
+
+        // No embedding — ORM fallback. The compound unique no longer exists in the Prisma
+        // schema (the partial unique index is SQL-only), so upsert is replaced by
+        // find-live-then-update/create, with a one-shot retry if a concurrent create wins
+        // the race (the partial unique index is the backstop; Prisma maps 23505 → P2002).
+        const live = await prisma.agentMemory.findFirst({
+            where: { tenantId: m.tenantId, namespace, key: m.key, supersededById: null },
+            select: { id: true },
+        });
+        if (live) {
+            await prisma.agentMemory.updateMany({
+                where: { id: live.id, tenantId: m.tenantId },
+                data: { value: m.value as Prisma.InputJsonValue, kind: m.kind, expiresAt, updatedAt: new Date() },
+            });
+            return live.id;
+        }
+        try {
+            const created = await prisma.agentMemory.create({
+                data: { tenantId: m.tenantId, userId: m.userId, namespace, key: m.key, value: m.value as Prisma.InputJsonValue, kind: m.kind, sourceThreadId: m.sourceThreadId ?? null, expiresAt },
+            });
+            return created.id;
+        } catch (err) {
+            if ((err as { code?: string })?.code === 'P2002') {
+                const winner = await prisma.agentMemory.findFirst({
+                    where: { tenantId: m.tenantId, namespace, key: m.key, supersededById: null },
+                    select: { id: true },
+                });
+                if (winner) {
+                    await prisma.agentMemory.updateMany({
+                        where: { id: winner.id, tenantId: m.tenantId },
+                        data: { value: m.value as Prisma.InputJsonValue, kind: m.kind, expiresAt, updatedAt: new Date() },
+                    });
+                    return winner.id;
+                }
+            }
+            throw err;
+        }
+    }
+```
+
+- [ ] **Step 4: Same conflict-target edit in `PostgresMemoryStore.batch()`**
+
+In `apps/web-ui/lib/agent/persistence.ts` (~line 139), change:
+
+```sql
+ON CONFLICT ("tenantId", "namespace", "key") DO UPDATE
+```
+to
+```sql
+ON CONFLICT ("tenantId", "namespace", "key") WHERE "supersededById" IS NULL DO UPDATE
+```
+
+(Deep-agent behavior unchanged — still a blind upsert.)
+
+- [ ] **Step 5: Update the remember test (raw path now uses $queryRaw + RETURNING)**
+
+In `memory-service.test.ts`, replace the `MemoryService.remember` describe block with:
+
+```typescript
+describe('MemoryService.remember', () => {
+    it('upserts with an embedding vector and returns the row id', async () => {
+        mockQueryRaw.mockClear();
+        mockQueryRaw.mockResolvedValueOnce([{ id: 'row-1' }]);
+        const svc = getMemoryService();
+        const id = await svc.remember({
+            tenantId: 't1', userId: 'u1', kind: 'SEMANTIC',
+            namespace: ['infra', '123'], key: 'region',
+            value: { fact: 'us-east-1', source: 'cli', confidence: 'high' },
+        });
+        expect(id).toBe('row-1');
+        expect(mockQueryRaw).toHaveBeenCalledTimes(1);
+    });
+});
+```
+
+(If the mock harness declares `mockExecuteRaw` expectations for remember, remove them — remember no longer uses `$executeRaw`.)
+
+- [ ] **Step 6: Run the focused tests**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/memory/memory-service.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Apply the migration + regenerate BOTH clients**
+
+```bash
+cd /Users/kartik/.superset/worktrees/nucleus-cloud-ops/agent-memory
+bunx prisma migrate deploy --schema=./libs/prisma/schema.prisma
+cd apps/web-ui && bun run db:generate && cd ../workers && bun run db:generate
+```
+Expected: migration applied; both clients regenerate.
+
+- [ ] **Step 8: Verify in the DB**
+
+```bash
+docker exec -i nucleus-postgres psql -U nucleus -d nucleus -c "SELECT indexname FROM pg_indexes WHERE tablename='agent_memories' AND indexname IN ('agent_memories_live_tenant_ns_key','agent_memories_tenantId_namespace_key_idx','agent_memories_tenantId_namespace_key_key');"
+```
+Expected: the two NEW indexes present; the old `..._key_key` GONE.
+
+Coexistence check (insert superseded + same-key live row, then clean up):
+
+```bash
+docker exec -i nucleus-postgres psql -U nucleus -d nucleus -c "
+BEGIN;
+INSERT INTO agent_memories (\"id\",\"tenantId\",\"userId\",\"namespace\",\"key\",\"value\",\"createdAt\",\"updatedAt\",\"expiresAt\",\"supersededById\",\"supersededAt\")
+VALUES ('mig-test-old','mig-t','u','ns','k','{}'::jsonb,NOW(),NOW(),NOW(),'mig-test-new',NOW());
+INSERT INTO agent_memories (\"id\",\"tenantId\",\"userId\",\"namespace\",\"key\",\"value\",\"createdAt\",\"updatedAt\",\"expiresAt\")
+VALUES ('mig-test-new','mig-t','u','ns','k','{}'::jsonb,NOW(),NOW(),NOW());
+SELECT count(*) AS coexist FROM agent_memories WHERE \"tenantId\"='mig-t';
+ROLLBACK;"
+```
+Expected: `coexist = 2` (then rolled back). A third live insert of the same key inside that transaction would fail — optional to verify.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add libs/prisma/schema.prisma libs/prisma/migrations/ apps/web-ui/lib/agent/memory/memory-service.ts apps/web-ui/lib/agent/persistence.ts apps/web-ui/lib/agent/memory/memory-service.test.ts
+git commit -m "feat(memory): partial unique index on live rows + remember returns id"
+```
+
+---
+
+## Task 2: MemoryService — recall id+distance, update/supersede/reinforce
+
+**Files:**
+- Modify: `apps/web-ui/lib/agent/memory/types.ts` (MemoryHit)
+- Modify: `apps/web-ui/lib/agent/memory/memory-service.ts:76-134` (recall) + new methods
+- Modify: `apps/web-ui/lib/agent/memory/memory-service.test.ts`
+
+**Interfaces:**
+- Consumes: Task 1's `remember(): Promise<string>`.
+- Produces: `MemoryHit` with `id`/`distance?`; `update(tenantId, id, value)`, `supersede(tenantId, oldId, newId)`, `reinforce(tenantId, id)` (exact signatures in the Interfaces section).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `memory-service.test.ts` (the harness's `mockPrisma`-style mocks already exist; add `updateMany` to the `agentMemory` mock in the `vi.mock` factory: `agentMemory: { upsert: mockUpsert, findFirst: mockFindUnique, create: mockUpsert, updateMany: mockUpdateMany }` with `const mockUpdateMany = vi.fn().mockResolvedValue({ count: 1 });` declared beside the other mocks — adapt names to the file's existing factory):
+
+```typescript
+describe('MemoryService.recall hit shape', () => {
+    it('returns id and distance on vector hits', async () => {
+        mockQueryRaw.mockClear();
+        mockQueryRaw.mockResolvedValueOnce([
+            { id: 'm-1', namespace: 'infra/123', key: 'region', value: { fact: 'us-east-1' }, kind: 'SEMANTIC', distance: 0.12 },
+        ]);
+        const svc = getMemoryService();
+        const hits = await svc.recall({ tenantId: 't1', userId: 'u1', query: 'region', limit: 5 });
+        expect(hits[0]).toMatchObject({ id: 'm-1', kind: 'SEMANTIC', distance: 0.12 });
+    });
+});
+
+describe('MemoryService.supersede', () => {
+    it('marks the old row tenant-scoped', async () => {
+        const svc = getMemoryService();
+        await svc.supersede('t1', 'old-1', 'new-1');
+        expect(mockUpdateMany).toHaveBeenCalledWith(expect.objectContaining({
+            where: { id: 'old-1', tenantId: 't1' },
+            data: expect.objectContaining({ supersededById: 'new-1' }),
+        }));
+    });
+});
+
+describe('MemoryService.reinforce', () => {
+    it('refreshes TTL and bumps accessCount tenant-scoped', async () => {
+        const svc = getMemoryService();
+        await svc.reinforce('t1', 'm-1');
+        const arg = mockUpdateMany.mock.calls.at(-1)![0];
+        expect(arg.where).toEqual({ id: 'm-1', tenantId: 't1' });
+        expect(arg.data.accessCount).toEqual({ increment: 1 });
+        expect(arg.data.expiresAt).toBeInstanceOf(Date);
+    });
+});
+
+describe('MemoryService.update', () => {
+    it('updates value + embedding via raw SQL when embedding succeeds', async () => {
+        mockExecuteRaw.mockClear();
+        const svc = getMemoryService();
+        await svc.update('t1', 'm-1', { fact: 'refined' });
+        expect(mockExecuteRaw).toHaveBeenCalledTimes(1);
+    });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/memory/memory-service.test.ts`
+Expected: FAIL — `supersede`/`reinforce`/`update` not functions; recall hit missing `id`.
+
+- [ ] **Step 3: Implement**
+
+In `types.ts`, extend `MemoryHit`:
+
+```typescript
+export interface MemoryHit {
+    id: string;
+    namespace: string;
+    key: string;
+    value: Record<string, unknown>;
+    kind: MemoryKind;
+    /** Cosine distance to the query (0 = identical); present only on vector-search hits. */
+    distance?: number;
+}
+```
+
+In `memory-service.ts`, update both `recall` queries to select `"id"` and distance, and the mapper:
+
+```typescript
+        let rows: Array<{ id: string; namespace: string; key: string; value: unknown; kind: MemoryKind; distance: number | null }>;
+        if (queryVec) {
+            const vecStr = `[${queryVec.join(',')}]`;
+            rows = await prisma.$queryRaw<Array<{ id: string; namespace: string; key: string; value: unknown; kind: MemoryKind; distance: number | null }>>`
+                SELECT "id","namespace","key","value","kind", (embedding <=> ${vecStr}::vector) AS distance
+                FROM agent_memories
+                WHERE "tenantId" = ${p.tenantId}
+                  AND "supersededById" IS NULL
+                  AND (${nsPrefix} = '' OR "namespace" LIKE ${nsPrefix + '%'})
+                  AND (${kindList}::text[] IS NULL OR "kind"::text = ANY(${kindList}::text[]))
+                ORDER BY embedding <=> ${vecStr}::vector
+                LIMIT ${limit}
+            `;
+        } else {
+            rows = await prisma.$queryRaw<Array<{ id: string; namespace: string; key: string; value: unknown; kind: MemoryKind; distance: number | null }>>`
+                SELECT "id","namespace","key","value","kind", NULL::float8 AS distance
+                FROM agent_memories
+                WHERE "tenantId" = ${p.tenantId}
+                  AND "supersededById" IS NULL
+                  AND (${nsPrefix} = '' OR "namespace" LIKE ${nsPrefix + '%'})
+                  AND (${kindList}::text[] IS NULL OR "kind"::text = ANY(${kindList}::text[]))
+                ORDER BY "createdAt" DESC
+                LIMIT ${limit}
+            `;
+        }
+```
+
+and the return mapping:
+
+```typescript
+        return rows.map((r) => ({
+            id: r.id,
+            namespace: r.namespace,
+            key: r.key,
+            value: (r.value ?? {}) as Record<string, unknown>,
+            kind: r.kind,
+            ...(r.distance !== null && r.distance !== undefined ? { distance: Number(r.distance) } : {}),
+        }));
+```
+
+Add the three methods to the class (after `recall`):
+
+```typescript
+    /** Replace a memory's value in place (judge UPDATE). Re-embeds; embed failure keeps the old vector. */
+    async update(tenantId: string, id: string, value: Record<string, unknown>): Promise<void> {
+        const prisma = getPrismaClient();
+        const expiresAt = new Date(Date.now() + TTL_MS);
+        let vec: number[] | null = null;
+        try {
+            const emb = await this.getEmbeddings(tenantId);
+            vec = await emb.embedQuery(JSON.stringify(value));
+        } catch {
+            // keep the old embedding
+        }
+        if (vec) {
+            const vecStr = `[${vec.join(',')}]`;
+            await prisma.$executeRaw`
+                UPDATE agent_memories
+                SET "value" = ${JSON.stringify(value)}::jsonb, "embedding" = ${vecStr}::vector, "updatedAt" = NOW(), "expiresAt" = ${expiresAt}
+                WHERE "id" = ${id} AND "tenantId" = ${tenantId}
+            `;
+        } else {
+            await prisma.agentMemory.updateMany({
+                where: { id, tenantId },
+                data: { value: value as Prisma.InputJsonValue, expiresAt, updatedAt: new Date() },
+            });
+        }
+    }
+
+    /** Mark `oldId` as displaced by `newId` (judge SUPERSEDE). Old row is never deleted. */
+    async supersede(tenantId: string, oldId: string, newId: string): Promise<void> {
+        const prisma = getPrismaClient();
+        await prisma.agentMemory.updateMany({
+            where: { id: oldId, tenantId },
+            data: { supersededById: newId, supersededAt: new Date(), updatedAt: new Date() },
+        });
+    }
+
+    /** A duplicate re-confirmed this memory (judge REINFORCE): refresh TTL, bump the signal. */
+    async reinforce(tenantId: string, id: string): Promise<void> {
+        const prisma = getPrismaClient();
+        await prisma.agentMemory.updateMany({
+            where: { id, tenantId },
+            data: { expiresAt: new Date(Date.now() + TTL_MS), accessCount: { increment: 1 }, lastAccessedAt: new Date(), updatedAt: new Date() },
+        });
+    }
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/memory/memory-service.test.ts`
+Expected: PASS (all).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web-ui/lib/agent/memory/types.ts apps/web-ui/lib/agent/memory/memory-service.ts apps/web-ui/lib/agent/memory/memory-service.test.ts
+git commit -m "feat(memory): recall returns id+distance; update/supersede/reinforce primitives"
+```
+
+---
+
+## Task 3: Reconcile pipeline
+
+**Files:**
+- Modify: `apps/web-ui/lib/agent/memory/types.ts` (ExtractedFact + decision types)
+- Create: `apps/web-ui/lib/agent/memory/reconcile.ts`
+- Create: `apps/web-ui/lib/agent/memory/reconcile.test.ts`
+
+**Interfaces:**
+- Consumes: `getMemoryService()` primitives from Tasks 1–2; `SemanticValue`/`MemoryHit` from types.
+- Produces: `reconcileEnabled()`, `reconcileMemories(params): Promise<ReconcileSummary>`, `RECONCILE_TOP_K`, `RECONCILE_DISTANCE_THRESHOLD` (exact shapes in the Interfaces section).
+
+- [ ] **Step 1: Add the types**
+
+Append to `types.ts`:
+
+```typescript
+export interface ExtractedFact {
+    namespace: string[];
+    key: string;
+    value: SemanticValue;
+}
+
+export type ReconcileAction = 'ADD' | 'UPDATE' | 'SUPERSEDE' | 'REINFORCE' | 'NOOP';
+
+export interface ReconcileDecision {
+    factIndex: number;
+    action: ReconcileAction;
+    targetId?: string;                     // UPDATE / SUPERSEDE / REINFORCE
+    mergedValue?: Record<string, unknown>; // UPDATE only
+}
+
+export interface ReconcileSummary {
+    added: number;
+    updated: number;
+    superseded: number;
+    reinforced: number;
+    noop: number;
+    failed: number;
+}
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `reconcile.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('./memory-service', () => ({ getMemoryService: vi.fn() }));
+
+import { getMemoryService } from './memory-service';
+import { reconcileMemories, reconcileEnabled } from './reconcile';
+import type { ExtractedFact } from './types';
+
+const mockSvc = {
+    recall: vi.fn(),
+    remember: vi.fn(),
+    update: vi.fn(),
+    supersede: vi.fn(),
+    reinforce: vi.fn(),
+};
+
+const fact = (key: string): ExtractedFact => ({
+    namespace: ['infra', 'a1'], key,
+    value: { fact: `${key} fact`, source: 's', confidence: 'high' },
+});
+const neighbor = (id: string, distance = 0.1) => ({
+    id, namespace: 'infra/a1', key: 'existing', value: { fact: 'old' }, kind: 'SEMANTIC', distance,
+});
+const judgeReturning = (json: unknown) => ({
+    invoke: vi.fn().mockResolvedValue({ content: JSON.stringify(json) }),
+}) as any;
+const base = { tenantId: 't1', userId: 'u1', sourceThreadId: 'th-1' };
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mockSvc.recall.mockResolvedValue([]);
+    mockSvc.remember.mockResolvedValue('new-id');
+    mockSvc.update.mockResolvedValue(undefined);
+    mockSvc.supersede.mockResolvedValue(undefined);
+    mockSvc.reinforce.mockResolvedValue(undefined);
+    vi.mocked(getMemoryService).mockReturnValue(mockSvc as any);
+});
+afterEach(() => { delete process.env.MEMORY_RECONCILE_ENABLED; });
+
+describe('reconcileEnabled', () => {
+    it('defaults true; false/0 disable', () => {
+        expect(reconcileEnabled()).toBe(true);
+        process.env.MEMORY_RECONCILE_ENABLED = 'false';
+        expect(reconcileEnabled()).toBe(false);
+    });
+});
+
+describe('reconcileMemories', () => {
+    it('no near neighbors → ADD without calling the judge', async () => {
+        mockSvc.recall.mockResolvedValue([neighbor('far-1', 0.9)]); // beyond threshold
+        const judge = judgeReturning([]);
+        const summary = await reconcileMemories({ ...base, facts: [fact('k1')], judgeModel: judge });
+        expect(judge.invoke).not.toHaveBeenCalled();
+        expect(mockSvc.remember).toHaveBeenCalledTimes(1);
+        expect(summary.added).toBe(1);
+    });
+
+    it('SUPERSEDE → remember new then supersede old with the new id', async () => {
+        mockSvc.recall.mockResolvedValue([neighbor('old-1')]);
+        const judge = judgeReturning([{ factIndex: 0, action: 'SUPERSEDE', targetId: 'old-1' }]);
+        const summary = await reconcileMemories({ ...base, facts: [fact('k1')], judgeModel: judge });
+        expect(mockSvc.remember).toHaveBeenCalledTimes(1);
+        expect(mockSvc.supersede).toHaveBeenCalledWith('t1', 'old-1', 'new-id');
+        expect(summary.superseded).toBe(1);
+    });
+
+    it('REINFORCE → reinforce only, no new row', async () => {
+        mockSvc.recall.mockResolvedValue([neighbor('old-1')]);
+        const judge = judgeReturning([{ factIndex: 0, action: 'REINFORCE', targetId: 'old-1' }]);
+        const summary = await reconcileMemories({ ...base, facts: [fact('k1')], judgeModel: judge });
+        expect(mockSvc.reinforce).toHaveBeenCalledWith('t1', 'old-1');
+        expect(mockSvc.remember).not.toHaveBeenCalled();
+        expect(summary.reinforced).toBe(1);
+    });
+
+    it('UPDATE → update target with mergedValue', async () => {
+        mockSvc.recall.mockResolvedValue([neighbor('old-1')]);
+        const merged = { fact: 'merged', source: 's', confidence: 'high' };
+        const judge = judgeReturning([{ factIndex: 0, action: 'UPDATE', targetId: 'old-1', mergedValue: merged }]);
+        const summary = await reconcileMemories({ ...base, facts: [fact('k1')], judgeModel: judge });
+        expect(mockSvc.update).toHaveBeenCalledWith('t1', 'old-1', merged);
+        expect(summary.updated).toBe(1);
+    });
+
+    it('NOOP → nothing written', async () => {
+        mockSvc.recall.mockResolvedValue([neighbor('old-1')]);
+        const judge = judgeReturning([{ factIndex: 0, action: 'NOOP' }]);
+        const summary = await reconcileMemories({ ...base, facts: [fact('k1')], judgeModel: judge });
+        expect(mockSvc.remember).not.toHaveBeenCalled();
+        expect(summary.noop).toBe(1);
+    });
+
+    it('judge throws → ADD fallback', async () => {
+        mockSvc.recall.mockResolvedValue([neighbor('old-1')]);
+        const judge = { invoke: vi.fn().mockRejectedValue(new Error('boom')) } as any;
+        const summary = await reconcileMemories({ ...base, facts: [fact('k1')], judgeModel: judge });
+        expect(mockSvc.remember).toHaveBeenCalledTimes(1);
+        expect(summary.added).toBe(1);
+    });
+
+    it('invalid targetId → ADD fallback', async () => {
+        mockSvc.recall.mockResolvedValue([neighbor('old-1')]);
+        const judge = judgeReturning([{ factIndex: 0, action: 'SUPERSEDE', targetId: 'not-a-neighbor' }]);
+        const summary = await reconcileMemories({ ...base, facts: [fact('k1')], judgeModel: judge });
+        expect(mockSvc.supersede).not.toHaveBeenCalled();
+        expect(summary.added).toBe(1);
+    });
+
+    it('one fact failing does not block its sibling', async () => {
+        mockSvc.recall.mockResolvedValue([neighbor('old-1')]);
+        mockSvc.reinforce.mockRejectedValueOnce(new Error('db down'));
+        const judge = judgeReturning([
+            { factIndex: 0, action: 'REINFORCE', targetId: 'old-1' },
+            { factIndex: 1, action: 'NOOP' },
+        ]);
+        const summary = await reconcileMemories({ ...base, facts: [fact('k1'), fact('k2')], judgeModel: judge });
+        expect(summary.failed).toBe(1);
+        expect(summary.noop).toBe(1);
+    });
+});
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/memory/reconcile.test.ts`
+Expected: FAIL — `Cannot find module './reconcile'`.
+
+- [ ] **Step 4: Implement `reconcile.ts`**
+
+```typescript
+/**
+ * reconcile.ts — save-time semantic conflict resolution (Phase 2).
+ *
+ * extract → neighbor fetch (pgvector) → one batched LLM judge call →
+ * apply (ADD / UPDATE / SUPERSEDE / REINFORCE / NOOP) via MemoryService.
+ * Policy layer only — MemoryService stays a pure data layer.
+ * Never throws; every failure degrades to ADD (legacy behavior).
+ */
+
+import { SystemMessage, HumanMessage } from '@langchain/core/messages';
+import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
+import { getMemoryService } from './memory-service';
+import type { ExtractedFact, MemoryHit, ReconcileDecision, ReconcileSummary } from './types';
+
+export const RECONCILE_TOP_K = 5;
+// Cosine distance (0 = identical). Neighbors farther than this are treated as
+// unrelated and the fact goes straight to ADD. Initial guess — tune from logs.
+export const RECONCILE_DISTANCE_THRESHOLD = 0.55;
+
+export function reconcileEnabled(): boolean {
+    const v = process.env.MEMORY_RECONCILE_ENABLED?.toLowerCase();
+    return !(v === 'false' || v === '0');
+}
+
+interface FactWithNeighbors {
+    factIndex: number;
+    fact: ExtractedFact;
+    neighbors: MemoryHit[];
+}
+
+const JUDGE_SYSTEM = new SystemMessage(
+    `You reconcile newly extracted agent memories against similar existing memories.
+For each new fact, choose exactly one action:
+- "ADD": genuinely new information not covered by any neighbor.
+- "UPDATE": same fact as one neighbor but with more or refined detail. Provide "mergedValue": the neighbor's value enriched with the new detail (same JSON shape as the new fact's value).
+- "SUPERSEDE": the new fact EXPLICITLY CONTRADICTS one neighbor — both cannot be true (e.g. a resource moved region). The new fact wins. Provide "targetId".
+- "REINFORCE": semantically the same fact as one neighbor; nothing new. Provide "targetId".
+- "NOOP": ephemeral or not worth remembering.
+Rules:
+- SUPERSEDE only on mutual exclusivity, NEVER on similarity or partial overlap.
+- Uncertain between UPDATE and REINFORCE → choose REINFORCE.
+- Uncertain whether facts contradict → choose ADD (keep both).
+Return ONLY a JSON array with one object per fact:
+[{"factIndex": 0, "action": "SUPERSEDE", "targetId": "..."}]
+"targetId" must be an id from that fact's own neighbors. Include "mergedValue" only for UPDATE.`,
+);
+
+function parseDecisions(content: string): ReconcileDecision[] {
+    const match = content.match(/\[[\s\S]*\]/);
+    if (!match) return [];
+    try {
+        const parsed = JSON.parse(match[0]);
+        return Array.isArray(parsed) ? (parsed as ReconcileDecision[]) : [];
+    } catch {
+        return [];
+    }
+}
+
+function isValidDecision(d: ReconcileDecision, item: FactWithNeighbors): boolean {
+    const neighborIds = new Set(item.neighbors.map((n) => n.id));
+    switch (d.action) {
+        case 'ADD':
+        case 'NOOP':
+            return true;
+        case 'REINFORCE':
+        case 'SUPERSEDE':
+            return !!d.targetId && neighborIds.has(d.targetId);
+        case 'UPDATE':
+            return !!d.targetId && neighborIds.has(d.targetId)
+                && !!d.mergedValue && typeof d.mergedValue === 'object';
+        default:
+            return false;
+    }
+}
+
+export async function reconcileMemories(params: {
+    tenantId: string;
+    userId: string;
+    facts: ExtractedFact[];
+    judgeModel: BaseChatModel;
+    sourceThreadId?: string;
+}): Promise<ReconcileSummary> {
+    const { tenantId, userId, facts, judgeModel, sourceThreadId } = params;
+    const summary: ReconcileSummary = { added: 0, updated: 0, superseded: 0, reinforced: 0, noop: 0, failed: 0 };
+    const svc = getMemoryService();
+
+    const add = async (fact: ExtractedFact): Promise<void> => {
+        await svc.remember({
+            tenantId, userId, kind: 'SEMANTIC',
+            namespace: fact.namespace, key: fact.key,
+            value: fact.value as unknown as Record<string, unknown>,
+            sourceThreadId,
+        });
+        summary.added++;
+    };
+
+    // 1. Neighbor fetch — facts with no near neighbor skip the judge entirely.
+    const withNeighbors: FactWithNeighbors[] = [];
+    for (const [factIndex, fact] of facts.entries()) {
+        let neighbors: MemoryHit[] = [];
+        try {
+            // Query by the value JSON — the same text remember() embeds, so distances are comparable.
+            const hits = await svc.recall({
+                tenantId, userId, query: JSON.stringify(fact.value),
+                kinds: ['SEMANTIC'], limit: RECONCILE_TOP_K,
+            });
+            neighbors = hits.filter((h) => h.distance !== undefined && h.distance <= RECONCILE_DISTANCE_THRESHOLD);
+        } catch {
+            // recall failure → treat as no neighbors
+        }
+        if (neighbors.length === 0) {
+            try { await add(fact); } catch (err: any) {
+                console.warn(`[Reconcile] ADD failed for ${fact.key}: ${err?.message ?? err}`);
+                summary.failed++;
+            }
+        } else {
+            withNeighbors.push({ factIndex, fact, neighbors });
+        }
+    }
+    if (withNeighbors.length === 0) return summary;
+
+    // 2. One batched judge call for every fact that has neighbors.
+    const decisions = new Map<number, ReconcileDecision>();
+    try {
+        const input = new HumanMessage(JSON.stringify(
+            withNeighbors.map((w) => ({
+                factIndex: w.factIndex,
+                newFact: { namespace: w.fact.namespace.join('/'), key: w.fact.key, value: w.fact.value },
+                neighbors: w.neighbors.map((n) => ({ id: n.id, namespace: n.namespace, key: n.key, value: n.value })),
+            })), null, 2,
+        ));
+        const resp = await judgeModel.invoke([JUDGE_SYSTEM, input]);
+        const content = typeof resp.content === 'string' ? resp.content : JSON.stringify(resp.content);
+        for (const d of parseDecisions(content)) {
+            if (typeof d?.factIndex === 'number') decisions.set(d.factIndex, d);
+        }
+    } catch (err: any) {
+        console.warn(`[Reconcile] Judge failed, falling back to ADD: ${err?.message ?? err}`);
+        // decisions stays empty → every fact falls back to ADD below
+    }
+
+    // 3. Apply — anything missing/invalid degrades to ADD; one failure never blocks siblings.
+    for (const item of withNeighbors) {
+        const d = decisions.get(item.factIndex);
+        try {
+            if (!d || !isValidDecision(d, item)) {
+                await add(item.fact);
+                continue;
+            }
+            switch (d.action) {
+                case 'ADD':
+                    await add(item.fact);
+                    break;
+                case 'UPDATE':
+                    await svc.update(tenantId, d.targetId!, d.mergedValue!);
+                    summary.updated++;
+                    break;
+                case 'SUPERSEDE': {
+                    const newId = await svc.remember({
+                        tenantId, userId, kind: 'SEMANTIC',
+                        namespace: item.fact.namespace, key: item.fact.key,
+                        value: item.fact.value as unknown as Record<string, unknown>,
+                        sourceThreadId,
+                    });
+                    await svc.supersede(tenantId, d.targetId!, newId);
+                    summary.superseded++;
+                    summary.added++;
+                    break;
+                }
+                case 'REINFORCE':
+                    await svc.reinforce(tenantId, d.targetId!);
+                    summary.reinforced++;
+                    break;
+                case 'NOOP':
+                    summary.noop++;
+                    break;
+            }
+        } catch (err: any) {
+            console.warn(`[Reconcile] Apply failed for ${item.fact.key}: ${err?.message ?? err}`);
+            summary.failed++;
+        }
+    }
+
+    return summary;
+}
+```
+
+NOTE on the SUPERSEDE counter: it increments BOTH `superseded` and `added` (a new row was added AND an old one displaced). The Task 3 test asserts `summary.superseded === 1` only — keep the extra `added++`; adjust no tests.
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/memory/reconcile.test.ts`
+Expected: PASS (all 9).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web-ui/lib/agent/memory/types.ts apps/web-ui/lib/agent/memory/reconcile.ts apps/web-ui/lib/agent/memory/reconcile.test.ts
+git commit -m "feat(memory): reconcile pipeline — batched judge + apply with ADD fallback"
+```
+
+---
+
+## Task 4: Wire reconcile into memorySaveNode + env flag
+
+**Files:**
+- Modify: `apps/web-ui/lib/agent/memory-nodes.ts:108-215` (memorySaveNode)
+- Modify: `apps/web-ui/env.ts:82-88` (feature-flags block)
+- Modify: `.env.example` (working-memory block)
+
+**Interfaces:**
+- Consumes: `reconcileMemories`, `reconcileEnabled` from `./memory/reconcile`; `ExtractedFact` from `./memory/types`.
+
+- [ ] **Step 1: env.ts**
+
+In the `server:` object's feature-flags block (after `WORKING_MEMORY_KEEP_RECENT`), add:
+
+```typescript
+        MEMORY_RECONCILE_ENABLED: z.string().optional(),
+```
+
+- [ ] **Step 2: memory-nodes.ts imports + node signature**
+
+Add imports:
+
+```typescript
+import { reconcileMemories, reconcileEnabled } from "./memory/reconcile";
+import type { ExtractedFact } from "./memory/types";
+```
+
+Change the node signature (line ~111) from
+`return async function memorySaveNode(state: ReflectionState): Promise<Partial<ReflectionState>> {` to:
+
+```typescript
+    return async function memorySaveNode(state: ReflectionState, runtimeConfig?: any): Promise<Partial<ReflectionState>> {
+```
+
+- [ ] **Step 3: Replace the save loop**
+
+Replace (lines ~199-208):
+
+```typescript
+            console.log(`🧠 [MEMORY SAVE] Saving ${toSave.length} memories...`);
+
+            for (const mem of toSave) {
+                try {
+                    await saveMemory(tenantId, userId, mem.namespace, mem.key, mem.value as Record<string, unknown>);
+                    console.log(`   ✅ Saved: ${mem.namespace.join("/")}/${mem.key}`);
+                } catch (err: any) {
+                    console.warn(`   ⚠️ Failed to save ${mem.key}: ${err?.message ?? err}`);
+                }
+            }
+```
+
+with:
+
+```typescript
+            if (reconcileEnabled()) {
+                console.log(`🧠 [MEMORY SAVE] Reconciling ${toSave.length} extracted facts...`);
+                const threadId = runtimeConfig?.configurable?.thread_id as string | undefined;
+                const summary = await reconcileMemories({
+                    tenantId, userId,
+                    facts: toSave.map(m => ({ namespace: m.namespace, key: m.key, value: m.value })) as ExtractedFact[],
+                    judgeModel: reflectorModel,
+                    sourceThreadId: threadId,
+                });
+                console.log(`🧠 [MEMORY SAVE] Reconcile: ${summary.added} added, ${summary.updated} updated, ${summary.superseded} superseded, ${summary.reinforced} reinforced, ${summary.noop} noop, ${summary.failed} failed`);
+            } else {
+                console.log(`🧠 [MEMORY SAVE] Saving ${toSave.length} memories (reconcile disabled)...`);
+                for (const mem of toSave) {
+                    try {
+                        await saveMemory(tenantId, userId, mem.namespace, mem.key, mem.value as Record<string, unknown>);
+                        console.log(`   ✅ Saved: ${mem.namespace.join("/")}/${mem.key}`);
+                    } catch (err: any) {
+                        console.warn(`   ⚠️ Failed to save ${mem.key}: ${err?.message ?? err}`);
+                    }
+                }
+            }
+```
+
+- [ ] **Step 4: .env.example**
+
+After the `WORKING_MEMORY_KEEP_RECENT=8` line, add:
+
+```
+# Save-time memory reconciliation (Phase 2) — dedup/contradiction resolution via an
+# LLM judge before writing. Set false to restore blind upserts (legacy behavior).
+MEMORY_RECONCILE_ENABLED=true
+```
+
+- [ ] **Step 5: Verify**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/memory/ && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep "memory-nodes.ts" || echo "no errors in memory-nodes.ts"`
+Expected: all memory tests PASS; `no errors in memory-nodes.ts`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web-ui/lib/agent/memory-nodes.ts apps/web-ui/env.ts .env.example
+git commit -m "feat(memory): memorySaveNode reconciles via LLM judge (MEMORY_RECONCILE_ENABLED)"
+```
+
+---
+
+## Task 5: Memory-module — hide superseded + provenance
+
+**Files:**
+- Modify: `apps/web-ui/lib/db/repositories/agent-memory/interface.ts` (record fields)
+- Modify: `apps/web-ui/lib/db/repositories/agent-memory/postgres.ts` (filter + mapping)
+- Modify: `apps/web-ui/lib/db/repositories/agent-memory/postgres.test.ts`
+- Modify: `apps/web-ui/lib/queries/agent-memories.ts` (`MemoryRow`)
+- Modify: `apps/web-ui/components/memory/memory-detail-dialog.tsx`
+
+**Interfaces:**
+- Produces: `AgentMemoryRecord`/`MemoryRow` gain `supersededById: string | null; supersededAt: string | null;`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `postgres.test.ts`: add `supersededById: null, supersededAt: null,` to the `makeRow` defaults, then add:
+
+```typescript
+    it('listByTenant excludes superseded rows', async () => {
+        const repo = new AgentMemoryPostgresRepository();
+        await repo.listByTenant({ tenantId: 't1' });
+        const arg = mockPrisma.agentMemory.findMany.mock.calls[0][0];
+        expect(arg.where.supersededById).toBeNull();
+    });
+
+    it('getById still returns superseded rows with provenance fields', async () => {
+        mockPrisma.agentMemory.findFirst.mockResolvedValueOnce(
+            makeRow({ supersededById: 'mem-2', supersededAt: new Date('2026-07-01T00:00:00Z') }),
+        );
+        const repo = new AgentMemoryPostgresRepository();
+        const rec = await repo.getById('t1', 'mem-1');
+        expect(rec?.supersededById).toBe('mem-2');
+        expect(rec?.supersededAt).toBe('2026-07-01T00:00:00.000Z');
+    });
+```
+
+Run: `cd apps/web-ui && bunx vitest run lib/db/repositories/agent-memory/postgres.test.ts`
+Expected: FAIL (where has no `supersededById`; record lacks the fields).
+
+- [ ] **Step 2: Implement**
+
+`interface.ts` — in `AgentMemoryRecord`, after `expiresAt: string;` add:
+
+```typescript
+    supersededById: string | null;
+    supersededAt: string | null;
+```
+
+`postgres.ts` — `MemoryRow` type gains `supersededById: string | null; supersededAt: Date | null;`; `toRecord` returns them:
+
+```typescript
+        supersededById: row.supersededById,
+        supersededAt: row.supersededAt ? row.supersededAt.toISOString() : null,
+```
+
+`listByTenant` base where becomes:
+
+```typescript
+        const where: Record<string, unknown> = { tenantId: filters.tenantId, supersededById: null };
+```
+
+(`getById`/`deleteById` unchanged — direct fetch still reaches superseded rows.)
+
+`lib/queries/agent-memories.ts` — `MemoryRow` gains:
+
+```typescript
+    supersededById: string | null;
+    supersededAt: string | null;
+```
+
+`memory-detail-dialog.tsx` — after the `Expires` Row (line ~47), add:
+
+```tsx
+                        {memory.supersededAt ? (
+                            <Row
+                                label="Superseded"
+                                value={
+                                    <span className="text-destructive">
+                                        {new Date(memory.supersededAt).toLocaleString()} — replaced by a newer memory
+                                    </span>
+                                }
+                            />
+                        ) : null}
+```
+
+- [ ] **Step 3: Run tests to verify pass**
+
+Run: `cd apps/web-ui && bunx vitest run lib/db/repositories/agent-memory/postgres.test.ts`
+Expected: PASS (existing + 2 new).
+
+- [ ] **Step 4: Typecheck touched UI files**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep -E "agent-memory|agent-memories|memory-detail-dialog" || echo "no errors"`
+Expected: `no errors`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web-ui/lib/db/repositories/agent-memory/ apps/web-ui/lib/queries/agent-memories.ts apps/web-ui/components/memory/memory-detail-dialog.tsx
+git commit -m "feat(memory): hide superseded memories from list + provenance in detail"
+```
+
+---
+
+## Task 6: Full verification + docs
+
+**Files:**
+- Modify: `CLAUDE.md` (Agent Architecture key-modules table)
+
+- [ ] **Step 1: Full memory + repo suites**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/memory/ lib/db/repositories/agent-memory/`
+Expected: all PASS.
+
+- [ ] **Step 2: Typecheck all touched files (only pre-existing baseline errors allowed)**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep -E "memory/|memory-nodes|persistence.ts|agent-memories|memory-detail" | grep -v -E "persistence.ts\((56|146|147)," || echo "no new errors"`
+Expected: `no new errors`.
+
+- [ ] **Step 3: CLAUDE.md**
+
+In the "Key shared modules" table (after the `memory/working-memory.ts` row), add:
+
+```markdown
+| `memory/reconcile.ts` | Save-time conflict resolution: batched LLM judge (ADD/UPDATE/SUPERSEDE/REINFORCE/NOOP) applied via MemoryService with an auditable supersede trail. Gated by `MEMORY_RECONCILE_ENABLED`. |
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(memory): document reconcile module"
+```
+
+---
+
+## Self-Review (completed against the spec)
+
+- **Spec §A (pipeline, fast path, batched judge, apply, failure containment, gate):** Task 3 (pipeline + tests) + Task 4 (gate + wiring). ✅
+- **Spec §B (partial unique index + 3 upsert-site ripples + remember returns id):** Task 1, atomic commit. ✅
+- **Spec §C (recall id+distance; update/supersede/reinforce):** Task 2. ✅
+- **Spec §D (hide superseded, record fields, provenance line):** Task 5. ✅
+- **Spec §E (env flag + constants):** Tasks 3 (constants) + 4 (flag, .env.example). ✅
+- **Testing section:** action-apply/fallback/no-LLM tests (Task 3), primitives (Tasks 1–2), migration verify incl. coexistence (Task 1 Step 8), repo exclusion (Task 5). ✅
+- **Type consistency:** `remember → Promise<string>`, `MemoryHit.id/distance?`, `ReconcileDecision`, `updateMany({ where: { id, tenantId } })` used identically across tasks. ✅
+- **No placeholders:** every code step carries full code; commands carry expected output. ✅

--- a/docs/superpowers/plans/2026-07-02-agent-memory-phase3-episodic.md
+++ b/docs/superpowers/plans/2026-07-02-agent-memory-phase3-episodic.md
@@ -1,0 +1,619 @@
+# Agent Memory Phase 3 — Episodic Memory Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Capture one distilled cognitive snapshot (context/reasoning/action/outcome) per tool-using run and replay the 1–2 most similar past episodes as structured few-shot experience at task start.
+
+**Architecture:** Zero-wiring composition — a new `episode.ts` holds capture (distiller LLM with SKIP veto, one episode per thread refreshed via the Phase 2 live-unique upsert, bypassing the reconcile judge) and pure replay formatters. `memoryRecallNode` runs two typed recalls (semantic → existing LLM filter; episodic → distance-gated, no LLM) and composes both into the **existing `memoryContext` string** — fast/planning agents are untouched. `memorySaveNode` calls `captureEpisode` after the reconcile block, gated on tools-used + threadId + flag.
+
+**Tech Stack:** TypeScript 5, LangGraph JS, PostgreSQL + pgvector (via existing MemoryService), Vitest.
+
+## Global Constraints
+
+- **Non-fatal everywhere:** `captureEpisode` never throws (returns boolean); episodic recall failure degrades to facts-only; capture failure/SKIP never blocks END.
+- **Feature gate:** `EPISODIC_MEMORY_ENABLED` read from `process.env` (accessor pattern of `working-memory.ts`/`reconcile.ts`); default true; `'false'`/`'0'` disable BOTH capture and episodic recall. Off = byte-for-byte Phase 2 behavior.
+- **Episodes bypass the reconcile judge** — straight `remember({ kind: 'EPISODIC', namespace: ['episodes'], key: 'thread-<threadId>', sourceThreadId: threadId })`.
+- **Distiller model:** the node's existing `reflectorModel`, passed in — never instantiate a model.
+- **Facts-only output shape unchanged:** when no episodes render, `memoryContext` must be byte-identical to today's (no added headers) — `composeMemoryContext` guarantees this.
+- **Constants:** `EPISODE_RECALL_LIMIT = 2`, `EPISODE_DISTANCE_THRESHOLD = 0.65` (module constants, not env).
+- **Style:** named exports, 4-space indent in `lib/` files, `@/` alias cross-dir.
+- **Known tsc baseline (do not fix/count):** `persistence.ts(57)`, `persistence.test.ts(68)`, fast/planning-agent store→BaseStore, `agent-shared.ts:530-531`.
+- **Deep-agent untouched.**
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `apps/web-ui/lib/agent/memory/episode.ts` | **new** — flag accessor, constants, distiller prompt, `captureEpisode`, `formatEpisodesSection`, `composeMemoryContext` |
+| `apps/web-ui/lib/agent/memory/episode.test.ts` | **new** — capture gating/validation + formatting tests |
+| `apps/web-ui/lib/agent/memory-nodes.ts` | recall: two typed recalls + composed context; save: capture call |
+| `apps/web-ui/env.ts` + `.env.example` | `EPISODIC_MEMORY_ENABLED` |
+| `apps/web-ui/lib/agent-memory/category.ts` | `'episodes'` category |
+| `apps/web-ui/lib/db/repositories/agent-memory/postgres.ts` (+test) | list fact-column falls back to `value.outcome` |
+| `CLAUDE.md` | one table row for episode.ts |
+
+## Interfaces (locked — every task must match)
+
+```typescript
+// episode.ts
+export const EPISODE_RECALL_LIMIT = 2;
+export const EPISODE_DISTANCE_THRESHOLD = 0.65;
+export function episodicMemoryEnabled(): boolean;
+export interface CaptureEpisodeParams {
+    tenantId: string;
+    userId: string;
+    threadId: string;
+    distillerModel: BaseChatModel;
+    taskDescription: string;
+    plan: Array<{ step: string; status: string }>;
+    toolResults: Array<{ toolName: string; output: string; isError: boolean }>;
+    errors: string[];
+    reflection: string;
+    isComplete: boolean;
+    iterationCount: number;
+}
+export async function captureEpisode(p: CaptureEpisodeParams): Promise<boolean>;   // true = saved
+export function formatEpisodesSection(episodes: EpisodicValue[]): string;          // '' for []
+export function composeMemoryContext(factsSection: string, episodesSection: string): string;
+```
+
+`EpisodicValue` (exists in `types.ts`): `{ context: string; reasoning: string; action: string; outcome: string }`.
+`ReflectionState.plan` is `PlanStep[]` (`{ step: string; status: 'pending' | 'in_progress' | 'completed' | 'failed' }`) — assignable to `Array<{ step: string; status: string }>`.
+
+---
+
+## Task 1: episode.ts — capture + replay formatters
+
+**Files:**
+- Create: `apps/web-ui/lib/agent/memory/episode.ts`
+- Create: `apps/web-ui/lib/agent/memory/episode.test.ts`
+
+**Interfaces:**
+- Consumes: `getMemoryService()` (`remember` returns `Promise<string>`); `compressToolOutput(content, maxChars)` from `./working-memory`; `EpisodicValue` from `./types`.
+- Produces: everything in the Interfaces section above.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/web-ui/lib/agent/memory/episode.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('./memory-service', () => ({ getMemoryService: vi.fn() }));
+
+import { getMemoryService } from './memory-service';
+import {
+    captureEpisode, formatEpisodesSection, composeMemoryContext, episodicMemoryEnabled,
+} from './episode';
+import type { EpisodicValue } from './types';
+
+const mockSvc = { remember: vi.fn() };
+
+const goodEpisode: EpisodicValue = {
+    context: 'ECS service stuck in DRAINING',
+    reasoning: 'cycle the tasks via force-new-deployment',
+    action: 'aws ecs update-service --force-new-deployment',
+    outcome: 'SUCCEEDED — service returned to steady state',
+};
+
+const distillerReturning = (content: string) =>
+    ({ invoke: vi.fn().mockResolvedValue({ content }) }) as any;
+
+const baseParams = (overrides: Record<string, unknown> = {}) => ({
+    tenantId: 't1', userId: 'u1', threadId: 'th-9',
+    distillerModel: distillerReturning(JSON.stringify(goodEpisode)),
+    taskDescription: 'restart stuck ECS service',
+    plan: [{ step: 'find service', status: 'completed' }],
+    toolResults: [{ toolName: 'execute_command', output: 'service restarted', isError: false }],
+    errors: [], reflection: 'looks good', isComplete: true, iterationCount: 3,
+    ...overrides,
+});
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mockSvc.remember.mockResolvedValue('ep-row-id');
+    vi.mocked(getMemoryService).mockReturnValue(mockSvc as any);
+});
+afterEach(() => { delete process.env.EPISODIC_MEMORY_ENABLED; });
+
+describe('episodicMemoryEnabled', () => {
+    it('defaults true; false/0 disable', () => {
+        expect(episodicMemoryEnabled()).toBe(true);
+        process.env.EPISODIC_MEMORY_ENABLED = 'false';
+        expect(episodicMemoryEnabled()).toBe(false);
+    });
+});
+
+describe('captureEpisode', () => {
+    it('distills and saves an EPISODIC memory keyed by thread', async () => {
+        const saved = await captureEpisode(baseParams() as any);
+        expect(saved).toBe(true);
+        expect(mockSvc.remember).toHaveBeenCalledWith(expect.objectContaining({
+            tenantId: 't1', userId: 'u1', kind: 'EPISODIC',
+            namespace: ['episodes'], key: 'thread-th-9', sourceThreadId: 'th-9',
+            value: expect.objectContaining({ outcome: goodEpisode.outcome }),
+        }));
+    });
+
+    it('SKIP → no save, returns false', async () => {
+        const saved = await captureEpisode(baseParams({ distillerModel: distillerReturning('SKIP') }) as any);
+        expect(saved).toBe(false);
+        expect(mockSvc.remember).not.toHaveBeenCalled();
+    });
+
+    it('invalid distiller output (missing outcome) → no save, false', async () => {
+        const bad = JSON.stringify({ context: 'c', reasoning: 'r', action: 'a' });
+        const saved = await captureEpisode(baseParams({ distillerModel: distillerReturning(bad) }) as any);
+        expect(saved).toBe(false);
+        expect(mockSvc.remember).not.toHaveBeenCalled();
+    });
+
+    it('distiller throwing → false, does not throw', async () => {
+        const boom = { invoke: vi.fn().mockRejectedValue(new Error('llm down')) } as any;
+        const saved = await captureEpisode(baseParams({ distillerModel: boom }) as any);
+        expect(saved).toBe(false);
+    });
+
+    it('flag off → short-circuits before invoking the distiller', async () => {
+        process.env.EPISODIC_MEMORY_ENABLED = 'false';
+        const distiller = distillerReturning(JSON.stringify(goodEpisode));
+        const saved = await captureEpisode(baseParams({ distillerModel: distiller }) as any);
+        expect(saved).toBe(false);
+        expect(distiller.invoke).not.toHaveBeenCalled();
+    });
+});
+
+describe('formatEpisodesSection', () => {
+    it("returns '' for empty input", () => {
+        expect(formatEpisodesSection([])).toBe('');
+    });
+    it('renders all four labeled fields', () => {
+        const s = formatEpisodesSection([goodEpisode]);
+        expect(s).toContain('### Past experience');
+        expect(s).toContain(`**Situation:** ${goodEpisode.context}`);
+        expect(s).toContain(`**Approach:** ${goodEpisode.reasoning}`);
+        expect(s).toContain(`**Actions taken:** ${goodEpisode.action}`);
+        expect(s).toContain(`**Outcome:** ${goodEpisode.outcome}`);
+    });
+});
+
+describe('composeMemoryContext', () => {
+    it('facts only → bare facts (legacy shape, no headers added)', () => {
+        expect(composeMemoryContext('- [a/b] fact', '')).toBe('- [a/b] fact');
+    });
+    it('episodes only → episodes section as-is', () => {
+        expect(composeMemoryContext('', '### Past experience\nX')).toBe('### Past experience\nX');
+    });
+    it('both → facts under a Known facts header, then episodes', () => {
+        const s = composeMemoryContext('- [a/b] fact', '### Past experience\nX');
+        expect(s).toBe('### Known facts\n- [a/b] fact\n\n### Past experience\nX');
+    });
+    it("both empty → ''", () => {
+        expect(composeMemoryContext('', '')).toBe('');
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/memory/episode.test.ts`
+Expected: FAIL — `Cannot find module './episode'`.
+
+- [ ] **Step 3: Implement `episode.ts`**
+
+```typescript
+/**
+ * episode.ts — episodic memory: capture + replay formatting (Phase 3).
+ *
+ * Capture: distill one cognitive snapshot (context/reasoning/action/outcome)
+ * per tool-using run; the distiller may SKIP routine runs; failures are
+ * first-class ("what didn't work" is the most valuable experience). One
+ * episode per thread (key `thread-<threadId>`), refreshed via the live-unique
+ * upsert. Episodes bypass the reconcile judge — they are historical records.
+ * Replay: pure formatters that compose episodes into the memoryContext string.
+ * Never throws.
+ */
+
+import { SystemMessage, HumanMessage } from '@langchain/core/messages';
+import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
+import { getMemoryService } from './memory-service';
+import { compressToolOutput } from './working-memory';
+import type { EpisodicValue } from './types';
+
+export const EPISODE_RECALL_LIMIT = 2;
+// Looser than reconcile's 0.55 — an ANALOGOUS past experience is useful even
+// when not near-identical. Initial guess — tune from recall logs.
+export const EPISODE_DISTANCE_THRESHOLD = 0.65;
+
+export function episodicMemoryEnabled(): boolean {
+    const v = process.env.EPISODIC_MEMORY_ENABLED?.toLowerCase();
+    return !(v === 'false' || v === '0');
+}
+
+export interface CaptureEpisodeParams {
+    tenantId: string;
+    userId: string;
+    threadId: string;
+    distillerModel: BaseChatModel;
+    taskDescription: string;
+    plan: Array<{ step: string; status: string }>;
+    toolResults: Array<{ toolName: string; output: string; isError: boolean }>;
+    errors: string[];
+    reflection: string;
+    isComplete: boolean;
+    iterationCount: number;
+}
+
+function isNonEmptyString(v: unknown): v is string {
+    return typeof v === 'string' && v.trim().length > 0;
+}
+
+const DISTILLER_SYSTEM = new SystemMessage(
+    `You distill a completed agent run into ONE reusable episode for future few-shot recall.
+Return ONLY a JSON object with exactly these four non-empty string fields:
+{"context": "...", "reasoning": "...", "action": "...", "outcome": "..."}
+- context: the task/situation the agent faced (generalized; drop ephemeral IDs unless essential).
+- reasoning: the approach taken and why.
+- action: the key tool calls / steps actually executed.
+- outcome: whether it SUCCEEDED or FAILED, and why. Failures are valuable — capture what didn't work.
+If the run was routine or unremarkable (simple lookups, trivial queries), return exactly: SKIP`,
+);
+
+export async function captureEpisode(p: CaptureEpisodeParams): Promise<boolean> {
+    if (!episodicMemoryEnabled()) return false;
+    try {
+        const toolSummary = p.toolResults
+            .map((t) => `- ${t.toolName} [${t.isError ? 'ERROR' : 'OK'}]: ${compressToolOutput(t.output, 400)}`)
+            .join('\n');
+        const planSummary = p.plan.length
+            ? p.plan.map((s, i) => `${i + 1}. [${s.status}] ${s.step}`).join('\n')
+            : '(no explicit plan)';
+
+        const input = new HumanMessage(
+            `**Task:** ${compressToolOutput(p.taskDescription || '(unknown)', 1000)}\n\n` +
+            `**Plan:**\n${planSummary}\n\n` +
+            `**Tool executions:**\n${compressToolOutput(toolSummary, 4000)}\n\n` +
+            `**Errors:** ${p.errors.length ? p.errors.join('; ') : '(none)'}\n\n` +
+            `**Reviewer reflection:** ${compressToolOutput(p.reflection || '(none)', 800)}\n\n` +
+            `**Completed:** ${p.isComplete} after ${p.iterationCount} iterations.\n\n` +
+            `Distill the episode now.`,
+        );
+
+        const resp = await p.distillerModel.invoke([DISTILLER_SYSTEM, input]);
+        const content = typeof resp.content === 'string' ? resp.content : JSON.stringify(resp.content);
+        if (content.trim() === 'SKIP') {
+            console.log('🧠 [EPISODE] Distiller skipped — routine run');
+            return false;
+        }
+        const match = content.match(/\{[\s\S]*\}/);
+        if (!match) {
+            console.warn('🧠 [EPISODE] No JSON object in distiller output — not saved');
+            return false;
+        }
+        const parsed = JSON.parse(match[0]) as Partial<EpisodicValue>;
+        if (!isNonEmptyString(parsed.context) || !isNonEmptyString(parsed.reasoning)
+            || !isNonEmptyString(parsed.action) || !isNonEmptyString(parsed.outcome)) {
+            console.warn('🧠 [EPISODE] Distiller output invalid — not saved');
+            return false;
+        }
+        const value: EpisodicValue = {
+            context: parsed.context, reasoning: parsed.reasoning,
+            action: parsed.action, outcome: parsed.outcome,
+        };
+        await getMemoryService().remember({
+            tenantId: p.tenantId, userId: p.userId, kind: 'EPISODIC',
+            namespace: ['episodes'], key: `thread-${p.threadId}`,
+            value: value as unknown as Record<string, unknown>,
+            sourceThreadId: p.threadId,
+        });
+        console.log(`🧠 [EPISODE] Captured episode for thread ${p.threadId}`);
+        return true;
+    } catch (err: any) {
+        console.warn(`🧠 [EPISODE] Capture failed (non-fatal): ${err?.message ?? err}`);
+        return false;
+    }
+}
+
+/** Render episodes as few-shot experience blocks; '' for empty input. */
+export function formatEpisodesSection(episodes: EpisodicValue[]): string {
+    if (!episodes.length) return '';
+    const blocks = episodes.map((e) =>
+        `**Situation:** ${e.context}\n**Approach:** ${e.reasoning}\n**Actions taken:** ${e.action}\n**Outcome:** ${e.outcome}`,
+    ).join('\n\n---\n\n');
+    return `### Past experience (similar previous sessions)\n${blocks}`;
+}
+
+/**
+ * Compose memoryContext from facts + episodes. Facts-only returns the bare
+ * facts string (byte-identical to pre-Phase-3 behavior); the "Known facts"
+ * header appears only when episodes are also present.
+ */
+export function composeMemoryContext(factsSection: string, episodesSection: string): string {
+    const facts = factsSection.trim();
+    const episodes = episodesSection.trim();
+    if (facts && episodes) return `### Known facts\n${facts}\n\n${episodes}`;
+    if (facts) return facts;
+    if (episodes) return episodes;
+    return '';
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/memory/episode.test.ts`
+Expected: PASS (all 12).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web-ui/lib/agent/memory/episode.ts apps/web-ui/lib/agent/memory/episode.test.ts
+git commit -m "feat(memory): episodic capture (distiller + SKIP veto) and replay formatters"
+```
+
+---
+
+## Task 2: Wire capture + replay into memory-nodes + env flag
+
+**Files:**
+- Modify: `apps/web-ui/lib/agent/memory-nodes.ts` (imports; recall node body :26-107; save node tail :223-228)
+- Modify: `apps/web-ui/env.ts` (feature-flags block, after `MEMORY_RECONCILE_ENABLED`)
+- Modify: `.env.example` (after the `MEMORY_RECONCILE_ENABLED=true` block)
+
+**Interfaces:**
+- Consumes: everything from Task 1; `getMemoryService()` (`recall({ kinds, limit, query, tenantId, userId })` → hits with `value`, `distance?`); existing node deps (`reflectorModel`, `tenantId`, `userId`); `runtimeConfig?.configurable?.thread_id` (already on the save node).
+
+- [ ] **Step 1: env.ts + .env.example**
+
+In `apps/web-ui/env.ts`, after `MEMORY_RECONCILE_ENABLED: z.string().optional(),` add:
+
+```typescript
+        EPISODIC_MEMORY_ENABLED: z.string().optional(),
+```
+
+In `.env.example`, after the `MEMORY_RECONCILE_ENABLED=true` line add:
+
+```
+# Episodic memory (Phase 3) — capture one distilled episode per tool-using run and
+# replay similar past episodes as few-shot experience at task start.
+EPISODIC_MEMORY_ENABLED=true
+```
+
+- [ ] **Step 2: memory-nodes.ts imports**
+
+Replace `import { searchMemory, saveMemory } from "./persistence";` with:
+
+```typescript
+import { saveMemory } from "./persistence";
+import { getMemoryService } from "./memory/memory-service";
+import {
+    captureEpisode, episodicMemoryEnabled, formatEpisodesSection, composeMemoryContext,
+    EPISODE_RECALL_LIMIT, EPISODE_DISTANCE_THRESHOLD,
+} from "./memory/episode";
+```
+
+and extend the type-only import:
+
+```typescript
+import type { ExtractedFact, EpisodicValue } from "./memory/types";
+```
+
+- [ ] **Step 3: Rework `memoryRecallNode` (two typed recalls + composition)**
+
+Replace the ENTIRE body of the returned `memoryRecallNode` function — from the `let rawResults: ...` line (currently :45) through the final `return { memoryContext: relevantMemories };` (currently :106) — with:
+
+```typescript
+        // ── Semantic facts → existing LLM relevance filter ──────────────────
+        let factsSection = "";
+        try {
+            const hits = await getMemoryService().recall({
+                tenantId, userId, query, kinds: ["SEMANTIC"], limit: 10,
+            });
+            if (hits.length > 0) {
+                console.log(`[MemoryRecall] Found ${hits.length} raw facts, filtering for relevance...`);
+                const memorySummary = hits.map((m, i) =>
+                    `${i + 1}. [${m.namespace}/${m.key}] ${JSON.stringify(m.value)}`
+                ).join("\n");
+                try {
+                    const filterPrompt = new SystemMessage(
+                        `You are a relevance filter. Given a user task and a list of memories from previous sessions, return ONLY the memories that are directly relevant to the current task.
+
+Return a markdown list of relevant memories, each on its own line with the format:
+- [namespace/key] One-line summary of the relevant fact
+
+If no memories are relevant, return exactly: NONE`
+                    );
+                    const filterInput = new HumanMessage({
+                        content: `**User Task:** ${truncateOutput(query, 2000)}
+
+**Available Memories:**
+${memorySummary}
+
+Return only the relevant memories.`
+                    });
+                    const response = await reflectorModel.invoke([filterPrompt, filterInput]);
+                    const content = typeof response.content === "string"
+                        ? response.content
+                        : JSON.stringify(response.content);
+                    factsSection = (content.trim() === "NONE") ? "" : content.trim();
+                } catch (err: any) {
+                    console.warn(`[MemoryRecall] Relevance filter failed: ${err?.message ?? err}`);
+                    factsSection = hits.slice(0, 5).map(m =>
+                        `- [${m.namespace}/${m.key}] ${JSON.stringify(m.value)}`
+                    ).join("\n");
+                }
+            }
+        } catch (err: any) {
+            console.warn(`[MemoryRecall] Semantic search failed: ${err?.message ?? err}`);
+        }
+
+        // ── Episodic few-shot replay — distance-gated, no LLM filter ────────
+        let episodesSection = "";
+        if (episodicMemoryEnabled()) {
+            try {
+                const eps = await getMemoryService().recall({
+                    tenantId, userId, query, kinds: ["EPISODIC"], limit: EPISODE_RECALL_LIMIT,
+                });
+                const near = eps.filter(e => e.distance !== undefined && e.distance <= EPISODE_DISTANCE_THRESHOLD);
+                if (near.length > 0) {
+                    console.log(`🧠 [MEMORY RECALL] Replaying ${near.length} past episode(s)`);
+                    episodesSection = formatEpisodesSection(near.map(e => e.value as unknown as EpisodicValue));
+                }
+            } catch (err: any) {
+                console.warn(`[MemoryRecall] Episodic search failed: ${err?.message ?? err}`);
+            }
+        }
+
+        const memoryContext = composeMemoryContext(factsSection, episodesSection);
+        if (memoryContext) {
+            console.log(`🧠 [MEMORY RECALL] Injecting relevant memories into context`);
+        } else {
+            console.log("[MemoryRecall] Nothing relevant found");
+        }
+        return { memoryContext };
+```
+
+(The guard clauses above it — store/tenantId/userId check, lastHuman extraction, `query`, the `🧠 [MEMORY RECALL] Searching...` log — stay exactly as they are.)
+
+- [ ] **Step 4: Episode capture in `memorySaveNode`**
+
+Immediately BEFORE the final `return {};` of `memorySaveNode` (after the extraction `try/catch` block closes at :225), add:
+
+```typescript
+        // ── Episodic capture — independent of fact extraction; never blocks END ──
+        const { plan, toolResults, errors, reflection, isComplete, iterationCount } = state;
+        const threadIdForEpisode = runtimeConfig?.configurable?.thread_id as string | undefined;
+        if (episodicMemoryEnabled() && threadIdForEpisode && toolResults.length > 0) {
+            await captureEpisode({
+                tenantId, userId, threadId: threadIdForEpisode,
+                distillerModel: reflectorModel,
+                taskDescription, plan, toolResults, errors, reflection, isComplete, iterationCount,
+            });
+        }
+```
+
+- [ ] **Step 5: Verify**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/memory/ && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep -E "^lib/agent/memory-nodes" || echo "no errors in memory-nodes.ts"`
+Expected: all memory tests PASS (45 = 33 + 12 new); `no errors in memory-nodes.ts`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web-ui/lib/agent/memory-nodes.ts apps/web-ui/env.ts .env.example
+git commit -m "feat(memory): episodic capture + few-shot replay wired into memory nodes"
+```
+
+---
+
+## Task 3: Memory-module — episodes category + list fallback
+
+**Files:**
+- Modify: `apps/web-ui/lib/agent-memory/category.ts:1-5`
+- Modify: `apps/web-ui/lib/db/repositories/agent-memory/postgres.ts` (`toRecord` fact mapping)
+- Modify: `apps/web-ui/lib/db/repositories/agent-memory/postgres.test.ts`
+
+**Interfaces:**
+- Produces: `MemoryCategory` includes `'episodes'`; episodic rows list their `outcome` in the fact column.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the `describe('AgentMemoryPostgresRepository', ...)` block in `postgres.test.ts`:
+
+```typescript
+    it('maps episodic rows: category from namespace, fact falls back to outcome', async () => {
+        mockPrisma.agentMemory.findFirst.mockResolvedValueOnce(makeRow({
+            namespace: 'episodes',
+            key: 'thread-th-9',
+            kind: 'EPISODIC',
+            value: { context: 'c', reasoning: 'r', action: 'a', outcome: 'SUCCEEDED — cycled tasks' },
+        }));
+        const repo = new AgentMemoryPostgresRepository();
+        const rec = await repo.getById('t1', 'mem-1');
+        expect(rec?.category).toBe('episodes');
+        expect(rec?.fact).toBe('SUCCEEDED — cycled tasks');
+    });
+```
+
+Run: `cd apps/web-ui && bunx vitest run lib/db/repositories/agent-memory/postgres.test.ts`
+Expected: FAIL — category is `'other'` and fact is `''`.
+
+- [ ] **Step 2: Implement**
+
+`category.ts` — extend the type and constant (update the stale "four" comment too):
+
+```typescript
+/** UI bucket derived from an AgentMemory namespace's first path segment. */
+export type MemoryCategory = 'infra' | 'user' | 'patterns' | 'errors' | 'episodes' | 'other';
+
+/** The agent-written namespace prefixes, in the order the UI shows them. */
+export const KNOWN_CATEGORIES: MemoryCategory[] = ['infra', 'user', 'patterns', 'errors', 'episodes'];
+```
+
+`postgres.ts` — in `toRecord`, change the fact mapping line to:
+
+```typescript
+        fact: asString(value.fact) ?? asString(value.outcome) ?? '',
+```
+
+- [ ] **Step 3: Run tests to verify pass**
+
+Run: `cd apps/web-ui && bunx vitest run lib/db/repositories/agent-memory/postgres.test.ts`
+Expected: PASS (all existing + 1 new).
+
+- [ ] **Step 4: Typecheck the UI surface**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep -E "^(lib/agent-memory/|lib/db/repositories/agent-memory/|components/memory/|lib/queries/agent-memories)" || echo "no errors"`
+Expected: `no errors`. (The category union is consumed by the memory client component's filter chips — driven by `KNOWN_CATEGORIES`, so no component edits are needed; the typecheck confirms it.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web-ui/lib/agent-memory/category.ts apps/web-ui/lib/db/repositories/agent-memory/postgres.ts apps/web-ui/lib/db/repositories/agent-memory/postgres.test.ts
+git commit -m "feat(memory): episodes category + outcome fallback in Memory module"
+```
+
+---
+
+## Task 4: Full verification + docs
+
+**Files:**
+- Modify: `CLAUDE.md` (Agent Architecture key-modules table, after the `memory/reconcile.ts` row)
+
+- [ ] **Step 1: Full memory + repo suites**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/memory/ lib/db/repositories/agent-memory/`
+Expected: all PASS (≥ 60 tests).
+
+- [ ] **Step 2: Typecheck all touched files (exact-path grep; only pre-existing baseline allowed)**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep -E "^(lib/agent/memory/|lib/agent/memory-nodes|lib/agent-memory/|lib/db/repositories/agent-memory/)" || echo "no new errors"`
+Expected: `no new errors`.
+
+- [ ] **Step 3: CLAUDE.md**
+
+After the `memory/reconcile.ts` table row, add:
+
+```markdown
+| `memory/episode.ts` | Episodic memory: one distilled episode (context/reasoning/action/outcome) per tool-using run, replayed as few-shot experience via memoryContext. Gated by `EPISODIC_MEMORY_ENABLED`. |
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(memory): document episodic memory module"
+```
+
+---
+
+## Self-Review (completed against the spec)
+
+- **Spec §A (capture: pre-filter, distiller, SKIP, validation, thread-keyed upsert, judge bypass, non-fatal):** Task 1 (`captureEpisode` + 5 tests) + Task 2 Step 4 (call-site gating `flag && threadId && toolResults.length > 0`). ✅
+- **Spec §B (replay: two typed recalls, distance gate 0.65, no second LLM, composed memoryContext, flag-gated episodic step, facts-only byte-identical):** Task 1 (`formatEpisodesSection`/`composeMemoryContext` + tests incl. legacy-shape assertion) + Task 2 Step 3. ✅
+- **Spec §C (UI: episodes category + outcome fallback):** Task 3. ✅
+- **Spec §D (env flag + constants):** Task 1 (accessor + constants) + Task 2 Step 1. ✅
+- **Testing section:** capture gating/validation (Task 1), composition combinations (Task 1), repo mapping (Task 3); manual smoke deferred to user per spec. ✅
+- **Type consistency:** `CaptureEpisodeParams`, `EpisodicValue`, `composeMemoryContext(factsSection, episodesSection)`, `EPISODE_*` constants used identically across Tasks 1–2. `PlanStep.status` union assignable to `string` — verified. ✅
+- **No placeholders:** every code step carries complete code; commands carry expected output. ✅

--- a/docs/superpowers/plans/2026-07-02-agent-memory-phase4-procedural.md
+++ b/docs/superpowers/plans/2026-07-02-agent-memory-phase4-procedural.md
@@ -1,0 +1,800 @@
+# Agent Memory Phase 4 — Procedural Memory + Skills Bridge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The agent learns operating rules (`PROCEDURAL` memories) from corrections/failures/preferences, applies the most relevant ones as an `### Operating rules (learned)` prompt section, and matured rules can be promoted — with human review — into full DB-backed Skills.
+
+**Architecture:** Capture rides the existing extraction LLM call (a fifth, flag-gated category emitting `{instruction, trigger, evidence, confidence}` items) and the existing reconcile pipeline made kind-aware (rules dedupe/supersede/reinforce against rules). Injection is a third distance-gated recall composed into the existing `memoryContext` (facts → rules → episodes; zero agent-file changes). The Skills bridge reuses the distill flow's pattern verbatim: a "Promote to skill" action on procedural rows pre-fills the existing `SkillFormDialog`; nothing persists until the human saves via the RBAC-enforced `POST /api/skills`.
+
+**Tech Stack:** TypeScript 5, LangGraph JS, existing MemoryService (pgvector), React 19 + TanStack Query (UI task), Vitest.
+
+## Global Constraints
+
+- **Feature gate:** `PROCEDURAL_MEMORY_ENABLED` (process.env accessor pattern; default true; `'false'`/`'0'` disable). Off → extraction prompt reverts to the Phase 3 four-category text and no procedural recall section.
+- **Kind-aware reconcile defaults:** `fact.kind ?? 'SEMANTIC'` everywhere — absent kind must behave byte-identically to Phase 3 (existing 13 reconcile tests must pass unchanged).
+- **`composeMemoryContext` exact-shape contract:** all existing two-arg behaviors byte-identical (facts-only bare; header only with company); new third param defaults `''`. Output order: facts → procedures → episodes.
+- **Legacy (reconcile-off) save loop stays semantic-only:** procedural items are skipped with a log when `MEMORY_RECONCILE_ENABLED=false` — rules are a new feature that rides reconcile; the off-switch remains a clean rollback to old behavior.
+- **Promotion is human-approved only:** no DB write from the memory side; the existing `SkillFormDialog` → `useCreateSkill` → `POST /api/skills` path (RBAC `create Skill`) is the only persistence route. `sourceRunId` carries the memory's `sourceThreadId` for provenance.
+- **Non-fatal:** procedural recall failure degrades to facts+episodes; invalid extracted items are dropped, never crash the node.
+- **Style:** named exports; 4-space indent in `lib/`, 2-space in `components/` (match surrounding); `@/` alias.
+- **Known tsc baseline (do not fix/count):** `persistence.ts(57)`, `persistence.test.ts(68)`, fast/planning-agent store→BaseStore, `agent-shared.ts:530-531`.
+- **Deep-agent untouched.**
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `apps/web-ui/lib/agent/memory/types.ts` | `ProceduralValue.confidence?`; `ExtractedFact.kind?` + value union |
+| `apps/web-ui/lib/agent/memory/procedural.ts` (+test) | **new** — flag, constants, `formatProceduresSection`, `isValidExtractedItem` |
+| `apps/web-ui/lib/agent/memory/episode.ts` (+test) | `composeMemoryContext` gains optional third param |
+| `apps/web-ui/lib/agent/memory/reconcile.ts` (+test) | kind threading |
+| `apps/web-ui/lib/agent/memory-nodes.ts` | extraction 5th category + shape-aware filter; third recall section |
+| `apps/web-ui/env.ts` + `.env.example` | `PROCEDURAL_MEMORY_ENABLED` |
+| `apps/web-ui/lib/db/repositories/agent-memory/{interface,postgres}.ts` (+test) | expose `sourceThreadId` |
+| `apps/web-ui/lib/queries/agent-memories.ts` | `MemoryRow` gains `kind`, `sourceThreadId` |
+| `apps/web-ui/lib/agent-memory/promote.ts` (+test) | **new** — `buildSkillDraftFromMemory` |
+| `apps/web-ui/components/memory/memory-client-component.tsx` | Promote action + `SkillFormDialog` wiring |
+| `CLAUDE.md` | one table row |
+
+## Interfaces (locked — every task must match)
+
+```typescript
+// types.ts changes
+export interface ProceduralValue { instruction: string; trigger: string; evidence: string; confidence?: 'high' | 'medium'; }
+export interface ExtractedFact {
+    kind?: MemoryKind;                      // absent = 'SEMANTIC'
+    namespace: string[];
+    key: string;
+    value: SemanticValue | ProceduralValue;
+}
+
+// procedural.ts
+export const PROCEDURE_RECALL_LIMIT = 3;
+export const PROCEDURE_DISTANCE_THRESHOLD = 0.65;
+export function proceduralMemoryEnabled(): boolean;
+export function formatProceduresSection(rules: ProceduralValue[]): string;   // '' for []
+export function isValidExtractedItem(item: { kind?: string; value?: Record<string, unknown> }): boolean;
+
+// episode.ts
+export function composeMemoryContext(factsSection: string, episodesSection: string, proceduresSection?: string): string;
+
+// promote.ts (client-safe, pure)
+export interface SkillDraft { name: string; description: string; tier: string; content: string; }
+export function buildSkillDraftFromMemory(row: MemoryRow): SkillDraft | null;  // null unless kind==='PROCEDURAL' with instruction+trigger
+
+// MemoryRow (lib/queries/agent-memories.ts) gains:
+kind: MemoryKind;
+sourceThreadId: string | null;
+
+// AgentMemoryRecord (repo interface) gains:
+sourceThreadId: string | null;
+```
+
+`SkillFormDialog` (existing, reused as-is): props `{ open, onOpenChange, initialDraft?: { name; description; tier; content } | null, sourceRunId?: string | null }` — create-mode submit posts via `useCreateSkill` with `sourceRunId`.
+
+---
+
+## Task 1: Types, procedural.ts core, composeMemoryContext third param
+
+**Files:**
+- Modify: `apps/web-ui/lib/agent/memory/types.ts` (ProceduralValue, ExtractedFact)
+- Create: `apps/web-ui/lib/agent/memory/procedural.ts`
+- Create: `apps/web-ui/lib/agent/memory/procedural.test.ts`
+- Modify: `apps/web-ui/lib/agent/memory/episode.ts` (composeMemoryContext only)
+- Modify: `apps/web-ui/lib/agent/memory/episode.test.ts` (append 3-arg tests; existing tests untouched)
+
+**Interfaces:**
+- Consumes: `ProceduralValue`/`MemoryKind` from `./types`.
+- Produces: everything in the Interfaces section above.
+
+- [ ] **Step 1: types.ts edits**
+
+Replace the `ProceduralValue` line with:
+
+```typescript
+export interface ProceduralValue { instruction: string; trigger: string; evidence: string; confidence?: 'high' | 'medium'; }
+```
+
+Replace the `ExtractedFact` interface with:
+
+```typescript
+export interface ExtractedFact {
+    /** Memory layer this item belongs to; absent = 'SEMANTIC'. */
+    kind?: MemoryKind;
+    namespace: string[];
+    key: string;
+    value: SemanticValue | ProceduralValue;
+}
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `apps/web-ui/lib/agent/memory/procedural.test.ts`:
+
+```typescript
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+    proceduralMemoryEnabled, formatProceduresSection, isValidExtractedItem,
+    PROCEDURE_RECALL_LIMIT, PROCEDURE_DISTANCE_THRESHOLD,
+} from './procedural';
+
+afterEach(() => { delete process.env.PROCEDURAL_MEMORY_ENABLED; });
+
+describe('proceduralMemoryEnabled', () => {
+    it('defaults true; false/0 disable', () => {
+        expect(proceduralMemoryEnabled()).toBe(true);
+        process.env.PROCEDURAL_MEMORY_ENABLED = 'false';
+        expect(proceduralMemoryEnabled()).toBe(false);
+    });
+});
+
+describe('constants', () => {
+    it('locked values', () => {
+        expect(PROCEDURE_RECALL_LIMIT).toBe(3);
+        expect(PROCEDURE_DISTANCE_THRESHOLD).toBe(0.65);
+    });
+});
+
+describe('formatProceduresSection', () => {
+    it("returns '' for empty input", () => {
+        expect(formatProceduresSection([])).toBe('');
+    });
+    it('renders one "- When <trigger>: <instruction>" line per rule under the header', () => {
+        const s = formatProceduresSection([
+            { instruction: 'Always paginate list calls', trigger: 'any AWS CLI list operation', evidence: 'e1' },
+            { instruction: 'Verify state before mutation', trigger: 'any resource mutation', evidence: 'e2' },
+        ]);
+        expect(s).toBe(
+            '### Operating rules (learned)\n' +
+            '- When any AWS CLI list operation: Always paginate list calls\n' +
+            '- When any resource mutation: Verify state before mutation',
+        );
+    });
+});
+
+describe('isValidExtractedItem', () => {
+    const semantic = (v: Record<string, unknown>) => ({ value: v });
+    const procedural = (v: Record<string, unknown>) => ({ kind: 'PROCEDURAL', value: v });
+
+    it('semantic: requires non-empty fact + high/medium confidence', () => {
+        expect(isValidExtractedItem(semantic({ fact: 'x', confidence: 'high' }))).toBe(true);
+        expect(isValidExtractedItem(semantic({ fact: 'x', confidence: 'low' }))).toBe(false);
+        expect(isValidExtractedItem(semantic({ fact: '  ', confidence: 'high' }))).toBe(false);
+        expect(isValidExtractedItem(semantic({ confidence: 'high' }))).toBe(false);
+    });
+
+    it('procedural: requires non-empty instruction/trigger/evidence + high/medium confidence', () => {
+        expect(isValidExtractedItem(procedural({ instruction: 'i', trigger: 't', evidence: 'e', confidence: 'medium' }))).toBe(true);
+        expect(isValidExtractedItem(procedural({ instruction: 'i', trigger: 't', confidence: 'high' }))).toBe(false);
+        expect(isValidExtractedItem(procedural({ instruction: 'i', trigger: 't', evidence: '', confidence: 'high' }))).toBe(false);
+        expect(isValidExtractedItem(procedural({ instruction: 'i', trigger: 't', evidence: 'e', confidence: 'low' }))).toBe(false);
+    });
+
+    it('rejects missing/non-object value', () => {
+        expect(isValidExtractedItem({} as any)).toBe(false);
+        expect(isValidExtractedItem({ value: undefined } as any)).toBe(false);
+    });
+});
+```
+
+Append to `episode.test.ts` (inside or after the existing `composeMemoryContext` describe — new describe keeps it clean):
+
+```typescript
+describe('composeMemoryContext with procedures (third arg)', () => {
+    it('third arg defaults empty — two-arg behavior unchanged', () => {
+        expect(composeMemoryContext('- [a/b] fact', '')).toBe('- [a/b] fact');
+    });
+    it('all three → facts header, procedures, episodes in order', () => {
+        const s = composeMemoryContext('- [a/b] fact', '### Past experience\nE', '### Operating rules (learned)\nR');
+        expect(s).toBe('### Known facts\n- [a/b] fact\n\n### Operating rules (learned)\nR\n\n### Past experience\nE');
+    });
+    it('procedures only → section as-is', () => {
+        expect(composeMemoryContext('', '', '### Operating rules (learned)\nR')).toBe('### Operating rules (learned)\nR');
+    });
+    it('procedures + episodes (no facts) → joined, no facts header', () => {
+        expect(composeMemoryContext('', '### Past experience\nE', '### Operating rules (learned)\nR'))
+            .toBe('### Operating rules (learned)\nR\n\n### Past experience\nE');
+    });
+    it('facts + procedures (no episodes) → facts header + procedures', () => {
+        expect(composeMemoryContext('- f', '', '### Operating rules (learned)\nR'))
+            .toBe('### Known facts\n- f\n\n### Operating rules (learned)\nR');
+    });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/memory/procedural.test.ts lib/agent/memory/episode.test.ts`
+Expected: procedural.test.ts FAILS (module not found); episode.test.ts new describe FAILS (third arg ignored / wrong output).
+
+- [ ] **Step 4: Implement**
+
+Create `apps/web-ui/lib/agent/memory/procedural.ts`:
+
+```typescript
+/**
+ * procedural.ts — procedural memory (Phase 4): learned operating rules.
+ *
+ * Capture rides the memory-save extraction (kind: 'PROCEDURAL' items) and the
+ * kind-aware reconcile pipeline. This module holds the flag, recall constants,
+ * the prompt-section formatter, and the shape-aware extraction-item validator.
+ */
+
+import type { ProceduralValue } from './types';
+
+export const PROCEDURE_RECALL_LIMIT = 3;
+// Shared value with EPISODE_DISTANCE_THRESHOLD — one knob until logs say otherwise.
+export const PROCEDURE_DISTANCE_THRESHOLD = 0.65;
+
+export function proceduralMemoryEnabled(): boolean {
+    const v = process.env.PROCEDURAL_MEMORY_ENABLED?.toLowerCase();
+    return !(v === 'false' || v === '0');
+}
+
+function isNonEmptyString(v: unknown): v is string {
+    return typeof v === 'string' && v.trim().length > 0;
+}
+
+/** Render learned rules as an imperative prompt section; '' for empty input. */
+export function formatProceduresSection(rules: ProceduralValue[]): string {
+    if (!rules.length) return '';
+    const lines = rules.map((r) => `- When ${r.trigger}: ${r.instruction}`);
+    return `### Operating rules (learned)\n${lines.join('\n')}`;
+}
+
+/**
+ * Shape-aware validity check for raw extracted items (semantic or procedural).
+ * Both shapes require high/medium confidence; procedural items additionally
+ * require instruction/trigger/evidence, semantic items require fact.
+ */
+export function isValidExtractedItem(item: { kind?: string; value?: Record<string, unknown> }): boolean {
+    const v = item?.value;
+    if (!v || typeof v !== 'object') return false;
+    if (v.confidence !== 'high' && v.confidence !== 'medium') return false;
+    if (item.kind === 'PROCEDURAL') {
+        return isNonEmptyString(v.instruction) && isNonEmptyString(v.trigger) && isNonEmptyString(v.evidence);
+    }
+    return isNonEmptyString(v.fact);
+}
+```
+
+In `episode.ts`, replace `composeMemoryContext` with:
+
+```typescript
+/**
+ * Compose memoryContext from facts + episodes + learned rules. Facts-only returns
+ * the bare facts string (byte-identical to pre-Phase-3 behavior); the "Known facts"
+ * header appears only when facts coexist with another section. Output order:
+ * facts → operating rules → past experience (imperatives before illustrations).
+ */
+export function composeMemoryContext(factsSection: string, episodesSection: string, proceduresSection = ''): string {
+    const facts = factsSection.trim();
+    const episodes = episodesSection.trim();
+    const procedures = proceduresSection.trim();
+    const others = [procedures, episodes].filter(Boolean);
+    if (facts && others.length) return [`### Known facts\n${facts}`, ...others].join('\n\n');
+    if (facts) return facts;
+    return others.join('\n\n');
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/memory/procedural.test.ts lib/agent/memory/episode.test.ts`
+Expected: ALL pass — including every pre-existing episode.test.ts assertion (byte-shape contract).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web-ui/lib/agent/memory/types.ts apps/web-ui/lib/agent/memory/procedural.ts apps/web-ui/lib/agent/memory/procedural.test.ts apps/web-ui/lib/agent/memory/episode.ts apps/web-ui/lib/agent/memory/episode.test.ts
+git commit -m "feat(memory): procedural core — rule formatter, item validator, 3-section compose"
+```
+
+---
+
+## Task 2: Kind-aware reconcile
+
+**Files:**
+- Modify: `apps/web-ui/lib/agent/memory/reconcile.ts` (neighbor recall, `add`, SUPERSEDE, judge prompt)
+- Modify: `apps/web-ui/lib/agent/memory/reconcile.test.ts` (append kind tests)
+
+**Interfaces:**
+- Consumes: `ExtractedFact.kind?` (Task 1).
+- Produces: reconcile threads `fact.kind ?? 'SEMANTIC'` end-to-end.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append inside the existing `describe('reconcileMemories', ...)` (helpers `fact`, `neighbor`, `judgeReturning`, `base`, `mockSvc` exist; add a procedural fixture beside `fact`):
+
+```typescript
+    const proceduralFact = (key: string): ExtractedFact => ({
+        kind: 'PROCEDURAL', namespace: ['procedures', 'aws-cli'], key,
+        value: { instruction: 'always paginate', trigger: 'list ops', evidence: 'missed items', confidence: 'high' } as any,
+    });
+
+    it('procedural fact → neighbors fetched with kinds PROCEDURAL and ADD saves kind PROCEDURAL', async () => {
+        mockSvc.recall.mockResolvedValue([]); // no neighbors → fast-path ADD
+        const judge = judgeReturning([]);
+        await reconcileMemories({ ...base, facts: [proceduralFact('paginate')], judgeModel: judge });
+        expect(mockSvc.recall).toHaveBeenCalledWith(expect.objectContaining({ kinds: ['PROCEDURAL'] }));
+        expect(mockSvc.remember).toHaveBeenCalledWith(expect.objectContaining({ kind: 'PROCEDURAL' }));
+    });
+
+    it('procedural SUPERSEDE → new row saved with kind PROCEDURAL', async () => {
+        mockSvc.recall.mockResolvedValue([neighbor('old-rule')]);
+        const judge = judgeReturning([{ factIndex: 0, action: 'SUPERSEDE', targetId: 'old-rule' }]);
+        await reconcileMemories({ ...base, facts: [proceduralFact('paginate')], judgeModel: judge });
+        expect(mockSvc.remember).toHaveBeenCalledWith(expect.objectContaining({ kind: 'PROCEDURAL' }));
+        expect(mockSvc.supersede).toHaveBeenCalledWith('t1', 'old-rule', 'new-id');
+    });
+
+    it('kind absent → SEMANTIC everywhere (legacy default)', async () => {
+        mockSvc.recall.mockResolvedValue([]);
+        const judge = judgeReturning([]);
+        await reconcileMemories({ ...base, facts: [fact('k1')], judgeModel: judge });
+        expect(mockSvc.recall).toHaveBeenCalledWith(expect.objectContaining({ kinds: ['SEMANTIC'] }));
+        expect(mockSvc.remember).toHaveBeenCalledWith(expect.objectContaining({ kind: 'SEMANTIC' }));
+    });
+```
+
+(Add `import type { ExtractedFact } from './types';` if not already imported in the test file.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/memory/reconcile.test.ts`
+Expected: the two procedural tests FAIL (`kinds: ['SEMANTIC']` / `kind: 'SEMANTIC'` received); the default test passes.
+
+- [ ] **Step 3: Implement kind threading in `reconcile.ts`**
+
+Three mechanical edits:
+
+1. In the `add` closure, change `kind: 'SEMANTIC',` to:
+```typescript
+            kind: fact.kind ?? 'SEMANTIC',
+```
+2. In the neighbor-fetch loop, change `kinds: ['SEMANTIC'],` to:
+```typescript
+                kinds: [fact.kind ?? 'SEMANTIC'],
+```
+3. In the SUPERSEDE case, change the inner `remember` call's `kind: 'SEMANTIC',` to:
+```typescript
+                        kind: item.fact.kind ?? 'SEMANTIC',
+```
+4. In `JUDGE_SYSTEM`, after the `- "NOOP": ...` line, add:
+```
+Items may be facts or operating rules; the same actions apply (a rule that changed = SUPERSEDE; the same rule re-learned = REINFORCE).
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/memory/reconcile.test.ts`
+Expected: ALL pass (13 existing + 3 new = 16).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web-ui/lib/agent/memory/reconcile.ts apps/web-ui/lib/agent/memory/reconcile.test.ts
+git commit -m "feat(memory): kind-aware reconcile — rules dedupe/supersede against rules"
+```
+
+---
+
+## Task 3: memory-nodes — extraction category, shape-aware filter, third recall + env flag
+
+**Files:**
+- Modify: `apps/web-ui/lib/agent/memory-nodes.ts`
+- Modify: `apps/web-ui/env.ts` (after `EPISODIC_MEMORY_ENABLED`)
+- Modify: `.env.example` (after the `EPISODIC_MEMORY_ENABLED=true` block)
+
+**Interfaces:**
+- Consumes: Task 1's `proceduralMemoryEnabled`/`formatProceduresSection`/`isValidExtractedItem`/`PROCEDURE_*`; Task 2's kind-aware reconcile; existing `getMemoryService`, `composeMemoryContext`.
+
+- [ ] **Step 1: env.ts + .env.example**
+
+`env.ts` — after `EPISODIC_MEMORY_ENABLED: z.string().optional(),` add:
+
+```typescript
+        PROCEDURAL_MEMORY_ENABLED: z.string().optional(),
+```
+
+`.env.example` — after `EPISODIC_MEMORY_ENABLED=true` add:
+
+```
+# Procedural memory (Phase 4) — learn operating rules from corrections/failures and
+# inject them as '### Operating rules (learned)'; promote matured rules to Skills (human-approved).
+PROCEDURAL_MEMORY_ENABLED=true
+```
+
+- [ ] **Step 2: memory-nodes.ts imports**
+
+Add:
+
+```typescript
+import {
+    proceduralMemoryEnabled, formatProceduresSection, isValidExtractedItem,
+    PROCEDURE_RECALL_LIMIT, PROCEDURE_DISTANCE_THRESHOLD,
+} from "./memory/procedural";
+```
+
+and extend the type-only import to include `ProceduralValue`:
+
+```typescript
+import type { ExtractedFact, EpisodicValue, ProceduralValue } from "./memory/types";
+```
+
+- [ ] **Step 3: Recall node — third section**
+
+In `memoryRecallNode`, between the semantic-facts block and the episodic block, insert:
+
+```typescript
+        // ── Learned operating rules — distance-gated, no LLM filter ─────────
+        let proceduresSection = "";
+        if (proceduralMemoryEnabled()) {
+            try {
+                const rules = await getMemoryService().recall({
+                    tenantId, userId, query, kinds: ["PROCEDURAL"], limit: PROCEDURE_RECALL_LIMIT,
+                });
+                const near = rules
+                    .filter(r => r.distance !== undefined && r.distance <= PROCEDURE_DISTANCE_THRESHOLD)
+                    .map(r => r.value as unknown as ProceduralValue)
+                    .filter(v => !!v?.instruction && !!v?.trigger);
+                if (near.length > 0) {
+                    console.log(`🧠 [MEMORY RECALL] Applying ${near.length} learned operating rule(s)`);
+                    proceduresSection = formatProceduresSection(near);
+                }
+            } catch (err: any) {
+                console.warn(`[MemoryRecall] Procedural search failed: ${err?.message ?? err}`);
+            }
+        }
+```
+
+and change the compose call to:
+
+```typescript
+        const memoryContext = composeMemoryContext(factsSection, episodesSection, proceduresSection);
+```
+
+- [ ] **Step 4: Save node — extraction category + shape-aware filter**
+
+In the extraction `SystemMessage`, after the errors-category lines (`- Error resolutions → ...\n  Examples: ...`), insert (template-concatenation, gated):
+
+```typescript
+` + (proceduralMemoryEnabled() ? `- Operating rules → add "kind": "PROCEDURAL", namespace: ["procedures", "<domain>"]
+  A rule for HOW the agent should behave in this environment, learned from this run.
+  Extract a rule ONLY from a correction, a failure the run recovered from, or an explicit user preference about behavior.
+  Shape: { "kind": "PROCEDURAL", "namespace": ["procedures", "aws-cli"], "key": "paginate-list-calls", "value": { "instruction": "Always paginate list/describe calls", "trigger": "any AWS CLI list operation", "evidence": "run truncated results and missed the target resource", "confidence": "high" } }
+` : '') + `
+```
+
+Widen the parse type from `Array<{ namespace: string[]; key: string; value: { fact: string; source: string; confidence: string } }>` to:
+
+```typescript
+            const memories: Array<{
+                kind?: string;
+                namespace: string[];
+                key: string;
+                value: Record<string, unknown>;
+            }> = JSON.parse(jsonMatch[0]);
+```
+
+Replace the confidence-only filter:
+
+```typescript
+            const toSave = memories.filter(m =>
+                m.value?.confidence === "high" || m.value?.confidence === "medium"
+            );
+```
+
+with:
+
+```typescript
+            const toSave = memories.filter(isValidExtractedItem);
+            if (toSave.length < memories.length) {
+                console.log(`[MemorySave] Dropped ${memories.length - toSave.length} invalid/low-confidence item(s)`);
+            }
+```
+
+Update the reconcile mapping to thread kind:
+
+```typescript
+                    facts: toSave.map(m => ({
+                        kind: m.kind === 'PROCEDURAL' ? 'PROCEDURAL' as const : undefined,
+                        namespace: m.namespace, key: m.key, value: m.value,
+                    })) as ExtractedFact[],
+```
+
+In the legacy (reconcile-disabled) branch, skip procedural items (rules ride reconcile; the off-switch stays a clean rollback):
+
+```typescript
+                for (const mem of toSave) {
+                    if (mem.kind === 'PROCEDURAL') {
+                        console.log(`   ⏭️ Skipped procedural rule ${mem.key} (reconcile disabled)`);
+                        continue;
+                    }
+                    try {
+                        await saveMemory(tenantId, userId, mem.namespace, mem.key, mem.value as Record<string, unknown>);
+                        console.log(`   ✅ Saved: ${mem.namespace.join("/")}/${mem.key}`);
+                    } catch (err: any) {
+                        console.warn(`   ⚠️ Failed to save ${mem.key}: ${err?.message ?? err}`);
+                    }
+                }
+```
+
+- [ ] **Step 5: Verify**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/memory/ && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep -E "^lib/agent/memory-nodes" || echo "no errors in memory-nodes.ts"`
+Expected: all memory tests PASS; `no errors in memory-nodes.ts`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web-ui/lib/agent/memory-nodes.ts apps/web-ui/env.ts .env.example
+git commit -m "feat(memory): procedural extraction + learned-rules injection in memory nodes"
+```
+
+---
+
+## Task 4: Repo/client fields + promote helper
+
+**Files:**
+- Modify: `apps/web-ui/lib/db/repositories/agent-memory/interface.ts` (`sourceThreadId`)
+- Modify: `apps/web-ui/lib/db/repositories/agent-memory/postgres.ts` (row type + mapping)
+- Modify: `apps/web-ui/lib/db/repositories/agent-memory/postgres.test.ts`
+- Modify: `apps/web-ui/lib/queries/agent-memories.ts` (`MemoryRow` gains `kind`, `sourceThreadId`)
+- Create: `apps/web-ui/lib/agent-memory/promote.ts`
+- Create: `apps/web-ui/lib/agent-memory/promote.test.ts`
+
+**Interfaces:**
+- Consumes: `MemoryKind` from `@/lib/agent/memory/types`; `MemoryRow` from `@/lib/queries/agent-memories`.
+- Produces: `buildSkillDraftFromMemory(row): SkillDraft | null`; `MemoryRow.kind`/`sourceThreadId`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`postgres.test.ts` — add `sourceThreadId: null,` to `makeRow` defaults, and append:
+
+```typescript
+    it('maps sourceThreadId through', async () => {
+        mockPrisma.agentMemory.findFirst.mockResolvedValueOnce(makeRow({ sourceThreadId: 'th-42' }));
+        const repo = new AgentMemoryPostgresRepository();
+        const rec = await repo.getById('t1', 'mem-1');
+        expect(rec?.sourceThreadId).toBe('th-42');
+    });
+```
+
+Create `apps/web-ui/lib/agent-memory/promote.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { buildSkillDraftFromMemory } from './promote';
+import type { MemoryRow } from '@/lib/queries/agent-memories';
+
+const row = (overrides: Partial<MemoryRow> = {}): MemoryRow => ({
+    id: 'm1', userId: 'u1', namespace: 'procedures/aws-cli', category: 'other' as any,
+    key: 'paginate-list-calls', fact: '', source: null, confidence: null,
+    value: { instruction: 'Always paginate list/describe calls', trigger: 'any AWS CLI list operation', evidence: 'missed a resource once' },
+    kind: 'PROCEDURAL', sourceThreadId: 'th-42',
+    supersededById: null, supersededAt: null,
+    createdAt: '2026-07-02T00:00:00Z', updatedAt: '2026-07-02T00:00:00Z', expiresAt: '2026-10-01T00:00:00Z',
+    ...overrides,
+});
+
+describe('buildSkillDraftFromMemory', () => {
+    it('builds a draft from a procedural row', () => {
+        const d = buildSkillDraftFromMemory(row());
+        expect(d).not.toBeNull();
+        expect(d!.name).toBe('Paginate List Calls');
+        expect(d!.description).toBe('any AWS CLI list operation');
+        expect(d!.tier).toBe('read-only');
+        expect(d!.content).toContain('## Rule\nAlways paginate list/describe calls');
+        expect(d!.content).toContain('## When it applies\nany AWS CLI list operation');
+        expect(d!.content).toContain('## Why (evidence)\nmissed a resource once');
+    });
+    it('returns null for non-procedural rows', () => {
+        expect(buildSkillDraftFromMemory(row({ kind: 'SEMANTIC' }))).toBeNull();
+        expect(buildSkillDraftFromMemory(row({ kind: 'EPISODIC' }))).toBeNull();
+    });
+    it('returns null when instruction or trigger missing', () => {
+        expect(buildSkillDraftFromMemory(row({ value: { trigger: 't' } }))).toBeNull();
+        expect(buildSkillDraftFromMemory(row({ value: { instruction: 'i' } }))).toBeNull();
+    });
+    it('evidence missing → placeholder, still promotable', () => {
+        const d = buildSkillDraftFromMemory(row({ value: { instruction: 'i', trigger: 't' } }));
+        expect(d!.content).toContain('## Why (evidence)\n(not recorded)');
+    });
+});
+```
+
+Run: `cd apps/web-ui && bunx vitest run lib/db/repositories/agent-memory/postgres.test.ts lib/agent-memory/promote.test.ts`
+Expected: FAIL — `sourceThreadId` undefined on record; promote module not found (and `MemoryRow` lacks `kind`).
+
+- [ ] **Step 2: Implement**
+
+`interface.ts` — after `supersededAt: string | null;` add:
+
+```typescript
+    sourceThreadId: string | null;
+```
+
+`postgres.ts` — `MemoryRow` type gains `sourceThreadId: string | null;`; `toRecord` returns `sourceThreadId: row.sourceThreadId,`.
+
+`lib/queries/agent-memories.ts` — add `import type { MemoryKind } from '@/lib/agent/memory/types';` and add to the `MemoryRow` interface:
+
+```typescript
+    kind: MemoryKind;
+    sourceThreadId: string | null;
+```
+
+Create `apps/web-ui/lib/agent-memory/promote.ts`:
+
+```typescript
+/**
+ * promote.ts — procedural memory → Skill draft mapping (Phase 4 bridge).
+ * Pure and client-safe; persistence happens only through the existing
+ * SkillFormDialog → useCreateSkill → POST /api/skills path (human-approved).
+ */
+
+import type { MemoryRow } from '@/lib/queries/agent-memories';
+
+export interface SkillDraft {
+    name: string;
+    description: string;
+    tier: string;
+    content: string;
+}
+
+function humanize(key: string): string {
+    return key
+        .split(/[-_]+/)
+        .filter(Boolean)
+        .map((w) => (w[0]?.toUpperCase() ?? '') + w.slice(1))
+        .join(' ');
+}
+
+export function buildSkillDraftFromMemory(row: MemoryRow): SkillDraft | null {
+    if (row.kind !== 'PROCEDURAL') return null;
+    const v = row.value as { instruction?: string; trigger?: string; evidence?: string };
+    if (!v?.instruction || !v?.trigger) return null;
+    return {
+        name: humanize(row.key),
+        description: v.trigger,
+        tier: 'read-only',
+        content:
+            `## Rule\n${v.instruction}\n\n` +
+            `## When it applies\n${v.trigger}\n\n` +
+            `## Why (evidence)\n${v.evidence || '(not recorded)'}\n\n` +
+            `_Learned by the agent; promoted from procedural memory._`,
+    };
+}
+```
+
+- [ ] **Step 3: Run tests to verify pass**
+
+Run: `cd apps/web-ui && bunx vitest run lib/db/repositories/agent-memory/postgres.test.ts lib/agent-memory/promote.test.ts`
+Expected: ALL pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web-ui/lib/db/repositories/agent-memory/ apps/web-ui/lib/queries/agent-memories.ts apps/web-ui/lib/agent-memory/promote.ts apps/web-ui/lib/agent-memory/promote.test.ts
+git commit -m "feat(memory): expose kind+sourceThreadId to the client + skill-draft mapper"
+```
+
+---
+
+## Task 5: Promote-to-skill UI wiring
+
+**Files:**
+- Modify: `apps/web-ui/components/memory/memory-client-component.tsx` (imports :3-29; actions cell :160-192; dialogs at the component tail)
+
+**Interfaces:**
+- Consumes: `buildSkillDraftFromMemory`/`SkillDraft` (Task 4); existing `SkillFormDialog` (`{ open, onOpenChange, initialDraft, sourceRunId }`).
+
+- [ ] **Step 1: Imports + state**
+
+Add imports (2-space file):
+
+```typescript
+import { Sparkles } from "lucide-react";
+import { SkillFormDialog } from "@/components/skills/skill-form-dialog";
+import { buildSkillDraftFromMemory, type SkillDraft } from "@/lib/agent-memory/promote";
+```
+
+(`Sparkles` joins the existing lucide import line.) Beside the other `useState` hooks add:
+
+```typescript
+    const [promote, setPromote] = useState<{ draft: SkillDraft; sourceRunId: string | null } | null>(null);
+```
+
+- [ ] **Step 2: Actions-cell item**
+
+In the actions `DropdownMenuContent`, between the View and Delete items, add:
+
+```tsx
+                                    {m.kind === "PROCEDURAL" ? (
+                                        <DropdownMenuItem
+                                            onClick={() => {
+                                                const draft = buildSkillDraftFromMemory(m);
+                                                if (draft) {
+                                                    setPromote({ draft, sourceRunId: m.sourceThreadId ?? null });
+                                                } else {
+                                                    toast.error("This memory is missing rule fields and can't be promoted");
+                                                }
+                                            }}
+                                        >
+                                            <Sparkles className="mr-2 h-4 w-4" />
+                                            Promote to skill
+                                        </DropdownMenuItem>
+                                    ) : null}
+```
+
+- [ ] **Step 3: Render the dialog**
+
+Next to the existing `<MemoryDetailDialog …/>` / `<DeleteMemoryDialog …/>` at the component tail, add:
+
+```tsx
+            <SkillFormDialog
+                open={!!promote}
+                onOpenChange={(v) => { if (!v) setPromote(null); }}
+                initialDraft={promote?.draft ?? null}
+                sourceRunId={promote?.sourceRunId ?? null}
+            />
+```
+
+- [ ] **Step 4: Verify (typecheck — no component test harness)**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep -E "^components/memory/" || echo "no errors in components/memory"`
+Expected: `no errors in components/memory`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web-ui/components/memory/memory-client-component.tsx
+git commit -m "feat(memory): Promote-to-skill action on procedural memories (human-approved)"
+```
+
+---
+
+## Task 6: Full verification + docs
+
+**Files:**
+- Modify: `CLAUDE.md` (after the `memory/episode.ts` row)
+
+- [ ] **Step 1: Full suites**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/memory/ lib/db/repositories/agent-memory/ lib/agent-memory/`
+Expected: all PASS (≥ 80 tests).
+
+- [ ] **Step 2: Exact-path typecheck of all Phase 4 touched files**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep -E "^(lib/agent/memory/|lib/agent/memory-nodes|lib/agent-memory/|lib/db/repositories/agent-memory/|lib/queries/agent-memories|components/memory/)" || echo "no new errors"`
+Expected: `no new errors`.
+
+- [ ] **Step 3: CLAUDE.md**
+
+After the `memory/episode.ts` table row, add:
+
+```markdown
+| `memory/procedural.ts` | Procedural memory: operating rules learned from corrections/failures, injected as "Operating rules (learned)"; matured rules promote to Skills via SkillFormDialog (human-approved). Gated by `PROCEDURAL_MEMORY_ENABLED`. |
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(memory): document procedural memory module"
+```
+
+---
+
+## Self-Review (completed against the spec)
+
+- **Spec §A (extraction category, ProceduralValue.confidence, ExtractedFact.kind, shape-aware filter via isValidExtractedItem):** Tasks 1 + 3. ✅
+- **Spec §B (kind-aware reconcile: neighbor kinds, add/supersede kind, judge line):** Task 2. ✅
+- **Spec §C (procedural.ts, third recall section, 3-arg compose with exact-shape preservation, field-validity filter on replay):** Tasks 1 + 3 (recall block includes the `!!v?.instruction && !!v?.trigger` filter). ✅
+- **Spec §D (MemoryRow kind+sourceThreadId, promote.ts mapping, Promote action → SkillFormDialog with sourceRunId, human-approved only):** Tasks 4 + 5. ✅
+- **Spec §E (flag + constants):** Tasks 1 (constants/flag) + 3 (env). ✅
+- **Legacy reconcile-off branch semantic-only:** Task 3 Step 4. ✅
+- **Type consistency:** `SkillDraft`, `buildSkillDraftFromMemory`, `composeMemoryContext(facts, episodes, procedures?)`, `PROCEDURE_*`, `isValidExtractedItem` used identically across tasks; `SkillFormDialog` props verified against the actual component source. ✅
+- **No placeholders:** every code step carries complete code; commands carry expected output. ✅

--- a/docs/superpowers/specs/2026-07-01-agent-memory-foundation-working-memory-design.md
+++ b/docs/superpowers/specs/2026-07-01-agent-memory-foundation-working-memory-design.md
@@ -1,0 +1,243 @@
+# Agent Memory Refactor — Phase 0 (Foundation) + Phase 1 (Working Memory)
+
+**Status:** Approved design, ready for implementation planning
+**Date:** 2026-07-01
+**Branch:** `agent-memory`
+**Scope:** Phases 0 and 1 of a larger 5-phase memory roadmap (see "Roadmap Context")
+
+---
+
+## Problem
+
+The current agent memory system is a **single-layer semantic store**. It works, but it cannot support autonomous agents that run for long hours, and it implements only one of the three cognitive-memory pillars (semantic facts). Concretely:
+
+1. **No in-session survival.** Mid-loop, each agent node assembles context with `getRecentMessages(messages, 20)` — a naive last-20-message slice (`fast-agent.ts:108`). On a long run, everything older is *silently dropped*, nothing is summarized, and large tool outputs sit full-size in the window. A multi-hour run will lose its early context and/or overflow the model's context window. **This is the single biggest blocker for autonomous long runs.**
+2. **Only semantic memory exists.** No episodic (experience replay) or procedural (self-improving instructions) layers. Procedural knowledge lives in a *separate* DB-backed Skills module, disconnected from the memory loop.
+3. **No conflict resolution.** `PostgresMemoryStore.batch()` upserts on `(tenantId, namespace, key)` with `ON CONFLICT DO UPDATE` (`persistence.ts:139`), so a "conflicting" fact blindly overwrites the old one — no supersede, no audit trail, no contradiction detection.
+4. **No vector index.** Similarity search is a raw `ORDER BY embedding <=> $vec` (`persistence.ts:175`) against `agent_memories` with **no HNSW/IVFFlat index** — a sequential scan that degrades past ~10k memories/tenant.
+
+## Goal
+
+Refactor the memory system into a proper multi-layer cognitive architecture, built **natively in TypeScript** on the existing Postgres + pgvector + repository-factory foundation (no LangMem — Python-only; no Mem0-JS dependency). This spec covers the two foundational phases:
+
+- **Phase 0 — Foundation:** typed multi-layer schema, vector index, and a single typed retrieval/write service that all later layers extend.
+- **Phase 1 — Working memory:** in-session compaction + budget-aware context assembly so agents survive long runs.
+
+### Non-goals (explicitly deferred to later cycles)
+
+- **Deep-agent unification** — the deep agent keeps its separate MongoDB store + explicit memory tools untouched in this cycle.
+- **Semantic conflict-resolution *logic*** (dedup/contradiction/supersede) — Phase 2.
+- **Episodic *capture logic*** (experience replay) — Phase 3.
+- **Procedural memory + Skills bridge** — Phase 4.
+
+Phase 0 lays the *columns and interfaces* these later phases need; it does not implement their logic.
+
+---
+
+## Roadmap Context
+
+This is the first spec in a 5-phase effort (approved sequencing):
+
+| Phase | Deliverable | Status |
+|-------|-------------|--------|
+| **0** | Foundation: typed schema, HNSW index, `MemoryService`, one substrate | **this spec** |
+| **1** | Working memory: compaction + budget-aware assembly (unblocks long runs) | **this spec** |
+| 2 | Semantic + conflict resolution (dedup / contradiction / supersede) | later |
+| 3 | Episodic: `Episode` capture + few-shot replay | later |
+| 4 | Procedural: learned instructions bridged into the Skills module | later |
+
+Each later phase gets its own spec → plan → build cycle. Design decisions locked for this cycle: **native TS build**, **defer deep-agent**, **spec Phase 0+1 together** (they are tightly coupled — working memory needs the foundation's service layer).
+
+---
+
+## Current State (grounding)
+
+Key files and behaviors this refactor builds on:
+
+- **`libs/prisma/schema.prisma`** — `AgentMemory` model (~line 494): `{ id, tenantId, userId, namespace, key, value Json, embedding Unsupported("vector(1024)")?, createdAt, updatedAt, expiresAt }`, unique `(tenantId, namespace, key)`, indexes on `(tenantId, userId)` and `expiresAt`, 90-day TTL. Maps to table `agent_memories`.
+- **`apps/web-ui/lib/agent/persistence.ts`** — `PostgresMemoryStore.batch()` handles put (upsert + embed) and search (pgvector `<=>` with recency-text fallback). Exposes loose helpers `saveMemory(...)` / `searchMemory(...)`. Also holds `PostgresSaver` checkpointer + `PostgresChatHistory`. Singletons via `globalThis`.
+- **`apps/web-ui/lib/agent/memory-nodes.ts`** — `createMemoryRecallNode` (semantic search top-10 → LLM relevance filter → `memoryContext` string) and `createMemorySaveNode` (reflector LLM extracts JSON facts → save). Note: recall queries by `tenantId` only (empty namespace prefix), not `userId`.
+- **`apps/web-ui/lib/agent/fast-agent.ts`** / **`planning-agent.ts`** — graph: `START → memory_recall → agent → (tools|reflect|finalize) → memory_save → END`. Agent node builds the system prompt fresh per iteration and injects `memoryContext` as a `## Relevant Context from Memory` section. Context window = `getRecentMessages(messages, 20)`.
+- **`apps/web-ui/lib/agent/agent-shared.ts`** — `ReflectionState` (fields incl. `messages`, `memoryContext`, `iterationCount`, `toolResults`), `graphState` channels, `sanitizeMessagesForBedrock`, re-exports `getCheckpointer`/`getStore`.
+- **`apps/web-ui/lib/agent/embeddings-factory.ts`** — `getTenantEmbeddings(tenantId)`, fixed **1024-dim** (provider-only; no Bedrock fallback).
+- **Memory module UI** — `app/api/agent-memories/*`, `components/memory/*`, repository at `lib/db/repositories/agent-memory/`, category taxonomy in `lib/agent-memory/category.ts` (namespace-prefix → infra/user/patterns/errors/other). RBAC subject `Memory`.
+
+---
+
+## Phase 0 — Foundation
+
+### A. Schema evolution
+
+Evolve `AgentMemory` into a single long-term store with a `kind` discriminator, rather than table-per-layer. Rationale: one vector index, one retrieval path, and the Memory UI already lists this table. **All changes are additive/non-breaking.**
+
+Add to `AgentMemory`:
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `kind` | enum `MemoryKind { SEMANTIC, EPISODIC, PROCEDURAL }`, default `SEMANTIC` | layer discriminator; existing rows backfill to `SEMANTIC` |
+| `sourceThreadId` | `String?` | provenance — which run created this memory |
+| `supersededById` | `String?` (self-relation) | Phase 2 conflict resolution marks stale facts instead of overwriting |
+| `supersededAt` | `DateTime?` | when it was superseded |
+| `lastAccessedAt` | `DateTime?` | reinforcement/decay signal |
+| `accessCount` | `Int @default(0)` | reinforcement/decay signal |
+
+Add index `@@index([tenantId, kind])`. Keep existing unique `(tenantId, namespace, key)`, TTL, and the `value Json` column. TypeScript discriminated-union types over `value` live in `lib/agent/memory/types.ts`:
+
+- `SEMANTIC` → `{ fact: string; source: string; confidence: "high" | "medium" }`
+- `EPISODIC` → `{ context: string; reasoning: string; action: string; outcome: string }` *(populated in Phase 3)*
+- `PROCEDURAL` → `{ instruction: string; trigger: string; evidence: string }` *(populated in Phase 4)*
+
+New model **`AgentWorkingMemory`** (thread-scoped, mutable, **no embedding** — it is the live context, not semantically searched):
+
+```prisma
+model AgentWorkingMemory {
+  id             String   @id @default(cuid())
+  tenantId       String
+  threadId       String
+  runningSummary String   @db.Text          // rolling NL summary of the run so far
+  scratchpad     Json                        // { openGoals, keyFindings, resourceIds, pendingSteps }
+  tokenCount     Int      @default(0)         // last estimated window size
+  turnCount      Int      @default(0)         // turns folded into summary
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+  expiresAt      DateTime                     // TTL aligned with checkpoint retention
+
+  @@unique([tenantId, threadId])
+  @@index([expiresAt])
+  @@map("agent_working_memory")
+}
+```
+
+### B. pgvector HNSW index
+
+Prisma's `Unsupported("vector(1024)")` cannot declare an index, so add it via raw SQL in the migration (the `pgvector/pgvector:pg16` image supports HNSW):
+
+```sql
+CREATE INDEX IF NOT EXISTS agent_memories_embedding_hnsw
+  ON agent_memories USING hnsw (embedding vector_cosine_ops);
+```
+
+`vector_cosine_ops` matches the existing `<=>` cosine-distance queries in `persistence.ts`. Migration also backfills `kind = 'SEMANTIC'` for existing rows (the enum default handles new rows; existing NULLs get a one-time `UPDATE`). Volume is low (young feature), so the index build is cheap.
+
+### C. `MemoryService` (typed retrieval/write layer)
+
+New `apps/web-ui/lib/agent/memory/memory-service.ts`, following the repository-factory convention. It becomes the single entry point for all long-term + working memory, collapsing the loose string-based helpers and the raw SQL currently inline in `PostgresMemoryStore`.
+
+Interface (illustrative):
+
+```typescript
+interface RecallParams {
+  tenantId: string;
+  userId: string;
+  query: string;
+  kinds?: MemoryKind[];          // filter by layer; default all
+  namespacePrefix?: string[];
+  limit?: number;
+}
+
+interface MemoryService {
+  recall(p: RecallParams): Promise<MemoryHit[]>;   // pgvector search + updates lastAccessedAt/accessCount
+  remember(m: RememberParams): Promise<void>;       // upsert + embed via getTenantEmbeddings
+  getWorkingMemory(tenantId: string, threadId: string): Promise<WorkingMemory | null>;
+  putWorkingMemory(wm: WorkingMemorySnapshot): Promise<void>;   // upsert on (tenantId, threadId)
+}
+```
+
+`recall` records access stats (`lastAccessedAt`, `accessCount++`) on returned rows — cheap signal for later decay/reinforcement. Multi-tenant scoping is enforced in every query (raw SQL paths manually scope `tenantId`, per the `$executeRaw`-not-intercepted gotcha).
+
+**Compatibility shim:** `PostgresMemoryStore.batch()` stays in `persistence.ts` but delegates to `MemoryService`, so the deep-agent's `save_memory`/`search_memory` tools keep working with zero changes. `memory-nodes.ts` recall/save switch to calling `MemoryService` directly (typed, kind-aware) instead of the string helpers.
+
+---
+
+## Phase 1 — Working Memory
+
+### D. Compaction
+
+A new **`compact`** node runs before the agent node when the estimated window token count exceeds `WORKING_MEMORY_TOKEN_BUDGET`. Token estimation reuses the existing `chars/4` heuristic. On trigger it:
+
+1. Selects the older turns about to be evicted from the verbatim window.
+2. Folds them into `runningSummary` via the **reflector model** (provider-only, cheaper than main): `summary' = summarize(summary + evictedTurns)`. Summarization is instructed to **never drop a recorded goal or an unresolved error** (monotonicity — see testing).
+3. Compresses oversized tool-result content (keep head+tail, insert `"… full output elided …"`).
+4. Updates the structured `scratchpad`: `{ openGoals[], keyFindings[], resourceIds[], pendingSteps[] }`.
+5. Persists the snapshot (see F).
+
+### E. Budget-aware context assembly
+
+Replace the `getRecentMessages(messages, 20)` call sites with a `assembleContext(...)` helper that builds the model input as:
+
+```
+[ systemPrompt ]
+[ ## Working Memory : runningSummary + scratchpad ]   (only when non-empty)
+[ ## Relevant Context from Memory : memoryContext ]    (existing recall output)
+[ last-K verbatim turns that fit remaining budget ]    (K = WORKING_MEMORY_KEEP_RECENT)
+```
+
+The agent always sees a compact, faithful view regardless of run length. `sanitizeMessagesForBedrock` still runs on the verbatim tail to preserve tool_call/tool_result adjacency.
+
+### F. Storage model (approved: checkpoint-live + table snapshot)
+
+- **Source of truth during a run:** working memory lives in the checkpointed `ReflectionState` (new fields `runningSummary`, `scratchpad`). LangGraph's `PostgresSaver` already persists this per-thread across interrupts/resumes — zero extra plumbing mid-run.
+- **Durable mirror:** at each compaction, `compact` calls `MemoryService.putWorkingMemory(...)` to snapshot into `AgentWorkingMemory`. This gives durable, inspectable state (and a hook for the Memory UI later) without a DB write every turn — only on compaction.
+
+### G. Configuration
+
+Feature-gated like `RIGHT_SIZING_ENABLED`:
+
+| Env var | Default | Meaning |
+|---------|---------|---------|
+| `WORKING_MEMORY_ENABLED` | `true` | master gate for the compaction node |
+| `WORKING_MEMORY_TOKEN_BUDGET` | `60000` | window token budget that triggers compaction |
+| `WORKING_MEMORY_KEEP_RECENT` | `8` | verbatim turns kept after the summary |
+
+When `WORKING_MEMORY_ENABLED=false`, the `compact` node is a pass-through and assembly falls back to the current last-N behavior — safe rollback with no schema removal.
+
+---
+
+## Files Touched
+
+| File | Change |
+|------|--------|
+| `libs/prisma/schema.prisma` | `MemoryKind` enum + new `AgentMemory` columns + `AgentWorkingMemory` model |
+| migration (`libs/prisma/migrations/...`) | additive columns, `AgentWorkingMemory` table, raw-SQL HNSW index, `kind` backfill |
+| `apps/web-ui/lib/agent/memory/types.ts` | **new** — `MemoryKind`, per-kind value unions, WM types |
+| `apps/web-ui/lib/agent/memory/memory-service.ts` | **new** — typed recall/remember + working-memory get/put |
+| `apps/web-ui/lib/agent/memory/working-memory.ts` | **new** — compaction (summary folding, tool-log compression) + `assembleContext` |
+| `apps/web-ui/lib/agent/persistence.ts` | `PostgresMemoryStore.batch()` delegates to `MemoryService`; init unchanged |
+| `apps/web-ui/lib/agent/memory-nodes.ts` | recall/save use `MemoryService` (typed, kind-aware); export `createCompactNode` factory |
+| `apps/web-ui/lib/agent/agent-shared.ts` | `ReflectionState` + `graphState` channels gain `runningSummary`/`scratchpad`; house `assembleContext` |
+| `apps/web-ui/lib/agent/fast-agent.ts` | add `compact` node + budget-aware assembly; wire WM deps |
+| `apps/web-ui/lib/agent/planning-agent.ts` | same wiring as fast-agent |
+| `apps/web-ui/lib/db/repositories/agent-memory/*` | extend repo/interface for `kind` + working-memory (keeps Memory UI working) |
+| **deep-agent** | **untouched** (deferred) |
+
+---
+
+## Testing
+
+- **Vitest (web-ui):**
+  - `MemoryService.recall/remember` — kind filtering, tenant scoping, access-stat increment.
+  - `working-memory` — summary folding (`summary'` contains prior goals), tool-log compression (head+tail preserved), `assembleContext` output ordering.
+- **fast-check property tests** (pattern already used under `tests/agent-ops/`):
+  - **Budget invariant:** for arbitrary message histories, `assembleContext(...)` estimated tokens ≤ `WORKING_MEMORY_TOKEN_BUDGET`.
+  - **Monotonicity:** any goal/unresolved-error present before compaction is still represented after (in summary or scratchpad).
+- **Migration verify:** assert HNSW index exists (`pg_indexes`) and no `agent_memories.kind` is NULL post-migration.
+- **Manual smoke:** run a long fast-agent session locally, confirm compaction fires past the budget and the summary is injected (`🧠` logs).
+- No new E2E in this cycle (a long-run smoke can be added when Phase 1 lands).
+
+---
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Summarization latency/cost on every compaction | Threshold-triggered (not every turn); uses the cheaper reflector model; gated by env |
+| Summary loses critical state | Monotonicity property test + explicit "never drop goals/errors" instruction |
+| HNSW build on existing data | Table volume is low; `CREATE INDEX IF NOT EXISTS`; can be `CONCURRENTLY` if needed |
+| Delegation shim breaks deep-agent tools | `PostgresMemoryStore.batch()` signature preserved; contract test on put/search |
+| Migration on live data | All additive; `kind` defaults + one-time backfill; no drops |
+
+---
+
+## Open Questions
+
+None blocking. Deferred design work (conflict resolution, episodic capture, procedural/Skills bridge) is scoped into Phases 2–4, each with its own spec.

--- a/docs/superpowers/specs/2026-07-02-agent-memory-phase2-conflict-resolution-design.md
+++ b/docs/superpowers/specs/2026-07-02-agent-memory-phase2-conflict-resolution-design.md
@@ -1,0 +1,178 @@
+# Agent Memory Phase 2 — Semantic Conflict Resolution
+
+**Status:** Approved design, ready for implementation planning
+**Date:** 2026-07-02
+**Branch:** `agent-memory` (continues PR #55; Phase 0+1 already landed on this branch)
+**Roadmap:** Phase 2 of 5 (see `2026-07-01-agent-memory-foundation-working-memory-design.md` for the roadmap; Phases 3–4 + deep-agent unification remain)
+
+---
+
+## Problem
+
+Phase 0 built the read side of supersede (`recall` filters `"supersededById" IS NULL`) but the write side is still naive. When `memory_save` extracts facts at the end of a run:
+
+- Same `(tenantId, namespace, key)` → **silent overwrite** (`ON CONFLICT DO UPDATE`), no audit trail.
+- Different key but semantically identical or contradicting fact → **duplicates accumulate forever**; recall returns both the stale and the fresh fact and the agent must guess.
+- The only dedup today is a prompt instruction in the extractor ("do NOT re-save facts that already exist") — unenforced.
+- `lastAccessedAt`/`accessCount` exist but nothing refreshes TTL when a fact is re-confirmed, so persistently-true facts still expire at 90 days.
+
+For long-lived autonomous agents this is the "accuracy over time" gap: the store degrades as it grows.
+
+## Goal
+
+A Mem0-style **inline reconciliation pipeline** at save time: *extract → retrieve similar → judge → apply with audit trail*. After Phase 2, the store never knowingly holds a contradiction, duplicates reinforce instead of accumulate, and every displacement is auditable via `supersededById`.
+
+### Decisions locked during design
+
+- **Inline at save time** (in the graph tail, after the user-visible answer) — not a background sweep.
+- **Auto-supersede with audit trail** on contradiction — new fact wins; old row marked, never deleted.
+- **Minimal UI**: hide superseded rows from the Memory-module list + show provenance in the detail dialog.
+- **Same branch**: work continues on `agent-memory`; PR #55 grows.
+
+### Non-goals
+
+- Episodic capture/replay (Phase 3), procedural memory (Phase 4).
+- Background reconciliation sweep (revisit only if inline proves insufficient).
+- Full history UI (show-superseded toggle, supersede-chain view).
+- Deep-agent reconciliation — its `save_memory` tool keeps blind-upsert semantics via `PostgresMemoryStore.batch()` (one mechanical SQL edit required, see §C, but no behavior change).
+- Re-ranking recall by `accessCount`/recency (decay/reinforcement *scoring* is future work; Phase 2 only maintains the signals).
+
+---
+
+## Current State (grounding)
+
+- `apps/web-ui/lib/agent/memory-nodes.ts` — `memorySaveNode`: reflector LLM extracts a JSON array of `{namespace[], key, value:{fact,source,confidence}}`, filters to high/medium confidence, loops `saveMemory(...)`.
+- `apps/web-ui/lib/agent/persistence.ts` — `saveMemory` delegates to `MemoryService.remember` (kind `SEMANTIC`); `PostgresMemoryStore.batch()` still has its own raw upsert (deep-agent path).
+- `apps/web-ui/lib/agent/memory/memory-service.ts` — `remember` (raw upsert with embedding, `ON CONFLICT ("tenantId","namespace","key") DO UPDATE`; ORM `upsert` fallback when no embedding), `recall` (pgvector `<=>`, filters superseded, updates access stats; returns `{namespace,key,value,kind}` — **no id, no distance**), working-memory get/put.
+- `libs/prisma/schema.prisma` — `AgentMemory` has `@@unique([tenantId, namespace, key])`, plus Phase 0 scaffolding: `kind`, `sourceThreadId`, `supersededById`, `supersededAt`, `lastAccessedAt`, `accessCount`.
+- `apps/web-ui/lib/db/repositories/agent-memory/` — `listByTenant` does **not** filter superseded rows (they'd show in the UI today).
+- Precedents: feature gating via env flag read from `process.env` (`working-memory.ts`), non-fatal LLM/parse failure with fallback, batched-JSON judge prompts, `.superpowers/sdd/` execution flow.
+
+---
+
+## Design
+
+### A. Reconcile pipeline — new `apps/web-ui/lib/agent/memory/reconcile.ts`
+
+`memorySaveNode` stops calling `saveMemory` directly. After extraction+confidence filtering it calls:
+
+```typescript
+reconcileMemories(params: {
+    tenantId: string;
+    userId: string;
+    facts: ExtractedFact[];          // { namespace: string[]; key: string; value: SemanticValue }
+    judgeModel: BaseChatModel;       // the reflector model, passed in (provider-only)
+    sourceThreadId?: string;
+}): Promise<ReconcileSummary>        // counts per action, for logging
+```
+
+Pipeline per invocation:
+
+1. **Neighbor fetch.** For each fact, `MemoryService.recall` top-K (K=5, module constant `RECONCILE_TOP_K`) similar live memories, now returning `id` and `distance`. A fact whose nearest neighbor is farther than `RECONCILE_DISTANCE_THRESHOLD` (module constant, cosine distance, initial value 0.55 — tune empirically) is treated as having no neighbors.
+2. **Fast path.** Facts with no neighbors → **ADD** immediately; no LLM call. (Fresh tenants never pay judge latency.)
+3. **Batched judge.** All facts *with* neighbors go to **one** LLM call. Input: per fact, the new fact + its neighbors `{id, namespace, key, fact, updatedAt}`. Output: strict JSON array of decisions:
+   - `{ factIndex, action: "ADD" }` — novel despite similarity.
+   - `{ factIndex, action: "UPDATE", targetId, mergedValue }` — same fact, refined/enriched; judge supplies the merged `SemanticValue`.
+   - `{ factIndex, action: "SUPERSEDE", targetId }` — **explicit contradiction only** (mutually exclusive claims), never mere similarity. New fact wins.
+   - `{ factIndex, action: "REINFORCE", targetId }` — semantically the same fact; nothing new.
+   - `{ factIndex, action: "NOOP" }` — ephemeral/worthless; drop.
+4. **Apply**, via MemoryService primitives:
+   - ADD → `remember(...)` (returns new id).
+   - UPDATE → `update(tenantId, targetId, mergedValue)` — value replaced in place, embedding recomputed, `updatedAt`/`expiresAt` refreshed; key/row unchanged.
+   - SUPERSEDE → `remember(...)` the new fact (returns `newId`), then `supersede(tenantId, targetId, newId)` — sets `supersededById = newId`, `supersededAt = NOW()` on the old row. Old row never deleted (TTL cleans eventually); recall already filters it.
+   - REINFORCE → `reinforce(tenantId, targetId)` — `expiresAt = NOW() + 90d`, `accessCount + 1`, `lastAccessedAt = NOW()`. (Deliberate overload of `accessCount` as a general "proved useful/true again" signal.)
+   - NOOP → skip.
+5. **Failure containment.** Judge call failure, JSON parse failure, or an unrecognized/invalid decision (bad `targetId`, missing `mergedValue`) → the affected fact(s) fall back to **ADD** (today's behavior). Per-fact apply errors are caught and logged; one bad fact never blocks the rest. `reconcileMemories` itself never throws.
+6. **Gate.** `MEMORY_RECONCILE_ENABLED` env flag (read from `process.env`, same pattern as `working-memory.ts`; default **true**). Off → `memorySaveNode` uses the legacy direct-save loop, byte-for-byte.
+
+Scoping: reconciliation is **tenant-wide**, matching `recall` (the store is effectively tenant-shared; a user's new fact may supersede another user's stale one within the same tenant).
+
+Layering: `MemoryService` stays a pure data layer (no LLM dependency); `reconcile.ts` holds the policy, judge prompt, and orchestration.
+
+### B. Schema — partial unique index (the one migration)
+
+`@@unique([tenantId, namespace, key])` breaks supersede in the **common case**: a contradicted fact usually re-extracts under the *same key* (e.g. `prod-cluster-region`: us-east-1 → us-west-2), and inserting the winning row would collide with the superseded loser. Fix:
+
+- **Drop** the full unique constraint.
+- **Add** (raw SQL in the migration) a **partial unique index**:
+  ```sql
+  CREATE UNIQUE INDEX "agent_memories_live_tenant_ns_key"
+    ON "agent_memories" ("tenantId", "namespace", "key")
+    WHERE "supersededById" IS NULL;
+  ```
+  Only *live* rows contend for a key; superseded history rows keep their original key.
+- Prisma schema: replace `@@unique([tenantId, namespace, key])` with `@@index([tenantId, namespace, key])` (lookup performance; the partial unique lives only in SQL — Prisma cannot express it).
+
+**Ripples (all required, all small):**
+
+1. `MemoryService.remember` raw path: conflict target becomes
+   `ON CONFLICT ("tenantId","namespace","key") WHERE "supersededById" IS NULL DO UPDATE ...`
+   (Postgres matches this to the partial index.)
+2. `MemoryService.remember` ORM fallback: Prisma `upsert` targeted the now-removed compound unique — replace with *find live row* (`findFirst` where tenant/ns/key + `supersededById: null`) then `update` by id or `create`. (Benign race: two concurrent saves of the same new key could both pass `findFirst`; the partial unique index makes one `create` fail — catch the unique-violation and retry once as an update. Raw path is immune via ON CONFLICT.)
+3. `PostgresMemoryStore.batch()` raw upsert (deep-agent path): same 1-line conflict-target edit. Behavior unchanged (still blind upsert, no reconcile) — deep-agent remains out of scope semantically.
+4. `remember` now **returns the row id** (raw path: `RETURNING id`; fallback: id from update/create) — required by SUPERSEDE.
+
+Migration is additive/non-destructive for data (constraint swap only; no rows touched). Regenerate **both** Prisma clients afterward (dual-generator gotcha).
+
+### C. MemoryService additions (data primitives)
+
+```typescript
+// MemoryHit gains: id: string; distance?: number  (distance only on vector-search hits)
+remember(m: RememberParams): Promise<string>                       // now returns row id
+update(tenantId: string, id: string, value: Record<string, unknown>): Promise<void>   // re-embeds, refreshes updatedAt/expiresAt
+supersede(tenantId: string, oldId: string, newId: string): Promise<void>
+reinforce(tenantId: string, id: string): Promise<void>
+```
+
+All tenant-scoped in every statement (raw SQL binds `tenantId` explicitly; `$executeRaw` is not tenant-intercepted). `update`'s re-embed failure is non-fatal (keeps old embedding, still updates value).
+
+### D. Memory-module UI (minimal)
+
+- `listByTenant` `where` gains `supersededById: null` — stale facts vanish from the table.
+- `AgentMemoryRecord` gains `supersededById: string | null`, `supersededAt: string | null`; `getById` still returns superseded rows (direct fetch).
+- `memory-detail-dialog.tsx`: when `supersededAt` is present, render a small provenance line ("Superseded on <date>"). No other UI work.
+
+### E. Configuration
+
+| Env var | Default | Meaning |
+|---------|---------|---------|
+| `MEMORY_RECONCILE_ENABLED` | `true` | off → legacy direct-save loop in `memorySaveNode` |
+
+Module constants (not env): `RECONCILE_TOP_K = 5`, `RECONCILE_DISTANCE_THRESHOLD = 0.55`.
+
+---
+
+## Files Touched
+
+| File | Change |
+|------|--------|
+| `libs/prisma/schema.prisma` + migration | drop compound unique → `@@index` + raw-SQL partial unique index |
+| `apps/web-ui/lib/agent/memory/types.ts` | `MemoryHit` gains `id`/`distance?`; `ExtractedFact`, decision types |
+| `apps/web-ui/lib/agent/memory/memory-service.ts` | `remember` returns id + partial-index conflict target + ORM fallback rework; new `update`/`supersede`/`reinforce`; recall returns id+distance |
+| `apps/web-ui/lib/agent/memory/reconcile.ts` | **new** — pipeline, judge prompt, apply, gate |
+| `apps/web-ui/lib/agent/memory-nodes.ts` | `memorySaveNode` save-loop → `reconcileMemories` (legacy loop behind the flag) |
+| `apps/web-ui/lib/agent/persistence.ts` | `PostgresMemoryStore.batch()` conflict-target edit (1 line) |
+| `apps/web-ui/lib/db/repositories/agent-memory/{interface,postgres}.ts` | hide superseded in list; expose supersede fields |
+| `apps/web-ui/components/memory/memory-detail-dialog.tsx` | provenance line |
+| `.env.example` | document the flag |
+
+## Testing
+
+- **reconcile.ts (Vitest, fake judge + mocked MemoryService):** each action applies the right primitive with the right args; no-neighbor facts skip the LLM entirely; judge throw / bad JSON / bad targetId → ADD fallback; per-fact apply error doesn't block siblings; flag off → legacy path (no reconcile import executed).
+- **memory-service.ts:** `remember` returns id (both raw and fallback paths); `supersede` sets both fields tenant-scoped; `reinforce` refreshes TTL + bumps count; fallback create-race retry.
+- **Migration verify (live DB):** partial index exists; inserting a duplicate *live* key fails; a superseded row + same-key live row coexist.
+- **Repo:** superseded rows excluded from `listByTenant`; still returned by `getById`.
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Hallucinated "new fact" displaces a correct old one | Judge instructed: SUPERSEDE requires explicit mutual exclusivity, never similarity; audit trail (`supersededById`) makes displacement inspectable/recoverable |
+| Judge latency in the run tail | One batched call; fast-path skips LLM when no neighbors; gated by flag |
+| Partial-index migration breaks existing upserts | All three upsert sites updated in the same phase + migration-verify step; flag-off path exercises the same updated SQL (legacy loop still calls `remember`) |
+| ORM-fallback race on concurrent same-key creates | Partial unique index is the backstop; catch unique-violation → retry as update |
+| Double embedding per fact (recall query + remember insert) | Accepted for simplicity; noted as future optimization (pass embedding through) |
+
+## Open Questions
+
+None blocking. `RECONCILE_DISTANCE_THRESHOLD` is an initial guess — tune after observing real distances in logs.

--- a/docs/superpowers/specs/2026-07-02-agent-memory-phase3-episodic-design.md
+++ b/docs/superpowers/specs/2026-07-02-agent-memory-phase3-episodic-design.md
@@ -1,0 +1,159 @@
+# Agent Memory Phase 3 — Episodic Memory (Capture + Replay)
+
+**Status:** Approved design, ready for implementation planning
+**Date:** 2026-07-02
+**Branch:** `agent-memory` (continues PR #55; Phases 0–2 already landed)
+**Roadmap:** Phase 3 of 5 (Phase 4 procedural + deep-agent unification remain)
+
+---
+
+## Problem
+
+The agent learns *facts* (Phase 2 keeps them accurate) but forgets *experiences*. At END of every run, the knowledge of how the run actually went — what was asked, what approach was taken, which tool calls worked, what failed and why — evaporates. When the agent later faces a similar incident or task, it re-derives the approach from scratch instead of replaying a past experience as a few-shot example (the Hermes "experience replay" pattern).
+
+Phase 0 laid the scaffolding deliberately: `MemoryKind.EPISODIC`, `EpisodicValue { context, reasoning, action, outcome }`, `sourceThreadId`, and kind-filtered `recall`. Nothing populates or consumes it. `ReflectionState` already carries the raw material (`taskDescription`, `plan`, `toolResults` with error flags, `errors`, `reflection`, `iterationCount`, `isComplete`).
+
+## Goal
+
+**Capture** one distilled cognitive snapshot per qualifying run and **replay** the 1–2 most similar past episodes at task start, formatted as structured experience alongside (but distinct from) semantic facts.
+
+### Decisions locked during design
+
+- **Capture policy:** only runs that executed tools (deterministic pre-filter — no LLM cost for chat-only turns); the distiller LLM may still return `SKIP` for routine runs; **failures are captured** (outcome states success/failure and why).
+- **Approach: zero-wiring composition.** Capture and replay live entirely in `memory-nodes.ts` + a new `episode.ts`; the replay is composed into the **existing `memoryContext` string**, so fast/planning agents and their 5 prompt sites are untouched.
+- **One episode per thread, refreshed:** key `thread-<threadId>`, upserted via the Phase 2 live-unique index. Store stays bounded; a thread's episode always reflects its latest state. (Episode-per-run append rejected: unbounded growth, needs pruning — YAGNI.)
+- **Episodes bypass the reconcile judge:** they are historical records with no contradiction semantics; straight `remember`.
+- **Minimal UI:** `'episodes'` category + a sensible list-column fallback; no episode-browser.
+- **Same branch:** PR #55 grows.
+
+### Non-goals
+
+- Procedural memory / Skills bridge (Phase 4).
+- Episode pruning, decay, or cross-thread episode merging.
+- A dedicated episode-browser UI.
+- Deep-agent (still deferred).
+- Changing semantic recall behavior (the `kinds: ['SEMANTIC']` filter added below is a no-op today — only semantic rows exist — but keeps episodes out of the facts list going forward).
+
+---
+
+## Current State (grounding)
+
+- `apps/web-ui/lib/agent/memory-nodes.ts` — `memoryRecallNode`: single `searchMemory(tenantId, userId, [], query, 10)` (all kinds) → LLM relevance filter → `memoryContext` string injected as `## Relevant Context from Memory` in all agent prompts. `memorySaveNode` (has `runtimeConfig` → `thread_id` since Phase 2): extraction → `reconcileMemories` (SEMANTIC) behind `MEMORY_RECONCILE_ENABLED`.
+- `apps/web-ui/lib/agent/memory/types.ts` — `EpisodicValue { context, reasoning, action, outcome }`, `MemoryHit { id, namespace, key, value, kind, distance? }`.
+- `apps/web-ui/lib/agent/memory/memory-service.ts` — `recall({ kinds, limit, ... })` returns distance on vector hits; `remember({ kind, namespace, key, sourceThreadId, ... })` upserts live rows (partial unique index).
+- `apps/web-ui/lib/agent/agent-shared.ts` — `ReflectionState` fields available in `memorySaveNode`'s state: `taskDescription`, `plan` (PlanStep[]), `toolResults` (ToolResultEntry[]: toolName/output/isError/iterationIndex), `errors`, `reflection`, `iterationCount`, `isComplete`, `messages`.
+- `apps/web-ui/lib/agent-memory/category.ts` — `KNOWN_CATEGORIES = ['infra', 'user', 'patterns', 'errors']`; namespace prefix → category; unknown → `'other'`.
+- Repo `toRecord` (`repositories/agent-memory/postgres.ts`): `fact: asString(value.fact) ?? ''` — episodic values have no `.fact`, so the list column would render empty.
+- Precedents: env-flag accessors reading `process.env`, non-fatal LLM steps, `compressToolOutput` for transcript compression, per-phase spec/plan/SDD flow.
+
+---
+
+## Design
+
+### A. Capture — new `apps/web-ui/lib/agent/memory/episode.ts`
+
+```typescript
+export function episodicMemoryEnabled(): boolean;   // EPISODIC_MEMORY_ENABLED, default true ('false'/'0' disable)
+
+export interface CaptureEpisodeParams {
+    tenantId: string;
+    userId: string;
+    threadId: string;
+    distillerModel: BaseChatModel;      // the reflector model, passed in
+    taskDescription: string;
+    plan: Array<{ step: string; status: string }>;
+    toolResults: Array<{ toolName: string; output: string; isError: boolean }>;
+    errors: string[];
+    reflection: string;
+    isComplete: boolean;
+    iterationCount: number;
+}
+export async function captureEpisode(p: CaptureEpisodeParams): Promise<boolean>;  // true = saved
+```
+
+`captureEpisode` (never throws; returns false on skip/failure):
+1. Builds a distiller prompt from the run summary (tool outputs compressed via `compressToolOutput`, capped transcript).
+2. Distiller returns strict JSON `{ "context": ..., "reasoning": ..., "action": ..., "outcome": ... }` — or the literal `SKIP` when the run was routine/unremarkable. The prompt requires `outcome` to state success or failure **and why**; failed runs are explicitly worth capturing.
+3. Validates all four fields are non-empty strings; anything else → no save, `false`.
+4. Saves via `getMemoryService().remember({ tenantId, userId, kind: 'EPISODIC', namespace: ['episodes'], key: 'thread-' + threadId, value, sourceThreadId: threadId })` — the live-unique index makes repeat captures on the same thread a refresh, not a duplicate.
+
+**Call site** — `memorySaveNode`, after the existing reconcile/save block (independent of it):
+
+```
+if (episodicMemoryEnabled() && threadId && toolResults.length > 0) → captureEpisode(...)
+```
+
+Chat-only turns (no tools) never invoke the distiller. Capture failure/SKIP is logged and never blocks END.
+
+### B. Replay — `memoryRecallNode` rework
+
+Replace the single untyped `searchMemory` with two typed recalls via `getMemoryService()`:
+
+1. **Semantic:** `recall({ kinds: ['SEMANTIC'], limit: 10, query })` → existing LLM relevance filter, unchanged.
+2. **Episodic** (only when `episodicMemoryEnabled()`): `recall({ kinds: ['EPISODIC'], limit: EPISODE_RECALL_LIMIT (2), query })` → keep hits with `distance !== undefined && distance <= EPISODE_DISTANCE_THRESHOLD (0.65)` (looser than reconcile's 0.55 — an *analogous* experience is useful even when not near-identical). **No second LLM call.** Flag off → this step is skipped entirely (facts-only, byte-for-byte Phase 2 behavior).
+
+`memoryContext` becomes a composed string:
+
+```
+### Known facts
+<filtered fact lines — existing format>
+
+### Past experience (similar previous sessions)
+**Situation:** <context>
+**Approach:** <reasoning>
+**Actions taken:** <action>
+**Outcome:** <outcome>
+```
+
+Formatting lives in a pure exported helper `formatEpisodesSection(episodes: EpisodicValue[]): string` in `episode.ts` (returns `''` for empty input). When only one section has content, only that section renders; when both are empty, `memoryContext` stays `''` (existing downstream behavior preserved). Since the composed string flows through the existing `memoryContext` channel, **zero changes to fast-agent.ts / planning-agent.ts**.
+
+Failure containment: episodic recall failure degrades to facts-only (log + continue); the recall node never throws (existing contract).
+
+### C. Memory-module UI (minimal)
+
+- `apps/web-ui/lib/agent-memory/category.ts`: add `'episodes'` to `KNOWN_CATEGORIES` and the `MemoryCategory` type — list badge + multi-select filter work automatically (both are driven by the constant).
+- Repo `toRecord`: `fact: asString(value.fact) ?? asString(value.outcome) ?? ''` — episodic rows show their outcome (their most informative one-liner) in the list's fact column. `source` stays null for episodes; detail dialog already renders the full raw value JSON.
+
+### D. Configuration
+
+| Env var | Default | Meaning |
+|---------|---------|---------|
+| `EPISODIC_MEMORY_ENABLED` | `true` | off → no capture and no episodic recall (facts-only, byte-for-byte Phase 2 behavior) |
+
+Module constants (not env): `EPISODE_RECALL_LIMIT = 2`, `EPISODE_DISTANCE_THRESHOLD = 0.65`.
+
+---
+
+## Files Touched
+
+| File | Change |
+|------|--------|
+| `apps/web-ui/lib/agent/memory/episode.ts` | **new** — flag accessor, distiller prompt, `captureEpisode`, `formatEpisodesSection`, constants |
+| `apps/web-ui/lib/agent/memory/episode.test.ts` | **new** — capture gating/validation + formatting tests |
+| `apps/web-ui/lib/agent/memory-nodes.ts` | recall: two typed recalls + composed memoryContext; save: episode capture call |
+| `apps/web-ui/env.ts` | `EPISODIC_MEMORY_ENABLED` |
+| `.env.example` | document the flag |
+| `apps/web-ui/lib/agent-memory/category.ts` | `'episodes'` category |
+| `apps/web-ui/lib/db/repositories/agent-memory/postgres.ts` (+test) | fact-column fallback to `value.outcome` |
+| `CLAUDE.md` | one table row for episode.ts |
+
+## Testing
+
+- **episode.ts (Vitest, fake distiller + mocked getMemoryService):** captures and saves with correct key/namespace/kind; distiller `SKIP` → no save, returns false; invalid/partial JSON → no save, non-fatal; distiller throw → non-fatal false; flag off → short-circuits before the LLM; `formatEpisodesSection` renders all four fields and returns `''` on empty.
+- **memory-nodes recall composition:** the composed-context logic is exercised through `formatEpisodesSection` + a small pure `composeMemoryContext(factsSection, episodesSection)` helper (also in episode.ts, tested for the four empty/non-empty combinations); the node itself stays typecheck-verified (no existing node test harness).
+- **Repo test:** episodic-value row maps `fact` → outcome string; category `'episodes'` derived from namespace.
+- **Manual smoke (deferred to user, needs live provider):** run a tool-using session, confirm `🧠 [EPISODE]` capture log + a row in the Memory module under category `episodes`; start a similar new thread and confirm the `### Past experience` block appears in the recall log.
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Episode noise from trivial runs | tools-required pre-filter + distiller SKIP veto |
+| Stale episode misleads on a repurposed thread | one-per-thread refresh means the episode always reflects the thread's latest state |
+| Extra LLM call in run tail | only tool-using runs; single call; non-fatal; flag to disable |
+| Irrelevant episode injected (no LLM filter on replay) | limit 2 + distance gate 0.65; structured format makes irrelevance cheap for the agent to ignore |
+| `memoryContext` grows | facts already LLM-filtered; episodes capped at 2 compact blocks |
+
+## Open Questions
+
+None blocking. `EPISODE_DISTANCE_THRESHOLD = 0.65` is an initial guess — tune from recall logs alongside the reconcile threshold.

--- a/docs/superpowers/specs/2026-07-02-agent-memory-phase4-procedural-design.md
+++ b/docs/superpowers/specs/2026-07-02-agent-memory-phase4-procedural-design.md
@@ -1,0 +1,161 @@
+# Agent Memory Phase 4 — Procedural Memory + Skills Bridge
+
+**Status:** Approved design (bridge depth chosen autonomously — see Decisions; user to confirm at spec review)
+**Date:** 2026-07-02
+**Branch:** `agent-memory` (continues PR #55; Phases 0–3 already landed)
+**Roadmap:** Phase 4 of 5 — the final memory layer (deep-agent unification remains as a separate effort)
+
+---
+
+## Problem
+
+The agent now keeps facts accurate (Phase 2) and replays experiences (Phase 3), but it cannot **learn how to behave**. Operating rules it discovers the hard way — "always paginate AWS CLI list calls in this tenant", "check deployment state before mutating service X", "this user wants tables, not prose" — are at best captured as semantic facts and surfaced as trivia, not imperatives. And the roadmap's promise — mature rules feeding the DB-backed **Skills module** — is unbuilt: `MemoryKind.PROCEDURAL` and `ProceduralValue { instruction, trigger, evidence }` are declared with zero consumers.
+
+The Skills module (mapped on this branch) gives us strong rails:
+- `Skill` model: `source: 'user' | 'system'`, `sourceRunId`, `isEnabled`, unique `(tenantId, slug)` — **no draft/pending state**; a saved skill is live.
+- **Distill precedent:** `POST /api/skills/distill` returns a draft JSON that pre-fills `SkillFormDialog`; *nothing persists until the human saves* (`useCreateSkill` → `POST /api/skills`, RBAC `create Skill`). This is the codebase's established "AI proposes → human approves" pattern.
+- Exactly **one skill is active per run** (`selectedSkill`, singular) — learned rules cannot ride the skill slot and need their own injection path.
+
+## Goal
+
+1. **Capture** operating rules as `PROCEDURAL` memories during the existing save-time extraction, reconciled by the existing judge (rules can be contradicted, refined, and reinforced exactly like facts).
+2. **Inject** the most relevant learned rules at task start as a `### Operating rules (learned)` section — same zero-wiring composition as Phase 3.
+3. **Bridge**: a human-approved **"Promote to skill"** flow — procedural rows in the Memory module open the existing `SkillFormDialog` pre-filled from the rule; the human reviews, picks the tier, and saves through the existing API.
+
+### Decisions locked during design
+
+- **Bridge depth: human-approved promotion** (chosen autonomously when the scoping question timed out; rationale: reuses the distill flow's proven pattern, no schema change, no threshold machinery, and instruction content never goes live without review). Alternatives — auto-created disabled skills (list pollution, unreviewed content one toggle from live) and deferring the bridge (breaks the roadmap promise) — rejected. **User may override at spec review.**
+- **Capture source: the existing extraction call** — one LLM call still; the extraction prompt gains an "operating rules" category emitting procedural-shaped items. No separate mining pass (YAGNI).
+- **Rules ride the reconcile pipeline** — `reconcileMemories` becomes kind-aware (a rule reconciles against other rules; REINFORCE = the rule proved out again; SUPERSEDE = the rule changed).
+- **Injection: similarity recall, no LLM filter** (like episodes) — limit 3, distance ≤ 0.65 (shared threshold value with episodes for one fewer knob).
+- **Same branch:** PR #55 grows.
+
+### Non-goals
+
+- Auto-promotion, maturity thresholds, or promotion nudges ("this rule was reinforced 5×") — the promote action is available on every procedural row; human judgment decides.
+- Multi-skill activation, skill content editing from the memory side, or any `Skill` schema change.
+- Rule decay/expiry beyond the existing 90-day TTL + REINFORCE refresh.
+- Deep-agent (still deferred).
+
+---
+
+## Current State (grounding)
+
+- `apps/web-ui/lib/agent/memory/types.ts` — `ProceduralValue { instruction, trigger, evidence }` (dormant); `ExtractedFact { namespace, key, value: SemanticValue }` (no kind field); `MemoryHit` carries `kind`.
+- `apps/web-ui/lib/agent/memory-nodes.ts` — `memorySaveNode`: extraction prompt has four categories, all semantic-shaped; `toSave` filter checks `value.confidence`; reconcile call maps to `ExtractedFact[]`. `memoryRecallNode`: semantic recall (LLM filter) + episodic recall (distance-gated), composed via `composeMemoryContext(facts, episodes)`.
+- `apps/web-ui/lib/agent/memory/reconcile.ts` — `reconcileMemories` hardcodes `kind: 'SEMANTIC'` in its `add`/SUPERSEDE `remember` calls and `kinds: ['SEMANTIC']` in neighbor recall.
+- `apps/web-ui/lib/agent/memory/episode.ts` — `composeMemoryContext(factsSection, episodesSection)` with exact-shape tests (facts-only bare; header only when both).
+- Memory-module: `AgentMemoryRecord.kind` exists (Phase 0), but the client `MemoryRow` (`lib/queries/agent-memories.ts`) does **not** expose `kind`. `memory-client-component.tsx` has row actions (view/delete); `SkillFormDialog` accepts `initialDraft` and is already reused by the distill flow; `useCreateSkill` posts to `/api/skills` with RBAC.
+- Env-flag + constants precedents: `MEMORY_RECONCILE_ENABLED`, `EPISODIC_MEMORY_ENABLED`, `EPISODE_*` constants.
+
+---
+
+## Design
+
+### A. Capture — extraction emits procedural items
+
+`ProceduralValue` gains `confidence?: 'high' | 'medium'` (the extraction confidence gate applies to rules too). `ExtractedFact` gains `kind?: MemoryKind` (absent = `'SEMANTIC'`, so every existing call site is unchanged) and its `value` widens to `SemanticValue | ProceduralValue`.
+
+The extraction prompt in `memorySaveNode` gains a fifth category (only when `proceduralMemoryEnabled()`):
+
+```
+- Operating rules → kind: "PROCEDURAL", namespace: ["procedures", "<domain>"]
+  A rule for HOW the agent should behave in this environment, learned from this run.
+  Shape: { "kind": "PROCEDURAL", "namespace": ["procedures", "aws-cli"], "key": "paginate-list-calls",
+           "value": { "instruction": "Always paginate list/describe calls", "trigger": "any AWS CLI list operation",
+                      "evidence": "run truncated results at 50 items and missed the target resource", "confidence": "high" } }
+  Extract a rule ONLY from a correction, a failure the run recovered from, or an explicit user preference about behavior.
+```
+
+The `toSave` filter becomes shape-aware via a pure helper `isValidExtractedItem(item)` (lives in `procedural.ts`, unit-tested): semantic items require non-empty `fact` + high/medium `confidence`; procedural items require non-empty `instruction`/`trigger`/`evidence` + high/medium `confidence`. Invalid items are dropped (logged).
+
+### B. Reconcile becomes kind-aware
+
+In `reconcileMemories` (small, mechanical changes):
+- Neighbor recall: `kinds: [fact.kind ?? 'SEMANTIC']` — a rule reconciles only against rules.
+- `add` and SUPERSEDE `remember` calls: `kind: fact.kind ?? 'SEMANTIC'`.
+- Judge system prompt: one added line — "Items may be facts or operating rules; the same actions apply (a rule that changed = SUPERSEDE; the same rule re-learned = REINFORCE)."
+
+Semantics fall out for free: a rule that keeps proving out gets REINFORCE (TTL refresh + `accessCount++` — `accessCount` becomes the rule-maturity signal the UI can sort by later); a changed rule gets an auditable SUPERSEDE.
+
+### C. Inject — third section in the recall composition
+
+New tiny module `apps/web-ui/lib/agent/memory/procedural.ts`:
+
+```typescript
+export const PROCEDURE_RECALL_LIMIT = 3;
+export const PROCEDURE_DISTANCE_THRESHOLD = 0.65;   // shared value with episodes — one knob
+export function proceduralMemoryEnabled(): boolean;  // PROCEDURAL_MEMORY_ENABLED, default true
+export function formatProceduresSection(rules: ProceduralValue[]): string;
+// renders: "### Operating rules (learned)\n- When <trigger>: <instruction>" per rule; '' for []
+```
+
+`memoryRecallNode` gains a third recall (between facts and episodes, only when `proceduralMemoryEnabled()`): `recall({ kinds: ['PROCEDURAL'], limit: 3, query })`, distance-gated, **no LLM filter**, with a field-validity filter (all three fields non-empty — the belt-and-suspenders the Phase 3 review suggested for episodes, applied to rules from day one).
+
+`composeMemoryContext` gains an optional third parameter — `composeMemoryContext(factsSection, episodesSection, proceduresSection = '')` — output order: **facts → rules → episodes** (imperatives before illustrations). Exact-shape contract preserved: all existing two-arg behaviors byte-identical; the `### Known facts` header appears when facts coexist with either other section; single-section output stays bare.
+
+### D. Skills bridge — "Promote to skill" (human-approved)
+
+- `MemoryRow` (client type in `lib/queries/agent-memories.ts`) gains `kind: MemoryKind` (the API already returns it — repo record has carried it since Phase 0).
+- New pure helper `apps/web-ui/lib/agent-memory/promote.ts`:
+  ```typescript
+  buildSkillDraftFromMemory(row: MemoryRow): SkillDraft | null   // null for non-procedural rows
+  // name  = humanized key ("paginate-list-calls" → "Paginate List Calls")
+  // description = trigger
+  // tier  = 'read-only'   (safest default; human changes it in the dialog)
+  // content = markdown: "## Rule\n<instruction>\n\n## When it applies\n<trigger>\n\n## Why (evidence)\n<evidence>\n\n_Learned by the agent; promoted from procedural memory._"
+  ```
+  (`SkillDraft` is the existing shape `SkillFormDialog` accepts as `initialDraft`.)
+- `memory-client-component.tsx`: rows with `kind === 'PROCEDURAL'` get a **Promote to skill** row action; it opens the existing `SkillFormDialog` with `initialDraft = buildSkillDraftFromMemory(row)`. On save, `sourceRunId` is set to the memory's `sourceThreadId` when present (provenance, mirroring how the distill flow passes its `threadId`). Save goes through the existing `useCreateSkill` → `POST /api/skills` (RBAC `create Skill` server-side). **Nothing persists without the human clicking Save** — exactly the distill pattern.
+- `MemoryRow` also gains `sourceThreadId: string | null` (repo record + client type + `toRecord` mapping — one field, needed for provenance).
+
+### E. Configuration
+
+| Env var | Default | Meaning |
+|---------|---------|---------|
+| `PROCEDURAL_MEMORY_ENABLED` | `true` | off → extraction prompt reverts to the Phase 3 four-category version, no PROCEDURAL recall section; Promote action still shown for any pre-existing procedural rows |
+
+Constants (module, not env): `PROCEDURE_RECALL_LIMIT = 3`, `PROCEDURE_DISTANCE_THRESHOLD = 0.65`.
+
+---
+
+## Files Touched
+
+| File | Change |
+|------|--------|
+| `apps/web-ui/lib/agent/memory/types.ts` | `ProceduralValue.confidence?`; `ExtractedFact.kind?` + value union |
+| `apps/web-ui/lib/agent/memory/procedural.ts` | **new** — flag, constants, `formatProceduresSection`, `isValidExtractedItem` |
+| `apps/web-ui/lib/agent/memory/procedural.test.ts` | **new** |
+| `apps/web-ui/lib/agent/memory/reconcile.ts` (+test) | kind threading (neighbor recall, add/supersede remember, judge prompt line) |
+| `apps/web-ui/lib/agent/memory/episode.ts` (+test) | `composeMemoryContext` optional third param |
+| `apps/web-ui/lib/agent/memory-nodes.ts` | extraction 5th category + shape-aware filter; third recall section |
+| `apps/web-ui/env.ts` + `.env.example` | `PROCEDURAL_MEMORY_ENABLED` |
+| `apps/web-ui/lib/db/repositories/agent-memory/{interface,postgres}.ts` (+test) | expose `sourceThreadId` on the record |
+| `apps/web-ui/lib/queries/agent-memories.ts` | `MemoryRow` gains `kind`, `sourceThreadId` |
+| `apps/web-ui/lib/agent-memory/promote.ts` (+test) | **new** — `buildSkillDraftFromMemory` |
+| `apps/web-ui/components/memory/memory-client-component.tsx` | Promote row action + `SkillFormDialog` wiring |
+| `CLAUDE.md` | one table row |
+
+## Testing
+
+- **procedural.ts:** flag accessor; `formatProceduresSection` rendering + `''` for empty.
+- **reconcile.ts:** procedural fact → neighbor recall called with `kinds: ['PROCEDURAL']`; `remember` called with `kind: 'PROCEDURAL'`; semantic default unchanged (existing 13 tests untouched).
+- **episode.ts:** three-arg `composeMemoryContext` combinations; ALL existing two-arg assertions unchanged (byte-shape contract).
+- **memory-nodes filter logic:** exercised via a pure `isValidExtractedItem(item)` helper (in `procedural.ts`, testable) used by the `toSave` filter.
+- **promote.ts:** draft mapping for a procedural row; `null` for semantic/episodic rows.
+- **Repo:** `sourceThreadId` mapped through.
+- **Manual smoke (deferred, needs live provider):** teach the agent a behavioral correction, confirm a `procedures/*` row appears; new similar task shows `### Operating rules (learned)`; Promote opens the pre-filled dialog and Save creates the skill.
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Extraction over-produces rules (every run "learns" something) | prompt restricts to corrections/recovered failures/explicit preferences + confidence gate; reconcile dedupes via REINFORCE |
+| A wrong rule steers the agent | rules are similarity-recalled (only surface on matching triggers), auditable in the Memory module, deletable, supersedable; promotion to always-on skill requires human review |
+| composeMemoryContext regression | optional third param + all existing exact-shape tests must pass unchanged |
+| Cross-domain UI import (memory component → skills dialog) | both are client components in the same app; the distill flow already crosses this boundary (chat component → skills dialog) |
+
+## Open Questions
+
+- **Bridge depth** was chosen autonomously (human-approved promotion) — confirm or redirect at spec review.
+- `PROCEDURE_DISTANCE_THRESHOLD = 0.65` shared with episodes — revisit only if rule recall proves too eager/shy in logs.

--- a/libs/prisma/migrations/20260701235449_agent_memory_foundation/migration.sql
+++ b/libs/prisma/migrations/20260701235449_agent_memory_foundation/migration.sql
@@ -1,0 +1,39 @@
+-- CreateEnum
+CREATE TYPE "MemoryKind" AS ENUM ('SEMANTIC', 'EPISODIC', 'PROCEDURAL');
+
+-- AlterTable
+ALTER TABLE "agent_memories" ADD COLUMN     "accessCount" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN     "kind" "MemoryKind" NOT NULL DEFAULT 'SEMANTIC',
+ADD COLUMN     "lastAccessedAt" TIMESTAMP(3),
+ADD COLUMN     "sourceThreadId" TEXT,
+ADD COLUMN     "supersededAt" TIMESTAMP(3),
+ADD COLUMN     "supersededById" TEXT;
+
+-- CreateTable
+CREATE TABLE "agent_working_memory" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "threadId" TEXT NOT NULL,
+    "runningSummary" TEXT NOT NULL,
+    "scratchpad" JSONB NOT NULL,
+    "tokenCount" INTEGER NOT NULL DEFAULT 0,
+    "turnCount" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "agent_working_memory_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "agent_working_memory_expiresAt_idx" ON "agent_working_memory"("expiresAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "agent_working_memory_tenantId_threadId_key" ON "agent_working_memory"("tenantId", "threadId");
+
+-- CreateIndex
+CREATE INDEX "agent_memories_tenantId_kind_idx" ON "agent_memories"("tenantId", "kind");
+
+-- pgvector HNSW index for cosine similarity (matches the <=> queries in persistence.ts)
+CREATE INDEX IF NOT EXISTS "agent_memories_embedding_hnsw"
+  ON "agent_memories" USING hnsw ("embedding" vector_cosine_ops);

--- a/libs/prisma/migrations/20260702092242_agent_memory_partial_unique/migration.sql
+++ b/libs/prisma/migrations/20260702092242_agent_memory_partial_unique/migration.sql
@@ -1,0 +1,13 @@
+-- Replace the full unique constraint with a live-rows-only partial unique index so a
+-- superseded row and its same-key successor can coexist (supersede audit trail).
+-- Index name verified in DB: agent_memories_tenantId_namespace_key_key
+DROP INDEX "agent_memories_tenantId_namespace_key_key";
+
+-- Plain index for lookup performance (mirrors the schema's @@index).
+CREATE INDEX "agent_memories_tenantId_namespace_key_idx"
+  ON "agent_memories"("tenantId", "namespace", "key");
+
+-- Uniqueness applies to LIVE rows only.
+CREATE UNIQUE INDEX "agent_memories_live_tenant_ns_key"
+  ON "agent_memories" ("tenantId", "namespace", "key")
+  WHERE "supersededById" IS NULL;

--- a/libs/prisma/schema.prisma
+++ b/libs/prisma/schema.prisma
@@ -491,26 +491,59 @@ model ScheduledTaskLock {
   @@map("scheduled_task_locks")
 }
 
+enum MemoryKind {
+  SEMANTIC
+  EPISODIC
+  PROCEDURAL
+}
+
 // AgentMemory — long-term semantic memory for AI agents (LANG-03)
 // Uses pgvector for similarity search with Bedrock Titan v2 embeddings (1024-dim)
 // embedding column uses Unsupported() — raw SQL for vector queries (Prisma has no native pgvector support)
 // expiresAt: 90-day TTL (same cleanup pattern as other tables)
 model AgentMemory {
-  id            String                    @id @default(cuid())
-  tenantId      String
-  userId        String
-  namespace     String
-  key           String
-  value         Json
-  embedding     Unsupported("vector(1024)")?
-  createdAt     DateTime                  @default(now())
-  updatedAt     DateTime                  @updatedAt
-  expiresAt     DateTime                  // 90-day TTL
+  id             String                       @id @default(cuid())
+  tenantId       String
+  userId         String
+  namespace      String
+  key            String
+  value          Json
+  kind           MemoryKind                   @default(SEMANTIC)
+  embedding      Unsupported("vector(1024)")?
+  sourceThreadId String?
+  supersededById String?
+  supersededAt   DateTime?
+  lastAccessedAt DateTime?
+  accessCount    Int                          @default(0)
+  createdAt      DateTime                     @default(now())
+  updatedAt      DateTime                     @updatedAt
+  expiresAt      DateTime // 90-day TTL
 
   @@unique([tenantId, namespace, key])
   @@index([tenantId, userId])
+  @@index([tenantId, kind])
   @@index([expiresAt])
   @@map("agent_memories")
+}
+
+// AgentWorkingMemory — per-thread in-session scratchpad + rolling summary (Phase 1).
+// Live source of truth is the LangGraph checkpoint; this table is a durable mirror
+// written on each compaction. No embedding (this is live context, not searched).
+model AgentWorkingMemory {
+  id             String   @id @default(cuid())
+  tenantId       String
+  threadId       String
+  runningSummary String   @db.Text
+  scratchpad     Json
+  tokenCount     Int      @default(0)
+  turnCount      Int      @default(0)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+  expiresAt      DateTime
+
+  @@unique([tenantId, threadId])
+  @@index([expiresAt])
+  @@map("agent_working_memory")
 }
 
 // ChatMessage — chat session history for AI agent threads (LANG-02)

--- a/libs/prisma/schema.prisma
+++ b/libs/prisma/schema.prisma
@@ -519,7 +519,7 @@ model AgentMemory {
   updatedAt      DateTime                     @updatedAt
   expiresAt      DateTime // 90-day TTL
 
-  @@unique([tenantId, namespace, key])
+  @@index([tenantId, namespace, key])
   @@index([tenantId, userId])
   @@index([tenantId, kind])
   @@index([expiresAt])


### PR DESCRIPTION
## Summary

Refactors agent long-term memory into a **native-TS multi-layer cognitive memory system** on the existing Postgres/pgvector stack, to support long-running autonomous agents. This PR carries all five phases — the complete CoALA-style stack: **working + semantic + episodic + procedural memory**. (Chose native TS over LangMem — Python-only — and Mem0-JS, to honor the provider-only-LLM + strict multi-tenant constraints without a new dependency or service.)

Specs & plans under `docs/superpowers/` (one spec + plan per phase).

## Phase 0 — Foundation
- Additive schema: `kind` discriminator (`SEMANTIC`/`EPISODIC`/`PROCEDURAL`) + scaffolding columns on `AgentMemory`; new `AgentWorkingMemory` table; pgvector **HNSW** index. Typed **`MemoryService`** as the single entry point. Deep-agent untouched.

## Phase 1 — Working memory (long-run survival)
- **`prepareContext`**: budget-aware windowing; evicted turns fold into a rolling summary + scratchpad (**monotonicity enforced in code**). Wired into fast + planning agents. `WORKING_MEMORY_ENABLED`.

## Phase 2 — Semantic conflict resolution (accuracy over time)
- **Partial unique index** on live rows → auditable same-key supersede. **Reconcile pipeline**: neighbor fetch → ONE batched judge — ADD / UPDATE / SUPERSEDE (contradiction only) / REINFORCE (TTL refresh) / NOOP; never throws. UI hides superseded rows. `MEMORY_RECONCILE_ENABLED`.

## Phase 3 — Episodic memory (experience replay)
- One distilled `{context, reasoning, action, outcome}` snapshot per tool-using run (SKIP veto; failures first-class; one per thread, refreshed). Top-2 similar episodes replay as a `### Past experience` few-shot block — zero agent-file changes. `EPISODIC_MEMORY_ENABLED`.

## Phase 4 — Procedural memory + Skills bridge (self-improving behavior)
- **Capture:** the extraction call gains a flag-gated "operating rules" category — `{instruction, trigger, evidence, confidence}` rules learned ONLY from corrections, recovered failures, and explicit behavioral preferences.
- **Kind-aware reconcile:** rules dedupe/supersede/reinforce against rules — `accessCount` becomes a natural rule-maturity signal, and a changed rule leaves an audit trail.
- **Inject:** top-3 similar rules appear as `### Operating rules (learned)` (facts → rules → episodes composition; facts-only output stays byte-identical).
- **Skills bridge (human-approved):** a **Promote to skill** action on procedural rows pre-fills the existing `SkillFormDialog` (instruction → content, trigger → description, tier defaults read-only, `sourceRunId` provenance); persistence only through the existing RBAC'd `POST /api/skills` when a human saves — the same pattern as the chat→skill distill flow. `PROCEDURAL_MEMORY_ENABLED`.

## Testing & review
- **88 memory-suite tests green** (fast-check invariants, monotonicity, all judge actions, every capture/replay/promotion failure path pinned, migration coexistence verified live).
- Zero new TypeScript errors across all phases (two old baseline errors fixed in passing).
- Per-task spec+quality reviews + a final whole-phase review per phase — **all four verdicts clean** (0 Critical/Important each). Phase 4's one Minor (procedural rows unlabeled in the list) fixed before push.

## Follow-ups (not blocking)
- ~~Deep-agent MongoDB→Postgres unification~~ — **dropped by decision** (deep-agent not in the current use case; it keeps its MongoDB store + explicit memory tools as-is).
- Minor deferrals: validate episode fields on replay; superseded-row filter on recall's access-stat bump; type `runtimeConfig`; reconcile embedding pass-through; non-embedding fallback tests.
- **Manual smoke before prod enable:** long tool-using session (compaction + episode capture), a contradicting-fact scenario (supersede), a behavioral correction (rule capture → `### Operating rules` on the next similar task → Promote to skill). Needs a live LLM provider + dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
