### PR TITLE
fix(workers): stop perpetual ephemeral ECS task flood from empty-tenant scheduler scans

### DIFF
--- a/apps/workers/src/jobs/scheduler/index.test.ts
+++ b/apps/workers/src/jobs/scheduler/index.test.ts
@@ -12,8 +12,9 @@ const mockBoss = {
 } as any;
 
 const mockRegisterHandler = vi.fn();
-// Cron path scopes each scan to a tenant and only advances lastRunAt when the
-// scan reports that tenant had work (processedTenantIds includes it).
+// Cron path scopes each scan to a tenant and advances lastRunAt whenever the
+// scan actually evaluated that tenant (checkedTenantIds includes it) — even if
+// the tenant had no schedules/accounts, so it isn't re-dispatched every tick.
 const mockExecute = vi.fn().mockResolvedValue({
   success: true,
   executionId: 'test-exec',
@@ -24,6 +25,7 @@ const mockExecute = vi.fn().mockResolvedValue({
   resourcesFailed: 0,
   duration: 100,
   processedTenantIds: ['tenant-1'],
+  checkedTenantIds: ['tenant-1'],
 });
 const mockExecutor = {
   registerHandler: mockRegisterHandler,
@@ -172,5 +174,44 @@ describe('scheduler job registration', () => {
     await workCallback([{ id: 'job-1', data: {} }]);
 
     expect(pgService.updateTenantJobLastRun).toHaveBeenCalledWith('tenant-1', 'scheduler-cron', expect.any(String));
+  });
+
+  it('should still advance lastRunAt for a tenant with no schedules/accounts (checked but not processed)', async () => {
+    const pgService = await import('./services/pg-service.js');
+    vi.mocked(pgService.getTenantJobConfig).mockResolvedValueOnce({ intervalMinutes: 60, lastRunAt: null });
+    // Empty tenant: evaluated by the scan (checkedTenantIds) but had no work (processedTenantIds excludes it).
+    mockExecute.mockResolvedValueOnce({
+      success: true,
+      executionId: 'test-exec',
+      mode: 'full',
+      schedulesProcessed: 0,
+      resourcesStarted: 0,
+      resourcesStopped: 0,
+      resourcesFailed: 0,
+      duration: 100,
+      processedTenantIds: [],
+      checkedTenantIds: ['tenant-1'],
+    });
+
+    await register(mockBoss, mockExecutor);
+    const workCallback = mockWork.mock.calls[0][2];
+    await workCallback([{ id: 'job-1', data: {} }]);
+
+    // Regression guard: without this, an empty tenant's lastRunAt never advances and it
+    // gets re-dispatched (a real ECS RunTask under the horizontal executor) every single tick.
+    expect(pgService.updateTenantJobLastRun).toHaveBeenCalledWith('tenant-1', 'scheduler-cron', expect.any(String));
+  });
+
+  it('should not advance lastRunAt or abort the loop when executor.execute throws for a tenant', async () => {
+    const pgService = await import('./services/pg-service.js');
+    vi.mocked(pgService.getTenantJobConfig).mockResolvedValueOnce({ intervalMinutes: 60, lastRunAt: null });
+    mockExecute.mockRejectedValueOnce(new Error('AccessDeniedException: not authorized to perform ecs:RunTask'));
+
+    await register(mockBoss, mockExecutor);
+    const workCallback = mockWork.mock.calls[0][2];
+    // Must not throw — an unhandled rejection here previously crashed the whole worker process.
+    await expect(workCallback([{ id: 'job-1', data: {} }])).resolves.not.toThrow();
+
+    expect(pgService.updateTenantJobLastRun).not.toHaveBeenCalled();
   });
 });

--- a/apps/workers/src/jobs/scheduler/index.ts
+++ b/apps/workers/src/jobs/scheduler/index.ts
@@ -95,14 +95,29 @@ export async function register(boss: PgBoss, executor: JobExecutor): Promise<voi
                         continue;
                     }
 
-                    const scanResult = (await executor.execute(JOB_NAME, {
-                        triggeredBy: 'system',
-                        tenantId: tenant.id,
-                    })) as SchedulerResult | undefined;
+                    // A single tenant's dispatch failing (e.g. a transient ECS/IAM error)
+                    // must not abort the rest of the tenant loop or crash the worker
+                    // process — pg-boss's handler callback has no outer catch, so an
+                    // unhandled rejection here previously took the whole service down.
+                    let scanResult: SchedulerResult | undefined;
+                    try {
+                        scanResult = (await executor.execute(JOB_NAME, {
+                            triggeredBy: 'system',
+                            tenantId: tenant.id,
+                        })) as SchedulerResult | undefined;
+                    } catch (err) {
+                        log.error('Tenant scan dispatch failed — will retry next tick', {
+                            tenantId: tenant.id,
+                            error: err instanceof Error ? err.message : String(err),
+                        });
+                        continue;
+                    }
 
