### PR TITLE
fix(cicd): use bun install in Preview/Deploy CodeBuild buildspecs

### DIFF
--- a/infra/cicd/README.md
+++ b/infra/cicd/README.md
@@ -22,7 +22,7 @@ The Pulumi stack creates the CodeStar Connection, S3 bucket, KMS key, IAM role, 
 cd infra/cicd
 pulumi stack select prod
 pulumi config set aws:region ap-south-1
-npm install && pulumi install
+bun install && pulumi install
 AWS_PROFILE=PLATFORM-ADMIN pulumi up --stack prod --yes
 ```
 

--- a/infra/cicd/index.ts
+++ b/infra/cicd/index.ts
@@ -387,10 +387,11 @@ phases:
     runtime-versions:
       nodejs: 20
     commands:
+      - npm install -g bun
       - curl -fsSL https://get.pulumi.com | sh
       - export PATH=$PATH:$HOME/.pulumi/bin
-      - cd infra/networking && npm install && pulumi install && cd ../..
-      - cd infra/compute && npm install && pulumi install && cd ../..
+      - cd infra/networking && bun install && pulumi install && cd ../..
+      - cd infra/compute && bun install && pulumi install && cd ../..
   build:
     commands:
       - cd infra/networking && pulumi preview --stack prod --non-interactive --diff
@@ -407,10 +408,11 @@ phases:
     runtime-versions:
       nodejs: 20
     commands:
+      - npm install -g bun
       - curl -fsSL https://get.pulumi.com | sh
       - export PATH=$PATH:$HOME/.pulumi/bin
-      - cd infra/networking && npm install && pulumi install && cd ../..
-      - cd infra/compute && npm install && pulumi install && cd ../..
+      - cd infra/networking && bun install && pulumi install && cd ../..
+      - cd infra/compute && bun install && pulumi install && cd ../..
   pre_build:
     commands:
       - (cd infra/networking && pulumi cancel --stack prod --yes) || true


### PR DESCRIPTION
## Summary
- Root cause of every recent `nucleus-cloud-ops-pipeline` Preview-stage failure: the CodeBuild projects (`nucleus-cloud-ops-preview`, `nucleus-cloud-ops-deploy`) run inline buildspecs baked into `infra/cicd/index.ts`, not the repo's `buildspec-preview.yml`/`buildspec-deploy.yml` files. The inline specs still ran `npm install` inside `infra/networking`/`infra/compute`, which are part of the root Bun workspace, so npm tried to resolve the whole workspace tree and failed with `ERESOLVE` (`fumadocs-core@14.7.7` vs. `fumadocs-mdx`'s peer `^13.2.1`).
- Switch both inline buildspecs to install and use `bun install`, matching the already-working `buildspec-build.yml`.
- Fix the same stale `npm install` reference in `infra/cicd/README.md`'s bootstrap instructions.

## Test plan
- [x] `bun install` + `pulumi install` verified locally in `infra/networking` and `infra/compute` — no ERESOLVE, clean install
- [x] `pulumi preview --stack prod` verified locally against both stacks (`AWS_PROFILE=STX-CLOUD-PLATFORM`) — no unexpected drift
- [ ] After merge: redeploy `infra/cicd` Pulumi stack so CodeBuild projects pick up the corrected buildspec, then re-run the pipeline end-to-end (Preview → Approval → Deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)