### PR TITLE
feat(right-sizing): account filter sourced from recommendation accounts

### DIFF
--- a/apps/web-ui/app/api/right-sizing/summary/route.ts
+++ b/apps/web-ui/app/api/right-sizing/summary/route.ts
@@ -18,6 +18,7 @@ export async function GET() {
                     byStatus: {},
                     savingsByResourceType: {},
                     savingsByAccount: {},
+                    accountIds: [],
                     lastRunAt: null,
                 },
             });

--- a/apps/web-ui/app/app/right-sizing/page.tsx
+++ b/apps/web-ui/app/app/right-sizing/page.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { PaginationBar } from "@/components/ui/pagination-bar";
-import { RefreshCw, Play, Search, TrendingDown, Loader2 } from "lucide-react";
+import { RefreshCw, Play, Search, TrendingDown, Loader2, X } from "lucide-react";
 import { toast } from "sonner";
 import { SummaryCards } from "@/components/right-sizing/summary-cards";
 import { RecommendationsTable } from "@/components/right-sizing/recommendations-table";
@@ -19,6 +19,7 @@ import {
     useRightSizingSummary,
     useRunRightSizingScan,
 } from "@/lib/queries/right-sizing";
+import { useAccounts } from "@/lib/queries/accounts";
 
 const PAGE_SIZE = 25;
 const ALL = "all";
