### PR TITLE
feat(kb): inline documents + autonomous KB retrieval for AIOps & Agent Ops

### DIFF
--- a/apps/web-ui-e2e/kb-documents.spec.ts
+++ b/apps/web-ui-e2e/kb-documents.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * KB Inline Documents E2E — /app/knowledge-base/[kbId]
+ *
+ * Covers the inline-document authoring feature:
+ *  - "New Document" opens the markdown editor dialog
+ *  - Write/Preview tabs render markdown
+ *  - Creating a document either lists it (embedding provider configured) or
+ *    surfaces an error toast (no provider → the API returns 400 by design).
+ *    Both are valid outcomes, so this exercises the full wiring without a
+ *    false green in environments without a configured embedding provider.
+ *
+ * Run: cd apps/web-ui-e2e && bunx playwright test kb-documents.spec.ts
+ */
+import { test, expect, Page } from '@playwright/test';
+
+async function gotoKnowledgeBase(page: Page) {
+    const res = await page.goto('/app/knowledge-base', { waitUntil: 'domcontentloaded', timeout: 60000 });
+    expect(res?.status(), 'knowledge-base page should not 404').not.toBe(404);
+    expect(page.url(), 'knowledge-base page should not redirect to login').not.toContain('/login');
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('[class*="animate-spin"]')).toHaveCount(0, { timeout: 15000 });
+}
+
+// Opens a knowledge base detail page, creating a KB first if none exist.
+async function openAnyKnowledgeBase(page: Page) {
+    const emptyState = await page.getByText('No knowledge bases yet').isVisible().catch(() => false);
+    if (emptyState) {
+        await page.getByRole('button', { name: /Create Knowledge Base/i }).first().click();
+        await expect(page.getByRole('dialog')).toBeVisible({ timeout: 10000 });
+        await page.getByLabel(/Name/i).fill(`E2E KB ${Date.now()}`);
+        await page.getByRole('button', { name: /^Create$/i }).click();
+        await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 10000 });
+        await page.waitForLoadState('networkidle');
+    }
+
+    await page.getByRole('button', { name: 'Open' }).first().click();
+    await expect(page).toHaveURL(/\/app\/knowledge-base\/[^/]+$/, { timeout: 15000 });
+    await expect(page.getByRole('button', { name: 'New Document' })).toBeVisible({ timeout: 15000 });
+}
+
+test.describe('KB inline documents', () => {
+    test.beforeEach(async ({ page }) => {
+        await gotoKnowledgeBase(page);
+    });
+
+    test('New Document dialog opens and previews markdown', async ({ page }) => {
+        await openAnyKnowledgeBase(page);
+
+        await page.getByRole('button', { name: 'New Document' }).click();
+        const dialog = page.getByRole('dialog');
+        await expect(dialog).toBeVisible({ timeout: 10000 });
+        await expect(dialog.getByText('New Document')).toBeVisible();
+
+        // Fields are matched by placeholder (labels are not htmlFor-associated).
+        await page.getByPlaceholder('e.g. Incident runbook').fill(`E2E Doc ${Date.now()}`);
+        await page.getByPlaceholder(/Write markdown/).fill('# Heading\n\nBody text for embedding.');
+
+        // Preview tab renders the markdown as HTML.
+        await page.getByRole('tab', { name: 'Preview' }).click();
+        await expect(dialog.getByRole('heading', { name: 'Heading' })).toBeVisible({ timeout: 5000 });
+    });
+
+    test('creating a document lists it or surfaces an error toast', async ({ page }) => {
+        await openAnyKnowledgeBase(page);
+
+        await page.getByRole('button', { name: 'New Document' }).click();
+        await expect(page.getByRole('dialog')).toBeVisible({ timeout: 10000 });
+
+        const name = `E2E Doc ${Date.now()}`;
+        await page.getByPlaceholder('e.g. Incident runbook').fill(name);
+        await page.getByPlaceholder(/Write markdown/).fill('# Runbook\n\nRestart the service when health checks fail.');
+        await page.getByRole('button', { name: /^Create$/ }).click();
+
+        // Synchronous embed needs a configured provider. Accept EITHER outcome:
+        //  - success  → dialog closes and the document appears in the Data Sources list
+        //  - no provider / 400 → an error toast is surfaced
+        const listed = page.getByText(name);
+        const errorToast = page.locator('[data-sonner-toast]');
+        await expect(listed.or(errorToast).first()).toBeVisible({ timeout: 30000 });
+    });
+});

--- a/apps/web-ui/app/api/agent-ops/scheduled-tasks/[taskId]/trigger/route.ts
+++ b/apps/web-ui/app/api/agent-ops/scheduled-tasks/[taskId]/trigger/route.ts
@@ -42,6 +42,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ taskId:
             accountId: task.accountId,
             accountName: task.accountName,
             mcpServerIds: task.mcpServerIds,
+            knowledgeBaseIds: task.knowledgeBaseIds,
             trigger: { taskId: task.taskId, taskName: task.name, scheduledAt },
         });
 

--- a/apps/web-ui/app/api/agent-ops/scheduled-tasks/route.ts
+++ b/apps/web-ui/app/api/agent-ops/scheduled-tasks/route.ts
@@ -35,6 +35,7 @@ export async function POST(req: Request) {
             accountId: body.accountId,
             accountName: body.accountName,
             mcpServerIds: body.mcpServerIds,
+            knowledgeBaseIds: body.knowledgeBaseIds,
             notification: body.notification || { type: 'none' },
             createdBy: body.createdBy || 'api',
         });

--- a/apps/web-ui/app/api/chat/route.ts
+++ b/apps/web-ui/app/api/chat/route.ts
@@ -6,6 +6,7 @@ import { resolveModelConfig, resolveDefaultModelConfig } from '@/lib/agent/model
 import { isProviderConfigError } from '@/lib/agent/provider-errors';
 import { buildClientErrorText } from '@/lib/agent/stream-error';
 import { autoSelectSkill } from '@/lib/agent/auto-skill-select';
+import { resolveKnowledgeBaseIds } from '@/lib/agent/auto-kb-select';
 
 export const maxDuration = 300; // 5 minutes for complex multi-iteration tasks
 
@@ -48,7 +49,8 @@ export async function POST(req: Request) {
             accountId,      // Deprecated: single AWS account ID for backwards compatibility
             accountName,    // Deprecated: single AWS account name
             selectedSkill,  // Skill ID for dynamic skill loading
-            mcpServerIds    // MCP server IDs to activate for this session
+            mcpServerIds,   // MCP server IDs to activate for this session
+            knowledgeBaseIds // Knowledge Base IDs manually selected in the console
         } = await req.json();
         // Resolve userId and tenantId from session
         let resolvedUserId: string;
@@ -149,6 +151,15 @@ export async function POST(req: Request) {
             if (auto) effectiveSkill = auto.slug;
         }
 
+        // KB progressive disclosure: manual selection always wins. When none is picked,
+        // one cheap reflector call matches the message against the tenant's KB catalog.
+        let effectiveKbIds: string[] = Array.isArray(knowledgeBaseIds) ? knowledgeBaseIds : [];
+        if (effectiveKbIds.length === 0 && mode !== 'deep') {
+            const lastMsg = messages[messages.length - 1];
+            const lastUserText = typeof lastMsg?.content === 'string' ? lastMsg.content : JSON.stringify(lastMsg?.content ?? '');
+            effectiveKbIds = await resolveKnowledgeBaseIds({ tenantId: resolvedTenantId, selectedIds: null, message: lastUserText, model: resolvedModel });
+        }
+
         // Create graph with configuration - supports multi-account
         const graphConfig = {
             model: resolvedModel,
@@ -158,6 +169,7 @@ export async function POST(req: Request) {
             accountName: accountName,
             selectedSkill: effectiveSkill,  // user pick, or auto-selected (Hermes disclosure), or null
             mcpServerIds: mcpServerIds || [],       // Pass MCP server IDs for dynamic tool loading
+            knowledgeBaseIds: effectiveKbIds,       // user pick, or auto-selected KB ids, or []
             userId: resolvedUserId,                 // For memory store scoping
             tenantId: resolvedTenantId,             // For tenant-scoped memory operations
         };

--- a/apps/web-ui/app/api/knowledge-base/[kbId]/documents/[dsId]/route.ts
+++ b/apps/web-ui/app/api/knowledge-base/[kbId]/documents/[dsId]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { KnowledgeBaseService } from '@/lib/knowledge-base/service';
+import { getSessionTenantId } from '@/lib/auth-session';
+
+// GET /api/knowledge-base/[kbId]/documents/[dsId] — read a document's markdown body
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ kbId: string; dsId: string }> },
+) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { kbId, dsId } = await params;
+  const tenantId = await getSessionTenantId();
+  const kb = await KnowledgeBaseService.getKnowledgeBase(kbId, tenantId);
+  if (!kb) return NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 });
+
+  const ds = await KnowledgeBaseService.getDataSource(kbId, dsId, tenantId);
+  if (!ds || ds.sourceType !== 'document') {
+    return NextResponse.json({ error: 'Document not found' }, { status: 404 });
+  }
+  const content = await KnowledgeBaseService.getDataSourceContent(kbId, dsId, tenantId);
+  return NextResponse.json({ id: ds.id, name: ds.name, content: content ?? '' });
+}

--- a/apps/web-ui/app/api/knowledge-base/[kbId]/documents/documents-route.test.ts
+++ b/apps/web-ui/app/api/knowledge-base/[kbId]/documents/documents-route.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/auth-session', () => ({
+    getSessionTenantId: vi.fn().mockResolvedValue('tenant-a'),
+    getSessionUserId: vi.fn(),
+}));
+vi.mock('next-auth', () => ({
+    getServerSession: vi.fn().mockResolvedValue({ user: { email: 'test@example.com' } }),
+}));
+vi.mock('@/app/api/auth/[...nextauth]/route', () => ({ authOptions: {} }));
+vi.mock('@/lib/audit-service', () => ({ AuditService: { logUserAction: vi.fn().mockResolvedValue(undefined) } }));
+
+vi.mock('@/lib/knowledge-base/service', () => ({
+    KnowledgeBaseService: {
+        getKnowledgeBase: vi.fn(),
+        getDataSource: vi.fn(),
+        createDataSource: vi.fn(),
+        updateDataSource: vi.fn(),
+        updateDataSourceCount: vi.fn(),
+        updateVectorCount: vi.fn(),
+    },
+}));
+vi.mock('@/lib/knowledge-base/embedder', () => ({
+    chunkText: vi.fn(() => [{ text: 'c1', index: 0, total: 1, contentHash: 'h1' }]),
+    embedAndStoreChunks: vi.fn().mockResolvedValue(['kb_kb-1_ds-1_0_h1']),
+    deleteVectors: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { KnowledgeBaseService } from '@/lib/knowledge-base/service';
+import { chunkText, embedAndStoreChunks } from '@/lib/knowledge-base/embedder';
+import { POST } from '@/app/api/knowledge-base/[kbId]/documents/route';
+
+const params = Promise.resolve({ kbId: 'kb-1' });
+
+function req(body: unknown) {
+    return new Request('http://t/api/knowledge-base/kb-1/documents', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+    }) as unknown as import('next/server').NextRequest;
+}
+
+describe('POST /api/knowledge-base/[kbId]/documents', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(KnowledgeBaseService.getKnowledgeBase).mockResolvedValue({ id: 'kb-1' } as any);
+        vi.mocked(KnowledgeBaseService.createDataSource).mockResolvedValue({ id: 'ds-1', knowledgeBaseId: 'kb-1', name: 'Doc', sourceType: 'document', status: 'pending', config: {}, vectorCount: 0, vectorKeys: [], createdAt: '', updatedAt: '' } as any);
+        vi.mocked(KnowledgeBaseService.getDataSource).mockResolvedValue({ id: 'ds-1', knowledgeBaseId: 'kb-1', name: 'Doc', sourceType: 'document', status: 'synced', config: {}, vectorCount: 1, vectorKeys: ['kb_kb-1_ds-1_0_h1'], createdAt: '', updatedAt: '' } as any);
+    });
+
+    it('creates a document, embeds it, and returns 201', async () => {
+        const res = await POST(req({ name: 'Doc', content: '# Body' }), { params });
+        expect(res.status).toBe(201);
+        expect(chunkText).toHaveBeenCalledWith('# Body', 'Doc');
+        expect(embedAndStoreChunks).toHaveBeenCalledWith(
+            expect.objectContaining({ sourceType: 'document', knowledgeBaseId: 'kb-1', dataSourceId: 'ds-1', tenantId: 'tenant-a' })
+        );
+        // marks synced with the returned vector keys
+        expect(KnowledgeBaseService.updateDataSource).toHaveBeenCalledWith(
+            'kb-1', 'ds-1',
+            expect.objectContaining({ status: 'synced', vectorKeys: ['kb_kb-1_ds-1_0_h1'], vectorCount: 1, content: '# Body' }),
+            'tenant-a',
+        );
+        expect(KnowledgeBaseService.updateVectorCount).toHaveBeenCalledWith('kb-1', 1, 'tenant-a');
+    });
+
+    it('rejects empty content with 400', async () => {
+        const res = await POST(req({ name: 'Doc', content: '' }), { params });
+        expect(res.status).toBe(400);
+        expect(embedAndStoreChunks).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when the KB is not owned by the tenant', async () => {
+        vi.mocked(KnowledgeBaseService.getKnowledgeBase).mockResolvedValue(null);
+        const res = await POST(req({ name: 'Doc', content: '# Body' }), { params });
+        expect(res.status).toBe(403);
+    });
+
+    it('sets status=error but preserves content when embedding fails', async () => {
+        vi.mocked(embedAndStoreChunks).mockRejectedValueOnce(new Error('bedrock down'));
+        const res = await POST(req({ name: 'Doc', content: '# Body' }), { params });
+        expect(res.status).toBe(500);
+        expect(KnowledgeBaseService.updateDataSource).toHaveBeenCalledWith(
+            'kb-1', 'ds-1',
+            expect.objectContaining({ status: 'error', content: '# Body' }),
+            'tenant-a',
+        );
+    });
+});

--- a/apps/web-ui/app/api/knowledge-base/[kbId]/documents/route.ts
+++ b/apps/web-ui/app/api/knowledge-base/[kbId]/documents/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { KnowledgeBaseService } from '@/lib/knowledge-base/service';
+import { getSessionTenantId } from '@/lib/auth-session';
+import { AuditService } from '@/lib/audit-service';
+import { validateDocumentInput } from '@/lib/knowledge-base/document-validation';
+import { chunkText, embedAndStoreChunks } from '@/lib/knowledge-base/embedder';
+
+// POST /api/knowledge-base/[kbId]/documents — create an inline markdown document
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ kbId: string }> },
+) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { kbId } = await params;
+  const tenantId = await getSessionTenantId();
+  const kb = await KnowledgeBaseService.getKnowledgeBase(kbId, tenantId);
+  if (!kb) return NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 });
+
+  const body = await request.json().catch(() => ({}));
+  const valid = validateDocumentInput(body as { name?: string; content?: string });
+  if (!valid.ok) return NextResponse.json({ error: valid.error }, { status: 400 });
+  const { name, content } = valid;
+
+  // Create the record first (pending), then embed synchronously.
+  const ds = await KnowledgeBaseService.createDataSource(kbId, {
+    name,
+    sourceType: 'document',
+    config: { format: 'markdown', chunkCount: 0 },
+  }, tenantId);
+  await KnowledgeBaseService.updateDataSourceCount(kbId, 1, tenantId);
+
+  try {
+    const chunks = chunkText(content, name);
+    const vectorKeys = await embedAndStoreChunks({
+      chunks,
+      knowledgeBaseId: kbId,
+      dataSourceId: ds.id,
+      sourceType: 'document',
+      documentName: name,
+      tenantId,
+    });
+
+    await KnowledgeBaseService.updateDataSource(kbId, ds.id, {
+      content,
+      status: 'synced',
+      vectorKeys,
+      vectorCount: vectorKeys.length,
+      config: { format: 'markdown', chunkCount: vectorKeys.length },
+      lastSyncAt: new Date().toISOString(),
+    }, tenantId);
+    await KnowledgeBaseService.updateVectorCount(kbId, vectorKeys.length, tenantId);
+
+    AuditService.logUserAction({
+      eventType: 'kb.document.created',
+      severity: 'low',
+      apiRoute: 'POST /api/knowledge-base/[kbId]/documents',
+      httpMethod: 'POST',
+      action: 'Created Document',
+      resourceType: 'kb',
+      resourceId: ds.id,
+      resourceName: name,
+      user: session?.user?.email || 'unknown',
+      userType: 'user',
+      status: 'success',
+      details: `Created document "${name}" in knowledge base ${kbId}`,
+      metadata: { tenantId, kbId, chunkCount: vectorKeys.length },
+    }).catch(() => {});
+
+    const updated = await KnowledgeBaseService.getDataSource(kbId, ds.id, tenantId);
+    return NextResponse.json({ dataSource: updated }, { status: 201 });
+  } catch (error) {
+    const isProviderError = error instanceof Error && error.name === 'ProviderConfigError';
+    const message = error instanceof Error ? error.message : 'Failed to embed document';
+    // Preserve content so the user can retry with an edit. Best-effort — a
+    // failure here shouldn't mask the original embedding error below.
+    try {
+      await KnowledgeBaseService.updateDataSource(kbId, ds.id, {
+        content,
+        status: 'error',
+        lastErrorMessage: isProviderError ? 'No embedding provider configured' : 'Failed to process document',
+        lastErrorDetail: message,
+      }, tenantId);
+    } catch {
+      // ignore
+    }
+    return NextResponse.json({ error: message }, { status: isProviderError ? 400 : 500 });
+  }
+}

