### PR TITLE
fix(inventory): filter discovery grid to latest batch per account

### DIFF
--- a/apps/web-ui/lib/db/repositories/inventory/postgres.test.ts
+++ b/apps/web-ui/lib/db/repositories/inventory/postgres.test.ts
@@ -135,6 +135,20 @@ describe('InventoryPostgresRepository', () => {
             const callArg = mockPrisma.inventoryResource.findMany.mock.calls[0][0];
             expect(callArg.where.tenantId).toBe('tenant-x');
         });
+
+        it('filters to isCurrent = true rows', async () => {
+            mockPrisma.inventoryResource.count.mockResolvedValue(1);
+            mockPrisma.inventoryResource.findMany.mockResolvedValue([makeRow()]);
+
+            const repo = new InventoryPostgresRepository();
+            await repo.listResources({ tenantId: 'org-default' });
+
+            const callArg = mockPrisma.inventoryResource.findMany.mock.calls[0][0];
+            expect(callArg.where.isCurrent).toBe(true);
+
+            const countArg = mockPrisma.inventoryResource.count.mock.calls[0][0];
+            expect(countArg.where.isCurrent).toBe(true);
+        });
     });
 
     describe('getResource', () => {
@@ -280,6 +294,23 @@ describe('InventoryPostgresRepository', () => {
                 })
             );
             expect(result).toBe(10);
+        });
+    });
+
+    describe('listResourcesFulltext (via searchTerm)', () => {
+        it('includes isCurrent = true in the WHERE clause', async () => {
+            mockPrisma.$queryRawUnsafe = vi
+                .fn()
+                .mockResolvedValueOnce([{ total: 0 }])
+                .mockResolvedValueOnce([]);
+
+            const repo = new InventoryPostgresRepository();
+            await repo.listResources({ tenantId: 'org-default', searchTerm: 'prod' });
+
+            const countSql = mockPrisma.$queryRawUnsafe.mock.calls[0][0];
+            const dataSql = mockPrisma.$queryRawUnsafe.mock.calls[1][0];
+            expect(countSql).toContain('"isCurrent" = true');
+            expect(dataSql).toContain('"isCurrent" = true');
         });
     });
 });

--- a/apps/web-ui/lib/db/repositories/inventory/postgres.ts
+++ b/apps/web-ui/lib/db/repositories/inventory/postgres.ts
@@ -75,7 +75,7 @@ export class InventoryPostgresRepository implements IInventoryRepository {
             }
 
             // Standard Prisma path (no search term)
-            const where: Record<string, unknown> = { tenantId };
+            const where: Record<string, unknown> = { tenantId, isCurrent: true };
 
             if (accountId) where.accountId = accountId;
             else if (accountIds?.length) where.accountId = { in: accountIds };