@@ -32,6 +33,7 @@ function RightSizingPageInner() {
     const [resourceType, setResourceType] = useState(() => searchParams.get("resourceType") ?? ALL);
     const [finding, setFinding] = useState(() => searchParams.get("finding") ?? ALL);
     const [status, setStatus] = useState(() => searchParams.get("status") ?? ALL);
+    const [account, setAccount] = useState(() => searchParams.get("account") ?? ALL);
     const [sort, setSort] = useState(() => searchParams.get("sort") ?? "savings");
 
     // Effective filters — also the query key.
@@ -43,6 +45,7 @@ function RightSizingPageInner() {
         resourceType: resourceType !== ALL ? resourceType : undefined,
         finding: finding !== ALL ? finding : undefined,
         status: status !== ALL ? status : undefined,
+        accountId: account !== ALL ? account : undefined,
     };
 
     function buildDetailHref(r: RightSizingRecommendation): string {
@@ -52,12 +55,43 @@ function RightSizingPageInner() {
         if (resourceType !== ALL) params.set("resourceType", resourceType);
         if (finding !== ALL) params.set("finding", finding);
         if (status !== ALL) params.set("status", status);
+        if (account !== ALL) params.set("account", account);
         return `/app/right-sizing/${r.id}?${params.toString()}`;
     }
 
     const recsQuery = useRightSizingRecommendations(filters);
     const summaryQuery = useRightSizingSummary();
     const scanMutation = useRunRightSizingScan();
+
+    // Account filter options are the DISTINCT accounts that actually appear in the
+    // recommendations (from the summary's server-side groupBy — not the current page,
+    // and not the full connected-accounts list). The accounts list (high limit so it
+    // isn't truncated by the default page size) is used only to enrich each ID with
+    // its friendly name when one exists.
+    const accountsQuery = useAccounts({ limit: 1000 });
+    const accountNameById = new Map(
+        (accountsQuery.data?.accounts ?? []).map((a) => [a.accountId, a.name]),
+    );
+    const accountOptions: [string, string][] = (summaryQuery.data?.accountIds ?? []).map((id) => {
+        const name = accountNameById.get(id);
+        return [id, name ? `${name} {${id}}` : id];
+    });
+
+    const hasActiveFilters =
+        search.trim() !== "" ||
+        account !== ALL ||
+        resourceType !== ALL ||
+        finding !== ALL ||
+        status !== ALL;
+
+    const resetFilters = () => {
+        setPage(1);
+        setSearch("");
+        setAccount(ALL);
+        setResourceType(ALL);
+        setFinding(ALL);
+        setStatus(ALL);
+    };
 
     const recommendations = recsQuery.data?.data ?? [];
     const total = recsQuery.data?.total ?? 0;
@@ -117,6 +151,8 @@ function RightSizingPageInner() {
                         className="w-56 pl-8"
                     />
                 </div>
+                <FilterSelect value={account} onChange={(v) => { setPage(1); setAccount(v); }} placeholder="Account"
+                    options={accountOptions} />
                 <FilterSelect value={resourceType} onChange={(v) => { setPage(1); setResourceType(v); }} placeholder="Resource type"
                     options={[["ec2_instances", "EC2"], ["rds_db_instances", "RDS"], ["ec2_volumes", "EBS"], ["autoscaling_auto_scaling_groups", "ASG"]]} />
                 <FilterSelect value={finding} onChange={(v) => { setPage(1); setFinding(v); }} placeholder="Finding"
@@ -131,6 +167,12 @@ function RightSizingPageInner() {
                         <SelectItem value="resource">Sort: Resource</SelectItem>
                     </SelectContent>
                 </Select>
+                {hasActiveFilters && (
+                    <Button variant="ghost" size="sm" onClick={resetFilters}>
+                        <X className="h-4 w-4" />
+                        <span className="ml-1">Reset</span>
+                    </Button>
+                )}
             </div>
 
             <RecommendationsTable

--- a/apps/web-ui/lib/db/repositories/right-sizing/interface.ts
+++ b/apps/web-ui/lib/db/repositories/right-sizing/interface.ts
@@ -76,6 +76,8 @@ export interface RightSizingSummary {
     byStatus: Record<string, number>;
     savingsByResourceType: Record<string, number>;
     savingsByAccount: Record<string, number>;
+    /** Distinct account IDs that appear in the recommendations (any status). Drives the account filter. */
+    accountIds: string[];
     lastRunAt: string | null;
 }
 

--- a/apps/web-ui/lib/db/repositories/right-sizing/postgres.ts
+++ b/apps/web-ui/lib/db/repositories/right-sizing/postgres.ts
@@ -257,7 +257,7 @@ export class RightSizingPostgresRepository implements IRightSizingRepository {
 
     async getSummary(tenantId: string): Promise<RightSizingSummary> {
         const client = getTenantClient(tenantId);
-        const [byFinding, byStatus, byType, byAccount, lastRun, savingsAgg] = await Promise.all([
+        const [byFinding, byStatus, byType, byAccount, distinctAccounts, lastRun, savingsAgg] = await Promise.all([
             client.rightSizingRecommendation.groupBy({ by: ['finding'], where: { tenantId }, _count: { _all: true } }),
             client.rightSizingRecommendation.groupBy({ by: ['status'], where: { tenantId }, _count: { _all: true } }),
             client.rightSizingRecommendation.groupBy({
@@ -269,6 +269,11 @@ export class RightSizingPostgresRepository implements IRightSizingRepository {
                 by: ['accountId'],
                 where: { tenantId, status: { in: ['open', 'approved'] } },
                 _sum: { estimatedMonthlySavings: true },
+            }),
+            client.rightSizingRecommendation.groupBy({
+                by: ['accountId'],
+                where: { tenantId },
+                orderBy: { accountId: 'asc' },
             }),
             client.rightSizingRun.findFirst({
                 where: { tenantId, status: 'completed' },
@@ -297,6 +302,7 @@ export class RightSizingPostgresRepository implements IRightSizingRepository {
             byStatus: toCountMap(byStatus as never, 'status'),
             savingsByResourceType: toSumMap(byType as never, 'resourceType'),
             savingsByAccount: toSumMap(byAccount as never, 'accountId'),
+            accountIds: (distinctAccounts as Array<{ accountId: string }>).map((r) => r.accountId),
             lastRunAt: lastRun ? (lastRun as RunRow).startedAt.toISOString() : null,
         };
     }

--- a/apps/web-ui/lib/queries/right-sizing.ts
+++ b/apps/web-ui/lib/queries/right-sizing.ts
@@ -22,6 +22,7 @@ export interface RightSizingFilters {
     resourceType?: string;
     finding?: string;
     status?: string;
+    accountId?: string;
 }
 
 interface RecommendationsResult {
@@ -42,6 +43,7 @@ export function useRightSizingRecommendations(filters: RightSizingFilters) {
             if (filters.resourceType) params.set('resourceType', filters.resourceType);
             if (filters.finding) params.set('finding', filters.finding);
             if (filters.status) params.set('status', filters.status);
+            if (filters.accountId) params.set('account', filters.accountId);
 
             const res = await fetch(`/api/right-sizing/recommendations?${params.toString()}`);
             const json = await res.json();


### PR DESCRIPTION
## What

Adds an **Account** filter to the Right Sizing table, plus a **Reset** control for the filter row.

## Why

The table already surfaces recommendations across many AWS accounts, but there was no way to narrow to one. A naive approach (reuse the connected-accounts list) is wrong here: that list can include accounts with zero recommendations and can omit accounts that do have rows — so you could pick an account that returns nothing and *couldn't* pick the ones actually in the table.

## How

- **Distinct accounts from the recommendations, server-side.** Added a `groupBy(accountId)` (all statuses) in `getSummary`, exposed as `RightSizingSummary.accountIds`. The dropdown is driven by this, so it's not limited to the current page and matches exactly the accounts present in the table.
- **Friendly names.** Each ID is enriched with its account name as `Name {accountId}` via the accounts list (fetched with a high limit so the lookup isn't truncated by the default page size); falls back to the bare ID when the account isn't in the accounts table.
- **Wiring.** Uses the `account` query param the recommendations API already reads. The filter seeds from / persists to the URL and is carried into the detail-page href, consistent with the other filters.
- **Reset.** Clears the search box and all filter dropdowns and returns to page 1; shown only when a filter is active. Sort order is left untouched (it's an ordering preference, not a filter).

## Files
- `lib/db/repositories/right-sizing/interface.ts` — `accountIds: string[]` on the summary
- `lib/db/repositories/right-sizing/postgres.ts` — distinct-account `groupBy` in `getSummary`
- `app/api/right-sizing/summary/route.ts` — `accountIds: []` in the flag-disabled fallback
- `lib/queries/right-sizing.ts` — `accountId` filter → `account` param
- `app/app/right-sizing/page.tsx` — Account `FilterSelect` + Reset button

## Testing
- `tsc --noEmit` clean for the right-sizing files.
- No new server round-trips: the distinct-account query runs alongside the existing summary aggregations in the same `Promise.all`.

> Note: branched from `master-v1` (not the local `agent-ops` working branch, which is behind on the right-sizing module — it predates #60's dedicated detail page). This PR re-applies the change on top of the current `master-v1` structure so it does not regress #60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)