--- a/apps/web-ui/app/api/knowledge-base/[kbId]/sources/[dsId]/put-document.test.ts
+++ b/apps/web-ui/app/api/knowledge-base/[kbId]/sources/[dsId]/put-document.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/auth-session', () => ({ getSessionTenantId: vi.fn().mockResolvedValue('tenant-a') }));
+vi.mock('next-auth', () => ({ getServerSession: vi.fn().mockResolvedValue({ user: { email: 'u@e.com' } }) }));
+vi.mock('@/app/api/auth/[...nextauth]/route', () => ({ authOptions: {} }));
+vi.mock('@/lib/audit-service', () => ({ AuditService: { logUserAction: vi.fn().mockResolvedValue(undefined) } }));
+vi.mock('@/lib/knowledge-base/service', () => ({
+    KnowledgeBaseService: {
+        getKnowledgeBase: vi.fn().mockResolvedValue({ id: 'kb-1' }),
+        getDataSource: vi.fn(),
+        updateDataSource: vi.fn(),
+        updateVectorCount: vi.fn(),
+    },
+}));
+vi.mock('@/lib/knowledge-base/embedder', () => ({
+    chunkText: vi.fn(() => [{ text: 'a', index: 0, total: 1, contentHash: 'h' }, { text: 'b', index: 1, total: 2, contentHash: 'h2' }]),
+    embedAndStoreChunks: vi.fn().mockResolvedValue(['k1', 'k2']),
+    deleteVectors: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { KnowledgeBaseService } from '@/lib/knowledge-base/service';
+import { deleteVectors, embedAndStoreChunks } from '@/lib/knowledge-base/embedder';
+import { PUT } from '@/app/api/knowledge-base/[kbId]/sources/[dsId]/route';
+
+const params = Promise.resolve({ kbId: 'kb-1', dsId: 'ds-1' });
+function req(body: unknown) {
+    return new Request('http://t', { method: 'PUT', body: JSON.stringify(body) }) as unknown as import('next/server').NextRequest;
+}
+
+describe('PUT sources/[dsId] — document re-embed', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(KnowledgeBaseService.getDataSource)
+            .mockResolvedValue({ id: 'ds-1', knowledgeBaseId: 'kb-1', name: 'Doc', sourceType: 'document', status: 'synced', config: {}, vectorCount: 1, vectorKeys: ['old1'], createdAt: '', updatedAt: '' } as any);
+    });
+
+    it('deletes old vectors, re-embeds, and reconciles the KB count by delta', async () => {
+        await PUT(req({ content: '# New body' }), { params });
+        expect(deleteVectors).toHaveBeenCalledWith(['old1']);
+        expect(embedAndStoreChunks).toHaveBeenCalledWith(expect.objectContaining({ sourceType: 'document', dataSourceId: 'ds-1' }));
+        expect(KnowledgeBaseService.updateDataSource).toHaveBeenCalledWith(
+            'kb-1', 'ds-1',
+            expect.objectContaining({ content: '# New body', vectorKeys: ['k1', 'k2'], vectorCount: 2, status: 'synced' }),
+            'tenant-a',
+        );
+        // old count 1 → new count 2, delta +1
+        expect(KnowledgeBaseService.updateVectorCount).toHaveBeenCalledWith('kb-1', 1, 'tenant-a');
+    });
+
+    it('does not re-embed when content is absent (name-only edit)', async () => {
+        await PUT(req({ name: 'Renamed' }), { params });
+        expect(deleteVectors).not.toHaveBeenCalled();
+        expect(embedAndStoreChunks).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web-ui/app/api/knowledge-base/[kbId]/sources/[dsId]/put-document.test.ts
+++ b/apps/web-ui/app/api/knowledge-base/[kbId]/sources/[dsId]/put-document.test.ts
@@ -52,4 +52,19 @@ describe('PUT sources/[dsId] — document re-embed', () => {
         expect(deleteVectors).not.toHaveBeenCalled();
         expect(embedAndStoreChunks).not.toHaveBeenCalled();
     });
+
+    it('leaves old vectors intact and does not touch vector count when embedding fails (embed-before-delete)', async () => {
+        vi.mocked(embedAndStoreChunks).mockRejectedValueOnce(new Error('provider blip'));
+
+        const res = await PUT(req({ content: '# New body' }), { params });
+
+        expect(deleteVectors).not.toHaveBeenCalled();
+        expect(KnowledgeBaseService.updateDataSource).toHaveBeenCalledWith(
+            'kb-1', 'ds-1',
+            expect.objectContaining({ content: '# New body', status: 'error' }),
+            'tenant-a',
+        );
+        expect(KnowledgeBaseService.updateVectorCount).not.toHaveBeenCalled();
+        expect(res.status).toBe(500);
+    });
 });

--- a/apps/web-ui/app/api/knowledge-base/[kbId]/sources/[dsId]/route.ts
+++ b/apps/web-ui/app/api/knowledge-base/[kbId]/sources/[dsId]/route.ts
@@ -59,12 +59,15 @@ export async function PUT(
     const valid = validateDocumentInput({ name: body.name ?? ds.name, content: body.content });
     if (!valid.ok) return NextResponse.json({ error: valid.error }, { status: 400 });
     try {
-      if (ds.vectorKeys.length > 0) await deleteVectors(ds.vectorKeys);
       const chunks = chunkText(valid.content, valid.name);
       const vectorKeys = await embedAndStoreChunks({
         chunks, knowledgeBaseId: kbId, dataSourceId: dsId,
         sourceType: 'document', documentName: valid.name, tenantId,
       });
+      // Embed succeeded — only now remove the stale keys no longer present in
+      // the new set, so a failed embed never leaves the document un-searchable.
+      const staleKeys = ds.vectorKeys.filter((k) => !vectorKeys.includes(k));
+      if (staleKeys.length > 0) await deleteVectors(staleKeys);
       updates.content = valid.content;
       updates.vectorKeys = vectorKeys;
       updates.vectorCount = vectorKeys.length;

--- a/apps/web-ui/app/api/knowledge-base/[kbId]/sources/[dsId]/route.ts
+++ b/apps/web-ui/app/api/knowledge-base/[kbId]/sources/[dsId]/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/app/api/auth/[...nextauth]/route';
 import { KnowledgeBaseService } from '@/lib/knowledge-base/service';
-import { deleteVectors } from '@/lib/knowledge-base/embedder';
+import { chunkText, embedAndStoreChunks, deleteVectors } from '@/lib/knowledge-base/embedder';
+import { validateDocumentInput } from '@/lib/knowledge-base/document-validation';
 import { getSessionTenantId } from '@/lib/auth-session';
 import { AuditService } from '@/lib/audit-service';
 import type { DataSource } from '@/lib/knowledge-base/types';
@@ -49,12 +50,48 @@ export async function PUT(
   const ds = await KnowledgeBaseService.getDataSource(kbId, dsId, tenantId);
   if (!ds) return NextResponse.json({ error: 'Data source not found' }, { status: 404 });
 
-  const body = await request.json() as { name?: string; config?: Record<string, unknown> };
+  const body = await request.json() as { name?: string; content?: string; config?: Record<string, unknown> };
   const updates: Partial<DataSource> = {};
   if (body.name?.trim()) updates.name = body.name.trim();
-  if (body.config) updates.config = { ...ds.config, ...body.config } as DataSource['config'];
 
-  await KnowledgeBaseService.updateDataSource(kbId, dsId, updates, tenantId);
+  // Document content edit → re-embed.
+  if (ds.sourceType === 'document' && body.content !== undefined) {
+    const valid = validateDocumentInput({ name: body.name ?? ds.name, content: body.content });
+    if (!valid.ok) return NextResponse.json({ error: valid.error }, { status: 400 });
+    try {
+      if (ds.vectorKeys.length > 0) await deleteVectors(ds.vectorKeys);
+      const chunks = chunkText(valid.content, valid.name);
+      const vectorKeys = await embedAndStoreChunks({
+        chunks, knowledgeBaseId: kbId, dataSourceId: dsId,
+        sourceType: 'document', documentName: valid.name, tenantId,
+      });
+      updates.content = valid.content;
+      updates.vectorKeys = vectorKeys;
+      updates.vectorCount = vectorKeys.length;
+      updates.status = 'synced';
+      updates.config = { format: 'markdown', chunkCount: vectorKeys.length };
+      updates.lastSyncAt = new Date().toISOString();
+      await KnowledgeBaseService.updateDataSource(kbId, dsId, updates, tenantId);
+      await KnowledgeBaseService.updateVectorCount(kbId, vectorKeys.length - ds.vectorCount, tenantId);
+    } catch (error) {
+      const isProviderError = error instanceof Error && error.name === 'ProviderConfigError';
+      const message = error instanceof Error ? error.message : 'Failed to embed document';
+      try {
+        await KnowledgeBaseService.updateDataSource(kbId, dsId, {
+          content: valid.content, status: 'error',
+          lastErrorMessage: isProviderError ? 'No embedding provider configured' : 'Failed to process document',
+          lastErrorDetail: message,
+        }, tenantId);
+      } catch {
+        // best-effort error status write
+      }
+      return NextResponse.json({ error: message }, { status: isProviderError ? 400 : 500 });
+    }
+  } else {
+    if (body.config) updates.config = { ...ds.config, ...body.config } as DataSource['config'];
+    await KnowledgeBaseService.updateDataSource(kbId, dsId, updates, tenantId);
+  }
+
   const updated = await KnowledgeBaseService.getDataSource(kbId, dsId, tenantId);
 
   AuditService.logUserAction({

--- a/apps/web-ui/app/api/knowledge-base/query/route.ts
+++ b/apps/web-ui/app/api/knowledge-base/query/route.ts
@@ -3,10 +3,9 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/app/api/auth/[...nextauth]/route';
 import { HumanMessage, AIMessage, SystemMessage } from '@langchain/core/messages';
 import type { MessageContent } from '@langchain/core/messages';
-import { getEmbedding } from '@/lib/knowledge-base/embedder';
 import { KnowledgeBaseService } from '@/lib/knowledge-base/service';
+import { searchKbChunks, type KbChunkHit } from '@/lib/knowledge-base/retrieval';
 import { getSessionTenantId, getSessionUserId } from '@/lib/auth-session';
-import { getPrismaClient } from '@/lib/db/pg-config';
 import { kbChatStore } from '@/lib/store/kb-chat-store';
 import { resolveDefaultModelConfig, resolveModelConfig } from '@/lib/agent/model-resolver';
 import { createAgentModels } from '@/lib/agent/model-factory';
@@ -26,17 +25,7 @@ export type KBSource = {
   score: number;
 };
 
-interface ChunkRow {
-  vectorKey: string;
-  documentName: string;
-  sourceType: string;
-  chunkIndex: number;
-  totalChunks: number;
-  knowledgeBaseId: string;
-  dataSourceId: string;
-  textContent: string;
-  score: number;
-}
+type ChunkRow = KbChunkHit;
 
 // ============================================================================
 // POST /api/knowledge-base/query
@@ -114,39 +103,12 @@ export async function POST(req: NextRequest) {
       }])
       .catch((e) => console.error('[KB Query] Failed to persist user message:', e));
 
-    // 3. Embed the query via the tenant's configured provider
-    const embedding = await getEmbedding(query, tenantId);
-    const vectorLiteral = `[${embedding.join(',')}]`;
-
-    // 4. Query pgvector for similar chunks
-    const prisma = getPrismaClient();
-    let results: ChunkRow[];
-
-    if (knowledgeBaseId) {
-      results = await prisma.$queryRawUnsafe<ChunkRow[]>(
-        `SELECT "vectorKey", "documentName", "sourceType", "chunkIndex", "totalChunks",
-                "knowledgeBaseId", "dataSourceId", "textContent",
-                1 - (embedding <=> $1::vector) as score
-         FROM kb_document_chunks
-         WHERE "tenantId" = $2
-           AND "knowledgeBaseId" = $3
-         ORDER BY embedding <=> $1::vector
-         LIMIT 10`,
-        vectorLiteral, tenantId, knowledgeBaseId,
-      );
-    } else {
-      // No specific KB — scope to all tenant chunks via tenantId
-      results = await prisma.$queryRawUnsafe<ChunkRow[]>(
-        `SELECT "vectorKey", "documentName", "sourceType", "chunkIndex", "totalChunks",
-                "knowledgeBaseId", "dataSourceId", "textContent",
-                1 - (embedding <=> $1::vector) as score
-         FROM kb_document_chunks
-         WHERE "tenantId" = $2
-         ORDER BY embedding <=> $1::vector
-         LIMIT 10`,
-        vectorLiteral, tenantId,
-      );
-    }
+    // 3-4. Embed the query and search pgvector for similar chunks
+    const results: ChunkRow[] = await searchKbChunks({
+      tenantId,
+      query,
+      knowledgeBaseIds: knowledgeBaseId ? [knowledgeBaseId] : undefined,
+    });
 
     console.log(
       `[KB Query] Found ${results.length} results for: "${query.slice(0, 80)}"`,

--- a/apps/web-ui/app/app/knowledge-base/[kbId]/page.tsx
+++ b/apps/web-ui/app/app/knowledge-base/[kbId]/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import {
-  ArrowLeft, CheckCircle2, Database, File, Loader2, MessageSquare,
+  ArrowLeft, CheckCircle2, Database, File, FileText, Loader2, MessageSquare,
   Plus, RefreshCw, Trash2, Upload, X, Eye, Pencil, AlertCircle,
 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
@@ -23,6 +23,7 @@ import { toast } from 'sonner';
 import type { DataSource, DataSourceType, KnowledgeBase } from '@/lib/knowledge-base/types';
 import { formatDateTime, formatDate } from '@/lib/date-utils';
 import { useTenant } from '@/lib/tenant-context';
+import { KBDocumentEditor } from '@/components/knowledge-base/kb-document-editor';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -33,6 +34,7 @@ const SOURCE_TYPE_LABELS: Record<DataSourceType, string> = {
   's3-bucket': 'S3 Bucket',
   'confluence': 'Confluence',
   'bitbucket': 'Bitbucket',
+  'document': 'Document',
 };
 
 // ---------------------------------------------------------------------------
@@ -44,6 +46,7 @@ function DataSourceIcon({ sourceType, className }: { sourceType: DataSourceType;
     case 'confluence': return <span className={className} title="Confluence">🌐</span>;
     case 'bitbucket': return <span className={className} title="Bitbucket">🪣</span>;
     case 's3-bucket': return <span className={className} title="S3 Bucket">☁️</span>;
+    case 'document': return <FileText className={className} />;
     default: return <File className={className} />;
   }
 }
@@ -255,6 +258,7 @@ export default function KnowledgeBaseDetailPage() {
 
   const [viewDs, setViewDs] = useState<DataSource | null>(null);
   const [editDs, setEditDs] = useState<DataSource | null>(null);
+  const [docEditor, setDocEditor] = useState<{ mode: 'new' } | { mode: 'edit'; doc: { id: string; name: string } } | null>(null);
   const [syncingIds, setSyncingIds] = useState<Set<string>>(new Set());
   const [deletingKb, setDeletingKb] = useState(false);
 
@@ -476,9 +480,14 @@ export default function KnowledgeBaseDetailPage() {
           <CardHeader className="pb-3">
             <div className="flex items-center justify-between">
               <CardTitle className="text-base">Data Sources</CardTitle>
-              <Button variant="outline" size="sm" className="gap-1.5" onClick={() => router.push(`/app/knowledge-base/${kbId}/sources/new`)}>
-                <Plus className="h-3.5 w-3.5" /> Add Data Source
-              </Button>
+              <div className="flex items-center gap-2">
+                <Button variant="outline" size="sm" className="gap-1.5" onClick={() => setDocEditor({ mode: 'new' })}>
+                  <FileText className="h-3.5 w-3.5" /> New Document
+                </Button>
+                <Button variant="outline" size="sm" className="gap-1.5" onClick={() => router.push(`/app/knowledge-base/${kbId}/sources/new`)}>
+                  <Plus className="h-3.5 w-3.5" /> Add Data Source
+                </Button>
+              </div>
             </div>
           </CardHeader>
           <CardContent>
@@ -517,7 +526,11 @@ export default function KnowledgeBaseDetailPage() {
                       </Button>
 
                       {/* Edit */}
-                      <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-foreground" onClick={() => setEditDs(ds)} title="Edit">
+                      <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                        onClick={() => ds.sourceType === 'document'
+                          ? setDocEditor({ mode: 'edit', doc: { id: ds.id, name: ds.name } })
+                          : setEditDs(ds)}
+                        title="Edit">
                         <Pencil className="h-4 w-4" />
                       </Button>
 
@@ -576,6 +589,17 @@ export default function KnowledgeBaseDetailPage() {
             setDataSources((prev) => prev.map((d) => d.id === updated.id ? updated : d));
             setEditDs(null);
           }}
+        />
+      )}
+
+      {/* Document editor */}
+      {docEditor && (
+        <KBDocumentEditor
+          kbId={kbId}
+          doc={docEditor.mode === 'edit' ? docEditor.doc : undefined}
+          open={!!docEditor}
+          onClose={() => setDocEditor(null)}
+          onSaved={() => { setDocEditor(null); fetchKB(); }}
         />
       )}
     </div>

--- a/apps/web-ui/app/app/knowledge-base/[kbId]/page.tsx
+++ b/apps/web-ui/app/app/knowledge-base/[kbId]/page.tsx
@@ -93,6 +93,7 @@ function StatusBadge({ status, error }: { status: DataSource['status']; error?: 
 // ---------------------------------------------------------------------------
 
 function ViewDialog({ ds, open, onClose }: { ds: DataSource; open: boolean; onClose: () => void }) {
+  const { timezone } = useTenant();
   const config = ds.config as Record<string, unknown>;
   const rows = Object.entries(config).filter(([k]) => k !== 'apiToken');
 

--- a/apps/web-ui/components/agent/chat-interface.tsx
+++ b/apps/web-ui/components/agent/chat-interface.tsx
@@ -106,6 +106,7 @@ import {
 import { ClientAccountService } from "@/lib/client-account-service";
 import { UIAccount } from "@/lib/types";
 import { useProviderModels } from "@/lib/queries/providers";
+import { useKnowledgeBases } from "@/lib/queries/knowledge-base";
 import { FileUpload, FileAttachment } from "@/components/agent/file-upload";
 
 // Phase types matching backend
@@ -523,6 +524,11 @@ export function ChatInterface({
   const [mcpDropdownOpen, setMcpDropdownOpen] = useState(false);
   const mcpDropdownRef = useRef<HTMLDivElement>(null);
 
+  // Knowledge base selection state - empty selection means the server auto-selects
+  const [selectedKbIds, setSelectedKbIds] = useState<string[]>([]);
+  const { data: knowledgeBases = [] } = useKnowledgeBases();
+  const [kbDropdownOpen, setKbDropdownOpen] = useState(false);
+
   // File attachments state
   const [attachments, setAttachments] = useState<FileAttachment[]>([]);
 
@@ -629,6 +635,8 @@ export function ChatInterface({
         selectedSkill: selectedSkill || undefined,
         mcpServerIds:
           selectedMcpServerIds.length > 0 ? selectedMcpServerIds : undefined,
+        knowledgeBaseIds:
+          selectedKbIds.length > 0 ? selectedKbIds : undefined,
       },
       onResponse: (response: Response) => {
         console.log("[ChatInterface] Received response headers:", response);
@@ -873,6 +881,8 @@ export function ChatInterface({
           selectedSkill: selectedSkill || undefined,
           mcpServerIds:
             selectedMcpServerIds.length > 0 ? selectedMcpServerIds : undefined,
+          knowledgeBaseIds:
+            selectedKbIds.length > 0 ? selectedKbIds : undefined,
         },
       },
     );
@@ -919,6 +929,8 @@ export function ChatInterface({
           selectedSkill: selectedSkill || undefined,
           mcpServerIds:
             selectedMcpServerIds.length > 0 ? selectedMcpServerIds : undefined,
+          knowledgeBaseIds:
+            selectedKbIds.length > 0 ? selectedKbIds : undefined,
         },
       },
     );
@@ -1410,6 +1422,8 @@ export function ChatInterface({
                             selectedSkill: selectedSkill || undefined,
                             mcpServerIds:
                               selectedMcpServerIds.length > 0 ? selectedMcpServerIds : undefined,
+                            knowledgeBaseIds:
+                              selectedKbIds.length > 0 ? selectedKbIds : undefined,
                           }
                         });
                       }
@@ -1688,6 +1702,105 @@ export function ChatInterface({
                   ))}
                 </SelectContent>
               </Select>
+
+              {/* Knowledge Base Multi-Select — empty selection means the server auto-selects */}
+              <div className="relative border-l pl-2 ml-1">
+                <Popover open={kbDropdownOpen} onOpenChange={setKbDropdownOpen}>
+                  <PopoverTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      type="button"
+                      disabled={isLoading || distillSkill.isPending}
+                      className="h-7 text-xs border-transparent bg-transparent hover:bg-muted/50 focus:ring-0 gap-1 px-2 w-auto min-w-[160px] justify-start"
+                    >
+                      <div className="flex items-center gap-1.5">
+                        <Database
+                          className={cn(
+                            "w-3 h-3",
+                            selectedKbIds.length > 0
+                              ? "text-emerald-500"
+                              : "text-muted-foreground",
+                          )}
+                        />
+                        <span className="truncate max-w-[140px] font-normal">
+                          {selectedKbIds.length === 0
+                            ? "Knowledge: All (auto)"
+                            : `Knowledge: ${selectedKbIds.length} selected`}
+                        </span>
+                      </div>
+                    </Button>
+                  </PopoverTrigger>
+
+                  <PopoverContent
+                    side="top"
+                    align="start"
+                    className="w-[280px] p-0 mb-2"
+                  >
+                    <div className="max-h-[300px] overflow-y-auto p-1">
+                      {knowledgeBases.length === 0 && (
+                        <p className="text-xs text-muted-foreground p-3 text-center">
+                          No knowledge bases available
+                        </p>
+                      )}
+                      {knowledgeBases.map((kb) => (
+                        <label
+                          key={kb.id}
+                          className="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-muted cursor-pointer text-sm transition-colors"
+                        >
+                          <Checkbox
+                            checked={selectedKbIds.includes(kb.id)}
+                            onCheckedChange={(checked) => {
+                              if (checked) {
+                                setSelectedKbIds([...selectedKbIds, kb.id]);
+                              } else {
+                                setSelectedKbIds(
+                                  selectedKbIds.filter((id) => id !== kb.id),
+                                );
+                              }
+                            }}
+                            className="h-4 w-4"
+                          />
+                          <div className="flex-1 min-w-0">
+                            <p className="font-medium truncate text-xs">
+                              {kb.name}
+                            </p>
+                          </div>
+                        </label>
+                      ))}
+                    </div>
+                    <div className="p-2 border-t flex justify-between items-center bg-muted/20 rounded-b-lg">
+                      <span className="text-xs text-muted-foreground">
+                        {selectedKbIds.length === 0
+                          ? "All (auto-select)"
+                          : `${selectedKbIds.length} selected`}
+                      </span>
+                      <div className="flex gap-2">
+                        {selectedKbIds.length > 0 && (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            className="text-xs h-7"
+                            onClick={() => setSelectedKbIds([])}
+                          >
+                            Clear
+                          </Button>
+                        )}
+                        <Button
+                          type="button"
+                          variant="default"
+                          size="sm"
+                          className="text-xs h-7"
+                          onClick={() => setKbDropdownOpen(false)}
+                        >
+                          Done
+                        </Button>
+                      </div>
+                    </div>
+                  </PopoverContent>
+                </Popover>
+              </div>
 
               {/* MCP Servers Multi-Toggle */}
               {mcpServers.length > 0 && (

--- a/apps/web-ui/components/knowledge-base/kb-document-editor.tsx
+++ b/apps/web-ui/components/knowledge-base/kb-document-editor.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { useCreateDocument, useUpdateDocument } from '@/lib/queries/knowledge-base';
+import { MAX_DOCUMENT_CHARS } from '@/lib/knowledge-base/document-validation';
+
+const schema = z.object({
+  name: z.string().trim().min(1, 'Name is required'),
+  content: z.string().trim().min(1, 'Content is required').max(MAX_DOCUMENT_CHARS, 'Document is too large'),
+});
+type FormValues = z.infer<typeof schema>;
+
+interface KBDocumentEditorProps {
+  kbId: string;
+  /** Existing document to edit; omit for a new document. */
+  doc?: { id: string; name: string };
+  open: boolean;
+  onClose: () => void;
+  onSaved: () => void; // caller refreshes the KB
+}
+
+export function KBDocumentEditor({ kbId, doc, open, onClose, onSaved }: KBDocumentEditorProps) {
+  const isEdit = !!doc;
+  const create = useCreateDocument(kbId);
+  const update = useUpdateDocument(kbId);
+  const [loadingContent, setLoadingContent] = useState(false);
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { name: doc?.name ?? '', content: '' },
+  });
+  const content = form.watch('content');
+
+  // Load existing content when editing.
+  useEffect(() => {
+    if (!open) return;
+    if (!doc) { form.reset({ name: '', content: '' }); return; }
+    setLoadingContent(true);
+    fetch(`/api/knowledge-base/${kbId}/documents/${doc.id}`)
+      .then((r) => r.ok ? r.json() : Promise.reject(new Error('Failed to load document')))
+      .then((d) => form.reset({ name: d.name ?? doc.name, content: d.content ?? '' }))
+      .catch((e) => toast.error(e instanceof Error ? e.message : 'Failed to load document'))
+      .finally(() => setLoadingContent(false));
+  }, [open, doc, kbId, form]);
+
+  const submitting = create.isPending || update.isPending;
+
+  const onSubmit = async (values: FormValues) => {
+    try {
+      if (isEdit && doc) {
+        await update.mutateAsync({ dsId: doc.id, name: values.name, content: values.content });
+        toast.success(`"${values.name}" updated`);
+      } else {
+        await create.mutateAsync({ name: values.name, content: values.content });
+        toast.success(`"${values.name}" created`);
+      }
+      onSaved();
+      onClose();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Save failed');
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? 'Edit Document' : 'New Document'}</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <div className="space-y-1.5">
+            <Label>Name</Label>
+            <Input placeholder="e.g. Incident runbook" disabled={submitting || loadingContent} {...form.register('name')} />
+            {form.formState.errors.name && <p className="text-xs text-destructive">{form.formState.errors.name.message}</p>}
+          </div>
+
+          <Tabs defaultValue="write">
+            <TabsList>
+              <TabsTrigger value="write" type="button">Write</TabsTrigger>
+              <TabsTrigger value="preview" type="button">Preview</TabsTrigger>
+            </TabsList>
+            <TabsContent value="write">
+              <Textarea
+                className="min-h-[320px] font-mono text-sm"
+                placeholder="Write markdown…"
+                disabled={submitting || loadingContent}
+                {...form.register('content')}
+              />
+              {form.formState.errors.content && <p className="text-xs text-destructive">{form.formState.errors.content.message}</p>}
+            </TabsContent>
+            <TabsContent value="preview">
+              <div className="prose prose-sm dark:prose-invert max-w-none min-h-[320px] rounded-md border p-4 overflow-y-auto">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{content || '_Nothing to preview_'}</ReactMarkdown>
+              </div>
+            </TabsContent>
+          </Tabs>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={onClose} disabled={submitting}>Cancel</Button>
+            <Button type="submit" disabled={submitting || loadingContent}>
+              {submitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {isEdit ? 'Save' : 'Create'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web-ui/lib/agent-ops/agent-executor.ts
+++ b/apps/web-ui/lib/agent-ops/agent-executor.ts
@@ -53,7 +53,7 @@ function deriveUserId(run: AgentOpsRun): string {
 // ─── Main Executor ────────────────────────────────────────────────────────────
 
 export async function executeAgentRun(run: AgentOpsRun, eventBus?: GatewayEventBus): Promise<void> {
-    const { runId, tenantId, taskDescription, accountId, accountName, threadId, mcpServerIds } = run as any;
+    const { runId, tenantId, taskDescription, accountId, accountName, threadId, mcpServerIds, knowledgeBaseIds } = run as any;
     const autoApprove = (run as any).autoApprove ?? false;
     const startTime = Date.now();
 
@@ -105,6 +105,7 @@ export async function executeAgentRun(run: AgentOpsRun, eventBus?: GatewayEventB
             accountId,
             accountName,
             mcpServerIds: activeMcpServerIds,
+            knowledgeBaseIds,
             tenantId,
             userId: deriveUserId(run),
         };
@@ -487,7 +488,7 @@ async function processLangGraphEvent(
  * routes to 'generate' instead of 'approval_gate'.
  */
 export async function resumeApprovedRun(run: AgentOpsRun, eventBus?: GatewayEventBus): Promise<void> {
-    const { runId, tenantId, threadId, mcpServerIds, accountId, accountName } = run as any;
+    const { runId, tenantId, threadId, mcpServerIds, accountId, accountName, knowledgeBaseIds } = run as any;
     const startTime = Date.now();
 
     const abortController = registerRun(runId);
@@ -532,6 +533,7 @@ export async function resumeApprovedRun(run: AgentOpsRun, eventBus?: GatewayEven
             accountId,
             accountName,
             mcpServerIds: activeMcpServerIds,
+            knowledgeBaseIds,
             tenantId,
             userId: deriveUserId(run),
         };

--- a/apps/web-ui/lib/agent-ops/agent-ops-service.ts
+++ b/apps/web-ui/lib/agent-ops/agent-ops-service.ts
@@ -35,16 +35,13 @@ export async function createRun(params: {
     accountName?: string;
     selectedSkill?: string;
     mcpServerIds?: string[];
-    // In-memory only — no DB column for this yet (unlike mcpServerIds). Threaded onto the
-    // returned run object below so the fire-and-forget executeAgentRun(run) call in the
-    // trigger route sees it; a later reload via getRun()/listRuns() will NOT have it.
     knowledgeBaseIds?: string[];
     autoApprove?: boolean;
     model?: string;
 }): Promise<AgentOpsRun> {
     const run = await getAgentOpsRunRepository().createRun(params);
     console.log(`[AgentOpsService] Created run: ${run.runId} (source: ${params.source})`);
-    return { ...run, knowledgeBaseIds: params.knowledgeBaseIds };
+    return run;
 }
 
 /**

--- a/apps/web-ui/lib/agent-ops/agent-ops-service.ts
+++ b/apps/web-ui/lib/agent-ops/agent-ops-service.ts
@@ -35,12 +35,16 @@ export async function createRun(params: {
     accountName?: string;
     selectedSkill?: string;
     mcpServerIds?: string[];
+    // In-memory only — no DB column for this yet (unlike mcpServerIds). Threaded onto the
+    // returned run object below so the fire-and-forget executeAgentRun(run) call in the
+    // trigger route sees it; a later reload via getRun()/listRuns() will NOT have it.
+    knowledgeBaseIds?: string[];
     autoApprove?: boolean;
     model?: string;
 }): Promise<AgentOpsRun> {
     const run = await getAgentOpsRunRepository().createRun(params);
     console.log(`[AgentOpsService] Created run: ${run.runId} (source: ${params.source})`);
-    return run;
+    return { ...run, knowledgeBaseIds: params.knowledgeBaseIds };
 }
 
 /**

--- a/apps/web-ui/lib/agent-ops/executor-graphs.ts
+++ b/apps/web-ui/lib/agent-ops/executor-graphs.ts
@@ -44,6 +44,7 @@ import { createAgentModels, assembleTools, createMemoryTools } from "@/lib/agent
 import { getCheckpointer, getMemoryStore } from "@/lib/agent/persistence";
 import { createMemoryRecallNode, createMemorySaveNode } from "@/lib/agent/memory-nodes";
 import { loadSkills, loadAllSkillContent } from "@/lib/skill-service";
+import { resolveKnowledgeBaseIds } from "@/lib/agent/auto-kb-select";
 
 // ── Agent Ops-specific imports ────────────────────────────────────────────────
 import { GraphConfig } from "@/lib/agent/agent-shared";
@@ -55,7 +56,7 @@ import { filterMutativeToolCalls } from "./tool-classifier";
 // ============================================================================
 
 export async function createDynamicExecutorGraph(config: GraphConfig) {
-    const { model: modelId, autoApprove, accounts, accountId, mcpServerIds, tenantId, userId } = config as any;
+    const { model: modelId, autoApprove, accounts, accountId, mcpServerIds, tenantId, userId, knowledgeBaseIds } = config as any;
 
     // ── Persistence (PostgreSQL checkpointer + long-term memory store) ────────
     const checkpointer = await getCheckpointer();
@@ -71,7 +72,7 @@ export async function createDynamicExecutorGraph(config: GraphConfig) {
 
     // ── Tools (shared factory keeps tool sets in sync) ────────────────────────
     const memoryTools = (store && tenantId && userId) ? createMemoryTools(tenantId, userId) : [];
-    const baseTools = await assembleTools({ includeS3Tools: false, mcpServerIds, tenantId });
+    const baseTools = await assembleTools({ includeS3Tools: false, mcpServerIds, tenantId, knowledgeBaseIds });
     const tools = [...baseTools, ...memoryTools];
     const modelWithTools = model.bindTools(tools);
     const toolNode = new ToolNode(tools);
@@ -114,7 +115,12 @@ export async function createDynamicExecutorGraph(config: GraphConfig) {
 
         const memorySection = memoryContext ? `\n## Relevant Context from Memory\n${memoryContext}\n` : '';
 
-        return { skillSection, accountContext, mutationInstruction, mcpInstructions, memorySection };
+        const kbIds = evaluation?.knowledgeBaseIds ?? [];
+        const kbSection = kbIds.length > 0
+            ? `\n## Knowledge Base Context\nRelevant knowledge base(s) for this task: ${kbIds.join(', ')}. When calling search_knowledge_base, pass these ids as the knowledgeBaseIds argument to scope your search; omit it to search all knowledge bases.\n`
+            : '';
+
+        return { skillSection, accountContext, mutationInstruction, mcpInstructions, memorySection, kbSection };
     }
 
     // ============================================================================
@@ -166,7 +172,7 @@ Return only the JSON object.`);
         let evalResult: RequestEvaluation = {
             mode: 'fast', skillId: null, accountId: null,
             requiresApproval: false, reasoning: 'Fallback to fast mode.',
-            clarificationQuestion: null, missingInfo: null,
+            clarificationQuestion: null, missingInfo: null, knowledgeBaseIds: [],
         };
 
         try {
@@ -182,13 +188,21 @@ Return only the JSON object.`);
                     reasoning: parsed.reasoning || '',
                     clarificationQuestion: parsed.clarificationQuestion || null,
                     missingInfo: parsed.missingInfo || null,
+                    knowledgeBaseIds: [],
                 };
             }
         } catch (e) {
             console.error('[EVALUATOR] Parse failed:', e);
         }
 
-        console.log(`[EVALUATOR] Mode: ${evalResult.mode} | Skill: ${evalResult.skillId} | Approval: ${evalResult.requiresApproval}`);
+        // KB autonomy: manual run-level selection (config.knowledgeBaseIds) always wins;
+        // otherwise a cheap reflector call (resolveKnowledgeBaseIds → autoSelectKb) matches
+        // the task against the tenant's KB catalog (vectorCount > 0). Never throws.
+        evalResult.knowledgeBaseIds = tenantId
+            ? await resolveKnowledgeBaseIds({ tenantId, selectedIds: knowledgeBaseIds, message: taskDescription, model: modelId }).catch(() => [])
+            : [];
+
+        console.log(`[EVALUATOR] Mode: ${evalResult.mode} | Skill: ${evalResult.skillId} | Approval: ${evalResult.requiresApproval} | KBs: ${evalResult.knowledgeBaseIds.join(', ') || 'none'}`);
         return { evaluation: evalResult };
     }
 
@@ -222,12 +236,13 @@ Return only the JSON object.`);
 
         console.log(`\n[PLANNER] Creating plan for: "${truncateOutput(taskDescription, 100)}"`);
 
-        const { skillSection, accountContext, mutationInstruction, memorySection } = getDynamicContext(state.evaluation, state.memoryContext);
+        const { skillSection, accountContext, mutationInstruction, memorySection, kbSection } = getDynamicContext(state.evaluation, state.memoryContext);
         const baseIdentity = buildBaseIdentity(state.evaluation?.skillId);
 
         const systemPrompt = new SystemMessage(`${baseIdentity}
 ${skillSection}
 ${memorySection}
+${kbSection}
 ${CORE_PRINCIPLES}
 ${mutationInstruction}
 
@@ -283,7 +298,7 @@ Return ONLY a JSON array of step strings. Example:
         const { messages, plan, iterationCount, evaluation } = state;
         console.log(`\n[EXECUTOR] Iteration ${iterationCount + 1}/${MAX_ITERATIONS}`);
 
-        const { skillSection, accountContext, mutationInstruction, mcpInstructions, memorySection } = getDynamicContext(evaluation, state.memoryContext);
+        const { skillSection, accountContext, mutationInstruction, mcpInstructions, memorySection, kbSection } = getDynamicContext(evaluation, state.memoryContext);
         const baseIdentity = buildBaseIdentity(evaluation?.skillId);
 
         let stepContext = '';
@@ -296,6 +311,7 @@ Return ONLY a JSON array of step strings. Example:
         const systemPrompt = new SystemMessage(`${baseIdentity}
 ${skillSection}
 ${memorySection}
+${kbSection}
 ${CORE_PRINCIPLES}
 ${mutationInstruction}
 ${mcpInstructions}
@@ -488,12 +504,13 @@ Otherwise list specific issues to fix. Do not generate the fixed answer.`);
         const { messages, reflection, errors, plan, evaluation } = state;
         console.log(`\n[REVISER] Applying targeted fixes`);
 
-        const { skillSection, accountContext, mutationInstruction, memorySection } = getDynamicContext(evaluation, state.memoryContext);
+        const { skillSection, accountContext, mutationInstruction, memorySection, kbSection } = getDynamicContext(evaluation, state.memoryContext);
         const baseIdentity = buildBaseIdentity(evaluation?.skillId);
 
         const systemPrompt = new SystemMessage(`${baseIdentity}
 ${skillSection}
 ${memorySection}
+${kbSection}
 ${CORE_PRINCIPLES}
 ${mutationInstruction}
 

--- a/apps/web-ui/lib/agent-ops/executor-graphs.ts
+++ b/apps/web-ui/lib/agent-ops/executor-graphs.ts
@@ -172,7 +172,7 @@ Return only the JSON object.`);
         let evalResult: RequestEvaluation = {
             mode: 'fast', skillId: null, accountId: null,
             requiresApproval: false, reasoning: 'Fallback to fast mode.',
-            clarificationQuestion: null, missingInfo: null, knowledgeBaseIds: [],
+            clarificationQuestion: null, missingInfo: null,
         };
 
         try {
@@ -188,7 +188,6 @@ Return only the JSON object.`);
                     reasoning: parsed.reasoning || '',
                     clarificationQuestion: parsed.clarificationQuestion || null,
                     missingInfo: parsed.missingInfo || null,
-                    knowledgeBaseIds: [],
                 };
             }
         } catch (e) {

--- a/apps/web-ui/lib/agent-ops/executor-kb.test.ts
+++ b/apps/web-ui/lib/agent-ops/executor-kb.test.ts
@@ -12,6 +12,15 @@ vi.mock('@/lib/skill-service', () => ({
     loadAllSkillContent: vi.fn().mockResolvedValue(new Map()),
 }));
 
+// Persistence touches a live Postgres (checkpointer setup + memory store), which
+// would require a running DB + DATABASE_URL. Mock it so this test is hermetic.
+vi.mock('@/lib/agent/persistence', () => ({
+    getCheckpointer: vi.fn().mockResolvedValue({}),
+    getMemoryStore: vi.fn().mockResolvedValue(undefined),
+    saveMemory: vi.fn(),
+    searchMemory: vi.fn().mockResolvedValue([]),
+}));
+
 import { assembleTools } from '@/lib/agent/model-factory';
 import { createDynamicExecutorGraph } from './executor-graphs';
 

--- a/apps/web-ui/lib/agent-ops/executor-kb.test.ts
+++ b/apps/web-ui/lib/agent-ops/executor-kb.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/agent/model-factory', async (orig) => {
+    const actual = await (orig as any)();
+    return { ...actual, assembleTools: vi.fn().mockResolvedValue([]) };
+});
+
+// Skill loading hits the repository factory's runtime require(), which vitest's
+// transform can't resolve — irrelevant to this test, so it's mocked out.
+vi.mock('@/lib/skill-service', () => ({
+    loadSkills: vi.fn().mockResolvedValue([]),
+    loadAllSkillContent: vi.fn().mockResolvedValue(new Map()),
+}));
+
+import { assembleTools } from '@/lib/agent/model-factory';
+import { createDynamicExecutorGraph } from './executor-graphs';
+
+describe('Agent Ops executor — KB tool wiring', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('forwards knowledgeBaseIds from config to assembleTools', async () => {
+        await createDynamicExecutorGraph({
+            model: { provider: 'bedrock', modelId: 'm', accessKeyId: 'x', secretAccessKey: 'x', region: 'us-east-1' },
+            tenantId: 't1',
+            knowledgeBaseIds: ['kb1'],
+        } as any);
+        expect(assembleTools).toHaveBeenCalledWith(expect.objectContaining({ knowledgeBaseIds: ['kb1'], tenantId: 't1' }));
+    });
+});

--- a/apps/web-ui/lib/agent-ops/executor-state.ts
+++ b/apps/web-ui/lib/agent-ops/executor-state.ts
@@ -9,6 +9,9 @@ export interface RequestEvaluation {
     reasoning: string;
     clarificationQuestion: string | null;
     missingInfo: string | null;
+    /** Effective knowledge base ids for this run: the run's configured ids, or — when
+     *  none were configured — the ids autonomously picked by resolveKnowledgeBaseIds(). */
+    knowledgeBaseIds: string[];
 }
 
 export interface PlanStep {

--- a/apps/web-ui/lib/agent-ops/executor-state.ts
+++ b/apps/web-ui/lib/agent-ops/executor-state.ts
@@ -10,8 +10,9 @@ export interface RequestEvaluation {
     clarificationQuestion: string | null;
     missingInfo: string | null;
     /** Effective knowledge base ids for this run: the run's configured ids, or — when
-     *  none were configured — the ids autonomously picked by resolveKnowledgeBaseIds(). */
-    knowledgeBaseIds: string[];
+     *  none were configured — the ids autonomously picked by resolveKnowledgeBaseIds().
+     *  Set once by evaluatorNode after parsing the LLM output; always an array by then. */
+    knowledgeBaseIds?: string[];
 }
 
 export interface PlanStep {

--- a/apps/web-ui/lib/agent-ops/scheduled-task-service.ts
+++ b/apps/web-ui/lib/agent-ops/scheduled-task-service.ts
@@ -22,6 +22,7 @@ export async function createScheduledTask(params: {
     accountId?: string;
     accountName?: string;
     mcpServerIds?: string[];
+    knowledgeBaseIds?: string[];
     notification: ScheduledTask['notification'];
     createdBy: string;
 }): Promise<ScheduledTask> {
@@ -45,7 +46,7 @@ export async function listAllActiveTasks(): Promise<ScheduledTask[]> {
 export async function updateScheduledTask(
     tenantId: string,
     taskId: string,
-    updates: Partial<Pick<ScheduledTask, 'name' | 'description' | 'cronExpression' | 'timezone' | 'mode' | 'autoApprove' | 'model' | 'accountId' | 'accountName' | 'mcpServerIds' | 'notification'>>
+    updates: Partial<Pick<ScheduledTask, 'name' | 'description' | 'cronExpression' | 'timezone' | 'mode' | 'autoApprove' | 'model' | 'accountId' | 'accountName' | 'mcpServerIds' | 'knowledgeBaseIds' | 'notification'>>
 ): Promise<ScheduledTask | null> {
     return getScheduledTaskRepository().updateScheduledTask(tenantId, taskId, updates);
 }

--- a/apps/web-ui/lib/agent-ops/types.ts
+++ b/apps/web-ui/lib/agent-ops/types.ts
@@ -110,9 +110,6 @@ export interface AgentOpsRun {
     model?: string;         // Bedrock model ID override
     threadId: string;       // LangGraph thread ID
     mcpServerIds?: string[];
-    // In-memory only — no DB column (unlike mcpServerIds). Set by agent-ops-service.createRun
-    // on the returned object so the immediate fire-and-forget executeAgentRun() call sees it;
-    // does NOT survive a reload via getRun()/listRuns().
     knowledgeBaseIds?: string[];
     trigger: TriggerMetadata;
     result?: AgentOpsResult;
@@ -180,6 +177,7 @@ export interface ScheduledTask {
     accountId?: string;
     accountName?: string;
     mcpServerIds?: string[];
+    knowledgeBaseIds?: string[];
     notification: ScheduledTaskNotification;
     lastRunId?: string;
     lastRunAt?: string;

--- a/apps/web-ui/lib/agent-ops/types.ts
+++ b/apps/web-ui/lib/agent-ops/types.ts
@@ -110,6 +110,10 @@ export interface AgentOpsRun {
     model?: string;         // Bedrock model ID override
     threadId: string;       // LangGraph thread ID
     mcpServerIds?: string[];
+    // In-memory only — no DB column (unlike mcpServerIds). Set by agent-ops-service.createRun
+    // on the returned object so the immediate fire-and-forget executeAgentRun() call sees it;
+    // does NOT survive a reload via getRun()/listRuns().
+    knowledgeBaseIds?: string[];
     trigger: TriggerMetadata;
     result?: AgentOpsResult;
     clarification?: AgentOpsClarification;   // Set when status is awaiting_input

--- a/apps/web-ui/lib/agent/agent-shared.ts
+++ b/apps/web-ui/lib/agent/agent-shared.ts
@@ -501,6 +501,7 @@ export interface GraphConfig {
     mcpServerIds?: string[];
     tenantId?: string;
     userId?: string;  // For long-term memory store scoping
+    knowledgeBaseIds?: string[] | null;
 }
 
 // --- MCP Integration ---

--- a/apps/web-ui/lib/agent/auto-kb-select.test.ts
+++ b/apps/web-ui/lib/agent/auto-kb-select.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/knowledge-base/service', () => ({
+    KnowledgeBaseService: { listKnowledgeBases: vi.fn() },
+}));
+vi.mock('./model-factory', () => ({ createAgentModels: vi.fn() }));
+
+import { KnowledgeBaseService } from '@/lib/knowledge-base/service';
+import { createAgentModels } from './model-factory';
+import { autoSelectKb } from './auto-kb-select';
+
+const model = { provider: 'x', modelId: 'm' } as any;
+function mockReflector(content: string) {
+    vi.mocked(createAgentModels).mockReturnValue({ reflector: { invoke: vi.fn().mockResolvedValue({ content }) } } as any);
+}
+
+describe('autoSelectKb', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(KnowledgeBaseService.listKnowledgeBases).mockResolvedValue([
+            { id: 'kb-runbooks', name: 'Runbooks', description: 'ops runbooks' },
+            { id: 'kb-hr', name: 'HR', description: 'people policies' },
+        ] as any);
+    });
+
+    it('returns the KB ids the reflector selected (validated against the catalog)', async () => {
+        mockReflector('{"kbIds":["kb-runbooks"],"reasoning":"ops question"}');
+        const r = await autoSelectKb({ tenantId: 't1', message: 'how do I restart the pipeline', model });
+        expect(r.kbIds).toEqual(['kb-runbooks']);
+    });
+
+    it('drops hallucinated ids not in the catalog', async () => {
+        mockReflector('{"kbIds":["kb-runbooks","kb-ghost"],"reasoning":"x"}');
+        const r = await autoSelectKb({ tenantId: 't1', message: 'q', model });
+        expect(r.kbIds).toEqual(['kb-runbooks']);
+    });
+
+    it('returns [] when the reflector picks none', async () => {
+        mockReflector('{"kbIds":[],"reasoning":"general question"}');
+        const r = await autoSelectKb({ tenantId: 't1', message: 'what is 2+2', model });
+        expect(r.kbIds).toEqual([]);
+    });
+
+    it('returns [] (never throws) when there are no KBs', async () => {
+        vi.mocked(KnowledgeBaseService.listKnowledgeBases).mockResolvedValue([]);
+        const r = await autoSelectKb({ tenantId: 't1', message: 'q', model });
+        expect(r.kbIds).toEqual([]);
+    });
+});

--- a/apps/web-ui/lib/agent/auto-kb-select.test.ts
+++ b/apps/web-ui/lib/agent/auto-kb-select.test.ts
@@ -7,7 +7,7 @@ vi.mock('./model-factory', () => ({ createAgentModels: vi.fn() }));
 
 import { KnowledgeBaseService } from '@/lib/knowledge-base/service';
 import { createAgentModels } from './model-factory';
-import { autoSelectKb } from './auto-kb-select';
+import { autoSelectKb, resolveKnowledgeBaseIds } from './auto-kb-select';
 
 const model = { provider: 'x', modelId: 'm' } as any;
 function mockReflector(content: string) {
@@ -55,5 +55,27 @@ describe('autoSelectKb', () => {
         mockReflector('{"kbIds":["kb-runbooks","kb-empty"],"reasoning":"x"}');
         const r = await autoSelectKb({ tenantId: 't1', message: 'q', model });
         expect(r.kbIds).toEqual(['kb-runbooks']);
+    });
+});
+
+describe('resolveKnowledgeBaseIds', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(KnowledgeBaseService.listKnowledgeBases).mockResolvedValue([
+            { id: 'kb-runbooks', name: 'R', description: 'ops', vectorCount: 5 },
+        ] as any);
+    });
+
+    it('returns the manual selection without calling the reflector', async () => {
+        const spy = vi.mocked(createAgentModels);
+        const ids = await resolveKnowledgeBaseIds({ tenantId: 't1', selectedIds: ['kb-x'], message: 'q', model });
+        expect(ids).toEqual(['kb-x']);
+        expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('auto-selects when no manual selection', async () => {
+        mockReflector('{"kbIds":["kb-runbooks"],"reasoning":"x"}');
+        const ids = await resolveKnowledgeBaseIds({ tenantId: 't1', selectedIds: null, message: 'restart pipeline', model });
+        expect(ids).toEqual(['kb-runbooks']);
     });
 });

--- a/apps/web-ui/lib/agent/auto-kb-select.test.ts
+++ b/apps/web-ui/lib/agent/auto-kb-select.test.ts
@@ -18,8 +18,8 @@ describe('autoSelectKb', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         vi.mocked(KnowledgeBaseService.listKnowledgeBases).mockResolvedValue([
-            { id: 'kb-runbooks', name: 'Runbooks', description: 'ops runbooks' },
-            { id: 'kb-hr', name: 'HR', description: 'people policies' },
+            { id: 'kb-runbooks', name: 'Runbooks', description: 'ops runbooks', vectorCount: 5 },
+            { id: 'kb-hr', name: 'HR', description: 'people policies', vectorCount: 3 },
         ] as any);
     });
 
@@ -45,5 +45,15 @@ describe('autoSelectKb', () => {
         vi.mocked(KnowledgeBaseService.listKnowledgeBases).mockResolvedValue([]);
         const r = await autoSelectKb({ tenantId: 't1', message: 'q', model });
         expect(r.kbIds).toEqual([]);
+    });
+
+    it('excludes empty KBs (vectorCount 0) from the catalog even if the reflector picks them', async () => {
+        vi.mocked(KnowledgeBaseService.listKnowledgeBases).mockResolvedValue([
+            { id: 'kb-runbooks', name: 'Runbooks', description: 'ops runbooks', vectorCount: 5 },
+            { id: 'kb-empty', name: 'Empty', description: 'no synced docs yet', vectorCount: 0 },
+        ] as any);
+        mockReflector('{"kbIds":["kb-runbooks","kb-empty"],"reasoning":"x"}');
+        const r = await autoSelectKb({ tenantId: 't1', message: 'q', model });
+        expect(r.kbIds).toEqual(['kb-runbooks']);
     });
 });

--- a/apps/web-ui/lib/agent/auto-kb-select.ts
+++ b/apps/web-ui/lib/agent/auto-kb-select.ts
@@ -24,10 +24,9 @@ export async function autoSelectKb(params: {
     if (!autoKbSelectionEnabled()) return empty;
     try {
         const kbs = await KnowledgeBaseService.listKnowledgeBases(params.tenantId);
-        // vectorCount is a required field in production (defaults to 0 for a KB with
-        // no synced documents yet); only exclude KBs explicitly known to have zero
-        // vectors, treating an absent value (e.g. lightweight test doubles) as active.
-        const active = kbs.filter((k) => k.vectorCount === undefined || k.vectorCount > 0);
+        // Only KBs with at least one embedded vector are worth searching — an empty
+        // KB would return nothing useful, so it must not be auto-selectable.
+        const active = kbs.filter((k) => (k.vectorCount ?? 0) > 0);
         if (active.length === 0) return empty;
 
         const catalog = active.map((k) => `- ${k.id}: ${k.name}${k.description ? ` — ${k.description}` : ''}`).join('\n');

--- a/apps/web-ui/lib/agent/auto-kb-select.ts
+++ b/apps/web-ui/lib/agent/auto-kb-select.ts
@@ -1,0 +1,59 @@
+/**
+ * auto-kb-select.ts — progressive disclosure for knowledge bases, mirroring
+ * auto-skill-select.ts. When the user picked no KB, one cheap reflector call
+ * matches the message against the tenant's KB catalog and returns the relevant
+ * KB ids (zero, one, or many). Manual selection always wins; never throws.
+ */
+
+import { SystemMessage, HumanMessage } from '@langchain/core/messages';
+import type { ResolvedModelConfig } from './agent-shared';
+import { createAgentModels } from './model-factory';
+import { KnowledgeBaseService } from '@/lib/knowledge-base/service';
+
+export function autoKbSelectionEnabled(): boolean {
+    const v = process.env.AUTO_KB_SELECTION_ENABLED?.toLowerCase();
+    return !(v === 'false' || v === '0');
+}
+
+export async function autoSelectKb(params: {
+    tenantId: string;
+    message: string;
+    model: ResolvedModelConfig;
+}): Promise<{ kbIds: string[]; reasoning: string }> {
+    const empty = { kbIds: [] as string[], reasoning: '' };
+    if (!autoKbSelectionEnabled()) return empty;
+    try {
+        const kbs = await KnowledgeBaseService.listKnowledgeBases(params.tenantId);
+        // vectorCount is a required field in production (defaults to 0 for a KB with
+        // no synced documents yet); only exclude KBs explicitly known to have zero
+        // vectors, treating an absent value (e.g. lightweight test doubles) as active.
+        const active = kbs.filter((k) => k.vectorCount === undefined || k.vectorCount > 0);
+        if (active.length === 0) return empty;
+
+        const catalog = active.map((k) => `- ${k.id}: ${k.name}${k.description ? ` — ${k.description}` : ''}`).join('\n');
+        const validIds = new Set(active.map((k) => k.id));
+
+        const { reflector } = createAgentModels(params.model);
+        const sys = new SystemMessage(
+            `You select which knowledge bases (if any) are relevant to a user request.\n\n` +
+            `Available knowledge bases:\n${catalog}\n\n` +
+            `Return ONLY a JSON object: {"kbIds": ["<id>", ...], "reasoning": "<one short line>"}\n` +
+            `Rules: include a KB id ONLY when its description clearly matches the request. Pick multiple if several are relevant. Return an empty array when none clearly apply.`,
+        );
+        const resp = await reflector.invoke([sys, new HumanMessage(params.message.slice(0, 4000))]);
+        const content = typeof resp.content === 'string' ? resp.content : JSON.stringify(resp.content);
+        const match = content.match(/\{[\s\S]*\}/);
+        if (!match) return empty;
+        const parsed = JSON.parse(match[0]) as { kbIds?: unknown; reasoning?: string };
+        const ids = Array.isArray(parsed.kbIds)
+            ? parsed.kbIds.filter((id): id is string => typeof id === 'string' && validIds.has(id))
+            : [];
+        if (ids.length > 0) {
+            console.log(`🎯 [KB AUTO-SELECT] Matched [${ids.join(', ')}] — ${parsed.reasoning ?? '(no reasoning)'}`);
+        }
+        return { kbIds: ids, reasoning: parsed.reasoning ?? '' };
+    } catch (err: any) {
+        console.warn(`🎯 [KB AUTO-SELECT] Failed (non-fatal): ${err?.message ?? err}`);
+        return empty;
+    }
+}

--- a/apps/web-ui/lib/agent/auto-kb-select.ts
+++ b/apps/web-ui/lib/agent/auto-kb-select.ts
@@ -56,3 +56,12 @@ export async function autoSelectKb(params: {
         return empty;
     }
 }
+
+/** Manual selection wins; otherwise auto-select. Returns the effective KB ids. */
+export async function resolveKnowledgeBaseIds(params: {
+    tenantId: string; selectedIds?: string[] | null; message: string; model: ResolvedModelConfig;
+}): Promise<string[]> {
+    if (params.selectedIds && params.selectedIds.length > 0) return params.selectedIds;
+    const { kbIds } = await autoSelectKb({ tenantId: params.tenantId, message: params.message, model: params.model });
+    return kbIds;
+}

--- a/apps/web-ui/lib/agent/fast-agent.ts
+++ b/apps/web-ui/lib/agent/fast-agent.ts
@@ -65,7 +65,7 @@ export async function createFastGraph(config: GraphConfig) {
 
     // --- Tool Assembly (fast-agent does not use S3 tools) ---
     // Memory tools excluded — memory_recall and memory_save graph nodes handle memory deterministically
-    const tools = await assembleTools({ includeS3Tools: false, includeMemoryTools: false, userId: config.userId, mcpServerIds, tenantId, accounts });
+    const tools = await assembleTools({ includeS3Tools: false, includeMemoryTools: false, userId: config.userId, mcpServerIds, tenantId, accounts, knowledgeBaseIds: config.knowledgeBaseIds });
     const modelWithTools = model.bindTools!(tools);
     const toolNode = new ToolNode(tools);
 

--- a/apps/web-ui/lib/agent/kb-tool.test.ts
+++ b/apps/web-ui/lib/agent/kb-tool.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/knowledge-base/retrieval', () => ({ searchKbChunks: vi.fn() }));
+
+import { searchKbChunks } from '@/lib/knowledge-base/retrieval';
+import { createSearchKnowledgeBaseTool } from './kb-tool';
+
+describe('createSearchKnowledgeBaseTool', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('searches with the tool-call ids when provided', async () => {
+        vi.mocked(searchKbChunks).mockResolvedValue([
+            { vectorKey: 'k', documentName: 'Runbook', sourceType: 'document', chunkIndex: 0, totalChunks: 1, knowledgeBaseId: 'kb1', dataSourceId: 'ds', textContent: 'restart the service', score: 0.88 },
+        ]);
+        const tool = createSearchKnowledgeBaseTool('t1', ['default-kb']);
+        const out = await tool.invoke({ query: 'how to restart', knowledgeBaseIds: ['kb1'] });
+        expect(searchKbChunks).toHaveBeenCalledWith(expect.objectContaining({ tenantId: 't1', query: 'how to restart', knowledgeBaseIds: ['kb1'] }));
+        expect(out).toContain('Runbook');
+        expect(out).toContain('restart the service');
+    });
+
+    it('falls back to the factory default kb ids when the call omits them', async () => {
+        vi.mocked(searchKbChunks).mockResolvedValue([]);
+        const tool = createSearchKnowledgeBaseTool('t1', ['default-kb']);
+        await tool.invoke({ query: 'q' });
+        expect(searchKbChunks).toHaveBeenCalledWith(expect.objectContaining({ knowledgeBaseIds: ['default-kb'] }));
+    });
+
+    it('returns a no-results message, never throws, when search fails', async () => {
+        vi.mocked(searchKbChunks).mockRejectedValue(new Error('db down'));
+        const tool = createSearchKnowledgeBaseTool('t1');
+        const out = await tool.invoke({ query: 'q' });
+        expect(typeof out).toBe('string');
+        expect(out.toLowerCase()).toContain('no');
+    });
+});

--- a/apps/web-ui/lib/agent/kb-tool.ts
+++ b/apps/web-ui/lib/agent/kb-tool.ts
@@ -1,0 +1,41 @@
+import { tool } from '@langchain/core/tools';
+import { z } from 'zod';
+import { searchKbChunks } from '@/lib/knowledge-base/retrieval';
+
+/**
+ * Autonomous knowledge-base retrieval tool. The agent decides when to call it.
+ * Scoping precedence: explicit knowledgeBaseIds arg → factory defaultKbIds →
+ * tenant-wide (all KBs). tenantId is captured in the closure, never client-supplied.
+ * Never throws — a retrieval failure returns a plain "no results" string so the
+ * agent turn continues.
+ */
+export function createSearchKnowledgeBaseTool(tenantId: string, defaultKbIds?: string[]) {
+    return tool(
+        async ({ query, knowledgeBaseIds }: { query: string; knowledgeBaseIds?: string[] }) => {
+            try {
+                const ids = knowledgeBaseIds && knowledgeBaseIds.length > 0
+                    ? knowledgeBaseIds
+                    : (defaultKbIds && defaultKbIds.length > 0 ? defaultKbIds : undefined);
+                const hits = await searchKbChunks({ tenantId, query, knowledgeBaseIds: ids, limit: 8 });
+                if (hits.length === 0) {
+                    return 'No relevant documents found in the knowledge base for that query.';
+                }
+                return hits
+                    .map((h, i) => `[${i + 1}] ${h.documentName} (kb:${h.knowledgeBaseId}, score:${h.score.toFixed(2)})\n${h.textContent}`)
+                    .join('\n\n');
+            } catch (err) {
+                console.warn(`[search_knowledge_base] failed (non-fatal): ${err instanceof Error ? err.message : err}`);
+                return 'No relevant documents found (knowledge base search is temporarily unavailable).';
+            }
+        },
+        {
+            name: 'search_knowledge_base',
+            description:
+                'Search the organization\'s knowledge bases (uploaded docs, wikis, runbooks, synced repos) for information relevant to the user request. Call this whenever the question may be answered by internal/organizational documentation rather than live AWS state or general knowledge. Optionally pass knowledgeBaseIds to restrict the search; omit to search all available knowledge bases.',
+            schema: z.object({
+                query: z.string().describe('A focused natural-language search query describing what information you need.'),
+                knowledgeBaseIds: z.array(z.string()).optional().describe('Optional list of knowledge base ids to restrict the search to. Omit to search across all of the tenant\'s knowledge bases.'),
+            }),
+        },
+    );
+}

--- a/apps/web-ui/lib/agent/model-factory.ts
+++ b/apps/web-ui/lib/agent/model-factory.ts
@@ -23,6 +23,7 @@ import {
     getFileFromS3Tool,
 } from "./tools";
 import { createGetRightSizingRecommendationsTool } from "./right-sizing-tool";
+import { createSearchKnowledgeBaseTool } from "./kb-tool";
 import { getActiveMCPTools, isOpenAICompatibleProvider, type AccountContext, type ResolvedModelConfig } from "./agent-shared";
 import { tool } from "@langchain/core/tools";
 import { z } from "zod";
@@ -145,6 +146,8 @@ export interface AssembleToolsOptions {
     tenantId?: string;
     /** AWS accounts for injecting STS credentials into credential-sensitive MCP servers. */
     accounts?: AccountContext[];
+    /** Knowledge base ids to default-scope the search_knowledge_base tool to. Omit/null to search tenant-wide. */
+    knowledgeBaseIds?: string[] | null;
 }
 
 /**
@@ -192,7 +195,7 @@ export function createMemoryTools(tenantId: string, userId: string) {
  * Logs MCP tool count when any are loaded.
  */
 export async function assembleTools(options: AssembleToolsOptions = {}) {
-    const { includeS3Tools = false, includeMemoryTools = false, userId, mcpServerIds, tenantId, accounts } = options;
+    const { includeS3Tools = false, includeMemoryTools = false, userId, mcpServerIds, tenantId, accounts, knowledgeBaseIds } = options;
 
     const effectiveTenantId = tenantId || 'default';
     if (!tenantId) {
@@ -200,6 +203,7 @@ export async function assembleTools(options: AssembleToolsOptions = {}) {
     }
 
     const memoryTools = (includeMemoryTools && tenantId && userId) ? createMemoryTools(tenantId, userId) : [];
+    const kbTools = tenantId ? [createSearchKnowledgeBaseTool(tenantId, knowledgeBaseIds ?? undefined)] : [];
 
     const customTools = [
         executeCommandTool,
@@ -214,6 +218,7 @@ export async function assembleTools(options: AssembleToolsOptions = {}) {
         createGetRightSizingRecommendationsTool(effectiveTenantId),
         ...(includeS3Tools ? [writeFileToS3Tool, getFileFromS3Tool] : []),
         ...memoryTools,
+        ...kbTools,
     ];
 
     const mcpTools = await getActiveMCPTools(mcpServerIds, tenantId, accounts);

--- a/apps/web-ui/lib/agent/planning-agent.ts
+++ b/apps/web-ui/lib/agent/planning-agent.ts
@@ -66,7 +66,7 @@ export async function createReflectionGraph(config: GraphConfig) {
 
     // --- Tool Assembly ---
     // Memory tools excluded — memory_recall and memory_save graph nodes handle memory deterministically
-    const tools = await assembleTools({ includeS3Tools: true, includeMemoryTools: false, userId: config.userId, mcpServerIds, tenantId, accounts });
+    const tools = await assembleTools({ includeS3Tools: true, includeMemoryTools: false, userId: config.userId, mcpServerIds, tenantId, accounts, knowledgeBaseIds: config.knowledgeBaseIds });
     const modelWithTools = model.bindTools!(tools);
     const toolNode = new ToolNode(tools);
 

--- a/apps/web-ui/lib/db/repositories/agent-ops-run/interface.ts
+++ b/apps/web-ui/lib/db/repositories/agent-ops-run/interface.ts
@@ -29,6 +29,7 @@ export interface CreateRunParams {
     accountName?: string;
     selectedSkill?: string;
     mcpServerIds?: string[];
+    knowledgeBaseIds?: string[];
     autoApprove?: boolean;
     model?: string;
 }

--- a/apps/web-ui/lib/db/repositories/agent-ops-run/postgres.ts
+++ b/apps/web-ui/lib/db/repositories/agent-ops-run/postgres.ts
@@ -37,6 +37,7 @@ function toAgentOpsRun(r: {
     model: string | null;
     threadId: string;
     mcpServerIds: string[];
+    knowledgeBaseIds: string[];
     trigger: unknown;
     result: unknown;
     clarification: unknown;
@@ -66,6 +67,7 @@ function toAgentOpsRun(r: {
         model: r.model ?? undefined,
         threadId: r.threadId,
         mcpServerIds: r.mcpServerIds,
+        knowledgeBaseIds: r.knowledgeBaseIds,
         trigger: r.trigger as AgentOpsRun['trigger'],
         result: r.result as AgentOpsRun['result'],
         clarification: r.clarification as AgentOpsRun['clarification'],
@@ -100,6 +102,7 @@ export class AgentOpsRunPostgresRepository implements IAgentOpsRunRepository {
                 model: params.model ?? null,
                 threadId,
                 mcpServerIds: params.mcpServerIds ?? [],
+                knowledgeBaseIds: params.knowledgeBaseIds ?? [],
                 trigger: (params.trigger as object) ?? {},
                 expiresAt,
             },

--- a/apps/web-ui/lib/db/repositories/data-source/interface.ts
+++ b/apps/web-ui/lib/db/repositories/data-source/interface.ts
@@ -13,4 +13,5 @@ export interface IDataSourceRepository {
     createDataSource(kbId: string, data: CreateDataSourceInput, tenantId: string): Promise<DataSource>;
     updateDataSource(kbId: string, dsId: string, updates: Partial<DataSource>, tenantId: string): Promise<void>;
     deleteDataSource(kbId: string, dsId: string, tenantId: string): Promise<void>;
+    getDataSourceContent(kbId: string, dsId: string, tenantId: string): Promise<string | null>;
 }

--- a/apps/web-ui/lib/db/repositories/data-source/postgres.test.ts
+++ b/apps/web-ui/lib/db/repositories/data-source/postgres.test.ts
@@ -182,6 +182,42 @@ describe('DataSourcePostgresRepository', () => {
             );
         });
     });
+
+    describe('updateDataSource — content', () => {
+        it('writes content when provided', async () => {
+            mockPrisma.dataSource.updateMany.mockResolvedValue({ count: 1 });
+
+            const repo = new DataSourcePostgresRepository();
+            await repo.updateDataSource('kb-1', 'ds-1', { content: '# Hello', status: 'synced' }, 'tenant-1');
+
+            const callArg = mockPrisma.dataSource.updateMany.mock.calls[0][0];
+            expect(callArg.data.content).toBe('# Hello');
+            expect(callArg.data.status).toBe('synced');
+        });
+    });
+
+    describe('getDataSourceContent', () => {
+        it('returns content string, scoped by tenant/kb/ds', async () => {
+            mockPrisma.dataSource.findFirst.mockResolvedValue({ content: '# Doc body' });
+
+            const repo = new DataSourcePostgresRepository();
+            const result = await repo.getDataSourceContent('kb-1', 'ds-1', 'tenant-1');
+
+            expect(result).toBe('# Doc body');
+            expect(mockPrisma.dataSource.findFirst).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: expect.objectContaining({ id: 'ds-1', knowledgeBaseId: 'kb-1', tenantId: 'tenant-1' }),
+                    select: { content: true },
+                })
+            );
+        });
+
+        it('returns null when row not found', async () => {
+            mockPrisma.dataSource.findFirst.mockResolvedValue(null);
+            const repo = new DataSourcePostgresRepository();
+            expect(await repo.getDataSourceContent('kb-1', 'missing', 'tenant-1')).toBeNull();
+        });
+    });
 });
 
 describe('DataSourcePostgresRepository — tenant isolation', () => {

--- a/apps/web-ui/lib/db/repositories/data-source/postgres.ts
+++ b/apps/web-ui/lib/db/repositories/data-source/postgres.ts
@@ -99,6 +99,7 @@ export class DataSourcePostgresRepository implements IDataSourceRepository {
                 'name',
                 'status',
                 'config',
+                'content',
                 'vectorCount',
                 'vectorKeys',
                 'lastSyncAt',
@@ -136,6 +137,19 @@ export class DataSourcePostgresRepository implements IDataSourceRepository {
         } catch (error: unknown) {
             console.error('[DataSourcePostgresRepository] Error deleting data source:', error);
             throw new Error(`Failed to delete data source: ${error instanceof Error ? error.message : String(error)}`);
+        }
+    }
+
+    async getDataSourceContent(kbId: string, dsId: string, tenantId: string): Promise<string | null> {
+        try {
+            const row = await getTenantClient(tenantId).dataSource.findFirst({
+                where: { id: dsId, knowledgeBaseId: kbId, tenantId },
+                select: { content: true },
+            });
+            return row?.content ?? null;
+        } catch (error: unknown) {
+            console.error('[DataSourcePostgresRepository] Error getting data source content:', error);
+            throw new Error(`Failed to get data source content: ${error instanceof Error ? error.message : String(error)}`);
         }
     }
 }

--- a/apps/web-ui/lib/db/repositories/scheduled-task/interface.ts
+++ b/apps/web-ui/lib/db/repositories/scheduled-task/interface.ts
@@ -19,6 +19,7 @@ export interface CreateScheduledTaskParams {
     accountId?: string;
     accountName?: string;
     mcpServerIds?: string[];
+    knowledgeBaseIds?: string[];
     notification: ScheduledTask['notification'];
     createdBy: string;
 }
@@ -34,6 +35,7 @@ export interface UpdateScheduledTaskParams {
     accountId?: string;
     accountName?: string;
     mcpServerIds?: string[];
+    knowledgeBaseIds?: string[];
     notification?: ScheduledTask['notification'];
 }
 

--- a/apps/web-ui/lib/db/repositories/scheduled-task/postgres.ts
+++ b/apps/web-ui/lib/db/repositories/scheduled-task/postgres.ts
@@ -44,6 +44,7 @@ function toScheduledTask(r: {
     accountId: string | null;
     accountName: string | null;
     mcpServerIds: string[];
+    knowledgeBaseIds: string[];
     notification: unknown;
     lastRunId: string | null;
     lastRunAt: Date | null;
@@ -72,6 +73,7 @@ function toScheduledTask(r: {
         accountId: r.accountId ?? undefined,
         accountName: r.accountName ?? undefined,
         mcpServerIds: r.mcpServerIds,
+        knowledgeBaseIds: r.knowledgeBaseIds,
         notification: r.notification as ScheduledTask['notification'],
         lastRunId: r.lastRunId ?? undefined,
         lastRunAt: r.lastRunAt?.toISOString(),
@@ -104,6 +106,7 @@ export class ScheduledTaskPostgresRepository implements IScheduledTaskRepository
                 accountId: params.accountId ?? null,
                 accountName: params.accountName ?? null,
                 mcpServerIds: params.mcpServerIds ?? [],
+                knowledgeBaseIds: params.knowledgeBaseIds ?? [],
                 notification: (params.notification as object) ?? {},
                 nextRunAt: nextRunAt ?? null,
                 runCount: 0,

--- a/apps/web-ui/lib/knowledge-base/document-validation.test.ts
+++ b/apps/web-ui/lib/knowledge-base/document-validation.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { validateDocumentInput, MAX_DOCUMENT_CHARS } from './document-validation';
+
+describe('validateDocumentInput', () => {
+    it('accepts a valid document and trims the name', () => {
+        const r = validateDocumentInput({ name: '  Runbook  ', content: '# Steps' });
+        expect(r).toEqual({ ok: true, name: 'Runbook', content: '# Steps' });
+    });
+
+    it('rejects an empty name', () => {
+        const r = validateDocumentInput({ name: '   ', content: 'body' });
+        expect(r).toEqual({ ok: false, error: 'name is required' });
+    });
+
+    it('rejects empty content', () => {
+        const r = validateDocumentInput({ name: 'Doc', content: '   ' });
+        expect(r).toEqual({ ok: false, error: 'content is required' });
+    });
+
+    it('rejects content over the size cap', () => {
+        const r = validateDocumentInput({ name: 'Doc', content: 'a'.repeat(MAX_DOCUMENT_CHARS + 1) });
+        expect(r.ok).toBe(false);
+        expect((r as { error: string }).error).toContain('too large');
+    });
+});

--- a/apps/web-ui/lib/knowledge-base/document-validation.ts
+++ b/apps/web-ui/lib/knowledge-base/document-validation.ts
@@ -1,0 +1,22 @@
+/**
+ * Validation for inline (authored) knowledge-base documents.
+ * Pure — no I/O — so it is shared by the create route and the edit route.
+ */
+
+export const MAX_DOCUMENT_CHARS = 200_000;
+
+export type DocumentValidationResult =
+    | { ok: true; name: string; content: string }
+    | { ok: false; error: string };
+
+export function validateDocumentInput(input: { name?: string; content?: string }): DocumentValidationResult {
+    const name = (input.name ?? '').trim();
+    const content = (input.content ?? '').trim();
+
+    if (!name) return { ok: false, error: 'name is required' };
+    if (!content) return { ok: false, error: 'content is required' };
+    if (content.length > MAX_DOCUMENT_CHARS) {
+        return { ok: false, error: `Document is too large (max ${MAX_DOCUMENT_CHARS.toLocaleString()} characters)` };
+    }
+    return { ok: true, name, content };
+}

--- a/apps/web-ui/lib/knowledge-base/retrieval.test.ts
+++ b/apps/web-ui/lib/knowledge-base/retrieval.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/knowledge-base/embedder', () => ({ getEmbedding: vi.fn().mockResolvedValue([0.1, 0.2]) }));
+vi.mock('@/lib/db/pg-config', () => ({ getPrismaClient: vi.fn() }));
+
+import { getEmbedding } from '@/lib/knowledge-base/embedder';
+import { getPrismaClient } from '@/lib/db/pg-config';
+import { searchKbChunks } from './retrieval';
+
+const rows = [
+    { vectorKey: 'k1', documentName: 'Doc', sourceType: 'document', chunkIndex: 0, totalChunks: 1, knowledgeBaseId: 'kb1', dataSourceId: 'ds1', textContent: 'hello', score: 0.9 },
+    { vectorKey: 'k2', documentName: 'Doc', sourceType: 'document', chunkIndex: 1, totalChunks: 2, knowledgeBaseId: 'kb1', dataSourceId: 'ds1', textContent: 'low', score: 0.2 },
+];
+
+describe('searchKbChunks', () => {
+    let q: ReturnType<typeof vi.fn>;
+    beforeEach(() => {
+        q = vi.fn().mockResolvedValue(rows);
+        vi.mocked(getPrismaClient).mockReturnValue({ $queryRawUnsafe: q } as any);
+        vi.mocked(getEmbedding).mockClear();
+    });
+
+    it('embeds the query with the tenant id', async () => {
+        await searchKbChunks({ tenantId: 't1', query: 'q' });
+        expect(getEmbedding).toHaveBeenCalledWith('q', 't1');
+    });
+
+    it('tenant-only scope when no kb ids', async () => {
+        await searchKbChunks({ tenantId: 't1', query: 'q' });
+        const sql = q.mock.calls[0][0] as string;
+        expect(sql).not.toContain('ANY(');
+        expect(sql).toContain('"tenantId" = $2');
+        expect(q.mock.calls[0].slice(1)).toEqual(['[0.1,0.2]', 't1']);
+    });
+
+    it('scopes to multiple kb ids via ANY($3::text[])', async () => {
+        await searchKbChunks({ tenantId: 't1', query: 'q', knowledgeBaseIds: ['kb1', 'kb2'] });
+        const sql = q.mock.calls[0][0] as string;
+        expect(sql).toContain('"knowledgeBaseId" = ANY($3::text[])');
+        expect(q.mock.calls[0][3]).toEqual(['kb1', 'kb2']);
+    });
+
+    it('applies minScore filtering in JS', async () => {
+        const hits = await searchKbChunks({ tenantId: 't1', query: 'q', minScore: 0.5 });
+        expect(hits.map((h) => h.vectorKey)).toEqual(['k1']);
+    });
+});

--- a/apps/web-ui/lib/knowledge-base/retrieval.ts
+++ b/apps/web-ui/lib/knowledge-base/retrieval.ts
@@ -1,0 +1,62 @@
+import { getEmbedding } from './embedder';
+import { getPrismaClient } from '@/lib/db/pg-config';
+
+export interface KbChunkHit {
+    vectorKey: string;
+    documentName: string;
+    sourceType: string;
+    chunkIndex: number;
+    totalChunks: number;
+    knowledgeBaseId: string;
+    dataSourceId: string;
+    textContent: string;
+    score: number;
+}
+
+/**
+ * Semantic search over kb_document_chunks (pgvector cosine). Scoped to the
+ * tenant; optionally narrowed to a set of knowledge bases. When no ids are
+ * given it searches ALL of the tenant's chunks. Never trusts a client tenantId —
+ * callers pass the session/graph-resolved tenantId.
+ */
+export async function searchKbChunks(params: {
+    tenantId: string;
+    query: string;
+    knowledgeBaseIds?: string[];
+    limit?: number;
+    minScore?: number;
+}): Promise<KbChunkHit[]> {
+    const { tenantId, query, knowledgeBaseIds, limit = 10, minScore = 0 } = params;
+    if (!query.trim()) return [];
+
+    const embedding = await getEmbedding(query, tenantId);
+    const vectorLiteral = `[${embedding.join(',')}]`;
+    const prisma = getPrismaClient();
+
+    const cols = `"vectorKey", "documentName", "sourceType", "chunkIndex", "totalChunks",
+                  "knowledgeBaseId", "dataSourceId", "textContent",
+                  1 - (embedding <=> $1::vector) as score`;
+
+    let rows: KbChunkHit[];
+    if (knowledgeBaseIds && knowledgeBaseIds.length > 0) {
+        rows = await prisma.$queryRawUnsafe<KbChunkHit[]>(
+            `SELECT ${cols}
+             FROM kb_document_chunks
+             WHERE "tenantId" = $2 AND "knowledgeBaseId" = ANY($3::text[])
+             ORDER BY embedding <=> $1::vector
+             LIMIT ${Number(limit)}`,
+            vectorLiteral, tenantId, knowledgeBaseIds,
+        );
+    } else {
+        rows = await prisma.$queryRawUnsafe<KbChunkHit[]>(
+            `SELECT ${cols}
+             FROM kb_document_chunks
+             WHERE "tenantId" = $2
+             ORDER BY embedding <=> $1::vector
+             LIMIT ${Number(limit)}`,
+            vectorLiteral, tenantId,
+        );
+    }
+
+    return minScore > 0 ? rows.filter((r) => (typeof r.score === 'number' ? r.score : 0) >= minScore) : rows;
+}

--- a/apps/web-ui/lib/knowledge-base/service.ts
+++ b/apps/web-ui/lib/knowledge-base/service.ts
@@ -62,6 +62,10 @@ export class KnowledgeBaseService {
     return getDataSourceRepository().getDataSource(kbId, dsId, tenantId);
   }
 
+  static async getDataSourceContent(kbId: string, dsId: string, tenantId: string): Promise<string | null> {
+    return getDataSourceRepository().getDataSourceContent(kbId, dsId, tenantId);
+  }
+
   static async createDataSource(
     kbId: string,
     data: CreateDataSourceInput,

--- a/apps/web-ui/lib/knowledge-base/types.ts
+++ b/apps/web-ui/lib/knowledge-base/types.ts
@@ -12,7 +12,7 @@
 // ---------------------------------------------------------------------------
 
 export type KnowledgeBaseStatus = 'active' | 'inactive';
-export type DataSourceType = 'file-upload' | 's3-bucket' | 'confluence' | 'bitbucket';
+export type DataSourceType = 'file-upload' | 's3-bucket' | 'confluence' | 'bitbucket' | 'document';
 export type DataSourceStatus = 'pending' | 'syncing' | 'synced' | 'error';
 
 // ---------------------------------------------------------------------------
@@ -41,6 +41,8 @@ export interface DataSource {
   config: DataSourceConfig;
   vectorCount: number;
   vectorKeys: string[];
+  /** Markdown body for sourceType='document'. Write-through: never returned by list/detail DTOs — read via the documents content endpoint. */
+  content?: string;
   lastSyncAt?: string;
   lastSyncError?: string;
   lastErrorMessage?: string;
@@ -101,11 +103,17 @@ export interface BitbucketConfig {
   baseUrl?: string;
 }
 
+export interface DocumentConfig {
+  format: 'markdown';
+  chunkCount: number;
+}
+
 export type DataSourceConfig =
   | FileUploadConfig
   | S3BucketConfig
   | ConfluenceConfig
-  | BitbucketConfig;
+  | BitbucketConfig
+  | DocumentConfig;
 
 // ---------------------------------------------------------------------------
 // Input types (for create / update operations)

--- a/apps/web-ui/lib/queries/knowledge-base.ts
+++ b/apps/web-ui/lib/queries/knowledge-base.ts
@@ -54,3 +54,41 @@ export function useDeleteKnowledgeBase() {
         onSuccess: () => qc.invalidateQueries({ queryKey: knowledgeBasesKey }),
     });
 }
+
+export function useCreateDocument(kbId: string) {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async (body: { name: string; content: string }) => {
+            const res = await fetch(`/api/knowledge-base/${kbId}/documents`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body),
+            });
+            if (!res.ok) {
+                const data = await res.json().catch(() => ({}));
+                throw new Error(data.error ?? 'Failed to create document');
+            }
+            return res.json();
+        },
+        onSuccess: () => qc.invalidateQueries({ queryKey: knowledgeBasesKey }),
+    });
+}
+
+export function useUpdateDocument(kbId: string) {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async ({ dsId, ...body }: { dsId: string; name?: string; content: string }) => {
+            const res = await fetch(`/api/knowledge-base/${kbId}/sources/${dsId}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body),
+            });
+            if (!res.ok) {
+                const data = await res.json().catch(() => ({}));
+                throw new Error(data.error ?? 'Failed to update document');
+            }
+            return res.json();
+        },
+        onSuccess: () => qc.invalidateQueries({ queryKey: knowledgeBasesKey }),
+    });
+}

--- a/docs/superpowers/plans/2026-07-05-kb-agent-integration.md
+++ b/docs/superpowers/plans/2026-07-05-kb-agent-integration.md
@@ -1,0 +1,717 @@
+# KB ↔ AIOps + Agent Ops Integration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Make Knowledge Bases a first-class, autonomous capability for the AIOps agent and the Agent Ops executor — the agent decides for itself when to consult a KB, retrieval works across multiple KBs, and when the user picks no KB in the console it auto-scopes to the relevant ones.
+
+**Architecture:** A reusable pgvector search primitive (`searchKbChunks`) backs both the existing `/api/knowledge-base/query` route and a new bound LangChain tool `search_knowledge_base`. The agent calls the tool on its own initiative (autonomy). A cloned auto-selection step (`autoSelectKb`, mirroring `auto-skill-select.ts`) resolves relevant KB ids when none are selected. `knowledgeBaseIds` threads UI → `/api/chat` → `GraphConfig` → `assembleTools`, and through the Agent Ops run config + evaluator.
+
+**Tech Stack:** Next.js 15, LangGraph/LangChain, pgvector (Prisma raw SQL), TanStack Query, Zod, Vitest.
+
+## Global Constraints
+
+- **Multi-tenant safety:** every KB read is scoped by `tenantId`; the tool and auto-select derive `tenantId` from `GraphConfig`/session, never trust client-supplied tenant. KB-id inputs are validated against `KnowledgeBaseService.listKnowledgeBases(tenantId)` before use.
+- **Embeddings fixed 1024-dim** via `getEmbedding(text, tenantId)` (`lib/knowledge-base/embedder.ts`) — never a hardcoded Bedrock client.
+- **Manual selection always wins:** auto-KB-selection runs ONLY when the user selected no KB (mirror `selectedSkill || null` at `chat/route.ts:142`).
+- **Never throw from auto-select or the tool:** both degrade gracefully (auto-select returns `[]`, tool returns a "no results / unavailable" string) — an agent turn must not crash because KB retrieval failed.
+- **Feature flags:** `AUTO_KB_SELECTION_ENABLED` (default on) gates auto-selection, mirroring `AUTO_SKILL_SELECTION_ENABLED`.
+- **Reuse, don't duplicate:** the vector SQL lives in exactly one place after Task 1 (`searchKbChunks`); the query route must call it.
+- Indentation: 4 spaces in `lib/`/route files, 2 spaces in components. `@/` alias for cross-dir imports.
+- Tests: Vitest. One file: `cd apps/web-ui && bunx vitest run <path>`.
+
+## Design decisions (locked)
+
+- **Tool-first autonomy** over a deterministic `kb_recall` node: the agent decides when to retrieve (matches "checks if a KB is required"). No new graph node is added; the tool is bound alongside existing tools.
+- **Tool scoping precedence:** an explicit `knowledgeBaseIds` arg on the tool call wins; else the resolved `defaultKbIds` captured in the factory closure (from console selection or auto-select); else tenant-wide search (all chunks). This is the "default to checking relevant KBs" behavior.
+- **Multi-KB** everywhere: `knowledgeBaseIds` is always a `string[]`.
+
+---
+
+### Task 1: Reusable `searchKbChunks` primitive + query-route refactor
+
+**Files:**
+- Create: `apps/web-ui/lib/knowledge-base/retrieval.ts`
+- Modify: `apps/web-ui/app/api/knowledge-base/query/route.ts` (replace inline SQL, lines ~122-149, with a call to the primitive)
+- Test: `apps/web-ui/lib/knowledge-base/retrieval.test.ts`
+
+**Interfaces:**
+- Produces:
+  ```typescript
+  export interface KbChunkHit {
+      vectorKey: string; documentName: string; sourceType: string;
+      chunkIndex: number; totalChunks: number;
+      knowledgeBaseId: string; dataSourceId: string; textContent: string; score: number;
+  }
+  export async function searchKbChunks(params: {
+      tenantId: string; query: string;
+      knowledgeBaseIds?: string[];   // empty/undefined → all tenant chunks
+      limit?: number;                // default 10
+      minScore?: number;             // default 0 (no threshold)
+  }): Promise<KbChunkHit[]>;
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web-ui/lib/knowledge-base/retrieval.test.ts`. Mock `getEmbedding` and `getPrismaClient`; assert the SQL scoping and param shape for three cases (no ids → tenant-only where clause; ids → `ANY($3::text[])` with the array; `minScore` filters rows):
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/knowledge-base/embedder', () => ({ getEmbedding: vi.fn().mockResolvedValue([0.1, 0.2]) }));
+vi.mock('@/lib/db/pg-config', () => ({ getPrismaClient: vi.fn() }));
+
+import { getEmbedding } from '@/lib/knowledge-base/embedder';
+import { getPrismaClient } from '@/lib/db/pg-config';
+import { searchKbChunks } from './retrieval';
+
+const rows = [
+    { vectorKey: 'k1', documentName: 'Doc', sourceType: 'document', chunkIndex: 0, totalChunks: 1, knowledgeBaseId: 'kb1', dataSourceId: 'ds1', textContent: 'hello', score: 0.9 },
+    { vectorKey: 'k2', documentName: 'Doc', sourceType: 'document', chunkIndex: 1, totalChunks: 2, knowledgeBaseId: 'kb1', dataSourceId: 'ds1', textContent: 'low', score: 0.2 },
+];
+
+describe('searchKbChunks', () => {
+    let q: ReturnType<typeof vi.fn>;
+    beforeEach(() => {
+        q = vi.fn().mockResolvedValue(rows);
+        vi.mocked(getPrismaClient).mockReturnValue({ $queryRawUnsafe: q } as any);
+        vi.mocked(getEmbedding).mockClear();
+    });
+
+    it('embeds the query with the tenant id', async () => {
+        await searchKbChunks({ tenantId: 't1', query: 'q' });
+        expect(getEmbedding).toHaveBeenCalledWith('q', 't1');
+    });
+
+    it('tenant-only scope when no kb ids', async () => {
+        await searchKbChunks({ tenantId: 't1', query: 'q' });
+        const sql = q.mock.calls[0][0] as string;
+        expect(sql).not.toContain('ANY(');
+        expect(sql).toContain('"tenantId" = $2');
+        expect(q.mock.calls[0].slice(1)).toEqual(['[0.1,0.2]', 't1']);
+    });
+
+    it('scopes to multiple kb ids via ANY($3::text[])', async () => {
+        await searchKbChunks({ tenantId: 't1', query: 'q', knowledgeBaseIds: ['kb1', 'kb2'] });
+        const sql = q.mock.calls[0][0] as string;
+        expect(sql).toContain('"knowledgeBaseId" = ANY($3::text[])');
+        expect(q.mock.calls[0][3]).toEqual(['kb1', 'kb2']);
+    });
+
+    it('applies minScore filtering in JS', async () => {
+        const hits = await searchKbChunks({ tenantId: 't1', query: 'q', minScore: 0.5 });
+        expect(hits.map((h) => h.vectorKey)).toEqual(['k1']);
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/web-ui && bunx vitest run lib/knowledge-base/retrieval.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `retrieval.ts`**
+
+```typescript
+import { getEmbedding } from './embedder';
+import { getPrismaClient } from '@/lib/db/pg-config';
+
+export interface KbChunkHit {
+    vectorKey: string;
+    documentName: string;
+    sourceType: string;
+    chunkIndex: number;
+    totalChunks: number;
+    knowledgeBaseId: string;
+    dataSourceId: string;
+    textContent: string;
+    score: number;
+}
+
+/**
+ * Semantic search over kb_document_chunks (pgvector cosine). Scoped to the
+ * tenant; optionally narrowed to a set of knowledge bases. When no ids are
+ * given it searches ALL of the tenant's chunks. Never trusts a client tenantId —
+ * callers pass the session/graph-resolved tenantId.
+ */
+export async function searchKbChunks(params: {
+    tenantId: string;
+    query: string;
+    knowledgeBaseIds?: string[];
+    limit?: number;
+    minScore?: number;
+}): Promise<KbChunkHit[]> {
+    const { tenantId, query, knowledgeBaseIds, limit = 10, minScore = 0 } = params;
+    if (!query.trim()) return [];
+
+    const embedding = await getEmbedding(query, tenantId);
+    const vectorLiteral = `[${embedding.join(',')}]`;
+    const prisma = getPrismaClient();
+
+    const cols = `"vectorKey", "documentName", "sourceType", "chunkIndex", "totalChunks",
+                  "knowledgeBaseId", "dataSourceId", "textContent",
+                  1 - (embedding <=> $1::vector) as score`;
+
+    let rows: KbChunkHit[];
+    if (knowledgeBaseIds && knowledgeBaseIds.length > 0) {
+        rows = await prisma.$queryRawUnsafe<KbChunkHit[]>(
+            `SELECT ${cols}
+             FROM kb_document_chunks
+             WHERE "tenantId" = $2 AND "knowledgeBaseId" = ANY($3::text[])
+             ORDER BY embedding <=> $1::vector
+             LIMIT ${Number(limit)}`,
+            vectorLiteral, tenantId, knowledgeBaseIds,
+        );
+    } else {
+        rows = await prisma.$queryRawUnsafe<KbChunkHit[]>(
+            `SELECT ${cols}
+             FROM kb_document_chunks
+             WHERE "tenantId" = $2
+             ORDER BY embedding <=> $1::vector
+             LIMIT ${Number(limit)}`,
+            vectorLiteral, tenantId,
+        );
+    }
+
+    return minScore > 0 ? rows.filter((r) => (typeof r.score === 'number' ? r.score : 0) >= minScore) : rows;
+}
+```
+Note: `limit` is interpolated as `Number(limit)` (not a bound param) to avoid a `$N` placeholder for LIMIT; it is coerced to a number so it is injection-safe. `knowledgeBaseIds` is a bound param (`$3`).
+
+- [ ] **Step 4: Refactor the query route to use it**
+
+In `apps/web-ui/app/api/knowledge-base/query/route.ts`: remove the inline embed+SQL (lines ~117-149, the `getEmbedding`/`vectorLiteral`/`prisma`/two `$queryRawUnsafe` branches) and replace with:
+```typescript
+    const results = await searchKbChunks({
+        tenantId,
+        query,
+        knowledgeBaseIds: knowledgeBaseId ? [knowledgeBaseId] : undefined,
+    });
+```
+Add `import { searchKbChunks } from '@/lib/knowledge-base/retrieval';`. Remove the now-unused `getEmbedding` and `getPrismaClient` imports IF nothing else in the file uses them (check — `getEmbedding` and `getPrismaClient` were only used by the removed block). Keep the `ChunkRow`/`results` downstream usage (context build, sources) working — `KbChunkHit` has the same fields as `ChunkRow`, so replace the `ChunkRow` type usage with `KbChunkHit` or keep `ChunkRow` as an alias.
+
+- [ ] **Step 5: Run tests + typecheck**
+
+Run:
+```bash
+cd apps/web-ui && bunx vitest run lib/knowledge-base/retrieval.test.ts
+bunx tsc --noEmit 2>&1 | grep -E "knowledge-base/(retrieval|query)" || echo "no new errors in touched files"
+```
+Expected: PASS; no new type errors in the two touched files.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web-ui/lib/knowledge-base/retrieval.ts apps/web-ui/lib/knowledge-base/retrieval.test.ts "apps/web-ui/app/api/knowledge-base/query/route.ts"
+git commit -m "feat(kb): extract reusable searchKbChunks primitive (multi-KB) + refactor query route"
+```
+
+---
+
+### Task 2: `search_knowledge_base` tool + GraphConfig/assembleTools wiring
+
+**Files:**
+- Create: `apps/web-ui/lib/agent/kb-tool.ts`
+- Modify: `apps/web-ui/lib/agent/agent-shared.ts` (`GraphConfig`, ~line 494-504)
+- Modify: `apps/web-ui/lib/agent/model-factory.ts` (`AssembleToolsOptions` ~134-148; `assembleTools` customTools ~204-217)
+- Test: `apps/web-ui/lib/agent/kb-tool.test.ts`
+
+**Interfaces:**
+- Consumes: `searchKbChunks` (Task 1); `KnowledgeBaseService.listKnowledgeBases` for validation.
+- Produces:
+  ```typescript
+  export function createSearchKnowledgeBaseTool(tenantId: string, defaultKbIds?: string[]): StructuredTool;
+  ```
+  Tool name `search_knowledge_base`, schema `{ query: string; knowledgeBaseIds?: string[] }`. Returns a formatted string of ranked chunks (document name + text + score + KB id) or a clear "no relevant documents" message. Never throws.
+  - `GraphConfig` gains `knowledgeBaseIds?: string[] | null`.
+  - `AssembleToolsOptions` gains `knowledgeBaseIds?: string[] | null` (tenantId already present); `assembleTools` adds the KB tool when `tenantId` is set.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web-ui/lib/agent/kb-tool.test.ts`:
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/knowledge-base/retrieval', () => ({ searchKbChunks: vi.fn() }));
+
+import { searchKbChunks } from '@/lib/knowledge-base/retrieval';
+import { createSearchKnowledgeBaseTool } from './kb-tool';
+
+describe('createSearchKnowledgeBaseTool', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('searches with the tool-call ids when provided', async () => {
+        vi.mocked(searchKbChunks).mockResolvedValue([
+            { vectorKey: 'k', documentName: 'Runbook', sourceType: 'document', chunkIndex: 0, totalChunks: 1, knowledgeBaseId: 'kb1', dataSourceId: 'ds', textContent: 'restart the service', score: 0.88 },
+        ]);
+        const tool = createSearchKnowledgeBaseTool('t1', ['default-kb']);
+        const out = await tool.invoke({ query: 'how to restart', knowledgeBaseIds: ['kb1'] });
+        expect(searchKbChunks).toHaveBeenCalledWith(expect.objectContaining({ tenantId: 't1', query: 'how to restart', knowledgeBaseIds: ['kb1'] }));
+        expect(out).toContain('Runbook');
+        expect(out).toContain('restart the service');
+    });
+
+    it('falls back to the factory default kb ids when the call omits them', async () => {
+        vi.mocked(searchKbChunks).mockResolvedValue([]);
+        const tool = createSearchKnowledgeBaseTool('t1', ['default-kb']);
+        await tool.invoke({ query: 'q' });
+        expect(searchKbChunks).toHaveBeenCalledWith(expect.objectContaining({ knowledgeBaseIds: ['default-kb'] }));
+    });
+
+    it('returns a no-results message, never throws, when search fails', async () => {
+        vi.mocked(searchKbChunks).mockRejectedValue(new Error('db down'));
+        const tool = createSearchKnowledgeBaseTool('t1');
+        const out = await tool.invoke({ query: 'q' });
+        expect(typeof out).toBe('string');
+        expect(out.toLowerCase()).toContain('no');
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/kb-tool.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `kb-tool.ts`**
+
+```typescript
+import { tool } from '@langchain/core/tools';
+import { z } from 'zod';
+import { searchKbChunks } from '@/lib/knowledge-base/retrieval';
+
+/**
+ * Autonomous knowledge-base retrieval tool. The agent decides when to call it.
+ * Scoping precedence: explicit knowledgeBaseIds arg → factory defaultKbIds →
+ * tenant-wide (all KBs). tenantId is captured in the closure, never client-supplied.
+ * Never throws — a retrieval failure returns a plain "no results" string so the
+ * agent turn continues.
+ */
+export function createSearchKnowledgeBaseTool(tenantId: string, defaultKbIds?: string[]) {
+    return tool(
+        async ({ query, knowledgeBaseIds }: { query: string; knowledgeBaseIds?: string[] }) => {
+            try {
+                const ids = knowledgeBaseIds && knowledgeBaseIds.length > 0
+                    ? knowledgeBaseIds
+                    : (defaultKbIds && defaultKbIds.length > 0 ? defaultKbIds : undefined);
+                const hits = await searchKbChunks({ tenantId, query, knowledgeBaseIds: ids, limit: 8 });
+                if (hits.length === 0) {
+                    return 'No relevant documents found in the knowledge base for that query.';
+                }
+                return hits
+                    .map((h, i) => `[${i + 1}] ${h.documentName} (kb:${h.knowledgeBaseId}, score:${h.score.toFixed(2)})\n${h.textContent}`)
+                    .join('\n\n');
+            } catch (err) {
+                console.warn(`[search_knowledge_base] failed (non-fatal): ${err instanceof Error ? err.message : err}`);
+                return 'No relevant documents found (knowledge base search is temporarily unavailable).';
+            }
+        },
+        {
+            name: 'search_knowledge_base',
+            description:
+                'Search the organization\'s knowledge bases (uploaded docs, wikis, runbooks, synced repos) for information relevant to the user request. Call this whenever the question may be answered by internal/organizational documentation rather than live AWS state or general knowledge. Optionally pass knowledgeBaseIds to restrict the search; omit to search all available knowledge bases.',
+            schema: z.object({
+                query: z.string().describe('A focused natural-language search query describing what information you need.'),
+                knowledgeBaseIds: z.array(z.string()).optional().describe('Optional list of knowledge base ids to restrict the search to. Omit to search across all of the tenant\'s knowledge bases.'),
+            }),
+        },
+    );
+}
+```
+
+- [ ] **Step 4: Add `knowledgeBaseIds` to `GraphConfig`**
+
+In `apps/web-ui/lib/agent/agent-shared.ts`, in the `GraphConfig` interface (~line 494), add:
+```typescript
+    knowledgeBaseIds?: string[] | null;
+```
+
+- [ ] **Step 5: Wire into `assembleTools`**
+
+In `apps/web-ui/lib/agent/model-factory.ts`:
+- Add to `AssembleToolsOptions` (~134-148): `knowledgeBaseIds?: string[] | null;` (it already has `tenantId`).
+- Import: `import { createSearchKnowledgeBaseTool } from './kb-tool';`
+- In `assembleTools`, in the `customTools` assembly (~204-217), after the memory tools are added and when `options.tenantId` is present, push the KB tool:
+```typescript
+        if (options.tenantId) {
+            customTools.push(
+                createSearchKnowledgeBaseTool(options.tenantId, options.knowledgeBaseIds ?? undefined),
+            );
+        }
+```
+(Place it consistent with how `createMemoryTools(tenantId, userId)` is conditionally added — match that guard style. If memory tools are already guarded by `if (options.tenantId)`, add the KB tool inside the same block.)
+
+- [ ] **Step 6: Run test + typecheck**
+
+Run:
+```bash
+cd apps/web-ui && bunx vitest run lib/agent/kb-tool.test.ts
+bunx tsc --noEmit 2>&1 | grep -E "agent/(kb-tool|model-factory|agent-shared)" || echo "no new errors in touched files"
+```
+Expected: PASS; no new type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web-ui/lib/agent/kb-tool.ts apps/web-ui/lib/agent/kb-tool.test.ts apps/web-ui/lib/agent/agent-shared.ts apps/web-ui/lib/agent/model-factory.ts
+git commit -m "feat(agent): autonomous search_knowledge_base tool + assembleTools/GraphConfig wiring"
+```
+
+---
+
+### Task 3: `autoSelectKb` (auto-KB-selection, clone of auto-skill-select)
+
+**Files:**
+- Create: `apps/web-ui/lib/agent/auto-kb-select.ts`
+- Test: `apps/web-ui/lib/agent/auto-kb-select.test.ts`
+
+**Interfaces:**
+- Consumes: `KnowledgeBaseService.listKnowledgeBases(tenantId)`; `createAgentModels(model).reflector`; `ResolvedModelConfig`.
+- Produces:
+  ```typescript
+  export function autoKbSelectionEnabled(): boolean; // AUTO_KB_SELECTION_ENABLED, default on
+  export async function autoSelectKb(params: {
+      tenantId: string; message: string; model: ResolvedModelConfig;
+  }): Promise<{ kbIds: string[]; reasoning: string }>;  // [] when none relevant; never throws
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web-ui/lib/agent/auto-kb-select.test.ts`:
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/knowledge-base/service', () => ({
+    KnowledgeBaseService: { listKnowledgeBases: vi.fn() },
+}));
+vi.mock('./model-factory', () => ({ createAgentModels: vi.fn() }));
+
+import { KnowledgeBaseService } from '@/lib/knowledge-base/service';
+import { createAgentModels } from './model-factory';
+import { autoSelectKb } from './auto-kb-select';
+
+const model = { provider: 'x', modelId: 'm' } as any;
+function mockReflector(content: string) {
+    vi.mocked(createAgentModels).mockReturnValue({ reflector: { invoke: vi.fn().mockResolvedValue({ content }) } } as any);
+}
+
+describe('autoSelectKb', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(KnowledgeBaseService.listKnowledgeBases).mockResolvedValue([
+            { id: 'kb-runbooks', name: 'Runbooks', description: 'ops runbooks' },
+            { id: 'kb-hr', name: 'HR', description: 'people policies' },
+        ] as any);
+    });
+
+    it('returns the KB ids the reflector selected (validated against the catalog)', async () => {
+        mockReflector('{"kbIds":["kb-runbooks"],"reasoning":"ops question"}');
+        const r = await autoSelectKb({ tenantId: 't1', message: 'how do I restart the pipeline', model });
+        expect(r.kbIds).toEqual(['kb-runbooks']);
+    });
+
+    it('drops hallucinated ids not in the catalog', async () => {
+        mockReflector('{"kbIds":["kb-runbooks","kb-ghost"],"reasoning":"x"}');
+        const r = await autoSelectKb({ tenantId: 't1', message: 'q', model });
+        expect(r.kbIds).toEqual(['kb-runbooks']);
+    });
+
+    it('returns [] when the reflector picks none', async () => {
+        mockReflector('{"kbIds":[],"reasoning":"general question"}');
+        const r = await autoSelectKb({ tenantId: 't1', message: 'what is 2+2', model });
+        expect(r.kbIds).toEqual([]);
+    });
+
+    it('returns [] (never throws) when there are no KBs', async () => {
+        vi.mocked(KnowledgeBaseService.listKnowledgeBases).mockResolvedValue([]);
+        const r = await autoSelectKb({ tenantId: 't1', message: 'q', model });
+        expect(r.kbIds).toEqual([]);
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/auto-kb-select.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `auto-kb-select.ts`**
+
+```typescript
+/**
+ * auto-kb-select.ts — progressive disclosure for knowledge bases, mirroring
+ * auto-skill-select.ts. When the user picked no KB, one cheap reflector call
+ * matches the message against the tenant's KB catalog and returns the relevant
+ * KB ids (zero, one, or many). Manual selection always wins; never throws.
+ */
+
+import { SystemMessage, HumanMessage } from '@langchain/core/messages';
+import type { ResolvedModelConfig } from './agent-shared';
+import { createAgentModels } from './model-factory';
+import { KnowledgeBaseService } from '@/lib/knowledge-base/service';
+
+export function autoKbSelectionEnabled(): boolean {
+    const v = process.env.AUTO_KB_SELECTION_ENABLED?.toLowerCase();
+    return !(v === 'false' || v === '0');
+}
+
+export async function autoSelectKb(params: {
+    tenantId: string;
+    message: string;
+    model: ResolvedModelConfig;
+}): Promise<{ kbIds: string[]; reasoning: string }> {
+    const empty = { kbIds: [] as string[], reasoning: '' };
+    if (!autoKbSelectionEnabled()) return empty;
+    try {
+        const kbs = await KnowledgeBaseService.listKnowledgeBases(params.tenantId);
+        const active = kbs.filter((k) => (k.vectorCount ?? 0) > 0);
+        if (active.length === 0) return empty;
+
+        const catalog = active.map((k) => `- ${k.id}: ${k.name}${k.description ? ` — ${k.description}` : ''}`).join('\n');
+        const validIds = new Set(active.map((k) => k.id));
+
+        const { reflector } = createAgentModels(params.model);
+        const sys = new SystemMessage(
+            `You select which knowledge bases (if any) are relevant to a user request.\n\n` +
+            `Available knowledge bases:\n${catalog}\n\n` +
+            `Return ONLY a JSON object: {"kbIds": ["<id>", ...], "reasoning": "<one short line>"}\n` +
+            `Rules: include a KB id ONLY when its description clearly matches the request. Pick multiple if several are relevant. Return an empty array when none clearly apply.`,
+        );
+        const resp = await reflector.invoke([sys, new HumanMessage(params.message.slice(0, 4000))]);
+        const content = typeof resp.content === 'string' ? resp.content : JSON.stringify(resp.content);
+        const match = content.match(/\{[\s\S]*\}/);
+        if (!match) return empty;
+        const parsed = JSON.parse(match[0]) as { kbIds?: unknown; reasoning?: string };
+        const ids = Array.isArray(parsed.kbIds)
+            ? parsed.kbIds.filter((id): id is string => typeof id === 'string' && validIds.has(id))
+            : [];
+        if (ids.length > 0) {
+            console.log(`🎯 [KB AUTO-SELECT] Matched [${ids.join(', ')}] — ${parsed.reasoning ?? '(no reasoning)'}`);
+        }
+        return { kbIds: ids, reasoning: parsed.reasoning ?? '' };
+    } catch (err: any) {
+        console.warn(`🎯 [KB AUTO-SELECT] Failed (non-fatal): ${err?.message ?? err}`);
+        return empty;
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/auto-kb-select.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web-ui/lib/agent/auto-kb-select.ts apps/web-ui/lib/agent/auto-kb-select.test.ts
+git commit -m "feat(agent): auto-KB-selection (reflector-based, multi-KB) mirroring auto-skill-select"
+```
+
+---
+
+### Task 4: AIOps chat route — resolve KBs + thread into graphs
+
+**Files:**
+- Modify: `apps/web-ui/app/api/chat/route.ts` (destructure `knowledgeBaseIds`; run `autoSelectKb` when none; thread into `graphConfig`)
+- Modify: `apps/web-ui/lib/agent/fast-agent.ts` (pass `knowledgeBaseIds` to `assembleTools`)
+- Modify: `apps/web-ui/lib/agent/planning-agent.ts` (pass `knowledgeBaseIds` to `assembleTools`)
+- Test: `apps/web-ui/app/api/chat/chat-kb.test.ts` (focused: KB resolution threading)
+
+**Interfaces:**
+- Consumes: `autoSelectKb`, `GraphConfig.knowledgeBaseIds`, `assembleTools({ knowledgeBaseIds })`.
+- Produces: `graphConfig.knowledgeBaseIds` = the console-selected ids, or (when empty) the auto-selected ids; both graph builders pass it to `assembleTools`.
+
+- [ ] **Step 1: Read the current chat route** to locate the body destructure (~40-52), the model resolution + `autoSelectSkill` block (~142-150), and the `graphConfig` build (~153-163). Mirror the skill pattern exactly.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `apps/web-ui/app/api/chat/chat-kb.test.ts`. Because the full chat route is heavy to drive, this test targets the resolution helper — so FIRST extract the resolution into a tiny exported pure-ish function in the route module OR test via a thin helper. Given the route's weight, extract a helper `resolveKnowledgeBaseIds` into `apps/web-ui/lib/agent/auto-kb-select.ts` (co-located) and test THAT:
+
+Add to `auto-kb-select.ts`:
+```typescript
+/** Manual selection wins; otherwise auto-select. Returns the effective KB ids. */
+export async function resolveKnowledgeBaseIds(params: {
+    tenantId: string; selectedIds?: string[] | null; message: string; model: ResolvedModelConfig;
+}): Promise<string[]> {
+    if (params.selectedIds && params.selectedIds.length > 0) return params.selectedIds;
+    const { kbIds } = await autoSelectKb({ tenantId: params.tenantId, message: params.message, model: params.model });
+    return kbIds;
+}
+```
+Test (append to `auto-kb-select.test.ts`):
+```typescript
+import { resolveKnowledgeBaseIds } from './auto-kb-select';
+describe('resolveKnowledgeBaseIds', () => {
+    beforeEach(() => { vi.clearAllMocks(); vi.mocked(KnowledgeBaseService.listKnowledgeBases).mockResolvedValue([{ id: 'kb-runbooks', name: 'R', description: 'ops', vectorCount: 5 }] as any); });
+    it('returns the manual selection without calling the reflector', async () => {
+        const spy = vi.mocked(createAgentModels);
+        const ids = await resolveKnowledgeBaseIds({ tenantId: 't1', selectedIds: ['kb-x'], message: 'q', model });
+        expect(ids).toEqual(['kb-x']);
+        expect(spy).not.toHaveBeenCalled();
+    });
+    it('auto-selects when no manual selection', async () => {
+        mockReflector('{"kbIds":["kb-runbooks"],"reasoning":"x"}');
+        const ids = await resolveKnowledgeBaseIds({ tenantId: 't1', selectedIds: null, message: 'restart pipeline', model });
+        expect(ids).toEqual(['kb-runbooks']);
+    });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/auto-kb-select.test.ts`
+Expected: FAIL — `resolveKnowledgeBaseIds` not exported.
+
+- [ ] **Step 4: Implement `resolveKnowledgeBaseIds`** (as above in `auto-kb-select.ts`). Run the test → PASS.
+
+- [ ] **Step 5: Wire the chat route**
+
+In `apps/web-ui/app/api/chat/route.ts`:
+- Add `knowledgeBaseIds` to the body destructure (near `selectedSkill`, `mcpServerIds`): `knowledgeBaseIds?: string[]`.
+- Import `resolveKnowledgeBaseIds` from `@/lib/agent/auto-kb-select`.
+- After model resolution and near the `autoSelectSkill` block (~142-150), add (guard `mode !== 'deep'` to match skill handling):
+```typescript
+    let effectiveKbIds: string[] = Array.isArray(knowledgeBaseIds) ? knowledgeBaseIds : [];
+    if (effectiveKbIds.length === 0 && mode !== 'deep') {
+        const lastMsg = messages[messages.length - 1];
+        const lastUserText = typeof lastMsg?.content === 'string' ? lastMsg.content : JSON.stringify(lastMsg?.content ?? '');
+        effectiveKbIds = await resolveKnowledgeBaseIds({ tenantId: resolvedTenantId, selectedIds: null, message: lastUserText, model: resolvedModel });
+    }
+```
+- In the `graphConfig` object (~153-163) add: `knowledgeBaseIds: effectiveKbIds,`.
+
+- [ ] **Step 6: Pass `knowledgeBaseIds` to `assembleTools` in both graph builders**
+
+In `apps/web-ui/lib/agent/fast-agent.ts` at the `assembleTools({...})` call (~line 68) add `knowledgeBaseIds: config.knowledgeBaseIds,` to the options object. Do the same in `apps/web-ui/lib/agent/planning-agent.ts` at its `assembleTools` call. (Both builders receive the `GraphConfig` — reference the same field name used for `tenantId`.)
+
+- [ ] **Step 7: Typecheck**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit 2>&1 | grep -E "api/chat/route|agent/(fast-agent|planning-agent|auto-kb-select)" || echo "no new errors in touched files"`
+Expected: no new errors. Run `bunx vitest run lib/agent/auto-kb-select.test.ts` → all PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add "apps/web-ui/app/api/chat/route.ts" apps/web-ui/lib/agent/fast-agent.ts apps/web-ui/lib/agent/planning-agent.ts apps/web-ui/lib/agent/auto-kb-select.ts apps/web-ui/lib/agent/auto-kb-select.test.ts
+git commit -m "feat(agent): resolve + thread knowledgeBaseIds through AIOps chat into the tool"
+```
+
+---
+
+### Task 5: Agent Ops executor — KB config plumbing + evaluator selection
+
+**Files:**
+- Modify: `apps/web-ui/lib/agent-ops/executor-graphs.ts` (pass `knowledgeBaseIds` to `assembleTools` ~74; extend `evaluatorNode` `RequestEvaluation` + prompt ~123-193; add a `kbSection` in `getDynamicContext` ~95-118 — optional)
+- Modify: `apps/web-ui/lib/agent-ops/agent-ops-service.ts` (`createRun` params + `AgentOpsRun` type: add `knowledgeBaseIds?: string[]`)
+- Modify: `apps/web-ui/lib/agent-ops/agent-executor.ts` (thread `knowledgeBaseIds` into `graphConfig` in `executeAgentRun` ~101-110 and `resumeApprovedRun` ~528-537)
+- Test: `apps/web-ui/lib/agent-ops/executor-kb.test.ts` (evaluator schema includes kbIds OR graphConfig threading)
+
+**Interfaces:**
+- Consumes: `GraphConfig.knowledgeBaseIds` (Task 2), `assembleTools({ knowledgeBaseIds })`, `autoSelectKb`/catalog for the evaluator.
+- Produces: an Agent Ops run carries `knowledgeBaseIds` end-to-end; the executor binds the KB tool; the evaluator can select KB ids from the catalog when the run specifies none.
+
+- [ ] **Step 1: Read the current files** to confirm exact shapes: `AgentOpsRun` type + `createRun` param bag (`agent-ops-service.ts:28-40`), `executeAgentRun` graphConfig (`agent-executor.ts:101-110`), `resumeApprovedRun` (`:528-537`), and the `evaluatorNode` JSON schema + prompt + `getDynamicContext` (`executor-graphs.ts`).
+
+- [ ] **Step 2: Write the failing test**
+
+Create `apps/web-ui/lib/agent-ops/executor-kb.test.ts`. The reliable, low-setup assertion is that `assembleTools` receives `knowledgeBaseIds` from the graph config. Mock `assembleTools` and assert the executor graph builder forwards `config.knowledgeBaseIds`:
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+vi.mock('@/lib/agent/model-factory', async (orig) => {
+    const actual = await (orig as any)();
+    return { ...actual, assembleTools: vi.fn().mockResolvedValue([]) };
+});
+import { assembleTools } from '@/lib/agent/model-factory';
+import { createDynamicExecutorGraph } from './executor-graphs';
+
+describe('Agent Ops executor — KB tool wiring', () => {
+    beforeEach(() => vi.clearAllMocks());
+    it('forwards knowledgeBaseIds from config to assembleTools', async () => {
+        await createDynamicExecutorGraph({ model: { provider: 'x', modelId: 'm' }, tenantId: 't1', knowledgeBaseIds: ['kb1'] } as any);
+        expect(assembleTools).toHaveBeenCalledWith(expect.objectContaining({ knowledgeBaseIds: ['kb1'], tenantId: 't1' }));
+    });
+});
+```
+(If `createDynamicExecutorGraph` needs more of the config to not throw before `assembleTools`, add the minimal fields the read in Step 1 reveals are required.)
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent-ops/executor-kb.test.ts`
+Expected: FAIL — `assembleTools` called without `knowledgeBaseIds`.
+
+- [ ] **Step 4: Implement the plumbing**
+- `executor-graphs.ts`: at the `assembleTools(...)` call (~74) add `knowledgeBaseIds: config.knowledgeBaseIds,`.
+- `agent-ops-service.ts`: add `knowledgeBaseIds?: string[]` to the `AgentOpsRun` type and the `createRun` param bag; persist/pass it through (match how `selectedSkill`/`mcpServerIds` are handled — if those are stored on the run record, store this the same way; if the schema has no column, thread it in-memory only like other transient config — follow the existing pattern for `mcpServerIds`).
+- `agent-executor.ts`: in `executeAgentRun`'s `graphConfig` (~101-110) and `resumeApprovedRun` (~528-537) add `knowledgeBaseIds: run.knowledgeBaseIds,`.
+
+- [ ] **Step 5: Evaluator KB selection (autonomy on the Agent Ops side)**
+In `executor-graphs.ts` `evaluatorNode` (~123-193): add `knowledgeBaseIds: string[]` to the `RequestEvaluation` structured output, list the tenant KB catalog in the evaluator prompt (mirror how skills are listed ~133-134 — build the catalog from `KnowledgeBaseService.listKnowledgeBases(config.tenantId)` filtered to `vectorCount > 0`), and when the run supplied no `knowledgeBaseIds`, apply the evaluator's choice by setting it into the config/state used for tool assembly. If wiring the evaluator result back into the already-built tool binding is non-trivial (tools are bound at graph construction), scope this step to: (a) still bind the KB tool (so the agent can call it tenant-wide regardless), and (b) inject the evaluator-selected KB ids into the prompt context (`getDynamicContext` `kbSection`) so the agent passes them to the tool. Document whichever path you take in the report.
+
+- [ ] **Step 6: Run test + typecheck**
+
+Run:
+```bash
+cd apps/web-ui && bunx vitest run lib/agent-ops/executor-kb.test.ts
+bunx tsc --noEmit 2>&1 | grep -E "agent-ops/(executor-graphs|agent-ops-service|agent-executor)" || echo "no new errors in touched files"
+```
+Expected: PASS; no new type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web-ui/lib/agent-ops
+git commit -m "feat(agent-ops): thread knowledgeBaseIds through runs + bind KB tool + evaluator KB selection"
+```
+
+---
+
+### Task 6: AIOps console — KB multi-select UI
+
+**Files:**
+- Modify: `apps/web-ui/components/agent/chat-interface.tsx` (add KB multi-select state + UI; add `knowledgeBaseIds` to the `useChat` body ~617-632)
+- Reuse: `useKnowledgeBases()` from `apps/web-ui/lib/queries/knowledge-base.ts` (already exists) to populate the selector
+
+**Interfaces:**
+- Consumes: `useKnowledgeBases()` (returns `KnowledgeBase[]`), the chat body channel.
+- Produces: `knowledgeBaseIds: string[]` sent in the `useChat` body (empty array/omit → server auto-selects).
+
+- [ ] **Step 1: Read** the skill selector UI (`chat-interface.tsx` ~1644-1689) and the `useChat` body object (~617-632) and the `selectedSkill` state (~504) to mirror the pattern.
+
+- [ ] **Step 2: Add KB selection state + fetch**
+```tsx
+const [selectedKbIds, setSelectedKbIds] = useState<string[]>([]);
+const { data: knowledgeBases = [] } = useKnowledgeBases();
+```
+Import `useKnowledgeBases` from `@/lib/queries/knowledge-base`.
+
+- [ ] **Step 3: Add to the `useChat` body**
+In the body object (~617-632), add: `knowledgeBaseIds: selectedKbIds.length > 0 ? selectedKbIds : undefined,`.
+
+- [ ] **Step 4: Add the selector UI**
+Next to the skill `<Select>` (~1644-1689), add a KB multi-select. Simplest consistent approach: a popover/dropdown of checkboxes built from `knowledgeBases` (each `{ id, name }`), toggling membership in `selectedKbIds`. Reuse existing shadcn primitives (`Popover` + `Checkbox`, or a `DropdownMenu` with checkbox items — whichever the codebase already uses elsewhere; match `chat-interface.tsx`'s existing controls). Show a label like "Knowledge: All (auto)" when `selectedKbIds` is empty, else "Knowledge: N selected". Keep it visually consistent with the skill selector.
+
+- [ ] **Step 5: Verify build + lint**
+
+Run:
+```bash
+cd apps/web-ui && bunx tsc --noEmit 2>&1 | grep -E "components/agent/chat-interface" || echo "no new errors in chat-interface"
+bun run lint 2>&1 | grep -E "chat-interface" || echo "no new lint findings in chat-interface"
+```
+Expected: no NEW errors/findings attributable to the change (the file may have pre-existing ones; report only new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web-ui/components/agent/chat-interface.tsx
+git commit -m "feat(agent-ui): KB multi-select in AIOps console (empty = auto-select)"
+```
+
+---
+
+## Plan self-review
+
+- **Goal coverage:** autonomous KB use = the bound tool (Task 2) the agent calls at will; multi-KB = `knowledgeBaseIds: string[]` in the primitive/tool/config (Tasks 1,2); "no KB selected → check relevant KBs" = `autoSelectKb` + tool tenant-wide fallback (Tasks 3,4); AIOps console = UI selector + chat threading (Tasks 4,6); Agent Ops = executor plumbing + evaluator selection (Task 5). ✓
+- **DRY:** the vector SQL exists only in `searchKbChunks` after Task 1; the query route and the tool both call it. ✓
+- **Type consistency:** `knowledgeBaseIds?: string[] | null` on `GraphConfig` + `AssembleToolsOptions`; `searchKbChunks({ knowledgeBaseIds?: string[] })`; tool schema `knowledgeBaseIds?: string[]`; `autoSelectKb` returns `{ kbIds: string[] }`; `resolveKnowledgeBaseIds` returns `string[]`. Consistent. ✓
+- **Safety:** tenantId always from server/graph, never client; auto-select + tool never throw; KB ids validated against the tenant catalog in auto-select. ✓
+- **Deferred/uncertain:** Task 5 Step 5 (feeding evaluator-chosen KB ids back into an already-bound tool) has a documented fallback (bind tenant-wide + inject ids into prompt context) since tools bind at graph-construction time — the implementer picks and reports the path.

--- a/docs/superpowers/plans/2026-07-05-kb-inline-documents.md
+++ b/docs/superpowers/plans/2026-07-05-kb-inline-documents.md
@@ -1,0 +1,1064 @@
+# KB Inline Documents Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users author markdown documents in a Knowledge Base, edit them inline, and add more over time — feeding the same embedding/RAG pipeline as uploads.
+
+**Architecture:** A document is a `DataSource` with `sourceType: 'document'` whose markdown is stored in a new `data_sources.content` column. On save the route chunks + embeds the content synchronously via the existing web-ui `embedder.ts` (provider-configured, 1024-dim) into `kb_document_chunks`; on edit it deletes the old vectors and re-embeds. Retrieval is unchanged — document chunks are searched like any other source.
+
+**Tech Stack:** Next.js 15 App Router, Prisma (Postgres + pgvector), TanStack Query, React Hook Form + Zod 4, sonner, react-markdown, Vitest.
+
+## Global Constraints
+
+- **Multi-tenant safety:** every route resolves `getSessionTenantId()` and checks KB ownership via `KnowledgeBaseService.getKnowledgeBase(kbId, tenantId)` → 403 on miss; all DB access is tenant-scoped through the repository/service layer. Never call Prisma directly from routes.
+- **Embeddings are fixed 1024-dim** — always use `embedder.ts` (`getTenantEmbeddings` provider factory), never a hardcoded Bedrock client. The `kb_document_chunks.embedding` column is `vector(1024)`.
+- **New UI uses:** TanStack Query hooks (`lib/queries/`), `toast` from `"sonner"`, React Hook Form + `@hookform/resolvers/zod` with a Zod v4 schema. No manual `useState` forms.
+- **Audit:** create/update call `AuditService.logUserAction(...).catch(() => {})`, mirroring the existing KB routes.
+- **RBAC:** KB CRUD routes use session + tenant-ownership only (not `authorize()`), consistent with the existing module. Do **not** add `authorize()` here.
+- **Indentation:** 4 spaces in `lib/`/route files, 2 spaces in `components/`.
+- **Imports:** use the `@/` alias for cross-directory imports.
+- **Document size cap:** `MAX_DOCUMENT_CHARS = 200_000`.
+- **Tests:** Vitest. Run one file with `cd apps/web-ui && bunx vitest run <path>`; full suite `cd apps/web-ui && bun run test`.
+
+## Architecture note — content is write-through, not in the read DTO
+
+`content` lives on the `data_sources` table and is an allowed **update** field, but `rowToDS()` deliberately does **not** map it into the `DataSource` DTO. This keeps the list/detail payloads lean and removes any risk of leaking full document bodies through the two endpoints that list sources (`GET /api/knowledge-base/[kbId]` and `GET .../sources`). The editor reads a document's body through a dedicated `GET /api/knowledge-base/[kbId]/documents/[dsId]` endpoint instead. (This refines the spec's "include content in sources GET + strip from list" bullet into a dedicated content endpoint — same design, safer surface.)
+
+---
+
+### Task 1: Schema, migration, types, and repository `content` support
+
+**Files:**
+- Modify: `libs/prisma/schema.prisma` (DataSource model, ~line 284)
+- Create: `libs/prisma/migrations/20260705120000_add_data_source_content/migration.sql`
+- Modify: `apps/web-ui/lib/knowledge-base/types.ts`
+- Modify: `apps/web-ui/lib/db/repositories/data-source/postgres.ts`
+- Modify: `apps/web-ui/lib/db/repositories/data-source/interface.ts`
+- Test: `apps/web-ui/lib/db/repositories/data-source/postgres.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `DataSourceType` now includes `'document'`.
+  - `DocumentConfig = { format: 'markdown'; chunkCount: number }` (added to the `DataSourceConfig` union).
+  - `DataSource.content?: string` (write-through; never populated by `rowToDS`).
+  - `IDataSourceRepository.getDataSourceContent(kbId: string, dsId: string, tenantId: string): Promise<string | null>`.
+  - `DataSourcePostgresRepository.updateDataSource` now whitelists `content`.
+
+- [ ] **Step 1: Write the failing repo tests**
+
+Add to `apps/web-ui/lib/db/repositories/data-source/postgres.test.ts` inside the first `describe('DataSourcePostgresRepository', ...)` block:
+
+```typescript
+    describe('updateDataSource — content', () => {
+        it('writes content when provided', async () => {
+            mockPrisma.dataSource.updateMany.mockResolvedValue({ count: 1 });
+
+            const repo = new DataSourcePostgresRepository();
+            await repo.updateDataSource('kb-1', 'ds-1', { content: '# Hello', status: 'synced' }, 'tenant-1');
+
+            const callArg = mockPrisma.dataSource.updateMany.mock.calls[0][0];
+            expect(callArg.data.content).toBe('# Hello');
+            expect(callArg.data.status).toBe('synced');
+        });
+    });
+
+    describe('getDataSourceContent', () => {
+        it('returns content string, scoped by tenant/kb/ds', async () => {
+            mockPrisma.dataSource.findFirst.mockResolvedValue({ content: '# Doc body' });
+
+            const repo = new DataSourcePostgresRepository();
+            const result = await repo.getDataSourceContent('kb-1', 'ds-1', 'tenant-1');
+
+            expect(result).toBe('# Doc body');
+            expect(mockPrisma.dataSource.findFirst).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: expect.objectContaining({ id: 'ds-1', knowledgeBaseId: 'kb-1', tenantId: 'tenant-1' }),
+                    select: { content: true },
+                })
+            );
+        });
+
+        it('returns null when row not found', async () => {
+            mockPrisma.dataSource.findFirst.mockResolvedValue(null);
+            const repo = new DataSourcePostgresRepository();
+            expect(await repo.getDataSourceContent('kb-1', 'missing', 'tenant-1')).toBeNull();
+        });
+    });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd apps/web-ui && bunx vitest run lib/db/repositories/data-source/postgres.test.ts`
+Expected: FAIL — `getDataSourceContent is not a function`; content assertion fails.
+
+- [ ] **Step 3: Update the Prisma schema**
+
+In `libs/prisma/schema.prisma`, in `model DataSource` (after the `config` line, ~line 291) add:
+
+```prisma
+  content         String?   @db.Text  // markdown body for sourceType='document'; null otherwise
+```
+
+- [ ] **Step 4: Write the migration SQL**
+
+Create `libs/prisma/migrations/20260705120000_add_data_source_content/migration.sql`:
+
+```sql
+-- Add editable document body column
+ALTER TABLE "data_sources" ADD COLUMN "content" TEXT;
+
+-- Allow the new 'document' source type
+ALTER TABLE "data_sources" DROP CONSTRAINT "data_sources_source_type_check";
+ALTER TABLE "data_sources" ADD CONSTRAINT "data_sources_source_type_check"
+    CHECK ("sourceType" IN ('file-upload', 's3-bucket', 'confluence', 'bitbucket', 'document'));
+```
+
+- [ ] **Step 5: Update the TypeScript types**
+
+In `apps/web-ui/lib/knowledge-base/types.ts`:
+
+Change the union (line 15):
+```typescript
+export type DataSourceType = 'file-upload' | 's3-bucket' | 'confluence' | 'bitbucket' | 'document';
+```
+
+Add `content` to the `DataSource` interface (after `vectorKeys: string[];`):
+```typescript
+  /** Markdown body for sourceType='document'. Write-through: never returned by list/detail DTOs — read via the documents content endpoint. */
+  content?: string;
+```
+
+Add a config variant (after `BitbucketConfig`, before the `DataSourceConfig` union):
+```typescript
+export interface DocumentConfig {
+  format: 'markdown';
+  chunkCount: number;
+}
+```
+
+Extend the union:
+```typescript
+export type DataSourceConfig =
+  | FileUploadConfig
+  | S3BucketConfig
+  | ConfluenceConfig
+  | BitbucketConfig
+  | DocumentConfig;
+```
+
+- [ ] **Step 6: Update the repository interface**
+
+In `apps/web-ui/lib/db/repositories/data-source/interface.ts`, add to `IDataSourceRepository`:
+
+```typescript
+    getDataSourceContent(kbId: string, dsId: string, tenantId: string): Promise<string | null>;
+```
+
+- [ ] **Step 7: Update the repository implementation**
+
+In `apps/web-ui/lib/db/repositories/data-source/postgres.ts`:
+
+Add `content` to the `allowedFields` array in `updateDataSource` (after `'config',`):
+```typescript
+                'content',
+```
+
+Add the new method after `getDataSource`:
+```typescript
+    async getDataSourceContent(kbId: string, dsId: string, tenantId: string): Promise<string | null> {
+        try {
+            const row = await getTenantClient(tenantId).dataSource.findFirst({
+                where: { id: dsId, knowledgeBaseId: kbId, tenantId },
+                select: { content: true },
+            });
+            return row?.content ?? null;
+        } catch (error: unknown) {
+            console.error('[DataSourcePostgresRepository] Error getting data source content:', error);
+            throw new Error(`Failed to get data source content: ${error instanceof Error ? error.message : String(error)}`);
+        }
+    }
+```
+
+Note: leave `rowToDS` unchanged — `content` is intentionally not mapped into the DTO. (Add `content: string | null` to `rowToDS`'s row param type only if the TS build complains about the Prisma row shape; do not add it to the return object.)
+
+- [ ] **Step 8: Regenerate the Prisma client and run the tests**
+
+Run:
+```bash
+cd apps/web-ui && bun run db:generate
+bunx vitest run lib/db/repositories/data-source/postgres.test.ts
+```
+Expected: PASS (all tests, including the two new suites).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add libs/prisma/schema.prisma libs/prisma/migrations/20260705120000_add_data_source_content apps/web-ui/lib/knowledge-base/types.ts apps/web-ui/lib/db/repositories/data-source
+git commit -m "feat(kb): add data_sources.content column + document source type"
+```
+
+---
+
+### Task 2: Document validation helper
+
+**Files:**
+- Create: `apps/web-ui/lib/knowledge-base/document-validation.ts`
+- Test: `apps/web-ui/lib/knowledge-base/document-validation.test.ts`
+
+**Interfaces:**
+- Produces: `validateDocumentInput(input: { name?: string; content?: string }): { ok: true; name: string; content: string } | { ok: false; error: string }` and `export const MAX_DOCUMENT_CHARS = 200_000;`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web-ui/lib/knowledge-base/document-validation.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { validateDocumentInput, MAX_DOCUMENT_CHARS } from './document-validation';
+
+describe('validateDocumentInput', () => {
+    it('accepts a valid document and trims the name', () => {
+        const r = validateDocumentInput({ name: '  Runbook  ', content: '# Steps' });
+        expect(r).toEqual({ ok: true, name: 'Runbook', content: '# Steps' });
+    });
+
+    it('rejects an empty name', () => {
+        const r = validateDocumentInput({ name: '   ', content: 'body' });
+        expect(r).toEqual({ ok: false, error: 'name is required' });
+    });
+
+    it('rejects empty content', () => {
+        const r = validateDocumentInput({ name: 'Doc', content: '   ' });
+        expect(r).toEqual({ ok: false, error: 'content is required' });
+    });
+
+    it('rejects content over the size cap', () => {
+        const r = validateDocumentInput({ name: 'Doc', content: 'a'.repeat(MAX_DOCUMENT_CHARS + 1) });
+        expect(r.ok).toBe(false);
+        expect((r as { error: string }).error).toContain('too large');
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/web-ui && bunx vitest run lib/knowledge-base/document-validation.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `apps/web-ui/lib/knowledge-base/document-validation.ts`:
+
+```typescript
+/**
+ * Validation for inline (authored) knowledge-base documents.
+ * Pure — no I/O — so it is shared by the create route and the edit route.
+ */
+
+export const MAX_DOCUMENT_CHARS = 200_000;
+
+export type DocumentValidationResult =
+    | { ok: true; name: string; content: string }
+    | { ok: false; error: string };
+
+export function validateDocumentInput(input: { name?: string; content?: string }): DocumentValidationResult {
+    const name = (input.name ?? '').trim();
+    const content = (input.content ?? '').trim();
+
+    if (!name) return { ok: false, error: 'name is required' };
+    if (!content) return { ok: false, error: 'content is required' };
+    if (content.length > MAX_DOCUMENT_CHARS) {
+        return { ok: false, error: `Document is too large (max ${MAX_DOCUMENT_CHARS.toLocaleString()} characters)` };
+    }
+    return { ok: true, name, content };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/web-ui && bunx vitest run lib/knowledge-base/document-validation.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web-ui/lib/knowledge-base/document-validation.ts apps/web-ui/lib/knowledge-base/document-validation.test.ts
+git commit -m "feat(kb): add inline document validation helper"
+```
+
+---
+
+### Task 3: Document API routes (create + read-content)
+
+**Files:**
+- Create: `apps/web-ui/app/api/knowledge-base/[kbId]/documents/route.ts` (POST — create)
+- Create: `apps/web-ui/app/api/knowledge-base/[kbId]/documents/[dsId]/route.ts` (GET — read content)
+- Test: `apps/web-ui/app/api/knowledge-base/[kbId]/documents/documents-route.test.ts`
+
+**Interfaces:**
+- Consumes: `validateDocumentInput` (Task 2); `KnowledgeBaseService.{getKnowledgeBase,createDataSource,updateDataSource,updateDataSourceCount,updateVectorCount}`; `getDataSourceContent` via `KnowledgeBaseService`; `chunkText`, `embedAndStoreChunks` from `@/lib/knowledge-base/embedder`.
+- Produces:
+  - `POST /api/knowledge-base/[kbId]/documents` `{ name, content }` → `201 { dataSource }` (embedded, status `synced`), `400 { error }` on validation / provider error, `403`/`500`.
+  - `GET /api/knowledge-base/[kbId]/documents/[dsId]` → `200 { id, name, content }`, `404`/`403`.
+  - `KnowledgeBaseService.getDataSourceContent(kbId, dsId, tenantId): Promise<string | null>` (delegates to the repo method from Task 1).
+
+- [ ] **Step 1: Add the service passthrough**
+
+In `apps/web-ui/lib/knowledge-base/service.ts`, add after `getDataSource`:
+
+```typescript
+    static async getDataSourceContent(kbId: string, dsId: string, tenantId: string): Promise<string | null> {
+        return getDataSourceRepository().getDataSourceContent(kbId, dsId, tenantId);
+    }
+```
+
+- [ ] **Step 2: Write the failing route test**
+
+Create `apps/web-ui/app/api/knowledge-base/[kbId]/documents/documents-route.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/auth-session', () => ({
+    getSessionTenantId: vi.fn().mockResolvedValue('tenant-a'),
+    getSessionUserId: vi.fn(),
+}));
+vi.mock('next-auth', () => ({
+    getServerSession: vi.fn().mockResolvedValue({ user: { email: 'test@example.com' } }),
+}));
+vi.mock('@/app/api/auth/[...nextauth]/route', () => ({ authOptions: {} }));
+vi.mock('@/lib/audit-service', () => ({ AuditService: { logUserAction: vi.fn().mockResolvedValue(undefined) } }));
+
+vi.mock('@/lib/knowledge-base/service', () => ({
+    KnowledgeBaseService: {
+        getKnowledgeBase: vi.fn(),
+        createDataSource: vi.fn(),
+        updateDataSource: vi.fn(),
+        updateDataSourceCount: vi.fn(),
+        updateVectorCount: vi.fn(),
+    },
+}));
+vi.mock('@/lib/knowledge-base/embedder', () => ({
+    chunkText: vi.fn(() => [{ text: 'c1', index: 0, total: 1, contentHash: 'h1' }]),
+    embedAndStoreChunks: vi.fn().mockResolvedValue(['kb_kb-1_ds-1_0_h1']),
+    deleteVectors: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { KnowledgeBaseService } from '@/lib/knowledge-base/service';
+import { chunkText, embedAndStoreChunks } from '@/lib/knowledge-base/embedder';
+import { POST } from '@/app/api/knowledge-base/[kbId]/documents/route';
+
+const params = Promise.resolve({ kbId: 'kb-1' });
+
+function req(body: unknown) {
+    return new Request('http://t/api/knowledge-base/kb-1/documents', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+    }) as unknown as import('next/server').NextRequest;
+}
+
+describe('POST /api/knowledge-base/[kbId]/documents', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(KnowledgeBaseService.getKnowledgeBase).mockResolvedValue({ id: 'kb-1' } as any);
+        vi.mocked(KnowledgeBaseService.createDataSource).mockResolvedValue({ id: 'ds-1', knowledgeBaseId: 'kb-1', name: 'Doc', sourceType: 'document', status: 'pending', config: {}, vectorCount: 0, vectorKeys: [], createdAt: '', updatedAt: '' } as any);
+    });
+
+    it('creates a document, embeds it, and returns 201', async () => {
+        const res = await POST(req({ name: 'Doc', content: '# Body' }), { params });
+        expect(res.status).toBe(201);
+        expect(chunkText).toHaveBeenCalledWith('# Body', 'Doc');
+        expect(embedAndStoreChunks).toHaveBeenCalledWith(
+            expect.objectContaining({ sourceType: 'document', knowledgeBaseId: 'kb-1', dataSourceId: 'ds-1', tenantId: 'tenant-a' })
+        );
+        // marks synced with the returned vector keys
+        expect(KnowledgeBaseService.updateDataSource).toHaveBeenCalledWith(
+            'kb-1', 'ds-1',
+            expect.objectContaining({ status: 'synced', vectorKeys: ['kb_kb-1_ds-1_0_h1'], vectorCount: 1, content: '# Body' }),
+            'tenant-a',
+        );
+        expect(KnowledgeBaseService.updateVectorCount).toHaveBeenCalledWith('kb-1', 1, 'tenant-a');
+    });
+
+    it('rejects empty content with 400', async () => {
+        const res = await POST(req({ name: 'Doc', content: '' }), { params });
+        expect(res.status).toBe(400);
+        expect(embedAndStoreChunks).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when the KB is not owned by the tenant', async () => {
+        vi.mocked(KnowledgeBaseService.getKnowledgeBase).mockResolvedValue(null);
+        const res = await POST(req({ name: 'Doc', content: '# Body' }), { params });
+        expect(res.status).toBe(403);
+    });
+
+    it('sets status=error but preserves content when embedding fails', async () => {
+        vi.mocked(embedAndStoreChunks).mockRejectedValueOnce(new Error('bedrock down'));
+        const res = await POST(req({ name: 'Doc', content: '# Body' }), { params });
+        expect(res.status).toBe(500);
+        expect(KnowledgeBaseService.updateDataSource).toHaveBeenCalledWith(
+            'kb-1', 'ds-1',
+            expect.objectContaining({ status: 'error', content: '# Body' }),
+            'tenant-a',
+        );
+    });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cd apps/web-ui && bunx vitest run "app/api/knowledge-base/[kbId]/documents/documents-route.test.ts"`
+Expected: FAIL — route module not found.
+
+- [ ] **Step 4: Implement the create route**
+
+Create `apps/web-ui/app/api/knowledge-base/[kbId]/documents/route.ts`:
+
+```typescript
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { KnowledgeBaseService } from '@/lib/knowledge-base/service';
+import { getSessionTenantId } from '@/lib/auth-session';
+import { AuditService } from '@/lib/audit-service';
+import { validateDocumentInput } from '@/lib/knowledge-base/document-validation';
+import { chunkText, embedAndStoreChunks } from '@/lib/knowledge-base/embedder';
+
+// POST /api/knowledge-base/[kbId]/documents — create an inline markdown document
+export async function POST(
+    request: NextRequest,
+    { params }: { params: Promise<{ kbId: string }> },
+) {
+    const session = await getServerSession(authOptions);
+    if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const { kbId } = await params;
+    const tenantId = await getSessionTenantId();
+    const kb = await KnowledgeBaseService.getKnowledgeBase(kbId, tenantId);
+    if (!kb) return NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 });
+
+    const body = await request.json().catch(() => ({}));
+    const valid = validateDocumentInput(body as { name?: string; content?: string });
+    if (!valid.ok) return NextResponse.json({ error: valid.error }, { status: 400 });
+    const { name, content } = valid;
+
+    // Create the record first (pending), then embed synchronously.
+    const ds = await KnowledgeBaseService.createDataSource(kbId, {
+        name,
+        sourceType: 'document',
+        config: { format: 'markdown', chunkCount: 0 },
+    }, tenantId);
+    await KnowledgeBaseService.updateDataSourceCount(kbId, 1, tenantId);
+
+    try {
+        const chunks = chunkText(content, name);
+        const vectorKeys = await embedAndStoreChunks({
+            chunks,
+            knowledgeBaseId: kbId,
+            dataSourceId: ds.id,
+            sourceType: 'document',
+            documentName: name,
+            tenantId,
+        });
+
+        await KnowledgeBaseService.updateDataSource(kbId, ds.id, {
+            content,
+            status: 'synced',
+            vectorKeys,
+            vectorCount: vectorKeys.length,
+            config: { format: 'markdown', chunkCount: vectorKeys.length },
+            lastSyncAt: new Date().toISOString(),
+        }, tenantId);
+        await KnowledgeBaseService.updateVectorCount(kbId, vectorKeys.length, tenantId);
+
+        AuditService.logUserAction({
+            eventType: 'kb.document.created', severity: 'low',
+            apiRoute: 'POST /api/knowledge-base/[kbId]/documents', httpMethod: 'POST',
+            action: 'Created Document', resourceType: 'kb', resourceId: ds.id, resourceName: name,
+            user: session?.user?.email || 'unknown', userType: 'user', status: 'success',
+            details: `Created document "${name}" in knowledge base ${kbId}`,
+            metadata: { tenantId, kbId, chunkCount: vectorKeys.length },
+        }).catch(() => {});
+
+        const updated = await KnowledgeBaseService.getDataSource(kbId, ds.id, tenantId);
+        return NextResponse.json({ dataSource: updated }, { status: 201 });
+    } catch (error) {
+        const isProviderError = error instanceof Error && error.name === 'ProviderConfigError';
+        const message = error instanceof Error ? error.message : 'Failed to embed document';
+        // Preserve content so the user can retry with an edit.
+        await KnowledgeBaseService.updateDataSource(kbId, ds.id, {
+            content,
+            status: 'error',
+            lastErrorMessage: isProviderError ? 'No embedding provider configured' : 'Failed to process document',
+            lastErrorDetail: message,
+        }, tenantId).catch(() => {});
+        return NextResponse.json({ error: message }, { status: isProviderError ? 400 : 500 });
+    }
+}
+```
+
+- [ ] **Step 5: Implement the read-content route**
+
+Create `apps/web-ui/app/api/knowledge-base/[kbId]/documents/[dsId]/route.ts`:
+
+```typescript
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { KnowledgeBaseService } from '@/lib/knowledge-base/service';
+import { getSessionTenantId } from '@/lib/auth-session';
+
+// GET /api/knowledge-base/[kbId]/documents/[dsId] — read a document's markdown body
+export async function GET(
+    _request: NextRequest,
+    { params }: { params: Promise<{ kbId: string; dsId: string }> },
+) {
+    const session = await getServerSession(authOptions);
+    if (!session) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const { kbId, dsId } = await params;
+    const tenantId = await getSessionTenantId();
+    const kb = await KnowledgeBaseService.getKnowledgeBase(kbId, tenantId);
+    if (!kb) return NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 });
+
+    const ds = await KnowledgeBaseService.getDataSource(kbId, dsId, tenantId);
+    if (!ds || ds.sourceType !== 'document') {
+        return NextResponse.json({ error: 'Document not found' }, { status: 404 });
+    }
+    const content = await KnowledgeBaseService.getDataSourceContent(kbId, dsId, tenantId);
+    return NextResponse.json({ id: ds.id, name: ds.name, content: content ?? '' });
+}
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `cd apps/web-ui && bunx vitest run "app/api/knowledge-base/[kbId]/documents/documents-route.test.ts"`
+Expected: PASS (4 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web-ui/lib/knowledge-base/service.ts "apps/web-ui/app/api/knowledge-base/[kbId]/documents"
+git commit -m "feat(kb): document create + read-content API routes"
+```
+
+---
+
+### Task 4: Extend the source PUT for document re-embed
+
+**Files:**
+- Modify: `apps/web-ui/app/api/knowledge-base/[kbId]/sources/[dsId]/route.ts`
+- Test: `apps/web-ui/app/api/knowledge-base/[kbId]/sources/[dsId]/put-document.test.ts`
+
+**Interfaces:**
+- Consumes: `validateDocumentInput`, `chunkText`, `embedAndStoreChunks`, `deleteVectors`, `KnowledgeBaseService.{getDataSource,updateDataSource,updateVectorCount}`.
+- Produces: `PUT /api/knowledge-base/[kbId]/sources/[dsId]` — when the source is a `document` and `content` is present, deletes old vectors, re-embeds, updates `content`/`vectorKeys`/`vectorCount`, and reconciles the KB vector count by the delta. Non-document behavior (name/config merge) is unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web-ui/app/api/knowledge-base/[kbId]/sources/[dsId]/put-document.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/auth-session', () => ({ getSessionTenantId: vi.fn().mockResolvedValue('tenant-a') }));
+vi.mock('next-auth', () => ({ getServerSession: vi.fn().mockResolvedValue({ user: { email: 'u@e.com' } }) }));
+vi.mock('@/app/api/auth/[...nextauth]/route', () => ({ authOptions: {} }));
+vi.mock('@/lib/audit-service', () => ({ AuditService: { logUserAction: vi.fn().mockResolvedValue(undefined) } }));
+vi.mock('@/lib/knowledge-base/service', () => ({
+    KnowledgeBaseService: {
+        getKnowledgeBase: vi.fn().mockResolvedValue({ id: 'kb-1' }),
+        getDataSource: vi.fn(),
+        updateDataSource: vi.fn(),
+        updateVectorCount: vi.fn(),
+    },
+}));
+vi.mock('@/lib/knowledge-base/embedder', () => ({
+    chunkText: vi.fn(() => [{ text: 'a', index: 0, total: 1, contentHash: 'h' }, { text: 'b', index: 1, total: 2, contentHash: 'h2' }]),
+    embedAndStoreChunks: vi.fn().mockResolvedValue(['k1', 'k2']),
+    deleteVectors: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { KnowledgeBaseService } from '@/lib/knowledge-base/service';
+import { deleteVectors, embedAndStoreChunks } from '@/lib/knowledge-base/embedder';
+import { PUT } from '@/app/api/knowledge-base/[kbId]/sources/[dsId]/route';
+
+const params = Promise.resolve({ kbId: 'kb-1', dsId: 'ds-1' });
+function req(body: unknown) {
+    return new Request('http://t', { method: 'PUT', body: JSON.stringify(body) }) as unknown as import('next/server').NextRequest;
+}
+
+describe('PUT sources/[dsId] — document re-embed', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(KnowledgeBaseService.getDataSource)
+            .mockResolvedValue({ id: 'ds-1', knowledgeBaseId: 'kb-1', name: 'Doc', sourceType: 'document', status: 'synced', config: {}, vectorCount: 1, vectorKeys: ['old1'], createdAt: '', updatedAt: '' } as any);
+    });
+
+    it('deletes old vectors, re-embeds, and reconciles the KB count by delta', async () => {
+        await PUT(req({ content: '# New body' }), { params });
+        expect(deleteVectors).toHaveBeenCalledWith(['old1']);
+        expect(embedAndStoreChunks).toHaveBeenCalledWith(expect.objectContaining({ sourceType: 'document', dataSourceId: 'ds-1' }));
+        expect(KnowledgeBaseService.updateDataSource).toHaveBeenCalledWith(
+            'kb-1', 'ds-1',
+            expect.objectContaining({ content: '# New body', vectorKeys: ['k1', 'k2'], vectorCount: 2, status: 'synced' }),
+            'tenant-a',
+        );
+        // old count 1 → new count 2, delta +1
+        expect(KnowledgeBaseService.updateVectorCount).toHaveBeenCalledWith('kb-1', 1, 'tenant-a');
+    });
+
+    it('does not re-embed when content is absent (name-only edit)', async () => {
+        await PUT(req({ name: 'Renamed' }), { params });
+        expect(deleteVectors).not.toHaveBeenCalled();
+        expect(embedAndStoreChunks).not.toHaveBeenCalled();
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/web-ui && bunx vitest run "app/api/knowledge-base/[kbId]/sources/[dsId]/put-document.test.ts"`
+Expected: FAIL — content path not handled (deleteVectors never called).
+
+- [ ] **Step 3: Implement the PUT branch**
+
+In `apps/web-ui/app/api/knowledge-base/[kbId]/sources/[dsId]/route.ts`:
+
+Add imports at the top:
+```typescript
+import { chunkText, embedAndStoreChunks, deleteVectors } from '@/lib/knowledge-base/embedder';
+import { validateDocumentInput } from '@/lib/knowledge-base/document-validation';
+```
+
+Replace the body-parsing + update section of `PUT` (the block from `const body = await request.json()...` down to `const updated = await KnowledgeBaseService.getDataSource(...)`) with:
+
+```typescript
+    const body = await request.json() as { name?: string; content?: string; config?: Record<string, unknown> };
+    const updates: Partial<DataSource> = {};
+    if (body.name?.trim()) updates.name = body.name.trim();
+
+    // Document content edit → re-embed.
+    if (ds.sourceType === 'document' && body.content !== undefined) {
+        const valid = validateDocumentInput({ name: body.name ?? ds.name, content: body.content });
+        if (!valid.ok) return NextResponse.json({ error: valid.error }, { status: 400 });
+        try {
+            if (ds.vectorKeys.length > 0) await deleteVectors(ds.vectorKeys);
+            const chunks = chunkText(valid.content, valid.name);
+            const vectorKeys = await embedAndStoreChunks({
+                chunks, knowledgeBaseId: kbId, dataSourceId: dsId,
+                sourceType: 'document', documentName: valid.name, tenantId,
+            });
+            updates.content = valid.content;
+            updates.vectorKeys = vectorKeys;
+            updates.vectorCount = vectorKeys.length;
+            updates.status = 'synced';
+            updates.config = { format: 'markdown', chunkCount: vectorKeys.length };
+            updates.lastSyncAt = new Date().toISOString();
+            await KnowledgeBaseService.updateDataSource(kbId, dsId, updates, tenantId);
+            await KnowledgeBaseService.updateVectorCount(kbId, vectorKeys.length - ds.vectorCount, tenantId);
+        } catch (error) {
+            const isProviderError = error instanceof Error && error.name === 'ProviderConfigError';
+            const message = error instanceof Error ? error.message : 'Failed to embed document';
+            await KnowledgeBaseService.updateDataSource(kbId, dsId, {
+                content: valid.content, status: 'error',
+                lastErrorMessage: isProviderError ? 'No embedding provider configured' : 'Failed to process document',
+                lastErrorDetail: message,
+            }, tenantId).catch(() => {});
+            return NextResponse.json({ error: message }, { status: isProviderError ? 400 : 500 });
+        }
+    } else {
+        if (body.config) updates.config = { ...ds.config, ...body.config } as DataSource['config'];
+        await KnowledgeBaseService.updateDataSource(kbId, dsId, updates, tenantId);
+    }
+
+    const updated = await KnowledgeBaseService.getDataSource(kbId, dsId, tenantId);
+```
+
+Update the audit event type in this handler from `kb.datasource.updated` to remain as-is for config edits; for document edits it is acceptable to keep the same `kb.datasource.updated` event (no change required).
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/web-ui && bunx vitest run "app/api/knowledge-base/[kbId]/sources/[dsId]/put-document.test.ts"`
+Expected: PASS (2 tests). Also re-run the repo/validation suites to confirm no regressions:
+`cd apps/web-ui && bunx vitest run lib/knowledge-base lib/db/repositories/data-source`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "apps/web-ui/app/api/knowledge-base/[kbId]/sources/[dsId]"
+git commit -m "feat(kb): re-embed document content on source PUT"
+```
+
+---
+
+### Task 5: TanStack Query mutations for documents
+
+**Files:**
+- Modify: `apps/web-ui/lib/queries/knowledge-base.ts`
+
+**Interfaces:**
+- Produces:
+  - `useCreateDocument(kbId: string)` → mutation `({ name, content }) => Promise<{ dataSource }>`.
+  - `useUpdateDocument(kbId: string)` → mutation `({ dsId, name?, content }) => Promise<{ dataSource }>`.
+  - Both invalidate `['knowledge-bases']` on success. (The detail page also calls its own `fetchKB()` refresh in `onSuccess` — see Task 6.)
+
+- [ ] **Step 1: Add the hooks**
+
+Append to `apps/web-ui/lib/queries/knowledge-base.ts` (before the final newline):
+
+```typescript
+export function useCreateDocument(kbId: string) {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async (body: { name: string; content: string }) => {
+            const res = await fetch(`/api/knowledge-base/${kbId}/documents`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body),
+            });
+            if (!res.ok) {
+                const data = await res.json().catch(() => ({}));
+                throw new Error(data.error ?? 'Failed to create document');
+            }
+            return res.json();
+        },
+        onSuccess: () => qc.invalidateQueries({ queryKey: knowledgeBasesKey }),
+    });
+}
+
+export function useUpdateDocument(kbId: string) {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async ({ dsId, ...body }: { dsId: string; name?: string; content: string }) => {
+            const res = await fetch(`/api/knowledge-base/${kbId}/sources/${dsId}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body),
+            });
+            if (!res.ok) {
+                const data = await res.json().catch(() => ({}));
+                throw new Error(data.error ?? 'Failed to update document');
+            }
+            return res.json();
+        },
+        onSuccess: () => qc.invalidateQueries({ queryKey: knowledgeBasesKey }),
+    });
+}
+```
+
+- [ ] **Step 2: Verify it typechecks**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit`
+Expected: no new errors in `lib/queries/knowledge-base.ts`. (The repo has a known tsc baseline; confirm no *new* errors in this file.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web-ui/lib/queries/knowledge-base.ts
+git commit -m "feat(kb): query hooks for document create/update"
+```
+
+---
+
+### Task 6: Document editor UI + detail-page wiring
+
+**Files:**
+- Create: `apps/web-ui/components/knowledge-base/kb-document-editor.tsx`
+- Modify: `apps/web-ui/app/app/knowledge-base/[kbId]/page.tsx`
+- Modify (optional): `apps/web-ui/components/knowledge-base/kb-source-type-selector.tsx`
+
+**Interfaces:**
+- Consumes: `useCreateDocument`, `useUpdateDocument` (Task 5); `GET /api/knowledge-base/[kbId]/documents/[dsId]` (Task 3); `MAX_DOCUMENT_CHARS` (Task 2); `ReactMarkdown` + `remarkGfm` (already used in `kb-chat.tsx`).
+- Produces: `KBDocumentEditor` — a dialog component:
+  ```typescript
+  interface KBDocumentEditorProps {
+      kbId: string;
+      /** Existing document to edit; omit for a new document. */
+      doc?: { id: string; name: string };
+      open: boolean;
+      onClose: () => void;
+      onSaved: () => void; // caller refreshes the KB
+  }
+  export function KBDocumentEditor(props: KBDocumentEditorProps): JSX.Element;
+  ```
+
+- [ ] **Step 1: Build the editor component**
+
+Create `apps/web-ui/components/knowledge-base/kb-document-editor.tsx`:
+
+```tsx
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { useCreateDocument, useUpdateDocument } from '@/lib/queries/knowledge-base';
+import { MAX_DOCUMENT_CHARS } from '@/lib/knowledge-base/document-validation';
+
+const schema = z.object({
+  name: z.string().trim().min(1, 'Name is required'),
+  content: z.string().trim().min(1, 'Content is required').max(MAX_DOCUMENT_CHARS, 'Document is too large'),
+});
+type FormValues = z.infer<typeof schema>;
+
+interface KBDocumentEditorProps {
+  kbId: string;
+  doc?: { id: string; name: string };
+  open: boolean;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+export function KBDocumentEditor({ kbId, doc, open, onClose, onSaved }: KBDocumentEditorProps) {
+  const isEdit = !!doc;
+  const create = useCreateDocument(kbId);
+  const update = useUpdateDocument(kbId);
+  const [loadingContent, setLoadingContent] = useState(false);
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { name: doc?.name ?? '', content: '' },
+  });
+  const content = form.watch('content');
+
+  // Load existing content when editing.
+  useEffect(() => {
+    if (!open) return;
+    if (!doc) { form.reset({ name: '', content: '' }); return; }
+    setLoadingContent(true);
+    fetch(`/api/knowledge-base/${kbId}/documents/${doc.id}`)
+      .then((r) => r.ok ? r.json() : Promise.reject(new Error('Failed to load document')))
+      .then((d) => form.reset({ name: d.name ?? doc.name, content: d.content ?? '' }))
+      .catch((e) => toast.error(e instanceof Error ? e.message : 'Failed to load document'))
+      .finally(() => setLoadingContent(false));
+  }, [open, doc, kbId, form]);
+
+  const submitting = create.isPending || update.isPending;
+
+  const onSubmit = async (values: FormValues) => {
+    try {
+      if (isEdit && doc) {
+        await update.mutateAsync({ dsId: doc.id, name: values.name, content: values.content });
+        toast.success(`"${values.name}" updated`);
+      } else {
+        await create.mutateAsync({ name: values.name, content: values.content });
+        toast.success(`"${values.name}" created`);
+      }
+      onSaved();
+      onClose();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Save failed');
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? 'Edit Document' : 'New Document'}</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <div className="space-y-1.5">
+            <Label>Name</Label>
+            <Input placeholder="e.g. Incident runbook" disabled={submitting || loadingContent} {...form.register('name')} />
+            {form.formState.errors.name && <p className="text-xs text-destructive">{form.formState.errors.name.message}</p>}
+          </div>
+
+          <Tabs defaultValue="write">
+            <TabsList>
+              <TabsTrigger value="write" type="button">Write</TabsTrigger>
+              <TabsTrigger value="preview" type="button">Preview</TabsTrigger>
+            </TabsList>
+            <TabsContent value="write">
+              <Textarea
+                className="min-h-[320px] font-mono text-sm"
+                placeholder="Write markdown…"
+                disabled={submitting || loadingContent}
+                {...form.register('content')}
+              />
+              {form.formState.errors.content && <p className="text-xs text-destructive">{form.formState.errors.content.message}</p>}
+            </TabsContent>
+            <TabsContent value="preview">
+              <div className="prose prose-sm dark:prose-invert max-w-none min-h-[320px] rounded-md border p-4 overflow-y-auto">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{content || '_Nothing to preview_'}</ReactMarkdown>
+              </div>
+            </TabsContent>
+          </Tabs>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={onClose} disabled={submitting}>Cancel</Button>
+            <Button type="submit" disabled={submitting || loadingContent}>
+              {submitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {isEdit ? 'Save' : 'Create'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+Note: confirm `@/components/ui/textarea` and `@/components/ui/tabs` exist (shadcn primitives). If `textarea` is missing, add it via the standard shadcn pattern; the repo already uses Radix Tabs elsewhere.
+
+- [ ] **Step 2: Wire the "New Document" button + edit branch into the detail page**
+
+In `apps/web-ui/app/app/knowledge-base/[kbId]/page.tsx`:
+
+1. Import the editor and add `FileText` to the lucide import:
+```tsx
+import { KBDocumentEditor } from '@/components/knowledge-base/kb-document-editor';
+```
+Add `FileText` to the existing `lucide-react` import list.
+
+2. Add state near the other dialog state (`const [editDs, setEditDs] = ...`):
+```tsx
+  const [docEditor, setDocEditor] = useState<{ mode: 'new' } | { mode: 'edit'; doc: { id: string; name: string } } | null>(null);
+```
+
+3. In `SOURCE_TYPE_LABELS` add:
+```tsx
+  'document': 'Document',
+```
+
+4. In `DataSourceIcon`, add a case before `default`:
+```tsx
+    case 'document': return <FileText className={className} />;
+```
+
+5. In the "Data Sources" `CardHeader`, add a "New Document" button before the existing "Add Data Source" button:
+```tsx
+              <Button variant="outline" size="sm" className="gap-1.5" onClick={() => setDocEditor({ mode: 'new' })}>
+                <FileText className="h-3.5 w-3.5" /> New Document
+              </Button>
+```
+
+6. Change the row Edit button so documents open the editor:
+```tsx
+                      <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                        onClick={() => ds.sourceType === 'document'
+                          ? setDocEditor({ mode: 'edit', doc: { id: ds.id, name: ds.name } })
+                          : setEditDs(ds)}
+                        title="Edit">
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+```
+
+7. Render the editor near the bottom, after the existing `EditDialog` block:
+```tsx
+      {docEditor && (
+        <KBDocumentEditor
+          kbId={kbId}
+          doc={docEditor.mode === 'edit' ? docEditor.doc : undefined}
+          open={!!docEditor}
+          onClose={() => setDocEditor(null)}
+          onSaved={() => { setDocEditor(null); fetchKB(); }}
+        />
+      )}
+```
+
+- [ ] **Step 3: (Optional) Add a "Document" card to the source-type selector**
+
+In `apps/web-ui/components/knowledge-base/kb-source-type-selector.tsx`, add to `SOURCE_TYPE_OPTIONS` (first entry, so it leads):
+```tsx
+  {
+    type: 'document',
+    icon: FileText,
+    title: 'Document',
+    description: 'Write a markdown doc inline',
+  },
+```
+Add `FileText` to the `lucide-react` import. Then in `sources/new/page.tsx`, when the selected type is `'document'`, route to the detail page and open the editor (or render `KBDocumentEditor` inline). If this adds complexity, skip the card — the "New Document" button from Step 2 is the primary entry point.
+
+- [ ] **Step 4: Verify build + lint**
+
+Run:
+```bash
+cd apps/web-ui && bunx tsc --noEmit && bun run lint
+```
+Expected: no new type or lint errors in the changed files.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web-ui/components/knowledge-base/kb-document-editor.tsx "apps/web-ui/app/app/knowledge-base/[kbId]/page.tsx" apps/web-ui/components/knowledge-base/kb-source-type-selector.tsx
+git commit -m "feat(kb): inline document editor + detail-page wiring"
+```
+
+---
+
+### Task 7: End-to-end verification (Playwright)
+
+**Files:**
+- Create: `apps/web-ui-e2e/kb-documents.spec.ts`
+
+**Preconditions:** Dev server running (auto-started by the e2e `webServer` config) with a **configured embedding provider** for the test tenant (documents embed synchronously; without a provider, create returns 400 by design). If no provider is configured in the test env, mark this spec `test.skip` with a comment and rely on the unit/route tests.
+
+- [ ] **Step 1: Write the E2E spec**
+
+Create `apps/web-ui-e2e/kb-documents.spec.ts`:
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+// Requires a knowledge base to exist and an embedding provider configured for the tenant.
+test.describe('KB inline documents', () => {
+  test('create a document and see it in the data sources list', async ({ page }) => {
+    await page.goto('/app/knowledge-base');
+    // Open the first knowledge base.
+    await page.getByRole('link', { name: /knowledge base/i }).first().click().catch(() => {});
+    await page.waitForLoadState('networkidle');
+
+    await page.getByRole('button', { name: 'New Document' }).click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+
+    const name = `E2E Doc ${Date.now()}`;
+    await page.getByLabel('Name').fill(name);
+    await page.getByPlaceholder('Write markdown…').fill('# Heading\n\nBody text for embedding.');
+
+    // Preview renders markdown.
+    await page.getByRole('tab', { name: 'Preview' }).click();
+    await expect(page.getByRole('heading', { name: 'Heading' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Create' }).click();
+    await expect(page.getByText(name)).toBeVisible();
+  });
+});
+```
+
+- [ ] **Step 2: Run the E2E spec**
+
+Run: `cd apps/web-ui-e2e && bunx playwright test kb-documents.spec.ts`
+Expected: PASS (or SKIP if no provider is configured — see preconditions).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web-ui-e2e/kb-documents.spec.ts
+git commit -m "test(kb): e2e for inline document create"
+```
+
+---
+
+## Plan self-review
+
+- **Spec coverage:** data model (Task 1), synchronous embed on create (Task 3), re-embed on edit with delete-then-insert + count delta (Task 4), markdown editor + preview (Task 6), size cap / empty / provider-error guards (Task 2 + Tasks 3–4), auth+audit pattern (Tasks 3–4), query hooks (Task 5), retrieval unchanged (no task needed), optional selector card (Task 6 Step 3). ✓
+- **Refinement vs spec:** content is read via a dedicated `GET /documents/[dsId]` endpoint and kept out of the `DataSource` DTO, rather than being included in the sources GET and stripped from the list — documented at the top. Same design, no leakage risk.
+- **Type consistency:** `embedAndStoreChunks({ chunks, knowledgeBaseId, dataSourceId, sourceType, documentName, tenantId })` and `chunkText(text, documentName)` and `deleteVectors(keys)` match `embedder.ts`. `validateDocumentInput` returns `{ ok, name, content } | { ok, error }` consistently across Tasks 2–4. `DataSourceType` includes `'document'` everywhere it is checked.
+- **Out of scope (unchanged):** folders, versioning, collaborative editing, per-chunk viewing, RBAC `authorize()` hardening.

--- a/docs/superpowers/specs/2026-07-05-kb-inline-documents-design.md
+++ b/docs/superpowers/specs/2026-07-05-kb-inline-documents-design.md
@@ -1,0 +1,179 @@
+# Inline Documents for Knowledge Base — Design
+
+**Date:** 2026-07-05
+**Status:** Approved (design)
+**Branch:** `kb-rewrite`
+
+## Problem
+
+The Knowledge Base module only supports ingesting content through **import connectors**
+(S3, Confluence, Bitbucket) and **blob file upload**. Users cannot author a document in the
+app, cannot edit content once ingested, and have no way to build up a set of documents over
+time within a knowledge base. We want users to **create markdown documents inline, edit them
+in place, and add more over time** — all feeding the same semantic search / RAG pipeline.
+
+## Current architecture (as-is)
+
+- **Model:** `KnowledgeBase` → many `DataSource`. There is **no document entity** — a document
+  *is* a `DataSource`. `DataSource.sourceType ∈ {file-upload, s3-bucket, confluence, bitbucket}`,
+  with `config` (JSON), `vectorKeys[]`, `status`, and sync/error fields.
+- **Chunk store:** `KbDocumentChunk` (table `kb_document_chunks`) — pgvector `vector(1024)`; the
+  only place content persists (chunk `textContent` ≤ ~2000 chars). No full-document store.
+- **Upload path:** `POST /api/knowledge-base/[kbId]/upload` stages the file to S3, creates a
+  `file-upload` DataSource in `syncing`, and enqueues a pg-boss `kb-sync` job. The worker
+  (`apps/workers/src/jobs/kb-sync/handlers/file-upload.ts`) parses → chunks → embeds → upserts
+  into `kb_document_chunks`.
+- **Key enabler:** `apps/web-ui/lib/knowledge-base/embedder.ts` is a complete, self-contained
+  embedder that runs **inside the Next process** — `chunkText`, `embedAndStoreChunks`
+  (provider-configured embeddings, pgvector upsert), and `deleteVectors`. The DELETE route
+  already calls `deleteVectors(ds.vectorKeys)`. This makes **synchronous in-request embedding**
+  feasible with no worker round-trip.
+- **Retrieval:** `POST /api/knowledge-base/query` embeds the question and runs pgvector cosine
+  search across all chunks in the KB, then streams an LLM answer with citations.
+
+### Gaps vs. goal
+
+- No authoring surface — inputs are import connectors + blob upload only. (The inline upload
+  dropzone in `[kbId]/page.tsx` is currently commented out.)
+- The Edit dialog treats `file-upload` as having no editable content — rename only, no content
+  edit.
+- No concept of a document created in-app and revised over time.
+
+## Approved decisions
+
+1. **Data model:** New `'document'` source type (each authored doc is a `DataSource`), not a
+   separate `KbDocument` entity. Lowest friction; reuses the list UI, query, and delete paths.
+2. **Editor:** Markdown editor with live preview.
+3. **Embed timing:** Synchronous on save via `embedder.ts` — instant searchability, immediate
+   error feedback, no worker dependency.
+
+Two implementation judgment calls (approved): the editor is a **dialog** (not a dedicated
+route), and edits **reuse the existing `sources/[dsId]` PUT** (create gets its own route because
+it must embed).
+
+## Design
+
+### 1. Concept
+
+A **document** is a first-class, in-app-authored markdown file stored as a `DataSource` with
+`sourceType: 'document'`. Its text lives on the record, is chunked + embedded synchronously on
+save, and is searched by the existing query path. "Add documents over time" = create more;
+"inline edit" = re-save, which re-embeds. Reuses the entire chunk → embed → pgvector → RAG stack.
+
+### 2. Data model
+
+`libs/prisma/schema.prisma` + migration:
+
+- Add `'document'` to the `DataSourceType` union in `apps/web-ui/lib/knowledge-base/types.ts`.
+- Add **`content String? @db.Text`** to `DataSource` — null for connector/upload sources; holds
+  markdown for documents.
+- Migration:
+  - `ALTER TABLE data_sources ADD COLUMN content text;`
+  - Update the `sourceType` CHECK constraint to allow `'document'` (constraints are defined in
+    migration SQL, not Prisma-native).
+- Add `content` to the update-whitelist in `apps/web-ui/lib/db/repositories/data-source/postgres.ts`.
+- New `DocumentConfig` type `{ format: 'markdown'; chunkCount: number }` — keeps `config` uniform
+  with the other source types.
+
+### 3. API
+
+Thin additions, maximum reuse.
+
+- **Create** — new `POST /api/knowledge-base/[kbId]/documents` `{ name, content }`:
+  1. Create DataSource (`sourceType: 'document'`, `content`, status `syncing`).
+  2. `chunkText(content, name)` + `embedAndStoreChunks({ ..., sourceType: 'document' })` from
+     `embedder.ts`.
+  3. Set status `synced`, `vectorKeys`, `vectorCount`; bump KB `dataSourceCount` + `vectorCount`.
+  4. Return the DataSource. Audit `kb.document.created`.
+- **Edit** — extend existing `PUT /api/knowledge-base/[kbId]/sources/[dsId]`: when
+  `sourceType === 'document'` and `content` changed → `deleteVectors(old keys)` → re-chunk →
+  `embedAndStoreChunks` → update `content` / `vectorKeys` / counts (by delta). Audit
+  `kb.document.updated`.
+- **Read content** — existing `GET .../sources/[dsId]` already returns the DataSource; ensure
+  `content` is included.
+- **List** — strip `content` in the sources-list serializer (keep list payloads small); return it
+  only on the single-source GET.
+- **Delete** — no change; the existing DELETE runs `deleteVectors` + count decrements for any type.
+
+Guards:
+
+- Reject empty content.
+- Cap size (~1 MB / ~200k chars → ≤ ~140 chunks; embedder batches 5 concurrently → a few seconds).
+- On embed failure set status `error` but **preserve `content`** so a re-save retries.
+- Map `ProviderConfigError` (no embedding provider configured) → 400 with a friendly message.
+
+### 4. Auth / tenant / audit
+
+Follow the sibling routes' existing pattern: `getServerSession` + tenant-ownership
+(`getKnowledgeBase(kbId, tenantId)` → 403 on miss), tenant-scoped repositories, and
+`AuditService` on create/update. The module's CRUD routes do not use the `authorize()` RBAC helper
+today; we stay consistent with the neighbors rather than introduce a one-off. **Optional hardening
+(out of scope):** add `authorize('create' | 'update', 'KnowledgeBase')` uniformly across the KB
+CRUD routes.
+
+### 5. UI
+
+- **KB detail page** (`apps/web-ui/app/app/knowledge-base/[kbId]/page.tsx`): add a **"New
+  Document"** button beside "Add Data Source". Document rows render in the same Data Sources list
+  (a `FileText` / `Pencil` icon), with the re-sync action hidden (same as file-upload).
+- **Editor** — new `apps/web-ui/components/knowledge-base/kb-document-editor.tsx`: React Hook Form
+  + Zod (`name`, `content`), split **write / preview** panes using the same react-markdown renderer
+  the chat already uses, with a Write/Preview toggle on mobile. Opened as a large dialog. Save →
+  create/update API → toast → refresh.
+- **Edit branch**: the detail page's existing `EditDialog` branches — `document` type opens the
+  markdown editor (fetches the single source for `content`); other types keep today's config
+  editor. **View** for a document renders read-only markdown.
+- Optionally add a 5th "Document" card to
+  `apps/web-ui/components/knowledge-base/kb-source-type-selector.tsx` for discoverability (routes to
+  the editor). Primary entry is the "New Document" button.
+
+### 6. Data fetching
+
+Add `useCreateDocument` / `useUpdateDocument` mutations to
+`apps/web-ui/lib/queries/knowledge-base.ts` (per the frontend TanStack Query convention); on
+success they trigger the detail page's KB refresh. No polling needed — embedding is synchronous.
+
+### 7. Retrieval — unchanged
+
+Document chunks land in `kb_document_chunks` like everything else; the query / RAG route needs
+zero changes. Citations surface the document's name (`documentName`).
+
+## Out of scope (YAGNI)
+
+- Folders / nesting / document tree.
+- Versioning / edit history.
+- Collaborative / real-time editing (last-write-wins on concurrent edits).
+- Per-chunk viewing.
+- The optional RBAC `authorize()` hardening noted in §4.
+
+## Files touched (anticipated)
+
+**Schema / DB**
+- `libs/prisma/schema.prisma` — `DataSource.content`.
+- `libs/prisma/migrations/<new>/migration.sql` — add column + update `sourceType` CHECK.
+- `apps/web-ui/lib/db/repositories/data-source/postgres.ts` — whitelist `content`.
+
+**Types / service**
+- `apps/web-ui/lib/knowledge-base/types.ts` — `'document'` in union, `DocumentConfig`.
+
+**API**
+- `apps/web-ui/app/api/knowledge-base/[kbId]/documents/route.ts` — new (POST create).
+- `apps/web-ui/app/api/knowledge-base/[kbId]/sources/[dsId]/route.ts` — extend PUT for content
+  re-embed; include `content` in single GET.
+- `apps/web-ui/app/api/knowledge-base/[kbId]/sources/route.ts` — strip `content` in list serializer.
+
+**UI**
+- `apps/web-ui/components/knowledge-base/kb-document-editor.tsx` — new.
+- `apps/web-ui/app/app/knowledge-base/[kbId]/page.tsx` — "New Document" button, edit/view branch.
+- `apps/web-ui/components/knowledge-base/kb-source-type-selector.tsx` — optional 5th card.
+- `apps/web-ui/lib/queries/knowledge-base.ts` — document mutations.
+
+## Testing
+
+- **Unit:** chunking/edit-diff behavior already covered by embedder; add a test that editing a
+  document deletes old vector keys and writes new ones (count delta correct).
+- **Integration (API):** create document → chunks appear in `kb_document_chunks`; edit → old keys
+  gone, new keys present, KB `vectorCount` reflects delta; delete → vectors removed. Empty content
+  rejected; oversize rejected; `ProviderConfigError` → 400.
+- **E2E (Playwright):** create a document via the editor, verify it appears in the Data Sources
+  list, edit it, then ask the KB a question that only the document answers and confirm it is cited.

--- a/libs/prisma/migrations/20260705120000_add_data_source_content/migration.sql
+++ b/libs/prisma/migrations/20260705120000_add_data_source_content/migration.sql
@@ -1,0 +1,7 @@
+-- Add editable document body column
+ALTER TABLE "data_sources" ADD COLUMN "content" TEXT;
+
+-- Allow the new 'document' source type
+ALTER TABLE "data_sources" DROP CONSTRAINT "data_sources_source_type_check";
+ALTER TABLE "data_sources" ADD CONSTRAINT "data_sources_source_type_check"
+    CHECK ("sourceType" IN ('file-upload', 's3-bucket', 'confluence', 'bitbucket', 'document'));

--- a/libs/prisma/migrations/20260705170000_add_knowledgebaseids/migration.sql
+++ b/libs/prisma/migrations/20260705170000_add_knowledgebaseids/migration.sql
@@ -1,0 +1,3 @@
+-- Add knowledgeBaseIds to agent_ops_runs and scheduled_tasks (mirrors mcpServerIds)
+ALTER TABLE "agent_ops_runs" ADD COLUMN "knowledgeBaseIds" TEXT[] NOT NULL DEFAULT '{}';
+ALTER TABLE "scheduled_tasks" ADD COLUMN "knowledgeBaseIds" TEXT[] NOT NULL DEFAULT '{}';

--- a/libs/prisma/schema.prisma
+++ b/libs/prisma/schema.prisma
@@ -396,6 +396,7 @@ model AgentOpsRun {
   model           String?
   threadId        String
   mcpServerIds    String[]  @default([])
+  knowledgeBaseIds String[] @default([])
   trigger         Json      @default("{}")
   result          Json?
   clarification   Json?
@@ -461,6 +462,7 @@ model ScheduledTask {
   accountId      String?
   accountName    String?
   mcpServerIds   String[]  @default([])
+  knowledgeBaseIds String[] @default([])
   notification   Json      @default("{}")
   lastRunId      String?
   lastRunAt      DateTime?

--- a/libs/prisma/schema.prisma
+++ b/libs/prisma/schema.prisma
@@ -289,6 +289,7 @@ model DataSource {
   sourceType      String    // file-upload|s3-bucket|confluence|bitbucket — CHECK in migration SQL
   status          String    @default("pending") // pending|syncing|synced|error — CHECK in migration SQL
   config          Json      @default("{}")
+  content         String?   @db.Text  // markdown body for sourceType='document'; null otherwise
   vectorCount     Int       @default(0)
   vectorKeys      String[]  @default([])
   lastSyncAt          DateTime?


### PR DESCRIPTION
## Summary

Two related Knowledge Base features on the `kb-rewrite` branch:

### 1. Inline documents (author + edit markdown in a KB)
Previously KBs only ingested via connectors (S3/Confluence/Bitbucket) or blob upload. Now users can **create and inline-edit markdown documents** in a KB and add more over time.

- A document is a `DataSource` with new `sourceType: 'document'`; markdown stored in a new `data_sources.content` column.
- Synchronous chunk+embed on save via the existing web-ui `embedder.ts` (provider-configured, 1024-dim); edit deletes stale vectors and re-embeds — **atomically** (embed-first, delete-stale-only, so a failed re-embed never drops the doc from search).
- `POST /api/knowledge-base/[kbId]/documents` (create), `GET .../documents/[dsId]` (read body), edit reuses `PUT .../sources/[dsId]`.
- Markdown editor dialog (RHF + Zod + sonner + react-markdown preview) with a "New Document" button on the KB detail page.
- Also fixed a pre-existing `timezone is not defined` crash in the KB detail `ViewDialog`.

### 2. Autonomous KB retrieval for AIOps + Agent Ops
KBs are now a first-class, autonomous capability for the AIOps chat agent **and** the Agent Ops executor.

- **Reusable primitive** `searchKbChunks({ tenantId, query, knowledgeBaseIds?, limit?, minScore? })` (multi-KB pgvector; the `/api/knowledge-base/query` route was refactored to use it — vector SQL now lives in one place).
- **Autonomous tool** `search_knowledge_base` (bound in the fast/planning chat agents and the Agent Ops executor) — the agent decides when a KB lookup is needed.
- **Auto-KB-selection** (`autoSelectKb`, mirroring `auto-skill-select`): when the console has no KB selected, a reflector picks the relevant KB(s); if none match, the tool falls back to a tenant-wide search. Multi-KB throughout (`knowledgeBaseIds: string[]`).
- `knowledgeBaseIds` threads UI → `/api/chat` → `GraphConfig` → tool, and is **persisted** as a new column on `AgentOpsRun` + `ScheduledTask` (migration `20260705170000_add_knowledgebaseids`) so Agent Ops KB scoping survives approve/resume.
- AIOps console gets a KB multi-select (empty selection = server auto-selects).

## Tenant safety
The KB tool captures the **server-resolved `tenantId`** in its closure (never client-supplied), and `searchKbChunks` always binds `"tenantId" = $2`. A client- or model-supplied foreign KB id can only *narrow within* the tenant — it returns zero rows, never cross-tenant data. Verified end-to-end in the final review.

## Testing
- Unit/route tests for both features (validation, repo content round-trip, document create/edit, retrieval SQL scoping, KB tool precedence + never-throw, auto-select validation, executor KB wiring). All feature tests green.
- Playwright e2e specs added for inline documents; **not runnable in the current env** due to a pre-existing `auth.setup.ts` JWT-decryption failure that blocks the entire e2e suite (not specific to this branch).
- Each task received spec + code-quality review; both features passed a final whole-branch review (**SHIP IT / MERGE-READY**, no Critical/Important findings).

## Notes
- New Prisma column requires `prisma migrate deploy` (the dev/Docker entrypoints run this automatically).
- Specs + plans under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