-                    // Only advance lastRunAt when the tenant actually had work
-                    // (schedules > 0 AND accounts > 0); otherwise retry next tick.
-                    if (scanResult?.processedTenantIds?.includes(tenant.id)) {
+                    // Advance lastRunAt whenever the tenant was actually checked, even if
+                    // it had no schedules/accounts — otherwise an empty tenant's lastRunAt
+                    // never gets set and it gets re-dispatched (a real ECS RunTask) on
+                    // every single cron tick forever instead of once per interval.
+                    if (scanResult?.checkedTenantIds?.includes(tenant.id)) {
                         await updateTenantJobLastRun(tenant.id, 'scheduler-cron', runAt);
                     }
                 }

--- a/apps/workers/src/jobs/scheduler/services/scheduler-service.ts
+++ b/apps/workers/src/jobs/scheduler/services/scheduler-service.ts
@@ -134,6 +134,7 @@ export async function runFullScan(
     }> = [];
 
     let processedTenantIds: string[] = [];
+    let checkedTenantIds: string[] = [];
 
     {
         // Iterate all active tenants (optionally scoped to one tenant)
@@ -143,7 +144,7 @@ export async function runFullScan(
 
         if (tenants.length === 0) {
             logger.info('No active tenants to process');
-            return createResult(executionId, 'full', startTime, 0, 0, 0, 0, []);
+            return createResult(executionId, 'full', startTime, 0, 0, 0, 0, [], [], []);
         }
 
         // D-09: Process tenants sequentially
@@ -152,6 +153,11 @@ export async function runFullScan(
             const schedules = (await getSchedulesPg(tenant.id)).filter(s => s.type === 'schedule');
             const accounts = await getAccountsPg(tenant.id);
             logger.info(`Tenant ${tenant.name}: ${schedules.length} active schedules, ${accounts.length} accounts`);
+
+            // Evaluated regardless of outcome — the caller uses this to advance
+            // lastRunAt so a tenant with no schedules/accounts is only re-checked
+            // once per configured interval, not on every cron tick forever.
+            checkedTenantIds.push(tenant.id);
 
             if (schedules.length === 0 || accounts.length === 0) {
                 continue;
@@ -221,6 +227,7 @@ export async function runFullScan(
         totalStopped,
         totalFailed,
         processedTenantIds,
+        checkedTenantIds,
         aggregatedErrors
     );
 }
@@ -322,6 +329,7 @@ export async function runPartialScan(
             result.started,
             result.stopped,
             result.failed,
+            [event.tenantId],
             [event.tenantId],
             result.errors
         );
@@ -878,6 +886,7 @@ function createResult(
     resourcesStopped: number,
     resourcesFailed: number,
     processedTenantIds?: string[],
+    checkedTenantIds?: string[],
     errors?: string[]
 ): SchedulerResult {
     return {
@@ -890,6 +899,7 @@ function createResult(
         resourcesFailed,
         duration: Date.now() - startTime,
         processedTenantIds,
+        checkedTenantIds,
         errors: errors && errors.length > 0 ? errors : undefined,
     };
 }

--- a/apps/workers/src/jobs/scheduler/types/index.ts
+++ b/apps/workers/src/jobs/scheduler/types/index.ts
@@ -26,8 +26,10 @@ export interface SchedulerResult {
     resourcesFailed: number;
     duration: number;
     errors?: string[];
-    /** Tenant IDs that had actual work (schedules > 0 and accounts > 0). Caller uses this to update lastRunAt. */
+    /** Tenant IDs that had actual work (schedules > 0 and accounts > 0). Used for per-tenant audit logging. */
     processedTenantIds?: string[];
+    /** Tenant IDs the scan evaluated, whether or not they had work. Caller uses this to update lastRunAt so empty tenants aren't re-checked every tick. */
+    checkedTenantIds?: string[];
 }
 
 // DynamoDB Entity Types

--- a/infra/compute/index.ts
+++ b/infra/compute/index.ts
@@ -1138,8 +1138,9 @@ new aws.iam.RolePolicy("workers-rds-connect-policy", {
 });
 
 // Ephemeral worker task definition — lightweight tasks for horizontal dispatch
+const EPHEMERAL_WORKER_TASK_FAMILY = "nucleus-cloud-ops-ephemeral-worker-task";
 const ephemeralWorkerTaskDef = new aws.ecs.TaskDefinition("ephemeral-worker-task-def", {
-    family: "nucleus-cloud-ops-ephemeral-worker-task",
+    family: EPHEMERAL_WORKER_TASK_FAMILY,
     cpu: "2048",
     memory: "4096",
     networkMode: "awsvpc",
@@ -1187,15 +1188,21 @@ const ephemeralWorkerTaskDef = new aws.ecs.TaskDefinition("ephemeral-worker-task
 // IAM policy for workers to dispatch ECS tasks (horizontal executor)
 new aws.iam.RolePolicy("workers-ecs-dispatch-policy", {
     role: workersTaskRole.id,
-    policy: pulumi.all([ephemeralWorkerTaskDef.arn, ecsCluster.arn, workersTaskRole.arn, ecsTaskExecutionRole.arn]).apply(
-        ([taskDefArn, clusterArn, taskRoleArn, execRoleArn]) =>
+    policy: pulumi.all([ecsCluster.arn, workersTaskRole.arn, ecsTaskExecutionRole.arn, accountId]).apply(
+        ([clusterArn, taskRoleArn, execRoleArn, accId]) =>
             JSON.stringify({
                 Version: "2012-10-17",
                 Statement: [
                     {
                         Effect: "Allow",
                         Action: ["ecs:RunTask"],
-                        Resource: [taskDefArn],
+                        // Family wildcard, NOT the exact task-def ARN (which is pinned to one
+                        // revision). Every workers deploy bumps the ephemeral task-def revision;
+                        // pinning here creates a rollout race where the still-running old workers
+                        // container (holding the previous revision's ARN in HORIZONTAL_TASK_DEF_ARN)
+                        // gets AccessDenied against the just-updated policy until ECS finishes
+                        // replacing it — which crash-loops the service in the meantime.
+                        Resource: [`arn:aws:ecs:${region}:${accId}:task-definition/${EPHEMERAL_WORKER_TASK_FAMILY}:*`],
                     },
                     {
                         Effect: "Allow",


### PR DESCRIPTION
## Summary
- Tenants with zero active schedules/accounts never had `scheduler-cron` `lastRunAt` persisted, so the interval gate treated them as permanently overdue — the scheduler re-dispatched a real ECS `RunTask` (horizontal executor) for them on every 5-minute cron tick, forever. Track "checked" tenants separately from "had work" tenants so `lastRunAt` advances on a no-op scan too.
- Harden the per-tenant cron loop (`apps/workers/src/jobs/scheduler/index.ts`) so one tenant's dispatch failure is logged and skipped instead of throwing an unhandled rejection that crashes the whole worker process — this is what caused the observed `nucleus-cloud-ops-workers-service` restart loop.
- `ecs:RunTask` IAM policy for the ephemeral worker task was pinned to one exact task-definition revision ARN (`infra/compute/index.ts`). Every workers deploy bumps that revision, so during rollout the still-running old container (holding the previous revision's ARN) got `AccessDenied` against the already-updated policy until ECS finished replacing it. Switched to a task-definition family wildcard to remove the race.

## Root cause investigation
Found via live AWS investigation (CloudWatch Logs Insights on `/ecs/nucleus-cloud-ops-ephemeral-workers` + `/ecs/nucleus-cloud-ops-workers`, ECS service events, IAM role policy inspection):
- Distinct tenant IDs were being scanned sequentially roughly every ~60s (Fargate cold-start latency), not the intended 5-minute cadence — traced to `scheduler-service.ts`'s `continue` before pushing empty tenants into `processedTenantIds`, which `index.ts` used as the sole signal to persist `lastRunAt`.
- A separate historical restart loop (11:39–11:52 UTC) was traced to `AccessDeniedException: ... ecs:RunTask on resource task-definition/nucleus-cloud-ops-ephemeral-worker-task:49` — the IAM policy's `Resource` was pinned to an exact revision, creating a deploy-time race.

## Test plan
- [x] `cd apps/workers && bunx tsc --noEmit` — clean
- [x] `cd infra/compute && bunx tsc --noEmit` — clean
- [x] `cd apps/workers && bunx vitest run src/jobs/scheduler src/executor` — 52/52 passing (added 2 regression tests: empty-tenant `lastRunAt` advancement, executor failure doesn't crash the loop)
- [ ] `pulumi preview --stack prod` for `infra/compute` before merge/deploy (not run yet — infra change, needs review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)