### PR TITLE
fix(workers): advance scheduler lastRunAt on successful dispatch (horizontal executor)

### DIFF
--- a/apps/workers/src/jobs/scheduler/index.test.ts
+++ b/apps/workers/src/jobs/scheduler/index.test.ts
@@ -176,10 +176,10 @@ describe('scheduler job registration', () => {
     expect(pgService.updateTenantJobLastRun).toHaveBeenCalledWith('tenant-1', 'scheduler-cron', expect.any(String));
   });
 
-  it('should still advance lastRunAt for a tenant with no schedules/accounts (checked but not processed)', async () => {
+  it('should still advance lastRunAt for a tenant with no schedules/accounts', async () => {
     const pgService = await import('./services/pg-service.js');
     vi.mocked(pgService.getTenantJobConfig).mockResolvedValueOnce({ intervalMinutes: 60, lastRunAt: null });
-    // Empty tenant: evaluated by the scan (checkedTenantIds) but had no work (processedTenantIds excludes it).
+    // Empty tenant: the scan runs but reports no work.
     mockExecute.mockResolvedValueOnce({
       success: true,
       executionId: 'test-exec',
@@ -199,6 +199,24 @@ describe('scheduler job registration', () => {
 
     // Regression guard: without this, an empty tenant's lastRunAt never advances and it
     // gets re-dispatched (a real ECS RunTask under the horizontal executor) every single tick.
+    expect(pgService.updateTenantJobLastRun).toHaveBeenCalledWith('tenant-1', 'scheduler-cron', expect.any(String));
+  });
+
+  it('advances lastRunAt under the HORIZONTAL executor, which resolves to void (no SchedulerResult)', async () => {
+    // THE production case: WORKER_ARCH=horizontal dispatches the scan to a separate
+    // ephemeral ECS task and resolves execute() to `undefined` on exit 0 — the scan
+    // result never crosses the process boundary. Gating lastRunAt on the return value
+    // (processedTenantIds/checkedTenantIds) left it permanently null, so every tenant
+    // was re-dispatched every tick forever. lastRunAt must advance on a clean resolve.
+    const pgService = await import('./services/pg-service.js');
+    vi.mocked(pgService.getTenantJobConfig).mockResolvedValueOnce({ intervalMinutes: 60, lastRunAt: null });
+    mockExecute.mockResolvedValueOnce(undefined); // horizontal executor returns void
+
+    await register(mockBoss, mockExecutor);
+    const workCallback = mockWork.mock.calls[0][2];
+    await workCallback([{ id: 'job-1', data: {} }]);
+
+    expect(mockExecute).toHaveBeenCalledWith('scheduler-scan', { triggeredBy: 'system', tenantId: 'tenant-1' });
     expect(pgService.updateTenantJobLastRun).toHaveBeenCalledWith('tenant-1', 'scheduler-cron', expect.any(String));
   });
 

--- a/apps/workers/src/jobs/scheduler/index.ts
+++ b/apps/workers/src/jobs/scheduler/index.ts
@@ -3,7 +3,7 @@ import { createLogger } from '../../lib/logger.js';
 import type { JobExecutor } from '../../executor/index.js';
 import { runFullScan, runPartialScan } from './services/scheduler-service.js';
 import { getActiveTenants, getTenantJobConfig, updateTenantJobLastRun } from './services/pg-service.js';
-import type { SchedulerEvent, SchedulerResult } from './types/index.js';
+import type { SchedulerEvent } from './types/index.js';
 
 const log = createLogger('scheduler');
 
@@ -99,13 +99,14 @@ export async function register(boss: PgBoss, executor: JobExecutor): Promise<voi
                     // must not abort the rest of the tenant loop or crash the worker
                     // process — pg-boss's handler callback has no outer catch, so an
                     // unhandled rejection here previously took the whole service down.
-                    let scanResult: SchedulerResult | undefined;
                     try {
-                        scanResult = (await executor.execute(JOB_NAME, {
+                        await executor.execute(JOB_NAME, {
                             triggeredBy: 'system',
                             tenantId: tenant.id,
-                        })) as SchedulerResult | undefined;
+                        });
                     } catch (err) {
+                        // Dispatch failed — do NOT advance lastRunAt, so the tenant is
+                        // retried on the next tick.
                         log.error('Tenant scan dispatch failed — will retry next tick', {
                             tenantId: tenant.id,
                             error: err instanceof Error ? err.message : String(err),
@@ -113,13 +114,18 @@ export async function register(boss: PgBoss, executor: JobExecutor): Promise<voi
                         continue;
                     }
 
-                    // Advance lastRunAt whenever the tenant was actually checked, even if
-                    // it had no schedules/accounts — otherwise an empty tenant's lastRunAt
-                    // never gets set and it gets re-dispatched (a real ECS RunTask) on
-                    // every single cron tick forever instead of once per interval.
-                    if (scanResult?.checkedTenantIds?.includes(tenant.id)) {
-                        await updateTenantJobLastRun(tenant.id, 'scheduler-cron', runAt);
-                    }
+                    // Advance lastRunAt on any SUCCESSFUL dispatch, regardless of whether
+                    // the tenant had work. Do NOT gate this on the scan's return value:
+                    // under WORKER_ARCH=horizontal, executor.execute() dispatches the scan
+                    // to a separate ephemeral ECS task and resolves to `void` on exit 0 —
+                    // the SchedulerResult (checkedTenantIds/processedTenantIds) is produced
+                    // inside that task's process and never crosses back here. Gating on it
+                    // left lastRunAt permanently null, so every tenant looked perpetually
+                    // "due" and was re-dispatched (a real RunTask) on every cron tick.
+                    // execute() resolves on success and throws on failure for BOTH the
+                    // vertical (in-process) and horizontal (ECS) executors, so a clean
+                    // resolve here is the correct, arch-independent "it ran" signal.
+                    await updateTenantJobLastRun(tenant.id, 'scheduler-cron', runAt);
                 }
             }
         },


### PR DESCRIPTION
## Why #68 didn't stop the flood

#68 fixed the empty-tenant `lastRunAt` logic, but the ephemeral-task flood **persisted in production** because production runs `WORKER_ARCH=horizontal`.

`HorizontalExecutor.execute()` is typed `Promise<void>` — it dispatches the scan to a **separate ephemeral ECS task**, polls until that task exits 0, and returns `undefined`. The `SchedulerResult` (`processedTenantIds` / `checkedTenantIds`) is produced inside that task's own process and **never crosses back** to the parent workers container.

The cron loop gated the `lastRunAt` update on that return value:
```ts
scanResult = (await executor.execute(...)) as SchedulerResult | undefined; // undefined under horizontal!
if (scanResult?.checkedTenantIds?.includes(tenant.id)) {   // always false
    await updateTenantJobLastRun(...);                      // never runs
}
```
So `lastRunAt` stayed null forever → every tenant always "due" → a fresh `RunTask` launched for every tenant on every 5-minute tick. Both the original code (`processedTenantIds`) and #68 (`checkedTenantIds`) share this flaw. #68's unit tests passed only because they **mock** `executor.execute` to return a value — masking the exact gap that breaks in production.

## Fix

Advance `lastRunAt` after a **successful dispatch**, not by inspecting the scan result. `execute()` resolves on success and throws on failure for **both** the vertical (in-process) and horizontal (ECS) executors, so a clean resolve is the correct arch-independent "it ran" signal. Dispatch failures still skip the update so the tenant retries next tick.

## Production evidence
- `WORKER_ARCH=horizontal` confirmed on `nucleus-cloud-ops-workers-task:52`.
- Deployed #68 image (`sha256:29fc68b6…`) is live on both the workers service and ephemeral task def — yet the same tenants kept being re-dispatched every ~cron tick.
- **Zero** `"Skipping tenant — interval not elapsed"` log lines in `/ecs/nucleus-cloud-ops-workers` since the #68 rollout — proving the interval gate never tripped (i.e. `lastRunAt` never advanced).

## Test plan
- [x] `cd apps/workers && bunx tsc --noEmit` — clean
- [x] `cd apps/workers && bunx vitest run src/jobs/scheduler src/executor` — 51/51 passing
- [x] New regression test drives `executor.execute()` resolving to `void` (the horizontal case) and asserts `lastRunAt` still advances — fails against the old gating, passes now.

## Note
No infra change in this PR. Requires a workers image rebuild + ECS rollout to take effect. (Also: the workers service was found scaled to `desiredCount:0` during investigation and has since been scaled back to 1.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)