@@ -115,7 +115,7 @@ export class InventoryPostgresRepository implements IInventoryRepository {
     ): Promise<InventoryPage> {
         const client = getTenantClient(tenantId);
         const params: unknown[] = [tenantId, searchTerm];
-        let whereClause = `WHERE "tenantId" = $1 AND "searchVector" @@ plainto_tsquery('english', $2)`;
+        let whereClause = `WHERE "tenantId" = $1 AND "isCurrent" = true AND "searchVector" @@ plainto_tsquery('english', $2)`;
 
         if (filters.accountId) {
             params.push(filters.accountId);

--- a/apps/workers/src/jobs/discovery/__tests__/handle-discovery-scan.test.ts
+++ b/apps/workers/src/jobs/discovery/__tests__/handle-discovery-scan.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Declared via vi.hoisted() (rather than plain top-level `const`) because this file's
+// vi.mock() factories are hoisted above regular statements, and with six separate factories
+// each referencing external consts, Vitest 2.1's hoisting transform doesn't reliably hoist
+// the plain `const mock*` declarations along with them (TDZ ReferenceError at collection
+// time). vi.hoisted() guarantees these are initialized before any factory runs.
+const {
+  mockGetTenantAccounts,
+  mockUpdateAccountSyncStatus,
+  mockWriteAuditLog,
+  mockAssumeRole,
+  mockRunInventoryScan,
+  mockWriteResourcesToPg,
+  mockSaveSyncStatus,
+  mockReconcileStaleResources,
+  mockLogger,
+} = vi.hoisted(() => ({
+  mockGetTenantAccounts: vi.fn(),
+  mockUpdateAccountSyncStatus: vi.fn().mockResolvedValue(undefined),
+  mockWriteAuditLog: vi.fn().mockResolvedValue(undefined),
+  mockAssumeRole: vi.fn(),
+  mockRunInventoryScan: vi.fn(),
+  mockWriteResourcesToPg: vi.fn(),
+  mockSaveSyncStatus: vi.fn().mockResolvedValue(undefined),
+  mockReconcileStaleResources: vi.fn().mockResolvedValue(0),
+  // createLogger builds a fresh closure per call (not memoized by module name — see
+  // apps/workers/src/lib/logger.ts), so a logger obtained by calling the real createLogger
+  // in this test would be a different instance than the one index.ts holds in its module-level
+  // `log` const. Mock the module so both index.ts and this test share the same logger object.
+  mockLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('../services/account-service.js', () => ({
+  getAllTenants: vi.fn().mockResolvedValue([]),
+  getTenantAccounts: mockGetTenantAccounts,
+  updateAccountSyncStatus: mockUpdateAccountSyncStatus,
+}));
+
+vi.mock('../services/audit-service.js', () => ({
+  writeAuditLog: mockWriteAuditLog,
+}));
+
+vi.mock('../services/sts-service.js', () => ({
+  assumeRole: mockAssumeRole,
+}));
+
+vi.mock('../services/scanner.js', () => ({
+  runInventoryScan: mockRunInventoryScan,
+}));
+
+vi.mock('../services/pg-writer.js', () => ({
+  writeResourcesToPg: mockWriteResourcesToPg,
+  saveSyncStatus: mockSaveSyncStatus,
+  reconcileStaleResources: mockReconcileStaleResources,
+}));
+
+vi.mock('../../scheduler/services/pg-service.js', () => ({
+  getTenantJobConfig: vi.fn().mockResolvedValue({ period: 'daily', lastRunAt: null }),
+  updateTenantJobLastRun: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../lib/logger.js', () => ({
+  createLogger: vi.fn(() => mockLogger),
+}));
+
+import { handleDiscoveryScan } from '../index.js';
+
+const account = {
+  id: 'acc-row-1',
+  tenantId: 'tenant-1',
+  accountId: 'acc-123',
+  name: 'Prod',
+  roleArn: 'arn:aws:iam::123:role/Nucleus',
+  regions: ['us-east-1'],
+  active: true,
+};
+
+describe('handleDiscoveryScan — reconciliation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetTenantAccounts.mockResolvedValue([account]);
+    mockAssumeRole.mockResolvedValue({ credentials: {} });
+    mockUpdateAccountSyncStatus.mockResolvedValue(undefined);
+    mockSaveSyncStatus.mockResolvedValue(undefined);
+    mockReconcileStaleResources.mockResolvedValue(0);
+  });
+
+  it('reconciles the account after a successful scan with resources', async () => {
+    mockRunInventoryScan.mockResolvedValue({
+      resources: [{ resourceType: 'ec2_instances', resourceId: 'i-1', region: 'us-east-1', service: 'ec2', tags: {}, rawData: {} }],
+      regionsScanned: 1,
+      servicesScanned: 1,
+      elapsedMs: 10,
+      errors: [],
+    });
+
+    await handleDiscoveryScan({ type: 'scan', tenantId: 'tenant-1', triggeredBy: 'cron' });
+
+    expect(mockWriteResourcesToPg).toHaveBeenCalledOnce();
+    expect(mockReconcileStaleResources).toHaveBeenCalledOnce();
+    expect(mockReconcileStaleResources).toHaveBeenCalledWith('tenant-1', 'acc-123', expect.stringMatching(/^scan-/));
+  });
+
+  it('reconciles the account even when the scan returns zero resources', async () => {
+    mockRunInventoryScan.mockResolvedValue({
+      resources: [],
+      regionsScanned: 1,
+      servicesScanned: 1,
+      elapsedMs: 10,
+      errors: [],
+    });
+
+    await handleDiscoveryScan({ type: 'scan', tenantId: 'tenant-1', triggeredBy: 'cron' });
+
+    expect(mockReconcileStaleResources).toHaveBeenCalledOnce();
+  });
+
+  it('reconciles the account even when the scan throws before any resources are written', async () => {
+    mockAssumeRole.mockRejectedValue(new Error('assume role denied'));
+
+    // With only one account in the tenant and that account's scan failing, accountsSynced
+    // stays 0 and handleDiscoveryScan's pre-existing "all accounts failed" guard (unrelated
+    // to reconciliation, out of scope for this task) rethrows after the per-account loop.
+    // The reconciliation call under test happens inside the catch block, before that rethrow.
+    await expect(
+      handleDiscoveryScan({ type: 'scan', tenantId: 'tenant-1', triggeredBy: 'cron' }),
+    ).rejects.toThrow('assume role denied');
+
+    expect(mockWriteResourcesToPg).not.toHaveBeenCalled();
+    expect(mockReconcileStaleResources).toHaveBeenCalledOnce();
+    expect(mockReconcileStaleResources).toHaveBeenCalledWith('tenant-1', 'acc-123', expect.stringMatching(/^scan-/));
+  });
+
+  it('logs a warning when reconciliation stales rows after an empty scan', async () => {
+    mockRunInventoryScan.mockResolvedValue({
+      resources: [],
+      regionsScanned: 1,
+      servicesScanned: 1,
+      elapsedMs: 10,
+      errors: [],
+    });
+    mockReconcileStaleResources.mockResolvedValue(5);
+
+    await handleDiscoveryScan({ type: 'scan', tenantId: 'tenant-1', triggeredBy: 'cron' });
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('stale'),
+      expect.objectContaining({ tenantId: 'tenant-1', accountId: 'acc-123', staleCount: 5 }),
+    );
+  });
+
+  it('does not warn when reconciliation stales nothing after an empty scan', async () => {
+    mockRunInventoryScan.mockResolvedValue({
+      resources: [],
+      regionsScanned: 1,
+      servicesScanned: 1,
+      elapsedMs: 10,
+      errors: [],
+    });
+    mockReconcileStaleResources.mockResolvedValue(0);
+
+    await handleDiscoveryScan({ type: 'scan', tenantId: 'tenant-1', triggeredBy: 'cron' });
+
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+});

--- a/apps/workers/src/jobs/discovery/__tests__/handle-discovery-scan.test.ts
+++ b/apps/workers/src/jobs/discovery/__tests__/handle-discovery-scan.test.ts
@@ -81,6 +81,16 @@ const account = {
   active: true,
 };
 
+const account2 = {
+  id: 'acc-row-2',
+  tenantId: 'tenant-1',
+  accountId: 'acc-456',
+  name: 'Staging',
+  roleArn: 'arn:aws:iam::456:role/Nucleus',
+  regions: ['us-east-1'],
+  active: true,
+};
+
 describe('handleDiscoveryScan — reconciliation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -168,5 +178,100 @@ describe('handleDiscoveryScan — reconciliation', () => {
     await handleDiscoveryScan({ type: 'scan', tenantId: 'tenant-1', triggeredBy: 'cron' });
 
     expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+
+  it('continues to the next account when reconciliation throws on the success path', async () => {
+    mockGetTenantAccounts.mockResolvedValue([account, account2]);
+    mockRunInventoryScan.mockResolvedValue({
+      resources: [{ resourceType: 'ec2_instances', resourceId: 'i-1', region: 'us-east-1', service: 'ec2', tags: {}, rawData: {} }],
+      regionsScanned: 1,
+      servicesScanned: 1,
+      elapsedMs: 10,
+      errors: [],
+    });
+    mockReconcileStaleResources.mockRejectedValueOnce(new Error('db error during reconcile'));
+
+    await expect(
+      handleDiscoveryScan({ type: 'scan', tenantId: 'tenant-1', triggeredBy: 'cron' }),
+    ).resolves.toBeUndefined();
+
+    // Both accounts were scanned and written despite account 1's reconcile failing.
+    expect(mockWriteResourcesToPg).toHaveBeenCalledTimes(2);
+    expect(mockReconcileStaleResources).toHaveBeenCalledTimes(2);
+
+    // Reconcile failure is logged but does not propagate — a reconcile-only failure after
+    // a successful scan should not flip the account to "error" status.
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Reconciliation failed'),
+      expect.objectContaining({ tenantId: 'tenant-1', accountId: 'acc-123' }),
+    );
+    expect(mockUpdateAccountSyncStatus).toHaveBeenCalledWith(
+      'tenant-1',
+      'acc-123',
+      expect.objectContaining({ lastSyncStatus: 'success' }),
+    );
+    expect(mockUpdateAccountSyncStatus).toHaveBeenCalledWith(
+      'tenant-1',
+      'acc-456',
+      expect.objectContaining({ lastSyncStatus: 'success' }),
+    );
+  });
+
+  it('continues to the next account when reconciliation also throws on the error path', async () => {
+    mockGetTenantAccounts.mockResolvedValue([account, account2]);
+    mockAssumeRole.mockImplementation(async (_roleArn: string, accountId: string) => {
+      if (accountId === 'acc-123') throw new Error('assume role denied');
+      return { credentials: {} };
+    });
+    mockReconcileStaleResources.mockRejectedValueOnce(new Error('db error during reconcile'));
+    mockRunInventoryScan.mockResolvedValue({
+      resources: [{ resourceType: 'ec2_instances', resourceId: 'i-1', region: 'us-east-1', service: 'ec2', tags: {}, rawData: {} }],
+      regionsScanned: 1,
+      servicesScanned: 1,
+      elapsedMs: 10,
+      errors: [],
+    });
+
+    await expect(
+      handleDiscoveryScan({ type: 'scan', tenantId: 'tenant-1', triggeredBy: 'cron' }),
+    ).resolves.toBeUndefined();
+
+    // Account 2 must still be processed even though account 1 failed both its scan
+    // and its (fail-open) reconciliation.
+    expect(mockRunInventoryScan).toHaveBeenCalledOnce();
+    expect(mockWriteResourcesToPg).toHaveBeenCalledOnce();
+    expect(mockUpdateAccountSyncStatus).toHaveBeenCalledWith(
+      'tenant-1',
+      'acc-456',
+      expect.objectContaining({ lastSyncStatus: 'success' }),
+    );
+    expect(mockUpdateAccountSyncStatus).toHaveBeenCalledWith(
+      'tenant-1',
+      'acc-123',
+      expect.objectContaining({ lastSyncStatus: 'error' }),
+    );
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Reconciliation failed'),
+      expect.objectContaining({ tenantId: 'tenant-1', accountId: 'acc-123' }),
+    );
+  });
+
+  it('includes the scan error in the warning when reconciliation stales rows on the error path', async () => {
+    mockAssumeRole.mockRejectedValue(new Error('assume role denied'));
+    mockReconcileStaleResources.mockResolvedValue(5);
+
+    await expect(
+      handleDiscoveryScan({ type: 'scan', tenantId: 'tenant-1', triggeredBy: 'cron' }),
+    ).rejects.toThrow('assume role denied');
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('stale'),
+      expect.objectContaining({
+        tenantId: 'tenant-1',
+        accountId: 'acc-123',
+        staleCount: 5,
+        scanError: 'assume role denied',
+      }),
+    );
   });
 });

--- a/apps/workers/src/jobs/discovery/__tests__/pg-writer.test.ts
+++ b/apps/workers/src/jobs/discovery/__tests__/pg-writer.test.ts
@@ -1,19 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Resource } from '../types.js';
 
-const { mockQuery, mockRelease, mockConnect } = vi.hoisted(() => {
-  const mockQuery = vi.fn().mockResolvedValue({ rows: [], rowCount: 0 });
-  const mockRelease = vi.fn();
-  const mockConnect = vi.fn().mockResolvedValue({ query: mockQuery, release: mockRelease });
-  return { mockQuery, mockRelease, mockConnect };
-});
+const mockQuery = vi.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+const mockRelease = vi.fn();
+const mockConnect = vi.fn().mockResolvedValue({ query: mockQuery, release: mockRelease });
 
 vi.mock('pg', () => ({
-  Pool: class {
-    connect() {
-      return mockConnect();
-    }
-  },
+  Pool: vi.fn().mockImplementation(() => ({ connect: mockConnect })),
 }));
 
 import { writeResourcesToPg, saveSyncStatus, extractMetadata, reconcileStaleResources } from '../services/pg-writer.js';

--- a/apps/workers/src/jobs/discovery/__tests__/pg-writer.test.ts
+++ b/apps/workers/src/jobs/discovery/__tests__/pg-writer.test.ts
@@ -1,15 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Resource } from '../types.js';
 
-const mockQuery = vi.fn().mockResolvedValue({ rows: [], rowCount: 0 });
-const mockRelease = vi.fn();
-const mockConnect = vi.fn().mockResolvedValue({ query: mockQuery, release: mockRelease });
+const { mockQuery, mockRelease, mockConnect } = vi.hoisted(() => {
+  const mockQuery = vi.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+  const mockRelease = vi.fn();
+  const mockConnect = vi.fn().mockResolvedValue({ query: mockQuery, release: mockRelease });
+  return { mockQuery, mockRelease, mockConnect };
+});
 
 vi.mock('pg', () => ({
-  Pool: vi.fn().mockImplementation(() => ({ connect: mockConnect })),
+  Pool: class {
+    connect() {
+      return mockConnect();
+    }
+  },
 }));
 
