### PR TITLE
fix(workers): stop scheduler-scan ephemeral-task flood (bound queue + full flood-fix stack)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,4 @@ backups/
 
 # Playwright MCP navigation artifacts
 .playwright-mcp/
+.superpowers/

--- a/apps/workers/src/jobs/scheduler/index.test.ts
+++ b/apps/workers/src/jobs/scheduler/index.test.ts
@@ -12,8 +12,9 @@ const mockBoss = {
 } as any;
 
 const mockRegisterHandler = vi.fn();
-// Cron path scopes each scan to a tenant and only advances lastRunAt when the
-// scan reports that tenant had work (processedTenantIds includes it).
+// Cron path scopes each scan to a tenant and advances lastRunAt whenever the
+// scan actually evaluated that tenant (checkedTenantIds includes it) — even if
+// the tenant had no schedules/accounts, so it isn't re-dispatched every tick.
 const mockExecute = vi.fn().mockResolvedValue({
   success: true,
   executionId: 'test-exec',
@@ -24,6 +25,7 @@ const mockExecute = vi.fn().mockResolvedValue({
   resourcesFailed: 0,
   duration: 100,
   processedTenantIds: ['tenant-1'],
+  checkedTenantIds: ['tenant-1'],
 });
 const mockExecutor = {
   registerHandler: mockRegisterHandler,
@@ -172,5 +174,44 @@ describe('scheduler job registration', () => {
     await workCallback([{ id: 'job-1', data: {} }]);
 
     expect(pgService.updateTenantJobLastRun).toHaveBeenCalledWith('tenant-1', 'scheduler-cron', expect.any(String));
+  });
+
+  it('should still advance lastRunAt for a tenant with no schedules/accounts (checked but not processed)', async () => {
+    const pgService = await import('./services/pg-service.js');
+    vi.mocked(pgService.getTenantJobConfig).mockResolvedValueOnce({ intervalMinutes: 60, lastRunAt: null });
+    // Empty tenant: evaluated by the scan (checkedTenantIds) but had no work (processedTenantIds excludes it).
+    mockExecute.mockResolvedValueOnce({
+      success: true,
+      executionId: 'test-exec',
+      mode: 'full',
+      schedulesProcessed: 0,
+      resourcesStarted: 0,
+      resourcesStopped: 0,
+      resourcesFailed: 0,
+      duration: 100,
+      processedTenantIds: [],
+      checkedTenantIds: ['tenant-1'],
+    });
+
+    await register(mockBoss, mockExecutor);
+    const workCallback = mockWork.mock.calls[0][2];
+    await workCallback([{ id: 'job-1', data: {} }]);
+
+    // Regression guard: without this, an empty tenant's lastRunAt never advances and it
+    // gets re-dispatched (a real ECS RunTask under the horizontal executor) every single tick.
+    expect(pgService.updateTenantJobLastRun).toHaveBeenCalledWith('tenant-1', 'scheduler-cron', expect.any(String));
+  });
+
+  it('should not advance lastRunAt or abort the loop when executor.execute throws for a tenant', async () => {
+    const pgService = await import('./services/pg-service.js');
+    vi.mocked(pgService.getTenantJobConfig).mockResolvedValueOnce({ intervalMinutes: 60, lastRunAt: null });
+    mockExecute.mockRejectedValueOnce(new Error('AccessDeniedException: not authorized to perform ecs:RunTask'));
+
+    await register(mockBoss, mockExecutor);
+    const workCallback = mockWork.mock.calls[0][2];
+    // Must not throw — an unhandled rejection here previously crashed the whole worker process.
+    await expect(workCallback([{ id: 'job-1', data: {} }])).resolves.not.toThrow();
+
+    expect(pgService.updateTenantJobLastRun).not.toHaveBeenCalled();
   });
 });

--- a/apps/workers/src/jobs/scheduler/index.test.ts
+++ b/apps/workers/src/jobs/scheduler/index.test.ts
@@ -3,12 +3,16 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const mockWork = vi.fn();
 const mockSchedule = vi.fn();
 
+const mockExecuteSql = vi.fn().mockResolvedValue(undefined);
 const mockBoss = {
   work: mockWork,
   schedule: mockSchedule,
   send: vi.fn(),
   createQueue: vi.fn().mockResolvedValue(undefined),
   updateQueue: vi.fn().mockResolvedValue(undefined),
+  // Queue absent by default → register() takes the createQueue('stately') path.
+  getQueue: vi.fn().mockResolvedValue(null),
+  getDb: vi.fn().mockReturnValue({ executeSql: mockExecuteSql }),
 } as any;
 
 const mockRegisterHandler = vi.fn();
@@ -75,14 +79,51 @@ describe('scheduler job registration', () => {
     vi.clearAllMocks();
   });
 
-  it('should register cron as */5 * * * *', async () => {
+  it('should register cron as */5 * * * * with a cron-only singletonKey', async () => {
     await register(mockBoss, mockExecutor);
+    // singletonKey keeps cron ticks in their own 'stately' bucket so they can never
+    // stack into a backlog, while manual "Execute Now" triggers stay unsuppressed.
     expect(mockSchedule).toHaveBeenCalledWith(
       'scheduler-scan',
       '*/5 * * * *',
       {},
-      { tz: 'UTC' }
+      { tz: 'UTC', singletonKey: 'scheduler-cron' }
     );
+  });
+
+  it('should create scheduler-scan with stately policy when the queue is absent', async () => {
+    const pgBoss = mockBoss as any;
+    pgBoss.getQueue.mockResolvedValueOnce(null);
+    await register(mockBoss, mockExecutor);
+    expect(mockBoss.createQueue).toHaveBeenCalledWith(
+      'scheduler-scan',
+      expect.objectContaining({ name: 'scheduler-scan', policy: 'stately', retryLimit: 0 })
+    );
+    // No migration/purge needed for a fresh queue.
+    expect(mockExecuteSql).not.toHaveBeenCalled();
+  });
+
+  it('should migrate a legacy standard queue to stately and PURGE the stacked backlog', async () => {
+    const pgBoss = mockBoss as any;
+    pgBoss.getQueue.mockResolvedValueOnce({ name: 'scheduler-scan', policy: 'standard' });
+    await register(mockBoss, mockExecutor);
+    // The flood fix: drop every non-completed scheduler-scan job (the drain source)...
+    expect(mockExecuteSql).toHaveBeenCalledWith(
+      expect.stringMatching(/DELETE FROM pgboss\.job WHERE name = 'scheduler-scan' AND state NOT IN \('completed'\)/),
+      []
+    );
+    // ...then flip the queue policy so a backlog can never form again.
+    expect(mockExecuteSql).toHaveBeenCalledWith(
+      expect.stringMatching(/UPDATE pgboss\.queue SET policy = 'stately'.*WHERE name = 'scheduler-scan'/),
+      []
+    );
+  });
+
+  it('should NOT purge or re-migrate when the queue is already stately', async () => {
+    const pgBoss = mockBoss as any;
+    pgBoss.getQueue.mockResolvedValueOnce({ name: 'scheduler-scan', policy: 'stately' });
+    await register(mockBoss, mockExecutor);
+    expect(mockExecuteSql).not.toHaveBeenCalled();
   });
 
   it('should register handler with executor', async () => {

--- a/apps/workers/src/jobs/scheduler/index.test.ts
+++ b/apps/workers/src/jobs/scheduler/index.test.ts
@@ -176,10 +176,10 @@ describe('scheduler job registration', () => {
     expect(pgService.updateTenantJobLastRun).toHaveBeenCalledWith('tenant-1', 'scheduler-cron', expect.any(String));
   });
 
-  it('should still advance lastRunAt for a tenant with no schedules/accounts (checked but not processed)', async () => {
+  it('should still advance lastRunAt for a tenant with no schedules/accounts', async () => {
     const pgService = await import('./services/pg-service.js');
     vi.mocked(pgService.getTenantJobConfig).mockResolvedValueOnce({ intervalMinutes: 60, lastRunAt: null });
-    // Empty tenant: evaluated by the scan (checkedTenantIds) but had no work (processedTenantIds excludes it).
+    // Empty tenant: the scan runs but reports no work.
     mockExecute.mockResolvedValueOnce({
       success: true,
       executionId: 'test-exec',
@@ -199,6 +199,24 @@ describe('scheduler job registration', () => {
 
     // Regression guard: without this, an empty tenant's lastRunAt never advances and it
     // gets re-dispatched (a real ECS RunTask under the horizontal executor) every single tick.
+    expect(pgService.updateTenantJobLastRun).toHaveBeenCalledWith('tenant-1', 'scheduler-cron', expect.any(String));
+  });
+
+  it('advances lastRunAt under the HORIZONTAL executor, which resolves to void (no SchedulerResult)', async () => {
+    // THE production case: WORKER_ARCH=horizontal dispatches the scan to a separate
+    // ephemeral ECS task and resolves execute() to `undefined` on exit 0 — the scan
+    // result never crosses the process boundary. Gating lastRunAt on the return value
+    // (processedTenantIds/checkedTenantIds) left it permanently null, so every tenant
+    // was re-dispatched every tick forever. lastRunAt must advance on a clean resolve.
+    const pgService = await import('./services/pg-service.js');
+    vi.mocked(pgService.getTenantJobConfig).mockResolvedValueOnce({ intervalMinutes: 60, lastRunAt: null });
+    mockExecute.mockResolvedValueOnce(undefined); // horizontal executor returns void
+
+    await register(mockBoss, mockExecutor);
+    const workCallback = mockWork.mock.calls[0][2];
+    await workCallback([{ id: 'job-1', data: {} }]);
+
+    expect(mockExecute).toHaveBeenCalledWith('scheduler-scan', { triggeredBy: 'system', tenantId: 'tenant-1' });
     expect(pgService.updateTenantJobLastRun).toHaveBeenCalledWith('tenant-1', 'scheduler-cron', expect.any(String));
   });
 

--- a/apps/workers/src/jobs/scheduler/index.ts
+++ b/apps/workers/src/jobs/scheduler/index.ts
@@ -3,7 +3,7 @@ import { createLogger } from '../../lib/logger.js';
 import type { JobExecutor } from '../../executor/index.js';
 import { runFullScan, runPartialScan } from './services/scheduler-service.js';
 import { getActiveTenants, getTenantJobConfig, updateTenantJobLastRun } from './services/pg-service.js';
-import type { SchedulerEvent, SchedulerResult } from './types/index.js';
+import type { SchedulerEvent } from './types/index.js';
 
 const log = createLogger('scheduler');
 
@@ -99,13 +99,14 @@ export async function register(boss: PgBoss, executor: JobExecutor): Promise<voi
                     // must not abort the rest of the tenant loop or crash the worker
                     // process — pg-boss's handler callback has no outer catch, so an
                     // unhandled rejection here previously took the whole service down.
-                    let scanResult: SchedulerResult | undefined;
                     try {
-                        scanResult = (await executor.execute(JOB_NAME, {
+                        await executor.execute(JOB_NAME, {
                             triggeredBy: 'system',
                             tenantId: tenant.id,
-                        })) as SchedulerResult | undefined;
+                        });
                     } catch (err) {
+                        // Dispatch failed — do NOT advance lastRunAt, so the tenant is
+                        // retried on the next tick.
                         log.error('Tenant scan dispatch failed — will retry next tick', {
                             tenantId: tenant.id,
                             error: err instanceof Error ? err.message : String(err),
@@ -113,13 +114,18 @@ export async function register(boss: PgBoss, executor: JobExecutor): Promise<voi
                         continue;
                     }
 
-                    // Advance lastRunAt whenever the tenant was actually checked, even if
-                    // it had no schedules/accounts — otherwise an empty tenant's lastRunAt
-                    // never gets set and it gets re-dispatched (a real ECS RunTask) on
-                    // every single cron tick forever instead of once per interval.
-                    if (scanResult?.checkedTenantIds?.includes(tenant.id)) {
-                        await updateTenantJobLastRun(tenant.id, 'scheduler-cron', runAt);
-                    }
+                    // Advance lastRunAt on any SUCCESSFUL dispatch, regardless of whether
+                    // the tenant had work. Do NOT gate this on the scan's return value:
+                    // under WORKER_ARCH=horizontal, executor.execute() dispatches the scan
+                    // to a separate ephemeral ECS task and resolves to `void` on exit 0 —
+                    // the SchedulerResult (checkedTenantIds/processedTenantIds) is produced
+                    // inside that task's process and never crosses back here. Gating on it
+                    // left lastRunAt permanently null, so every tenant looked perpetually
+                    // "due" and was re-dispatched (a real RunTask) on every cron tick.
+                    // execute() resolves on success and throws on failure for BOTH the
+                    // vertical (in-process) and horizontal (ECS) executors, so a clean
+                    // resolve here is the correct, arch-independent "it ran" signal.
+                    await updateTenantJobLastRun(tenant.id, 'scheduler-cron', runAt);
                 }
             }
         },

--- a/apps/workers/src/jobs/scheduler/index.ts
+++ b/apps/workers/src/jobs/scheduler/index.ts
@@ -36,7 +36,31 @@ export async function handleSchedulerJob(jobData: unknown) {
 export async function register(boss: PgBoss, executor: JobExecutor): Promise<void> {
     executor.registerHandler?.(JOB_NAME, handleSchedulerJob);
 
-    await boss.createQueue(JOB_NAME);
+    // The scan queue MUST bound its own backlog, or it floods the cluster with
+    // ephemeral ECS tasks. Under WORKER_ARCH=horizontal each due-tenant dispatch
+    // blocks the single work() slot (batchSize:1) for the full lifetime of an
+    // ephemeral Fargate task — HorizontalExecutor fires RunTask then polls until
+    // STOPPED (tens of seconds/tenant). While that slot is blocked the '*/5' cron
+    // keeps firing, and on a 'standard' queue every tick enqueues ANOTHER
+    // scheduler-scan job that simply stacks in 'created'. Once consumption falls
+    // behind production the backlog grows without limit; on the next worker start
+    // pg-boss drains it at pollingIntervalSeconds (1s), re-running the whole tenant
+    // loop ~once/second and firing a real ephemeral RunTask for every tenant past
+    // its interval — the "ephemeral task flood". 'stately' caps the queue at one job
+    // in 'created' + one 'active' per singletonKey, so the cron can never stack.
+    // (Same fix discovery-scan / right-sizing already carry.)
+    const existingQueue = await boss.getQueue(JOB_NAME);
+    if (!existingQueue) {
+        await boss.createQueue(JOB_NAME, { name: JOB_NAME, policy: 'stately', retryLimit: 0, expireInSeconds: 900 });
+    } else if (existingQueue.policy !== 'stately') {
+        // One-time migration off the old unbounded 'standard' queue: purge the stacked
+        // backlog (everything not yet completed) so it stops draining, then flip the
+        // policy. Idempotent — skipped once the queue is already 'stately'.
+        log.info('Migrating scheduler-scan queue to stately policy', { oldPolicy: existingQueue.policy });
+        const db = boss.getDb();
+        await db.executeSql(`DELETE FROM pgboss.job WHERE name = 'scheduler-scan' AND state NOT IN ('completed')`, []);
+        await db.executeSql(`UPDATE pgboss.queue SET policy = 'stately', updated_on = now() WHERE name = 'scheduler-scan'`, []);
+    }
     // A scan MUTATES live AWS resources (start/stop). If the worker is killed
     // mid-scan the job is orphaned in 'active'; under the global defaults
     // (expireInHours: 4, retryLimit: 3) pg-boss would resurrect and re-run it up
@@ -48,12 +72,16 @@ export async function register(boss: PgBoss, executor: JobExecutor): Promise<voi
     //                       pg-boss fails it. This value also caps the handler runtime
     //                       (pg-boss derives the handler timeout from it), so it must
     //                       comfortably exceed the longest legitimate scan.
-    // createQueue uses ON CONFLICT DO NOTHING, so updateQueue enforces it on the
-    // pre-existing queue too (matches the discovery/right-sizing pattern).
+    // updateQueue enforces these on the pre-existing queue too (createQueue's opts are
+    // ON CONFLICT DO NOTHING); it does NOT change policy — the migration above owns that.
     await boss.updateQueue(JOB_NAME, { name: JOB_NAME, retryLimit: 0, expireInSeconds: 900 });
 
-    // Global tick — every 5 min (matches minimum supported tenant interval)
-    await boss.schedule(JOB_NAME, '*/5 * * * *', {}, { tz: 'UTC' });
+    // Global tick — every 5 min (matches minimum supported tenant interval).
+    // singletonKey scopes the 'stately' de-dup to a CRON-only bucket: at most one
+    // cron-originated scan is ever queued/active, while manual "Execute Now" triggers
+    // (sent from web-ui with no singletonKey) live in a separate bucket and are never
+    // suppressed by an in-flight cron scan.
+    await boss.schedule(JOB_NAME, '*/5 * * * *', {}, { tz: 'UTC', singletonKey: 'scheduler-cron' });
 
     // batchSize: 1 prevents concurrent scans
     await boss.work<SchedulerEvent>(

--- a/apps/workers/src/jobs/scheduler/index.ts
+++ b/apps/workers/src/jobs/scheduler/index.ts
@@ -95,14 +95,29 @@ export async function register(boss: PgBoss, executor: JobExecutor): Promise<voi
                         continue;
                     }
 
-                    const scanResult = (await executor.execute(JOB_NAME, {
-                        triggeredBy: 'system',
-                        tenantId: tenant.id,
-                    })) as SchedulerResult | undefined;
+                    // A single tenant's dispatch failing (e.g. a transient ECS/IAM error)
+                    // must not abort the rest of the tenant loop or crash the worker
+                    // process — pg-boss's handler callback has no outer catch, so an
+                    // unhandled rejection here previously took the whole service down.
+                    let scanResult: SchedulerResult | undefined;
+                    try {
+                        scanResult = (await executor.execute(JOB_NAME, {
+                            triggeredBy: 'system',
+                            tenantId: tenant.id,
+                        })) as SchedulerResult | undefined;
+                    } catch (err) {
+                        log.error('Tenant scan dispatch failed — will retry next tick', {
+                            tenantId: tenant.id,
+                            error: err instanceof Error ? err.message : String(err),
+                        });
+                        continue;
+                    }
 
-                    // Only advance lastRunAt when the tenant actually had work
-                    // (schedules > 0 AND accounts > 0); otherwise retry next tick.
-                    if (scanResult?.processedTenantIds?.includes(tenant.id)) {
+                    // Advance lastRunAt whenever the tenant was actually checked, even if
+                    // it had no schedules/accounts — otherwise an empty tenant's lastRunAt
+                    // never gets set and it gets re-dispatched (a real ECS RunTask) on
+                    // every single cron tick forever instead of once per interval.
+                    if (scanResult?.checkedTenantIds?.includes(tenant.id)) {
                         await updateTenantJobLastRun(tenant.id, 'scheduler-cron', runAt);
                     }
                 }

--- a/apps/workers/src/jobs/scheduler/services/scheduler-service.ts
+++ b/apps/workers/src/jobs/scheduler/services/scheduler-service.ts
@@ -134,6 +134,7 @@ export async function runFullScan(
     }> = [];
 
     let processedTenantIds: string[] = [];
+    let checkedTenantIds: string[] = [];
 
     {
         // Iterate all active tenants (optionally scoped to one tenant)
@@ -143,7 +144,7 @@ export async function runFullScan(
 
         if (tenants.length === 0) {
             logger.info('No active tenants to process');
-            return createResult(executionId, 'full', startTime, 0, 0, 0, 0, []);
+            return createResult(executionId, 'full', startTime, 0, 0, 0, 0, [], [], []);
         }
 
         // D-09: Process tenants sequentially
@@ -152,6 +153,11 @@ export async function runFullScan(
             const schedules = (await getSchedulesPg(tenant.id)).filter(s => s.type === 'schedule');
             const accounts = await getAccountsPg(tenant.id);
             logger.info(`Tenant ${tenant.name}: ${schedules.length} active schedules, ${accounts.length} accounts`);
+
+            // Evaluated regardless of outcome — the caller uses this to advance
+            // lastRunAt so a tenant with no schedules/accounts is only re-checked
+            // once per configured interval, not on every cron tick forever.
+            checkedTenantIds.push(tenant.id);
 
             if (schedules.length === 0 || accounts.length === 0) {
                 continue;
@@ -221,6 +227,7 @@ export async function runFullScan(
         totalStopped,
         totalFailed,
         processedTenantIds,
+        checkedTenantIds,
         aggregatedErrors
     );
 }
@@ -322,6 +329,7 @@ export async function runPartialScan(
             result.started,
             result.stopped,
             result.failed,
+            [event.tenantId],
             [event.tenantId],
             result.errors
         );
@@ -878,6 +886,7 @@ function createResult(
     resourcesStopped: number,
     resourcesFailed: number,
     processedTenantIds?: string[],
+    checkedTenantIds?: string[],
     errors?: string[]
 ): SchedulerResult {
     return {
@@ -890,6 +899,7 @@ function createResult(
         resourcesFailed,
         duration: Date.now() - startTime,
         processedTenantIds,
+        checkedTenantIds,
         errors: errors && errors.length > 0 ? errors : undefined,
     };
 }

--- a/apps/workers/src/jobs/scheduler/types/index.ts
+++ b/apps/workers/src/jobs/scheduler/types/index.ts
@@ -26,8 +26,10 @@ export interface SchedulerResult {
     resourcesFailed: number;
     duration: number;
     errors?: string[];
-    /** Tenant IDs that had actual work (schedules > 0 and accounts > 0). Caller uses this to update lastRunAt. */
+    /** Tenant IDs that had actual work (schedules > 0 and accounts > 0). Used for per-tenant audit logging. */
     processedTenantIds?: string[];
+    /** Tenant IDs the scan evaluated, whether or not they had work. Caller uses this to update lastRunAt so empty tenants aren't re-checked every tick. */
+    checkedTenantIds?: string[];
 }
 
 // DynamoDB Entity Types

--- a/infra/compute/index.ts
+++ b/infra/compute/index.ts
@@ -1138,8 +1138,9 @@ new aws.iam.RolePolicy("workers-rds-connect-policy", {
 });
 
 // Ephemeral worker task definition — lightweight tasks for horizontal dispatch
+const EPHEMERAL_WORKER_TASK_FAMILY = "nucleus-cloud-ops-ephemeral-worker-task";
 const ephemeralWorkerTaskDef = new aws.ecs.TaskDefinition("ephemeral-worker-task-def", {
-    family: "nucleus-cloud-ops-ephemeral-worker-task",
+    family: EPHEMERAL_WORKER_TASK_FAMILY,
     cpu: "2048",
     memory: "4096",
     networkMode: "awsvpc",
@@ -1187,15 +1188,21 @@ const ephemeralWorkerTaskDef = new aws.ecs.TaskDefinition("ephemeral-worker-task
 // IAM policy for workers to dispatch ECS tasks (horizontal executor)
 new aws.iam.RolePolicy("workers-ecs-dispatch-policy", {
     role: workersTaskRole.id,
-    policy: pulumi.all([ephemeralWorkerTaskDef.arn, ecsCluster.arn, workersTaskRole.arn, ecsTaskExecutionRole.arn]).apply(
-        ([taskDefArn, clusterArn, taskRoleArn, execRoleArn]) =>
+    policy: pulumi.all([ecsCluster.arn, workersTaskRole.arn, ecsTaskExecutionRole.arn, accountId]).apply(
+        ([clusterArn, taskRoleArn, execRoleArn, accId]) =>
             JSON.stringify({
                 Version: "2012-10-17",
                 Statement: [
                     {
                         Effect: "Allow",
                         Action: ["ecs:RunTask"],
-                        Resource: [taskDefArn],
+                        // Family wildcard, NOT the exact task-def ARN (which is pinned to one
+                        // revision). Every workers deploy bumps the ephemeral task-def revision;
+                        // pinning here creates a rollout race where the still-running old workers
+                        // container (holding the previous revision's ARN in HORIZONTAL_TASK_DEF_ARN)
+                        // gets AccessDenied against the just-updated policy until ECS finishes
+                        // replacing it — which crash-loops the service in the meantime.
+                        Resource: [`arn:aws:ecs:${region}:${accId}:task-definition/${EPHEMERAL_WORKER_TASK_FAMILY}:*`],
                     },
                     {
                         Effect: "Allow",

--- a/scripts/tunnel.sh
+++ b/scripts/tunnel.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-AWS_PROFILE=STX-CLOUD-PLATFORM aws ssm start-session --target i-05e5027eec38c6879 --document-name AWS-StartPortForwardingSessionToRemoteHost --parameters '{"host":["nucleus-cloud-ops-postgres.cxoucc8oef6b.ap-south-1.rds.amazonaws.com"],"portNumber":["5432"],"localPortNumber":["5432"]}' --region ap-south-1
+AWS_PROFILE=STX-CLOUD-PLATFORM aws ssm start-session --target i-0472dfbf02c83d920 --document-name AWS-StartPortForwardingSessionToRemoteHost --parameters '{"host":["nucleus-cloud-ops-postgres.cxoucc8oef6b.ap-south-1.rds.amazonaws.com"],"portNumber":["5432"],"localPortNumber":["5432"]}' --region ap-south-1


### PR DESCRIPTION
## Problem

In production (`WORKER_ARCH=horizontal`) the `scheduler-scan` job is dispatched repeatedly as an **ephemeral ECS task**, flooding the cluster. This PR brings `master-v1` the **complete** scheduler flood-fix stack, ending with the root-cause fix that the two prior layers missed.

## Root cause (the new layer, #70)

The `scheduler-scan` queue had **no pg-boss `policy` → defaults to `'standard'` (unbounded)**. Under `horizontal`, each due-tenant dispatch blocks the single `work()` slot (`batchSize:1`) for the entire lifetime of an ephemeral Fargate task (`HorizontalExecutor` polls `RunTask → STOPPED`). While that slot is blocked, the `*/5` cron keeps firing and every tick **stacks another job in `created`**. Once consumption lags production the backlog grows without bound; on the next worker start pg-boss drains it at `pollingIntervalSeconds` (1 s), re-running the whole tenant loop ~once/second and firing a real ephemeral `RunTask` for every tenant past its interval.

**Evidence (CloudWatch, prod):** one tenant skipped **1×/second** in bursts (impossible from a 5-min cron), 60 s pauses matching an active ECS poll, flood tied to the **worker restart** (not to the code going live), and it **self-drained to zero** once the backlog was exhausted — a finite backlog, not a live producer.

## Fix

Mirrors the pattern `discovery-scan` / right-sizing already carry:

- **Migrate `scheduler-scan` to `policy: 'stately'`** (≤1 `created` + ≤1 `active` per singletonKey) with an **idempotent startup purge** — `DELETE FROM pgboss.job WHERE name='scheduler-scan' AND state NOT IN ('completed')` then flip the policy, via `boss.getDb().executeSql`. Purge runs automatically on the next workers deploy.
- **Cron `singletonKey: 'scheduler-cron'`** so cron ticks de-dup in their own bucket and can never stack, while manual "Execute Now" triggers (web-ui, null key, `priority:10`) live in a separate bucket and are never suppressed.

## Commits

- `#68` — stop the empty-tenant re-dispatch (advance `lastRunAt` for checked tenants) + IAM `ecs:RunTask` scoping.
- `#69` — advance `lastRunAt` on successful **dispatch**, not on the scan return value (horizontal `execute()` resolves to `void`).
- `#70` (this) — bound the queue with `stately` + purge backlog + cron `singletonKey`. **This is the layer that actually ends the flood.**
- `chore` — ignore `.superpowers/`; update dev SSM tunnel bastion target.

> Note: `master-v1` did not contain #68 or #69 (its scheduler code was at #59), so this PR carries the full stack to make the fix coherent and compilable on that base.

## Verification

- 16/16 scheduler tests pass (new: stately-on-create, migrate+purge, no-op-when-already-stately, cron singletonKey).
- `workers` `tsc --noEmit` clean (0 errors).
- Diagnosed live via CloudWatch Logs Insights (`/ecs/*-workers` vs `/ecs/*-ephemeral-workers`); no direct prod DB access.

## Deploy

Takes effect on a workers image rebuild + ECS rollout (`pulumi up` on `infra/compute` detects the `apps/workers/` change). The one-time backlog purge runs on worker startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)