### PR TITLE
fix(aiops): halt LangGraph run on client abort + fix Agent Ops MCP tool description

### DIFF
--- a/apps/web-ui/app/api/chat/route.ts
+++ b/apps/web-ui/app/api/chat/route.ts
@@ -316,6 +316,14 @@ export async function POST(req: Request) {
                 {
                     version: "v2",
                     recursionLimit: 100,
+                    // Propagate the abort signal so a client "Stop" (or disconnect)
+                    // actually halts the LangGraph run. LangGraph forwards this signal
+                    // to every node/model call, so aborting throws an AbortError that
+                    // the stream handler catches and the `finally` block uses to release
+                    // the per-thread lock promptly — otherwise the run keeps executing
+                    // server-side, holding the lock, and the next "continue" POST is
+                    // rejected with 409 (breaking multi-turn continuity).
+                    signal: graphAbortController.signal,
                     configurable: { thread_id: threadId, user_id: resolvedUserId, tenant_id: resolvedTenantId },
                     ...(langfuseCallbacks.length > 0 ? { callbacks: langfuseCallbacks } : {}),
                 }

--- a/apps/web-ui/lib/agent-ops/executor-graphs.ts
+++ b/apps/web-ui/lib/agent-ops/executor-graphs.ts
@@ -30,6 +30,7 @@ import {
     llmAuditLog,
     getActiveMCPTools,
     getMCPToolsDescription,
+    getMCPManager,
     MAX_ITERATIONS,
 } from "@/lib/agent/agent-shared";
 import {
@@ -78,9 +79,17 @@ export async function createDynamicExecutorGraph(config: GraphConfig) {
     const toolNode = new ToolNode(tools);
 
     // ── MCP context description for prompts ───────────────────────────────────
-    const mcpContext = mcpServerIds?.length
-        ? await getMCPToolsDescription(mcpServerIds, tenantId).catch(() => '')
-        : '';
+    // assembleTools() above already connected the requested servers via the global
+    // MCPManager, so pull the description from that same instance (getMCPToolsDescription
+    // is synchronous and expects an MCPServerManager, not the id array).
+    let mcpContext = '';
+    if (mcpServerIds?.length) {
+        try {
+            mcpContext = getMCPToolsDescription(getMCPManager(), mcpServerIds);
+        } catch {
+            mcpContext = '';
+        }
+    }
 
     // ── Shared prompt fragments (built once, reused across nodes) ─────────────
     const awsCliStandards = buildAwsCliStandards();

--- a/bun.lock
+++ b/bun.lock
@@ -47,6 +47,7 @@
         "@ai-sdk/langchain": "^1.0.116",
         "@ai-sdk/react": "^2.0.116",
         "@auth/prisma-adapter": "^2.11.1",
+        "@aws-crypto/crc32": "^5.2.0",
         "@aws-sdk/client-acm": "^3.948.0",
         "@aws-sdk/client-auto-scaling": "^3.948.0",
         "@aws-sdk/client-bedrock": "^3.948.0",
@@ -186,6 +187,7 @@
       "name": "nucleus-workers",
       "version": "1.0.0",
       "dependencies": {
+        "@aws-crypto/crc32": "^5.2.0",
         "@aws-sdk/client-acm": "^3.1024.0",
         "@aws-sdk/client-api-gateway": "^3.1024.0",
         "@aws-sdk/client-auto-scaling": "^3.700.0",
@@ -2508,7 +2510,7 @@
 
     "immediate": ["immediate@3.0.6", "", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
 
-    "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
+    "immer": ["immer@11.1.8", "", {}, "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
@@ -3340,7 +3342,7 @@
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
-    "recharts": ["recharts@3.9.0", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.2.0", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-dCEcE9y20c8H2tkVeByrAXhhnBJk6/QLbxKmn+dJUptOfc5NMjwRh1jo0vZPRLD+5dMrHrP+hPEsfbGBMfnf5Q=="],
+    "recharts": ["recharts@3.9.2", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^11.1.8", "react-redux": "8.x.x || 9.x.x", "reselect": "5.2.0", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-G4fy+Pk46RaXgwWMh+Nzhyo/lbFAVqXo9gtetlyehe6Ehge9CsgDuOTwQDD+i1+llaLktNBiNq4bhnGlDRXFtw=="],
 
     "recma-build-jsx": ["recma-build-jsx@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-build-jsx": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew=="],
 
@@ -4633,8 +4635,6 @@
     "@radix-ui/react-collapsible/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
 
     "@radix-ui/react-use-effect-event/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
-
-    "@reduxjs/toolkit/immer": ["immer@11.1.8", "", {}, "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA=="],
 
     "@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
 

--- a/scripts/tunnel.sh
+++ b/scripts/tunnel.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-AWS_PROFILE=STX-CLOUD-PLATFORM aws ssm start-session --target i-05e5027eec38c6879 --document-name AWS-StartPortForwardingSessionToRemoteHost --parameters '{"host":["nucleus-cloud-ops-postgres.cxoucc8oef6b.ap-south-1.rds.amazonaws.com"],"portNumber":["5432"],"localPortNumber":["5432"]}' --region ap-south-1
+AWS_PROFILE=STX-CLOUD-PLATFORM aws ssm start-session --target i-0472dfbf02c83d920 --document-name AWS-StartPortForwardingSessionToRemoteHost --parameters '{"host":["nucleus-cloud-ops-postgres.cxoucc8oef6b.ap-south-1.rds.amazonaws.com"],"portNumber":["5432"],"localPortNumber":["5432"]}' --region ap-south-1


### PR DESCRIPTION
## Summary

Two AIOps fixes that were previously WIP (recovered from a stash), plus supporting file syncs.

### 1. Chat run halts on client abort — `apps/web-ui/app/api/chat/route.ts`
Propagates `graphAbortController.signal` into the LangGraph run config. LangGraph forwards this signal to every node/model call, so a client **Stop** (or disconnect) now throws an `AbortError` that the stream handler catches and the `finally` block uses to release the per-thread lock promptly.

**Before:** the run kept executing server-side after a Stop/disconnect, holding the per-thread lock, so the next "continue" POST was rejected with **409** — breaking multi-turn continuity.

### 2. Agent Ops MCP tool description — `apps/web-ui/lib/agent-ops/executor-graphs.ts`
`getMCPToolsDescription` expects an `MCPServerManager` instance and is **synchronous**, but the graph builder was passing the `mcpServerIds` **array** to an `await`ed call. That resolved to `array.getToolsForServers(...)`, crashing every Agent Ops run that used MCP servers with:

```
mcpManager.getToolsForServers is not a function
```

Fix: pull the already-connected manager via `getMCPManager()` (populated by `assembleTools` just above) and call it synchronously. (`config as any` had masked the type error from `tsc`.)

### Supporting
- `bun.lock` — lockfile sync
- `scripts/tunnel.sh` — dev SSM bastion target update (dev-only)

## Testing
- `tsc` — no new errors (pre-existing baseline unchanged).
- Agent Ops fix verified end-to-end against the running dev server: a run with MCP servers selected now flows `__start__ → memory_recall → evaluator → clarify` with no `getToolsForServers` error (previously crashed at graph build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)