-import { writeResourcesToPg, saveSyncStatus, extractMetadata } from '../services/pg-writer.js';
+import { writeResourcesToPg, saveSyncStatus, extractMetadata, reconcileStaleResources } from '../services/pg-writer.js';
 
 describe('pg-writer', () => {
   beforeEach(() => {
@@ -85,6 +92,17 @@ describe('pg-writer', () => {
         writeResourcesToPg(resources, 'tenant-1', 'acc-123', 'job-1'),
       ).rejects.toThrow('connection refused');
     });
+
+    it('reactivates previously-stale rows via isCurrent = true on conflict', async () => {
+      const resources: Resource[] = [
+        { resourceType: 'ec2_instances', resourceId: 'i-1', region: 'us-east-1', service: 'ec2', tags: {}, rawData: {} },
+      ];
+
+      await writeResourcesToPg(resources, 'tenant-1', 'acc-123', 'job-1');
+
+      const sql = mockQuery.mock.calls[0][0];
+      expect(sql).toContain('"isCurrent" = true');
+    });
   });
 
   describe('saveSyncStatus', () => {
@@ -95,6 +113,49 @@ describe('pg-writer', () => {
         expect.stringContaining('inventory_sync_status'),
         expect.arrayContaining(['scan-123', 'tenant-1', 500, 3, 'completed', ['Account 123: timeout']]),
       );
+      expect(mockRelease).toHaveBeenCalled();
+    });
+  });
+
+  describe('reconcileStaleResources', () => {
+    it('marks rows stale when jobRunId differs from the current scan', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 3 });
+
+      const count = await reconcileStaleResources('tenant-1', 'acc-123', 'scan-999');
+
+      expect(count).toBe(3);
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('SET "isCurrent" = false'),
+        ['tenant-1', 'acc-123', 'scan-999'],
+      );
+    });
+
+    it('scopes the UPDATE to tenantId, accountId, and a differing jobRunId', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      await reconcileStaleResources('tenant-1', 'acc-123', 'scan-999');
+
+      const sql = mockQuery.mock.calls[0][0];
+      expect(sql).toContain('"tenantId" = $1');
+      expect(sql).toContain('"accountId" = $2');
+      expect(sql).toContain('IS DISTINCT FROM $3');
+      expect(mockRelease).toHaveBeenCalled();
+    });
+
+    it('returns 0 when rowCount is null', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: null });
+
+      const count = await reconcileStaleResources('tenant-1', 'acc-123', 'scan-999');
+
+      expect(count).toBe(0);
+    });
+
+    it('releases the client and rethrows on query error', async () => {
+      mockQuery.mockRejectedValueOnce(new Error('db down'));
+
+      await expect(
+        reconcileStaleResources('tenant-1', 'acc-123', 'scan-999'),
+      ).rejects.toThrow('db down');
       expect(mockRelease).toHaveBeenCalled();
     });
   });

--- a/apps/workers/src/jobs/discovery/index.ts
+++ b/apps/workers/src/jobs/discovery/index.ts
@@ -4,7 +4,7 @@ import { getAllTenants, getTenantAccounts, updateAccountSyncStatus } from './ser
 import { writeAuditLog } from './services/audit-service.js';
 import { assumeRole } from './services/sts-service.js';
 import { runInventoryScan } from './services/scanner.js';
-import { writeResourcesToPg, saveSyncStatus } from './services/pg-writer.js';
+import { writeResourcesToPg, saveSyncStatus, reconcileStaleResources } from './services/pg-writer.js';
 import { getTenantJobConfig, updateTenantJobLastRun } from '../scheduler/services/pg-service.js';
 import type { DiscoveryFanOutJob, DiscoveryScanJob } from './types.js';
 import { readFileSync } from 'fs';
@@ -41,6 +41,23 @@ export function shouldRunTenant(
 export function resolveScanfilePath(configured: string | undefined, baseDir: string): string {
     if (!configured) return join(baseDir, 'scanfile.json');
     return isAbsolute(configured) ? configured : join(baseDir, configured);
+}
+
+async function reconcileAndWarnIfEmpty(
+    tenantId: string,
+    accountId: string,
+    scanId: string,
+    resourceCount: number,
+): Promise<void> {
+    const staleCount = await reconcileStaleResources(tenantId, accountId, scanId);
+    if (resourceCount === 0 && staleCount > 0) {
+        log.warn('Reconciliation marked previously-current resources stale after an empty/failed scan', {
+            tenantId,
+            accountId,
+            scanId,
+            staleCount,
+        });
+    }
 }
 
 function loadScanConfigs() {
@@ -87,6 +104,7 @@ export async function handleDiscoveryScan(jobData: unknown): Promise<void> {
             totalResources += result.resources.length;
 
             await writeResourcesToPg(result.resources, tenantId, account.accountId, scanId);
+            await reconcileAndWarnIfEmpty(tenantId, account.accountId, scanId, result.resources.length);
             await updateAccountSyncStatus(tenantId, account.accountId, {
                 lastSyncedAt: new Date().toISOString(),
                 lastSyncStatus: (result.errors?.length ?? 0) > 0 ? 'partial' : 'success',
@@ -107,6 +125,7 @@ export async function handleDiscoveryScan(jobData: unknown): Promise<void> {
             errors.push(`Account ${account.accountId}: ${msg}`);
             log.error('Account scan failed', { tenantId, accountId: account.accountId, error: msg });
 
+            await reconcileAndWarnIfEmpty(tenantId, account.accountId, scanId, 0);
             await updateAccountSyncStatus(tenantId, account.accountId, {
                 lastSyncedAt: new Date().toISOString(),
                 lastSyncStatus: 'error',

--- a/apps/workers/src/jobs/discovery/index.ts
+++ b/apps/workers/src/jobs/discovery/index.ts
@@ -48,14 +48,28 @@ async function reconcileAndWarnIfEmpty(
     accountId: string,
     scanId: string,
     resourceCount: number,
+    scanError?: string,
 ): Promise<void> {
-    const staleCount = await reconcileStaleResources(tenantId, accountId, scanId);
+    let staleCount: number;
+    try {
+        staleCount = await reconcileStaleResources(tenantId, accountId, scanId);
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        log.error('Reconciliation failed — leaving previous isCurrent state in place (fail open)', {
+            tenantId,
+            accountId,
+            scanId,
+            error: msg,
+        });
+        return;
+    }
     if (resourceCount === 0 && staleCount > 0) {
         log.warn('Reconciliation marked previously-current resources stale after an empty/failed scan', {
             tenantId,
             accountId,
             scanId,
             staleCount,
+            ...(scanError ? { scanError } : {}),
         });
     }
 }
@@ -125,7 +139,7 @@ export async function handleDiscoveryScan(jobData: unknown): Promise<void> {
             errors.push(`Account ${account.accountId}: ${msg}`);
             log.error('Account scan failed', { tenantId, accountId: account.accountId, error: msg });
 
-            await reconcileAndWarnIfEmpty(tenantId, account.accountId, scanId, 0);
+            await reconcileAndWarnIfEmpty(tenantId, account.accountId, scanId, 0, msg);
             await updateAccountSyncStatus(tenantId, account.accountId, {
                 lastSyncedAt: new Date().toISOString(),
                 lastSyncStatus: 'error',

--- a/apps/workers/src/jobs/discovery/services/pg-writer.ts
+++ b/apps/workers/src/jobs/discovery/services/pg-writer.ts
@@ -86,7 +86,8 @@ export async function writeResourcesToPg(
           metadata = EXCLUDED.metadata,
           "jobRunId" = EXCLUDED."jobRunId",
           "discoveredAt" = EXCLUDED."discoveredAt",
-          "updatedAt" = NOW()
+          "updatedAt" = NOW(),
+          "isCurrent" = true
       `;
 
       await client.query(sql, params);
@@ -100,6 +101,39 @@ export async function writeResourcesToPg(
   }
 
   return total;
+}
+
+// ---------------------------------------------------------------------------
+// reconcileStaleResources — mark resources not seen in the current scan as
+// isCurrent = false, scoped to one account. Never deletes rows.
+// ---------------------------------------------------------------------------
+
+export async function reconcileStaleResources(
+  tenantId: string,
+  accountId: string,
+  jobRunId: string,
+): Promise<number> {
+  const client: PoolClient = await getPool().connect();
+  try {
+    const result = await client.query(
+      `UPDATE inventory_resources
+       SET "isCurrent" = false
+       WHERE "tenantId" = $1 AND "accountId" = $2
+         AND "isCurrent" = true AND "jobRunId" IS DISTINCT FROM $3`,
+      [tenantId, accountId, jobRunId],
+    );
+    return result.rowCount ?? 0;
+  } catch (error) {
+    log.error('Failed reconciling stale resources', {
+      tenantId,
+      accountId,
+      jobRunId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  } finally {
+    client.release();
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/superpowers/plans/2026-07-08-inventory-latest-batch-filter.md
+++ b/docs/superpowers/plans/2026-07-08-inventory-latest-batch-filter.md
@@ -1,0 +1,849 @@
+# Inventory Latest-Batch Grid Filter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the inventory grid from showing stale resources (e.g. terminated instances, released IPs) alongside current ones, while keeping every historical row in Postgres for audit.
+
+**Architecture:** Add an `isCurrent` boolean to `InventoryResource`, defaulting to `true`. The discovery job's upsert already stamps every touched row with the scan's `jobRunId`; after an account's batch write completes (success, partial failure, or hard error), a new `reconcileStaleResources()` call flips `isCurrent = false` on that account's rows whose `jobRunId` doesn't match the current scan — nothing is deleted. The grid's repository read path filters on `isCurrent = true`.
+
+**Tech Stack:** Prisma (schema + migration), raw `pg` (discovery job's write path, `apps/workers`), Prisma-backed repository (`apps/web-ui`), Vitest.
+
+## Global Constraints
+
+- Batch currency is tracked **per account**, not per tenant-wide scan (spec: `docs/superpowers/specs/2026-07-08-inventory-latest-batch-filter-design.md`).
+- Stale rows are never deleted — only flagged `isCurrent = false`.
+- Reconciliation runs unconditionally per account, even when that account's scan fails or returns zero resources — this is a deliberate tradeoff, not a bug. When it flips rows to stale after an empty/failed scan, a warning must be logged.
+- No new API params, no UI changes, no audit-view toggle — the grid's existing query surface is unchanged except for the added filter.
+- Multi-tenant safety: every reconciliation/read query must be scoped by `tenantId` (project-wide rule; `$executeRaw`/raw `pg` queries are not auto-scoped).
+- This is a new branch off `master-v1` — the current worktree branch (`fix/scheduler-lastrunat-horizontal-void`) has unrelated in-progress changes and must not be touched.
+
+---
+
+## Pre-existing test baseline (do not try to fix these — out of scope)
+
+Before starting, note the current test state so you don't mistake pre-existing issues for regressions you caused:
+
+- `apps/web-ui/lib/db/repositories/inventory/postgres.test.ts` — 18/19 pass. The 1 failure (`adds ILIKE name filter for searchTerm`) is a pre-existing bug unrelated to this work (`listResourcesFulltext` calls `client.$queryRawUnsafe`, which the test's mock Prisma client doesn't implement). Leave it failing.
+- `apps/workers/src/jobs/discovery/__tests__/pg-writer.test.ts` and `index.test.ts` — 25/25 pass.
+
+---
+
+### Task 0: Create a new branch
+
+**Files:** none
+
+- [ ] **Step 1: Create and check out a new branch off `master-v1`**
+
+```bash
+git fetch origin master-v1
+git checkout -b fix/inventory-stale-batch-grid origin/master-v1
+```
+
+- [ ] **Step 2: Confirm the branch is clean and based on master-v1**
+
+```bash
+git status --short
+git log --oneline -1
+```
+
+Expected: no changes reported by `git status`, and the log shows the tip of `master-v1`.
+
+---
+
+### Task 1: Schema — add `isCurrent` to `InventoryResource`
+
+**Files:**
+- Modify: `libs/prisma/schema.prisma:339-360` (the `InventoryResource` model)
+- Create: `libs/prisma/migrations/20260708180000_add_inventory_is_current/migration.sql`
+
+**Interfaces:**
+- Produces: `InventoryResource.isCurrent: boolean` (Prisma-generated field, default `true`) — Tasks 2–4 read/write this column.
+
+- [ ] **Step 1: Edit the model**
+
+In `libs/prisma/schema.prisma`, change:
+
+```prisma
+model InventoryResource {
+  id           String   @id @default(cuid())
+  tenantId     String
+  accountId    String
+  region       String
+  resourceType String
+  resourceId   String
+  name         String?
+  status       String?
+  tags         Json     @default("{}")
+  metadata     Json     @default("{}")
+  jobRunId     String?
+  discoveredAt DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  searchVector Unsupported("tsvector")?
+
+  @@unique([tenantId, accountId, resourceType, resourceId])
+  @@index([tenantId, resourceType])
+  @@index([tenantId, accountId])
+  @@map("inventory_resources")
+}
+```
+
+to:
+
+```prisma
+model InventoryResource {
+  id           String   @id @default(cuid())
+  tenantId     String
+  accountId    String
+  region       String
+  resourceType String
+  resourceId   String
+  name         String?
+  status       String?
+  tags         Json     @default("{}")
+  metadata     Json     @default("{}")
+  jobRunId     String?
+  isCurrent    Boolean  @default(true)
+  discoveredAt DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  searchVector Unsupported("tsvector")?
+
+  @@unique([tenantId, accountId, resourceType, resourceId])
+  @@index([tenantId, resourceType, isCurrent])
+  @@index([tenantId, accountId, isCurrent])
+  @@map("inventory_resources")
+}
+```
+
+(The two existing indexes `[tenantId, resourceType]` and `[tenantId, accountId]` are replaced with versions that append `isCurrent`, since every read-path query filters on it.)
+
+- [ ] **Step 2: Start local Postgres**
+
+```bash
+docker compose up -d postgres
+```
+
+Expected: `pgvector/pgvector:pg16` container running on `:5432` (check with `docker compose ps`).
+
+- [ ] **Step 3: Generate and apply the migration**
+
+```bash
+cd apps/web-ui && bun run db:migrate -- --name add_inventory_is_current
+```
+
+Expected output includes `The following migration(s) have been created and applied` and a new folder `libs/prisma/migrations/<timestamp>_add_inventory_is_current/`.
+
+- [ ] **Step 4: Verify the generated SQL**
+
+```bash
+cat ../../libs/prisma/migrations/*_add_inventory_is_current/migration.sql
+```
+
+Expected: contains an `ALTER TABLE "inventory_resources" ADD COLUMN "isCurrent" BOOLEAN NOT NULL DEFAULT true;` statement and `CREATE INDEX` statements for `(tenantId, resourceType, isCurrent)` and `(tenantId, accountId, isCurrent)` (exact index naming is Prisma-generated — just confirm the three columns appear together per index).
+
+- [ ] **Step 5: Regenerate the workers Prisma client**
+
+```bash
+cd ../workers && bun run db:generate
+```
+
+(`apps/web-ui`'s client was already regenerated as part of `db:migrate`.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add libs/prisma/schema.prisma libs/prisma/migrations
+git commit -m "feat(db): add isCurrent flag to InventoryResource for batch reconciliation"
+```
+
+---
+
+### Task 2: `pg-writer.ts` — reactivate-on-upsert + `reconcileStaleResources`
+
+**Files:**
+- Modify: `apps/workers/src/jobs/discovery/services/pg-writer.ts:76-90` (upsert SQL)
+- Modify: `apps/workers/src/jobs/discovery/services/pg-writer.ts` (add new exported function, place after `writeResourcesToPg`, before `saveSyncStatus`)
+- Test: `apps/workers/src/jobs/discovery/__tests__/pg-writer.test.ts`
+
+**Interfaces:**
+- Consumes: `getPool()` from `./db.js` (existing), `createLogger` from `../../../lib/logger.js` (existing, already imported as `log`).
+- Produces: `reconcileStaleResources(tenantId: string, accountId: string, jobRunId: string): Promise<number>` — Task 3 calls this after `writeResourcesToPg`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `apps/workers/src/jobs/discovery/__tests__/pg-writer.test.ts`, inside the top-level `describe('pg-writer', ...)` block:
+
+Add this test inside the existing `describe('writeResourcesToPg', ...)` block (after the `'should include tenantId and accountId in every row'` test):
+
+```ts
+    it('reactivates previously-stale rows via isCurrent = true on conflict', async () => {
+      const resources: Resource[] = [
+        { resourceType: 'ec2_instances', resourceId: 'i-1', region: 'us-east-1', service: 'ec2', tags: {}, rawData: {} },
+      ];
+
+      await writeResourcesToPg(resources, 'tenant-1', 'acc-123', 'job-1');
+
+      const sql = mockQuery.mock.calls[0][0];
+      expect(sql).toContain('"isCurrent" = true');
+    });
+```
+
+Add a new top-level `describe` block (sibling to `describe('writeResourcesToPg', ...)`, `describe('saveSyncStatus', ...)`, `describe('extractMetadata', ...)`):
+
+```ts
+  describe('reconcileStaleResources', () => {
+    it('marks rows stale when jobRunId differs from the current scan', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 3 });
+
+      const count = await reconcileStaleResources('tenant-1', 'acc-123', 'scan-999');
+
+      expect(count).toBe(3);
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('SET "isCurrent" = false'),
+        ['tenant-1', 'acc-123', 'scan-999'],
+      );
+    });
+
+    it('scopes the UPDATE to tenantId, accountId, and a differing jobRunId', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+      await reconcileStaleResources('tenant-1', 'acc-123', 'scan-999');
+
+      const sql = mockQuery.mock.calls[0][0];
+      expect(sql).toContain('"tenantId" = $1');
+      expect(sql).toContain('"accountId" = $2');
+      expect(sql).toContain('IS DISTINCT FROM $3');
+      expect(mockRelease).toHaveBeenCalled();
+    });
+
+    it('returns 0 when rowCount is null', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [], rowCount: null });
+
+      const count = await reconcileStaleResources('tenant-1', 'acc-123', 'scan-999');
+
+      expect(count).toBe(0);
+    });
+
+    it('releases the client and rethrows on query error', async () => {
+      mockQuery.mockRejectedValueOnce(new Error('db down'));
+
+      await expect(
+        reconcileStaleResources('tenant-1', 'acc-123', 'scan-999'),
+      ).rejects.toThrow('db down');
+      expect(mockRelease).toHaveBeenCalled();
+    });
+  });
+```
+
+Update the import line at the top of the test file from:
+
+```ts
+import { writeResourcesToPg, saveSyncStatus, extractMetadata } from '../services/pg-writer.js';
+```
+
+to:
+
+```ts
+import { writeResourcesToPg, saveSyncStatus, extractMetadata, reconcileStaleResources } from '../services/pg-writer.js';
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd apps/workers && bunx vitest run src/jobs/discovery/__tests__/pg-writer.test.ts
+```
+
+Expected: FAIL — `reconcileStaleResources` is not exported, and the "reactivates previously-stale rows" test fails because the current SQL has no `"isCurrent" = true`.
+
+- [ ] **Step 3: Implement**
+
+In `apps/workers/src/jobs/discovery/services/pg-writer.ts`, change the upsert SQL (lines 76-90) from:
+
+```ts
+      const sql = `
+        INSERT INTO inventory_resources
+          (id, "tenantId", "accountId", region, "resourceType", "resourceId",
+           name, status, tags, metadata, "jobRunId", "discoveredAt", "updatedAt")
+        VALUES ${placeholders.join(', ')}
+        ON CONFLICT ("tenantId", "accountId", "resourceType", "resourceId")
+        DO UPDATE SET
+          name = EXCLUDED.name,
+          status = EXCLUDED.status,
+          tags = EXCLUDED.tags,
+          metadata = EXCLUDED.metadata,
+          "jobRunId" = EXCLUDED."jobRunId",
+          "discoveredAt" = EXCLUDED."discoveredAt",
+          "updatedAt" = NOW()
+      `;
+```
+
+to:
+
+```ts
+      const sql = `
+        INSERT INTO inventory_resources
+          (id, "tenantId", "accountId", region, "resourceType", "resourceId",
+           name, status, tags, metadata, "jobRunId", "discoveredAt", "updatedAt")
+        VALUES ${placeholders.join(', ')}
+        ON CONFLICT ("tenantId", "accountId", "resourceType", "resourceId")
+        DO UPDATE SET
+          name = EXCLUDED.name,
+          status = EXCLUDED.status,
+          tags = EXCLUDED.tags,
+          metadata = EXCLUDED.metadata,
+          "jobRunId" = EXCLUDED."jobRunId",
+          "discoveredAt" = EXCLUDED."discoveredAt",
+          "updatedAt" = NOW(),
+          "isCurrent" = true
+      `;
+```
+
+Then add this new function after `writeResourcesToPg` (before the `saveSyncStatus` section comment):
+
+```ts
+// ---------------------------------------------------------------------------
+// reconcileStaleResources — mark resources not seen in the current scan as
+// isCurrent = false, scoped to one account. Never deletes rows.
+// ---------------------------------------------------------------------------
+
+export async function reconcileStaleResources(
+  tenantId: string,
+  accountId: string,
+  jobRunId: string,
+): Promise<number> {
+  const client: PoolClient = await getPool().connect();
+  try {
+    const result = await client.query(
+      `UPDATE inventory_resources
+       SET "isCurrent" = false
+       WHERE "tenantId" = $1 AND "accountId" = $2
+         AND "isCurrent" = true AND "jobRunId" IS DISTINCT FROM $3`,
+      [tenantId, accountId, jobRunId],
+    );
+    return result.rowCount ?? 0;
+  } catch (error) {
+    log.error('Failed reconciling stale resources', {
+      tenantId,
+      accountId,
+      jobRunId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd apps/workers && bunx vitest run src/jobs/discovery/__tests__/pg-writer.test.ts
+```
+
+Expected: PASS, all tests in the file (the pre-existing ones plus the new ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/workers/src/jobs/discovery/services/pg-writer.ts apps/workers/src/jobs/discovery/__tests__/pg-writer.test.ts
+git commit -m "feat(discovery): reconcile stale inventory rows per account after each scan"
+```
+
+---
+
+### Task 3: `index.ts` — wire reconciliation into `handleDiscoveryScan`
+
+**Files:**
+- Modify: `apps/workers/src/jobs/discovery/index.ts:1-148`
+- Create: `apps/workers/src/jobs/discovery/__tests__/handle-discovery-scan.test.ts`
+
+**Interfaces:**
+- Consumes: `reconcileStaleResources(tenantId, accountId, jobRunId): Promise<number>` from Task 2.
+- Produces: nothing new consumed by later tasks — `handleDiscoveryScan` remains the pg-boss handler entry point.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/workers/src/jobs/discovery/__tests__/handle-discovery-scan.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetTenantAccounts = vi.fn();
+const mockUpdateAccountSyncStatus = vi.fn().mockResolvedValue(undefined);
+const mockWriteAuditLog = vi.fn().mockResolvedValue(undefined);
+const mockAssumeRole = vi.fn();
+const mockRunInventoryScan = vi.fn();
+const mockWriteResourcesToPg = vi.fn();
+const mockSaveSyncStatus = vi.fn().mockResolvedValue(undefined);
+const mockReconcileStaleResources = vi.fn().mockResolvedValue(0);
+
+// createLogger builds a fresh closure per call (not memoized by module name — see
+// apps/workers/src/lib/logger.ts), so a logger obtained by calling the real createLogger
+// in this test would be a different instance than the one index.ts holds in its module-level
+// `log` const. Mock the module so both index.ts and this test share the same logger object.
+const mockLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+vi.mock('../services/account-service.js', () => ({
+  getAllTenants: vi.fn().mockResolvedValue([]),
+  getTenantAccounts: mockGetTenantAccounts,
+  updateAccountSyncStatus: mockUpdateAccountSyncStatus,
+}));
+
+vi.mock('../services/audit-service.js', () => ({
+  writeAuditLog: mockWriteAuditLog,
+}));
+
+vi.mock('../services/sts-service.js', () => ({
+  assumeRole: mockAssumeRole,
+}));
+
+vi.mock('../services/scanner.js', () => ({
+  runInventoryScan: mockRunInventoryScan,
+}));
+
+vi.mock('../services/pg-writer.js', () => ({
+  writeResourcesToPg: mockWriteResourcesToPg,
+  saveSyncStatus: mockSaveSyncStatus,
+  reconcileStaleResources: mockReconcileStaleResources,
+}));
+
+vi.mock('../../scheduler/services/pg-service.js', () => ({
+  getTenantJobConfig: vi.fn().mockResolvedValue({ period: 'daily', lastRunAt: null }),
+  updateTenantJobLastRun: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../../lib/logger.js', () => ({
+  createLogger: vi.fn(() => mockLogger),
+}));
+
+import { handleDiscoveryScan } from '../index.js';
+
+const account = {
+  id: 'acc-row-1',
+  tenantId: 'tenant-1',
+  accountId: 'acc-123',
+  name: 'Prod',
+  roleArn: 'arn:aws:iam::123:role/Nucleus',
+  regions: ['us-east-1'],
+  active: true,
+};
+
+describe('handleDiscoveryScan — reconciliation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetTenantAccounts.mockResolvedValue([account]);
+    mockAssumeRole.mockResolvedValue({ credentials: {} });
+    mockUpdateAccountSyncStatus.mockResolvedValue(undefined);
+    mockSaveSyncStatus.mockResolvedValue(undefined);
+    mockReconcileStaleResources.mockResolvedValue(0);
+  });
+
+  it('reconciles the account after a successful scan with resources', async () => {
+    mockRunInventoryScan.mockResolvedValue({
+      resources: [{ resourceType: 'ec2_instances', resourceId: 'i-1', region: 'us-east-1', service: 'ec2', tags: {}, rawData: {} }],
+      regionsScanned: 1,
+      servicesScanned: 1,
+      elapsedMs: 10,
+      errors: [],
+    });
+
+    await handleDiscoveryScan({ type: 'scan', tenantId: 'tenant-1', triggeredBy: 'cron' });
+
+    expect(mockWriteResourcesToPg).toHaveBeenCalledOnce();
+    expect(mockReconcileStaleResources).toHaveBeenCalledOnce();
+    expect(mockReconcileStaleResources).toHaveBeenCalledWith('tenant-1', 'acc-123', expect.stringMatching(/^scan-/));
+  });
+
+  it('reconciles the account even when the scan returns zero resources', async () => {
+    mockRunInventoryScan.mockResolvedValue({
+      resources: [],
+      regionsScanned: 1,
+      servicesScanned: 1,
+      elapsedMs: 10,
+      errors: [],
+    });
+
+    await handleDiscoveryScan({ type: 'scan', tenantId: 'tenant-1', triggeredBy: 'cron' });
+
+    expect(mockReconcileStaleResources).toHaveBeenCalledOnce();
+  });
+
+  it('reconciles the account even when the scan throws before any resources are written', async () => {
+    mockAssumeRole.mockRejectedValue(new Error('assume role denied'));
+
+    await handleDiscoveryScan({ type: 'scan', tenantId: 'tenant-1', triggeredBy: 'cron' });
+
+    expect(mockWriteResourcesToPg).not.toHaveBeenCalled();
+    expect(mockReconcileStaleResources).toHaveBeenCalledOnce();
+    expect(mockReconcileStaleResources).toHaveBeenCalledWith('tenant-1', 'acc-123', expect.stringMatching(/^scan-/));
+  });
+
+  it('logs a warning when reconciliation stales rows after an empty scan', async () => {
+    mockRunInventoryScan.mockResolvedValue({
+      resources: [],
+      regionsScanned: 1,
+      servicesScanned: 1,
+      elapsedMs: 10,
+      errors: [],
+    });
+    mockReconcileStaleResources.mockResolvedValue(5);
+
+    await handleDiscoveryScan({ type: 'scan', tenantId: 'tenant-1', triggeredBy: 'cron' });
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('stale'),
+      expect.objectContaining({ tenantId: 'tenant-1', accountId: 'acc-123', staleCount: 5 }),
+    );
+  });
+
+  it('does not warn when reconciliation stales nothing after an empty scan', async () => {
+    mockRunInventoryScan.mockResolvedValue({
+      resources: [],
+      regionsScanned: 1,
+      servicesScanned: 1,
+      elapsedMs: 10,
+      errors: [],
+    });
+    mockReconcileStaleResources.mockResolvedValue(0);
+
+    await handleDiscoveryScan({ type: 'scan', tenantId: 'tenant-1', triggeredBy: 'cron' });
+
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd apps/workers && bunx vitest run src/jobs/discovery/__tests__/handle-discovery-scan.test.ts
+```
+
+Expected: FAIL — `reconcileStaleResources` mock is never called because `index.ts` doesn't call it yet.
+
+- [ ] **Step 3: Implement**
+
+In `apps/workers/src/jobs/discovery/index.ts`:
+
+Change the import on line 7 from:
+
+```ts
+import { writeResourcesToPg, saveSyncStatus } from './services/pg-writer.js';
+```
+
+to:
+
+```ts
+import { writeResourcesToPg, saveSyncStatus, reconcileStaleResources } from './services/pg-writer.js';
+```
+
+Add this helper function after `resolveScanfilePath` (before `loadScanConfigs`):
+
+```ts
+async function reconcileAndWarnIfEmpty(
+    tenantId: string,
+    accountId: string,
+    scanId: string,
+    resourceCount: number,
+): Promise<void> {
+    const staleCount = await reconcileStaleResources(tenantId, accountId, scanId);
+    if (resourceCount === 0 && staleCount > 0) {
+        log.warn('Reconciliation marked previously-current resources stale after an empty/failed scan', {
+            tenantId,
+            accountId,
+            scanId,
+            staleCount,
+        });
+    }
+}
+```
+
+Change the per-account loop body (lines 79-116) from:
+
+```ts
+    for (const account of targetAccounts) {
+        try {
+            log.debug('Scanning account', { tenantId, accountId: account.accountId, regions: account.regions });
+
+            const credentials = await assumeRole(account.roleArn, account.accountId, account.regions?.[0] ?? 'ap-south-1', account.externalId);
+            const regions = Array.isArray(account.regions) ? account.regions : [account.regions];
+
+            const result = await runInventoryScan(credentials, regions, scanConfigs);
+            totalResources += result.resources.length;
+
+            await writeResourcesToPg(result.resources, tenantId, account.accountId, scanId);
+            await updateAccountSyncStatus(tenantId, account.accountId, {
+                lastSyncedAt: new Date().toISOString(),
+                lastSyncStatus: (result.errors?.length ?? 0) > 0 ? 'partial' : 'success',
+                lastSyncResourceCount: result.resources.length,
+            });
+
+            accountsSynced++;
+            if (result.errors?.length) errors.push(...result.errors);
+
+            log.info('Account scan complete', {
+                tenantId,
+                accountId: account.accountId,
+                resourceCount: result.resources.length,
+                hasErrors: (result.errors?.length ?? 0) > 0,
+            });
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            errors.push(`Account ${account.accountId}: ${msg}`);
+            log.error('Account scan failed', { tenantId, accountId: account.accountId, error: msg });
+
+            await updateAccountSyncStatus(tenantId, account.accountId, {
+                lastSyncedAt: new Date().toISOString(),
+                lastSyncStatus: 'error',
+                lastSyncResourceCount: 0,
+                lastSyncError: msg,
+            });
+        }
+    }
+```
+
+to:
+
+```ts
+    for (const account of targetAccounts) {
+        try {
+            log.debug('Scanning account', { tenantId, accountId: account.accountId, regions: account.regions });
+
+            const credentials = await assumeRole(account.roleArn, account.accountId, account.regions?.[0] ?? 'ap-south-1', account.externalId);
+            const regions = Array.isArray(account.regions) ? account.regions : [account.regions];
+
+            const result = await runInventoryScan(credentials, regions, scanConfigs);
+            totalResources += result.resources.length;
+
+            await writeResourcesToPg(result.resources, tenantId, account.accountId, scanId);
+            await reconcileAndWarnIfEmpty(tenantId, account.accountId, scanId, result.resources.length);
+            await updateAccountSyncStatus(tenantId, account.accountId, {
+                lastSyncedAt: new Date().toISOString(),
+                lastSyncStatus: (result.errors?.length ?? 0) > 0 ? 'partial' : 'success',
+                lastSyncResourceCount: result.resources.length,
+            });
+
+            accountsSynced++;
+            if (result.errors?.length) errors.push(...result.errors);
+
+            log.info('Account scan complete', {
+                tenantId,
+                accountId: account.accountId,
+                resourceCount: result.resources.length,
+                hasErrors: (result.errors?.length ?? 0) > 0,
+            });
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            errors.push(`Account ${account.accountId}: ${msg}`);
+            log.error('Account scan failed', { tenantId, accountId: account.accountId, error: msg });
+
+            await reconcileAndWarnIfEmpty(tenantId, account.accountId, scanId, 0);
+            await updateAccountSyncStatus(tenantId, account.accountId, {
+                lastSyncedAt: new Date().toISOString(),
+                lastSyncStatus: 'error',
+                lastSyncResourceCount: 0,
+                lastSyncError: msg,
+            });
+        }
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd apps/workers && bunx vitest run src/jobs/discovery/__tests__/handle-discovery-scan.test.ts src/jobs/discovery/__tests__/index.test.ts src/jobs/discovery/__tests__/pg-writer.test.ts
+```
+
+Expected: PASS on all three files (confirms the new tests pass and nothing in the existing `index.test.ts`/`pg-writer.test.ts` regressed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/workers/src/jobs/discovery/index.ts apps/workers/src/jobs/discovery/__tests__/handle-discovery-scan.test.ts
+git commit -m "feat(discovery): call reconcileStaleResources per account, warn on empty-scan staling"
+```
+
+---
+
+### Task 4: Repository read path — filter `isCurrent = true`
+
+**Files:**
+- Modify: `apps/web-ui/lib/db/repositories/inventory/postgres.ts:78-96` (`listResources`) and `:109-173` (`listResourcesFulltext`)
+- Test: `apps/web-ui/lib/db/repositories/inventory/postgres.test.ts`
+
+**Interfaces:**
+- Consumes: `InventoryResource.isCurrent` from Task 1's migration (via the regenerated Prisma client).
+- Produces: nothing new consumed elsewhere — this is the grid's terminal read path.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `apps/web-ui/lib/db/repositories/inventory/postgres.test.ts`, inside `describe('listResources', ...)` (after the `'cross-tenant isolation'` test):
+
+```ts
+        it('filters to isCurrent = true rows', async () => {
+            mockPrisma.inventoryResource.count.mockResolvedValue(1);
+            mockPrisma.inventoryResource.findMany.mockResolvedValue([makeRow()]);
+
+            const repo = new InventoryPostgresRepository();
+            await repo.listResources({ tenantId: 'org-default' });
+
+            const callArg = mockPrisma.inventoryResource.findMany.mock.calls[0][0];
+            expect(callArg.where.isCurrent).toBe(true);
+
+            const countArg = mockPrisma.inventoryResource.count.mock.calls[0][0];
+            expect(countArg.where.isCurrent).toBe(true);
+        });
+```
+
+Add a new `describe` block (sibling to `describe('listResources', ...)`) for the fulltext path:
+
+```ts
+    describe('listResourcesFulltext (via searchTerm)', () => {
+        it('includes isCurrent = true in the WHERE clause', async () => {
+            mockPrisma.$queryRawUnsafe = vi
+                .fn()
+                .mockResolvedValueOnce([{ total: 0 }])
+                .mockResolvedValueOnce([]);
+
+            const repo = new InventoryPostgresRepository();
+            await repo.listResources({ tenantId: 'org-default', searchTerm: 'prod' });
+
+            const countSql = mockPrisma.$queryRawUnsafe.mock.calls[0][0];
+            const dataSql = mockPrisma.$queryRawUnsafe.mock.calls[1][0];
+            expect(countSql).toContain('"isCurrent" = true');
+            expect(dataSql).toContain('"isCurrent" = true');
+        });
+    });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd apps/web-ui && bunx vitest run lib/db/repositories/inventory/postgres.test.ts
+```
+
+Expected: the two new tests FAIL (`callArg.where.isCurrent` is `undefined`; the raw SQL strings don't contain `"isCurrent" = true`). The pre-existing `'adds ILIKE name filter for searchTerm'` failure is expected and unrelated — ignore it.
+
+- [ ] **Step 3: Implement**
+
+In `apps/web-ui/lib/db/repositories/inventory/postgres.ts`, change the `where` construction in `listResources` (lines 78-83) from:
+
+```ts
+            // Standard Prisma path (no search term)
+            const where: Record<string, unknown> = { tenantId };
+
+            if (accountId) where.accountId = accountId;
+            else if (accountIds?.length) where.accountId = { in: accountIds };
+            if (region) where.region = region;
+            if (resourceType) where.resourceType = resourceType;
+```
+
+to:
+
+```ts
+            // Standard Prisma path (no search term)
+            const where: Record<string, unknown> = { tenantId, isCurrent: true };
+
+            if (accountId) where.accountId = accountId;
+            else if (accountIds?.length) where.accountId = { in: accountIds };
+            if (region) where.region = region;
+            if (resourceType) where.resourceType = resourceType;
+```
+
+Change the `listResourcesFulltext` where-clause seed (line 118) from:
+
+```ts
+        let whereClause = `WHERE "tenantId" = $1 AND "searchVector" @@ plainto_tsquery('english', $2)`;
+```
+
+to:
+
+```ts
+        let whereClause = `WHERE "tenantId" = $1 AND "isCurrent" = true AND "searchVector" @@ plainto_tsquery('english', $2)`;
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd apps/web-ui && bunx vitest run lib/db/repositories/inventory/postgres.test.ts
+```
+
+Expected: 20/21 pass — the two new tests pass; the same 1 pre-existing unrelated failure remains (`adds ILIKE name filter for searchTerm`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web-ui/lib/db/repositories/inventory/postgres.ts apps/web-ui/lib/db/repositories/inventory/postgres.test.ts
+git commit -m "fix(inventory): exclude stale (isCurrent=false) rows from the grid read path"
+```
+
+---
+
+### Task 5: Full verification pass
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full workers test suite**
+
+```bash
+cd apps/workers && bun run test
+```
+
+Expected: PASS (no regressions beyond the pre-existing baseline noted above).
+
+- [ ] **Step 2: Run the full web-ui test suite**
+
+```bash
+cd apps/web-ui && bun run test
+```
+
+Expected: PASS except the 1 pre-existing unrelated failure (`adds ILIKE name filter for searchTerm`).
+
+- [ ] **Step 3: Typecheck both apps**
+
+```bash
+cd apps/web-ui && bunx tsc --noEmit
+cd apps/workers && bunx tsc --noEmit
+```
+
+Expected: no new errors introduced by this change (compare against whatever pre-existing baseline error count the repo already has, per `CLAUDE.md`'s note that the build ignores tsc/eslint errors — this is just a sanity check, not a hard gate).
+
+- [ ] **Step 4: Manual smoke test against local Postgres**
+
+```bash
+docker compose up -d postgres
+cd apps/workers && bun run dev
+# in another terminal, trigger a scan for a real/seeded tenant+account, e.g. via the web-ui's
+# "Sync Now" button or POST /api/inventory/sync, then re-run it a second time after manually
+# deleting/tagging a resource out of scanfile scope to simulate disappearance
+```
+
+Confirm via `psql`:
+
+```sql
+SELECT "resourceId", "jobRunId", "isCurrent" FROM inventory_resources WHERE "accountId" = '<account>';
+```
+
+Expected: rows from the most recent scan have `isCurrent = true`; a resource resynced with a stale `jobRunId` from a prior scan shows `isCurrent = false` and is excluded from `GET /api/inventory/resources`.
+
+---
+
+## Files Changed Summary
+
+| File | Task |
+|------|------|
+| `libs/prisma/schema.prisma` | 1 |
+| `libs/prisma/migrations/20260708180000_add_inventory_is_current/migration.sql` | 1 |
+| `apps/workers/src/jobs/discovery/services/pg-writer.ts` | 2 |
+| `apps/workers/src/jobs/discovery/__tests__/pg-writer.test.ts` | 2 |
+| `apps/workers/src/jobs/discovery/index.ts` | 3 |
+| `apps/workers/src/jobs/discovery/__tests__/handle-discovery-scan.test.ts` | 3 |
+| `apps/web-ui/lib/db/repositories/inventory/postgres.ts` | 4 |
+| `apps/web-ui/lib/db/repositories/inventory/postgres.test.ts` | 4 |

--- a/docs/superpowers/specs/2026-07-08-inventory-latest-batch-filter-design.md
+++ b/docs/superpowers/specs/2026-07-08-inventory-latest-batch-filter-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-08
 **Status:** Approved
-**Branch:** fix/scheduler-ephemeral-task-flood (or new branch — see Out of Scope)
+**Branch:** new branch off master-v1 (see Out of Scope)
 
 ---
 
@@ -164,6 +164,6 @@ Grid queries listResources(tenantId, accountId?) → WHERE isCurrent = true
   to `isCurrent = true` via the schema default, but no reconciliation runs for that path.
 - The dead `deleteResourcesByAccount` method — left as-is, not removed, not used by this fix.
 - Any UI surfacing of batch ID / stale-row browsing.
-- Current branch is `fix/scheduler-ephemeral-task-flood` with unrelated uncommitted changes
+- Current branch (`fix/scheduler-lastrunat-horizontal-void`) has unrelated uncommitted changes
   (chat route, executor-graphs, bun.lock) — this work should land on its own branch rather than
   stacking on top of unrelated in-progress changes.

--- a/docs/superpowers/specs/2026-07-08-inventory-latest-batch-filter-design.md
+++ b/docs/superpowers/specs/2026-07-08-inventory-latest-batch-filter-design.md
@@ -1,0 +1,169 @@
+# Inventory Discovery — Filter Grid to Latest Batch Per Account
+
+**Date:** 2026-07-08
+**Status:** Approved
+**Branch:** fix/scheduler-ephemeral-task-flood (or new branch — see Out of Scope)
+
+---
+
+## Problem
+
+`InventoryResource` rows are upserted by natural key (`tenantId`, `accountId`, `resourceType`,
+`resourceId`). When a discovery scan runs, matched resources get their `jobRunId`/`discoveredAt`
+overwritten, but nothing ever touches rows for resources that disappeared from AWS between scans
+(terminated instances, released IPs, deleted volumes, etc). Those rows sit in the table forever
+with a stale `jobRunId`, so the inventory grid mixes current and stale data with no way to tell
+them apart.
+
+---
+
+## Goals
+
+- The inventory grid always shows only the latest successful batch's resources per account.
+- Stale rows are never purged — they remain in Postgres for backward audit.
+- Batch currency is tracked **per account**, not per tenant-wide scan, so resyncing a single
+  account doesn't affect the currency of other accounts.
+
+## Non-Goals
+
+- No UI to browse/audit stale (non-current) rows — DB-level retention only, queryable directly in
+  Postgres. A dedicated audit view is a separate future feature.
+- No changes to the discovery scan logic itself (STS assume-role, resource collection, tagging).
+- No changes to `upsertResource`/`upsertBatch` callers outside the discovery job's write path.
+- No retroactive staleness detection for data written before this change (see Bootstrap Behavior).
+
+---
+
+## Architecture
+
+### Schema change
+
+Add `isCurrent Boolean @default(true)` to `InventoryResource` in `libs/prisma/schema.prisma`,
+plus supporting indexes:
+
+```prisma
+model InventoryResource {
+  // ...existing fields...
+  isCurrent    Boolean  @default(true)
+
+  @@unique([tenantId, accountId, resourceType, resourceId])
+  @@index([tenantId, resourceType, isCurrent])
+  @@index([tenantId, accountId, isCurrent])
+  @@map("inventory_resources")
+}
+```
+
+This is purely additive — no column removed, no row deleted.
+
+### Write path — `apps/workers/src/jobs/discovery/services/pg-writer.ts`
+
+1. The bulk upsert's `ON CONFLICT DO UPDATE` SET clause gets `"isCurrent" = true` added, so a
+   resource that reappears after being marked stale (e.g. an IP gets reused) flips back to
+   current automatically.
+
+2. After `writeResourcesToPg` completes for an account (success, partial failure, or empty
+   result), a new reconciliation step runs, scoped to that account only:
+
+   ```sql
+   UPDATE inventory_resources
+   SET "isCurrent" = false
+   WHERE "tenantId" = $1 AND "accountId" = $2
+     AND "isCurrent" = true AND "jobRunId" IS DISTINCT FROM $3
+   ```
+
+   `$3` is the current scan's `scanId`. Rows touched by this scan already have `jobRunId = $3`
+   (set by the upsert), so they're excluded from the `UPDATE` and remain current. Rows not seen
+   in this scan keep their old `jobRunId` and get flipped to `isCurrent = false`.
+
+3. **Reconciliation runs unconditionally per account** — including when the account's scan
+   errors out or returns zero resources. This means a hard failure (e.g. broken STS role) marks
+   that account's entire previous batch stale, and the grid shows nothing for that account until
+   the next successful scan. This is a deliberate tradeoff (confirmed during design) favoring "no
+   stale data shown" over "always show *something*." To make this failure mode visible rather
+   than silently confusing, the discovery job logs a warning via `createLogger('discovery')` when
+   reconciliation runs after a failed/empty scan, including the account ID and error.
+
+### Read path — `apps/web-ui/lib/db/repositories/inventory/postgres.ts`
+
+`listResources` and `listResourcesFulltext` add a hard-coded `isCurrent: true` to their `where`
+clause. No new query params, no API route changes (`apps/web-ui/app/api/inventory/resources/route.ts`
+is unaffected) — the grid keeps working exactly as today, just without stale rows.
+
+### Bootstrap behavior
+
+The Prisma migration backfills existing rows with `isCurrent = true` (the column default).
+Currently-stale data already in the table won't be filtered out until each account's *next*
+successful scan reconciles it — there's no reliable signal to retroactively determine staleness
+for rows written before this change.
+
+---
+
+## Data Flow
+
+```
+Discovery job scans account X (scanId = S)
+    ↓
+runInventoryScan(account X) → resources[] (may be empty on error)
+    ↓
+writeResourcesToPg(resources, tenantId, accountId=X, jobRunId=S)
+    → upsert by natural key, SET "isCurrent" = true, "jobRunId" = S on every touched row
+    ↓
+reconcileStaleResources(tenantId, accountId=X, scanId=S)
+    → UPDATE ... SET "isCurrent" = false WHERE jobRunId IS DISTINCT FROM S AND isCurrent = true
+    ↓ (runs even if resources[] was empty due to a scan error — logged as a warning)
+Grid queries listResources(tenantId, accountId?) → WHERE isCurrent = true
+    → only account X's batch-S rows (or whatever batch succeeded most recently) are shown
+```
+
+---
+
+## Error Handling
+
+- Reconciliation is a single `UPDATE` statement per account — no partial-failure state within it.
+- If `reconcileStaleResources` itself throws (DB error), the discovery job's existing per-account
+  try/catch in `apps/workers/src/jobs/discovery/index.ts` catches and logs it the same way scan
+  errors are handled today; the account's rows keep their previous `isCurrent` state (fail open,
+  not silently marked stale by a half-applied reconciliation).
+- A warning-level log line is added specifically for the "reconciled after failed/empty scan"
+  case so it's visible in CloudWatch without needing to correlate scan errors with a suddenly
+  empty grid.
+
+---
+
+## Testing
+
+- `pg-writer.test.ts` (or new `reconcile.test.ts`):
+  - Reconciliation flips only the target account's non-matching rows; other accounts/tenants in
+    the same tenant are untouched.
+  - A resource with a stale `jobRunId` that reappears in a later scan has `isCurrent` reset to
+    `true` via the upsert's `ON CONFLICT` clause.
+  - Reconciliation runs (and correctly stales out prior rows) even when `resources[]` is empty.
+- Repository test (`postgres.test.ts`): `listResources` / `listResourcesFulltext` exclude
+  `isCurrent = false` rows.
+- Discovery job integration test: reconciliation is invoked once per account, including on the
+  error path (mocked `runInventoryScan` throwing).
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `libs/prisma/schema.prisma` | Add `isCurrent` column + 2 indexes to `InventoryResource` |
+| `libs/prisma/migrations/<timestamp>_add_inventory_is_current/migration.sql` | New migration |
+| `apps/workers/src/jobs/discovery/services/pg-writer.ts` | Add `isCurrent = true` to upsert SET clause; add `reconcileStaleResources()` |
+| `apps/workers/src/jobs/discovery/index.ts` | Call `reconcileStaleResources()` per account after `writeResourcesToPg`, including on the error path; add warning log for failed/empty-scan reconciliation |
+| `apps/web-ui/lib/db/repositories/inventory/postgres.ts` | Add `isCurrent: true` to `listResources` / `listResourcesFulltext` where clauses |
+
+---
+
+## Out of Scope
+
+- `apps/web-ui/lib/db/repositories/inventory/postgres.ts` `upsertResource`/`upsertBatch` (the
+  separate Prisma-based write path used by non-discovery callers) — not touched; new rows default
+  to `isCurrent = true` via the schema default, but no reconciliation runs for that path.
+- The dead `deleteResourcesByAccount` method — left as-is, not removed, not used by this fix.
+- Any UI surfacing of batch ID / stale-row browsing.
+- Current branch is `fix/scheduler-ephemeral-task-flood` with unrelated uncommitted changes
+  (chat route, executor-graphs, bun.lock) — this work should land on its own branch rather than
+  stacking on top of unrelated in-progress changes.

--- a/libs/prisma/migrations/20260708225039_add_inventory_is_current/migration.sql
+++ b/libs/prisma/migrations/20260708225039_add_inventory_is_current/migration.sql
@@ -1,0 +1,13 @@
+-- Add isCurrent flag to InventoryResource for batch reconciliation
+-- This column tracks whether a resource is the most recent version from discovery
+
+-- 1. Add the isCurrent column with default true
+ALTER TABLE "inventory_resources" ADD COLUMN "isCurrent" BOOLEAN NOT NULL DEFAULT true;
+
+-- 2. Drop old indexes (they will be replaced with versions that include isCurrent)
+DROP INDEX IF EXISTS "inventory_resources_tenantId_resourceType_idx";
+DROP INDEX IF EXISTS "inventory_resources_tenantId_accountId_idx";
+
+-- 3. Create new indexes that include isCurrent for filtering
+CREATE INDEX "inventory_resources_tenantId_resourceType_isCurrent_idx" ON "inventory_resources"("tenantId", "resourceType", "isCurrent");
+CREATE INDEX "inventory_resources_tenantId_accountId_isCurrent_idx" ON "inventory_resources"("tenantId", "accountId", "isCurrent");

--- a/libs/prisma/schema.prisma
+++ b/libs/prisma/schema.prisma
@@ -348,14 +348,15 @@ model InventoryResource {
   tags         Json     @default("{}")
   metadata     Json     @default("{}")
   jobRunId     String?
+  isCurrent    Boolean  @default(true)
   discoveredAt DateTime @default(now())
   updatedAt    DateTime @updatedAt
 
   searchVector Unsupported("tsvector")?
 
   @@unique([tenantId, accountId, resourceType, resourceId])
-  @@index([tenantId, resourceType])
-  @@index([tenantId, accountId])
+  @@index([tenantId, resourceType, isCurrent])
+  @@index([tenantId, accountId, isCurrent])
   @@map("inventory_resources")
 }
 


### PR DESCRIPTION
## Summary

- Stops the inventory discovery grid from showing stale AWS resources (terminated instances, released IPs, etc.) mixed in with current ones. Root cause: the discovery job upserts resources by natural key but never marked/removed rows for resources that vanished from AWS between scans.
- Adds an `isCurrent` boolean to `InventoryResource` (default `true`, purely additive migration). After each account's discovery scan, `reconcileStaleResources()` flags that account's rows not touched by the current scan as `isCurrent = false` — **nothing is ever deleted**, so history stays queryable for audit.
- The grid's repository read path (`listResources` / `listResourcesFulltext`) now filters to `isCurrent = true` only. No new API params, no UI changes.
- Reconciliation runs unconditionally per account, including on scan failure/empty results (a deliberate tradeoff: "no stale data shown" over "always show something"), and is fail-open — a DB error during reconciliation itself is logged and swallowed rather than aborting the rest of a tenant's scan.
- Batch currency is tracked **per account**, not per tenant-wide scan, so resyncing one account doesn't affect others' currency.

Full design rationale: `docs/superpowers/specs/2026-07-08-inventory-latest-batch-filter-design.md`
Implementation plan: `docs/superpowers/plans/2026-07-08-inventory-latest-batch-filter.md`

Built via subagent-driven development — 4 implementation tasks (schema/migration, discovery write-path reconciliation, discovery job wiring, repository read-path filter), each independently reviewed and approved, followed by a whole-branch review that caught and fixed a fail-open gap in the error path before merge.

## Test plan

- [x] `apps/workers` discovery suite: `pg-writer.test.ts` + `index.test.ts` + `handle-discovery-scan.test.ts` — 26/26 passing
- [x] `apps/web-ui` inventory repository suite: `postgres.test.ts` — 20/21 passing (1 pre-existing, unrelated failure: `adds ILIKE name filter for searchTerm`, predates this branch)
- [x] `tsc --noEmit` clean on both apps for all touched files
- [x] Migration verified additive/safe (`ADD COLUMN ... DEFAULT true`, index rename references real pre-existing index names, `DROP INDEX IF EXISTS` idempotent)
- [ ] Manual live-scan smoke test against a real account — not completed in this PR (see note below)

## Note for reviewer

The plan's Task 5 called for a manual smoke test against local Postgres (trigger a scan, verify stale rows get excluded from the grid). While attempting this, I found the local dev environment's `localhost:5432` was ambiguous between the docker-compose Postgres and an active AWS SSM tunnel to `nucleus-cloud-ops-postgres...rds.amazonaws.com`. To avoid any risk of touching a shared database unexpectedly, I stopped short of the live smoke test — the schema/SQL correctness was instead verified by direct code review (migration SQL checked against the real prior index names, reconciliation SQL checked for tenant/account scoping) plus the mocked unit test suites above. Worth a real smoke test before this goes to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)