### PR TITLE
fix(aiops): production-hardening — multi-tenant isolation, sandboxing, agent reliability

### DIFF
--- a/apps/web-ui/app/api/chat/route.ts
+++ b/apps/web-ui/app/api/chat/route.ts
@@ -7,13 +7,39 @@ import { isProviderConfigError } from '@/lib/agent/provider-errors';
 import { buildClientErrorText } from '@/lib/agent/stream-error';
 import { autoSelectSkill } from '@/lib/agent/auto-skill-select';
 import { resolveKnowledgeBaseIds } from '@/lib/agent/auto-kb-select';
+import { acquireThreadLock, releaseThreadLock as releaseThreadLockDb } from '@/lib/agent/thread-lock';
 
 export const maxDuration = 300; // 5 minutes for complex multi-iteration tasks
 
-// Per-thread execution lock: prevents duplicate/parallel LangGraph executions on the same thread.
-// useChat's maxSteps fires follow-up POSTs when a streaming response ends; without this guard a
-// second graph execution re-plans from scratch, doubling LLM API cost and interleaving checkpoints.
-const activeThreads = new Map<string, boolean>();
+// Server-side attachment limits (client validation in file-upload.tsx is advisory only).
+const MAX_ATTACHMENTS_PER_MESSAGE = 5;
+const MAX_ATTACHMENT_BYTES = 5 * 1024 * 1024; // 5MB decoded
+
+// Validate experimental_attachments on inbound messages. Returns an error string
+// (→ 400) or null if all attachments are acceptable. The agent runs on shared
+// infra, so an unbounded/arbitrary data: URL would inflate the request and the
+// provider payload; only bounded image attachments are accepted.
+function validateAttachments(messages: Message[]): string | null {
+    for (const m of messages) {
+        const atts = (m as { experimental_attachments?: Array<{ url?: string; contentType?: string }> }).experimental_attachments;
+        if (!atts?.length) continue;
+        if (atts.length > MAX_ATTACHMENTS_PER_MESSAGE) {
+            return `Too many attachments (max ${MAX_ATTACHMENTS_PER_MESSAGE} per message).`;
+        }
+        for (const att of atts) {
+            const url = att.url ?? '';
+            const match = /^data:([^;,]+)(;base64)?,([\s\S]*)$/.exec(url);
+            if (!match) return 'Attachments must be inline data: URLs.';
+            const mime = match[1] || '';
+            if (!mime.startsWith('image/')) return 'Only image attachments are supported.';
+            const isBase64 = !!match[2];
+            const payload = match[3] ?? '';
+            const bytes = isBase64 ? Math.floor((payload.length * 3) / 4) : payload.length;
+            if (bytes > MAX_ATTACHMENT_BYTES) return 'Attachment exceeds the 5MB limit.';
+        }
+    }
+    return null;
+}
 
 // Phase types for UI segregation
 type AgentPhase = 'planning' | 'execution' | 'reflection' | 'revision' | 'final' | 'memory_recall' | 'memory_save' | 'text';
@@ -35,7 +61,7 @@ interface Message {
 
 export async function POST(req: Request) {
     // Declare outside try so the catch block can always call it safely
-    let releaseThreadLock: () => void = () => { };
+    let releaseLock: () => void = () => { };
 
     try {
         const {
@@ -88,15 +114,16 @@ export async function POST(req: Request) {
         // Langfuse expects a plain ID without the USER# prefix
         const langfuseUserId = resolvedUserId.replace(/^USER#/, '') || undefined;
 
-        // Reject duplicate requests on the same thread (e.g. from useChat maxSteps retries)
-        if (activeThreads.has(threadId)) {
+        // Reject duplicate/parallel requests on the same thread across ALL instances
+        // (cross-instance lock — see lib/agent/thread-lock.ts).
+        const lockToken = await acquireThreadLock(threadId);
+        if (lockToken === null) {
             return new Response(
                 JSON.stringify({ error: "Thread is already processing a request. Please wait for it to finish." }),
                 { status: 409, headers: { 'Content-Type': 'application/json' } }
             );
         }
-        activeThreads.set(threadId, true);
-        releaseThreadLock = () => activeThreads.delete(threadId);
+        releaseLock = () => { void releaseThreadLockDb(threadId, lockToken); };
 
         // Ensure thread exists in store (without persisting messages yet)
         const firstUserMsg = messages.find((m: Message) => m.role === 'user');
@@ -131,7 +158,7 @@ export async function POST(req: Request) {
                 ? await resolveModelConfig(modelString, resolvedTenantId)
                 : await resolveDefaultModelConfig(resolvedTenantId);
         } catch (e) {
-            releaseThreadLock();
+            releaseLock();
             if (isProviderConfigError(e)) {
                 return new Response(
                     JSON.stringify({ error: e.message }),
@@ -197,6 +224,16 @@ export async function POST(req: Request) {
 
         // Track pre-run message count so we only persist NEW messages from this turn
         let preRunMessageCount = 0;
+
+        // Server-side attachment validation (client checks are advisory only).
+        const attachmentError = validateAttachments(messages as Message[]);
+        if (attachmentError) {
+            releaseLock();
+            return new Response(
+                JSON.stringify({ error: attachmentError }),
+                { status: 400, headers: { 'Content-Type': 'application/json' } }
+            );
+        }
 
         if (lastMessage.role === 'tool') {
             // Tool result (Human-in-the-Loop approval)
@@ -334,7 +371,8 @@ export async function POST(req: Request) {
                     streamEvents,
                     autoApprove,
                     resumedToolCallId,
-                    releaseThreadLock,
+                    releaseLock,
+
                     threadId,
                     graph,
                     { configurable: { thread_id: threadId, user_id: resolvedUserId, tenant_id: resolvedTenantId } },
@@ -392,7 +430,7 @@ export async function POST(req: Request) {
             }
 
             // Also include tool calls if present, though likely handled by the loop if not simple text
-            releaseThreadLock();
+            releaseLock();
             return NextResponse.json({
                 role: 'assistant',
                 content: content,
@@ -401,7 +439,7 @@ export async function POST(req: Request) {
         }
 
     } catch (error) {
-        releaseThreadLock();
+        releaseLock();
         console.error('[API Error]:', error);
         return new Response(
             JSON.stringify({

--- a/apps/web-ui/app/api/mcp-servers/route.ts
+++ b/apps/web-ui/app/api/mcp-servers/route.ts
@@ -15,13 +15,21 @@ import {
     defaultsToJson,
     jsonToServerConfigs,
     validateMcpConfig,
+    maskServerConfigs,
+    maskMcpConfigJson,
+    restoreMaskedSecrets,
 } from '@/lib/agent/mcp-config';
 import { TenantConfigService } from '@/lib/tenant-config-service';
 import { getSessionTenantId, getSessionUserId } from '@/lib/auth-session';
+import { authorize } from '@/lib/rbac/authorize';
 
+// MCP config is part of the AI Ops module (agent integrations).
 const CONFIG_KEY = 'mcp-servers';
 
 export async function GET() {
+    const authError = await authorize('read', 'AIOps');
+    if (authError) return authError;
+
     let tenantId: string;
     try {
         tenantId = await getSessionTenantId();
@@ -44,9 +52,10 @@ export async function GET() {
         // Return both the server list and the raw JSON for the editor
         const editorJson = savedJson || defaultsToJson();
 
+        // Never return stored secrets (bearer tokens/API keys) in plaintext.
         return NextResponse.json({
-            servers,
-            config: editorJson,
+            servers: maskServerConfigs(servers),
+            config: maskMcpConfigJson(editorJson),
             isCustom: savedJson !== null,
         });
     } catch (error: any) {
@@ -59,6 +68,9 @@ export async function GET() {
 }
 
 export async function PUT(req: Request) {
+    const authError = await authorize('update', 'AIOps');
+    if (authError) return authError;
+
     let tenantId: string;
     let userId: string;
     try {
@@ -70,7 +82,17 @@ export async function PUT(req: Request) {
 
     try {
         const body = await req.json();
-        const config: MCPConfigJson = body.config;
+        const incoming: MCPConfigJson = body.config;
+
+        // Restore any masked secrets from the currently-stored config, so a save
+        // that left placeholders in place preserves the existing tokens/keys.
+        let stored: MCPConfigJson | null = null;
+        try {
+            stored = await TenantConfigService.getConfig<MCPConfigJson>(CONFIG_KEY, tenantId);
+        } catch (dbError) {
+            console.warn('[API /mcp-servers] Stored config read failed during save:', dbError);
+        }
+        const config = restoreMaskedSecrets(incoming, stored);
 
         const validation = validateMcpConfig(config);
         if (!validation.ok) {
@@ -79,7 +101,18 @@ export async function PUT(req: Request) {
 
         await TenantConfigService.saveConfig(CONFIG_KEY, config, tenantId);
 
-        // Return the resolved server list
+        // Drop this tenant's cached MCP connections so the next run reconnects
+        // with the new config/credentials (connections are per-tenant singletons
+        // and would otherwise serve stale endpoints/tokens). Safe here because a
+        // config save is a deliberate action, not a per-run event.
+        try {
+            const { getMCPManager } = await import('@/lib/agent/mcp-manager');
+            await getMCPManager().disconnectTenantServers(tenantId);
+        } catch (e) {
+            console.warn('[API /mcp-servers] Failed to reset MCP connections after save:', e);
+        }
+
+        // Return the resolved server list (secrets masked)
         const servers = jsonToServerConfigs(config);
 
         console.log(`[API /mcp-servers] Saved config with ${Object.keys(config.mcpServers).length} servers`);
@@ -103,8 +136,8 @@ export async function PUT(req: Request) {
 
         return NextResponse.json({
             success: true,
-            servers,
-            config,
+            servers: maskServerConfigs(servers),
+            config: maskMcpConfigJson(config),
             isCustom: true,
         });
     } catch (error: any) {
@@ -117,6 +150,9 @@ export async function PUT(req: Request) {
 }
 
 export async function DELETE() {
+    const authError = await authorize('delete', 'AIOps');
+    if (authError) return authError;
+
     let tenantId: string;
     let userId: string;
     try {
@@ -128,6 +164,15 @@ export async function DELETE() {
 
     try {
         await TenantConfigService.deleteConfig(CONFIG_KEY, tenantId);
+
+        // Drop this tenant's cached MCP connections so custom-server sessions are
+        // not reused after a reset to defaults.
+        try {
+            const { getMCPManager } = await import('@/lib/agent/mcp-manager');
+            await getMCPManager().disconnectTenantServers(tenantId);
+        } catch (e) {
+            console.warn('[API /mcp-servers] Failed to reset MCP connections after delete:', e);
+        }
 
         const servers = DEFAULT_MCP_SERVERS;
         const config = defaultsToJson();

--- a/apps/web-ui/app/api/threads/[threadId]/history/route.ts
+++ b/apps/web-ui/app/api/threads/[threadId]/history/route.ts
@@ -30,8 +30,35 @@ const PHASE_MARKERS = [
     'MEMORY_SAVE_PHASE_START\n',
 ];
 
+/**
+ * Multimodal user turns are persisted as a JSON-encoded LangChain content array
+ * (e.g. `[{"type":"text",...},{"type":"image_url",...}]`). Rendering that raw
+ * string shows a literal JSON blob. Extract the human-readable text so the UI
+ * shows the prompt; image parts are not reconstructed on reload (attachments are
+ * not persisted separately) — a known limitation, but far better than raw JSON.
+ */
+function extractDisplayText(content: string): string {
+    const trimmed = content.trimStart();
+    if (!trimmed.startsWith('[') && !trimmed.startsWith('{')) return content;
+    try {
+        const parsed = JSON.parse(content);
+        if (Array.isArray(parsed)) {
+            const texts = parsed
+                .filter((p) => p && typeof p === 'object' && p.type === 'text' && typeof p.text === 'string')
+                .map((p) => p.text as string);
+            const hasImage = parsed.some((p) => p && typeof p === 'object' && (p.type === 'image_url' || p.type === 'image'));
+            const joined = texts.join('');
+            if (joined || hasImage) return hasImage ? `${joined}${joined ? '\n\n' : ''}🖼️ [image attachment]` : joined;
+        }
+    } catch {
+        // Not JSON — fall through and return the original content.
+    }
+    return content;
+}
+
 function convertPlainMessage(msg: { role: string; content: string; metadata?: Record<string, unknown> }, index: number): HistoryMessage | null {
-    const { role, content, metadata } = msg;
+    const { role, metadata } = msg;
+    const content = (role === 'human' || role === 'ai') ? extractDisplayText(msg.content) : msg.content;
     if (!content && role !== 'ai') return null;
 
     if (role === 'human') {
@@ -122,33 +149,48 @@ export async function GET(
         const { threadId } = await params;
         if (!threadId) return NextResponse.json({ error: 'Thread ID is required' }, { status: 400 });
 
-        // Chat history lookup
-        {
-            let sessionUserId: string;
-            let sessionTenantId: string;
-            try {
-                sessionUserId = await getSessionUserId();
-                sessionTenantId = await getSessionTenantId();
-            } catch {
-                return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-            }
-            // Allow reading another user's thread by passing ownerUserId as a query param
-            const url = new URL(_req.url);
-            const ownerUserId = url.searchParams.get('ownerUserId');
-            const userId = ownerUserId ?? sessionUserId;
-            try {
-                const chatHistory = await getChatHistory();
-                const msgs = await chatHistory.getMessages(sessionTenantId, userId, threadId);
-                if (msgs.length > 0) {
-                    const converted = msgs.map((m, i) => convertPlainMessage(m, i)).filter(Boolean) as HistoryMessage[];
-                    return NextResponse.json({ messages: mergeToolResults(converted) });
-                }
-            } catch (err) {
-                console.warn('[History API] Chat history lookup failed, falling back to checkpoint:', err);
+        let sessionUserId: string;
+        let sessionTenantId: string;
+        try {
+            sessionUserId = await getSessionUserId();
+            sessionTenantId = await getSessionTenantId();
+        } catch {
+            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+        }
+
+        // Reject namespaced threads whose embedded tenant segment isn't ours.
+        if (threadId.includes(':')) {
+            const [embeddedTenantId] = threadId.split(':');
+            if (embeddedTenantId !== sessionTenantId) {
+                return NextResponse.json({ error: 'Forbidden: thread belongs to another tenant' }, { status: 403 });
             }
         }
 
-        // Fallback: extract from LangGraph checkpoint
+        // Tenant-scoped ownership gate. This guards BOTH the chat-history read and
+        // the checkpoint fallback below: PostgresSaver checkpoints are keyed only by
+        // thread_id (no tenant column), so without this a request could otherwise
+        // read another tenant's checkpoint via a guessable bare/un-namespaced ID.
+        // Chat sessions are seeded eagerly at chat start, so any thread with history
+        // has a ChatSession row; a thread absent from this tenant returns empty.
+        {
+            const { threadStore } = await import('@/lib/store/thread-store');
+            const owned = await threadStore.getThread(threadId, sessionTenantId);
+            if (!owned) return NextResponse.json({ messages: [] });
+        }
+
+        // Chat history lookup (tenant-scoped; intra-tenant chats are shared by design)
+        try {
+            const chatHistory = await getChatHistory();
+            const msgs = await chatHistory.getMessages(sessionTenantId, sessionUserId, threadId);
+            if (msgs.length > 0) {
+                const converted = msgs.map((m, i) => convertPlainMessage(m, i)).filter(Boolean) as HistoryMessage[];
+                return NextResponse.json({ messages: mergeToolResults(converted) });
+            }
+        } catch (err) {
+            console.warn('[History API] Chat history lookup failed, falling back to checkpoint:', err);
+        }
+
+        // Fallback: extract from LangGraph checkpoint (ownership already verified above)
         const checkpointer = await getCheckpointer();
         const checkpoint = await checkpointer.getTuple({ configurable: { thread_id: threadId } });
         if (!checkpoint) return NextResponse.json({ messages: [] });

--- a/apps/web-ui/app/api/threads/[threadId]/route.ts
+++ b/apps/web-ui/app/api/threads/[threadId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { AuditService } from '@/lib/audit-service';
-import { getSessionTenantId, getAuthSession } from '@/lib/auth-session';
+import { getSessionTenantId, getSessionUserId } from '@/lib/auth-session';
 
 interface NormalizedThread {
     id: string;
@@ -10,6 +10,30 @@ interface NormalizedThread {
     model?: string;
 }
 
+/**
+ * Resolve the caller's tenant/user and reject a threadId whose embedded tenant
+ * segment (tenantId:userId:ts) belongs to a different tenant. Returns the
+ * resolved identity, or a NextResponse to return early (401/403).
+ */
+async function resolveOwnership(threadId: string):
+    Promise<{ tenantId: string; userId: string } | NextResponse> {
+    let tenantId: string;
+    let userId: string;
+    try {
+        tenantId = await getSessionTenantId();
+        userId = await getSessionUserId();
+    } catch {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    if (threadId.includes(':')) {
+        const [embeddedTenantId] = threadId.split(':');
+        if (embeddedTenantId !== tenantId) {
+            return NextResponse.json({ error: 'Forbidden: thread belongs to another tenant' }, { status: 403 });
+        }
+    }
+    return { tenantId, userId };
+}
+
 export async function DELETE(
     _req: Request,
     { params }: { params: Promise<{ threadId: string }> }
@@ -17,8 +41,12 @@ export async function DELETE(
     try {
         const { threadId } = await params;
 
+        const owner = await resolveOwnership(threadId);
+        if (owner instanceof NextResponse) return owner;
+        const { tenantId, userId } = owner;
+
         const { threadStore } = await import('@/lib/store/thread-store');
-        const success = await threadStore.deleteThread(threadId);
+        const success = await threadStore.deleteThread(threadId, tenantId);
         if (!success) return NextResponse.json({ error: 'Thread not found' }, { status: 404 });
 
         AuditService.logUserAction({
@@ -30,11 +58,11 @@ export async function DELETE(
             resourceType: 'chat',
             resourceId: threadId,
             resourceName: threadId,
-            user: 'unknown',
+            user: userId,
             userType: 'user',
             status: 'success',
             details: `Deleted chat thread ${threadId}`,
-            tenantId: await getSessionTenantId().catch(() => 'unknown'),
+            tenantId,
         }).catch(() => {});
 
         return NextResponse.json({ success: true });
@@ -51,8 +79,12 @@ export async function PATCH(
         const { threadId } = await params;
         const { title } = await req.json();
 
+        const owner = await resolveOwnership(threadId);
+        if (owner instanceof NextResponse) return owner;
+        const { tenantId, userId } = owner;
+
         const { threadStore } = await import('@/lib/store/thread-store');
-        const updated = await threadStore.updateThread(threadId, { title });
+        const updated = await threadStore.updateThread(threadId, tenantId, { title });
         if (!updated) return NextResponse.json({ error: 'Thread not found' }, { status: 404 });
 
         AuditService.logUserAction({
@@ -64,11 +96,11 @@ export async function PATCH(
             resourceType: 'chat',
             resourceId: threadId,
             resourceName: title || threadId,
-            user: 'unknown',
+            user: userId,
             userType: 'user',
             status: 'success',
             details: `Updated chat thread ${threadId}`,
-            tenantId: await getSessionTenantId().catch(() => 'unknown'),
+            tenantId,
         }).catch(() => {});
 
         return NextResponse.json(updated);

--- a/apps/web-ui/app/app/agent/page.tsx
+++ b/apps/web-ui/app/app/agent/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useState } from 'react';
 import { ChatInterface } from '@/components/agent/chat-interface';
 import { ChatTabBar, ChatTab } from '@/components/agent/chat-tab-bar';
+import { cn } from '@/lib/utils';
 
 const MAX_TABS = 8;
 
@@ -98,61 +99,48 @@ export default function AgentPage() {
 
   // ──────────────────────────────────────────────────────────────────────────
 
+  // Each tab's ChatInterface is mounted EXACTLY ONCE and never conditionally
+  // duplicated — fullscreen is a pure layout toggle on the single outer wrapper
+  // (same DOM node, only its className changes), so every ChatInterface keeps
+  // its component identity and its useChat({ id }) state across the toggle. An
+  // in-progress stream is preserved when entering/exiting fullscreen; history is
+  // fetched once per thread rather than twice.
   return (
-    <>
-      {/* Fullscreen overlay — covers entire viewport including sidebar */}
-      {isFullscreen && (
-        <div className="fixed inset-0 z-50 bg-background/80 backdrop-blur-sm flex p-6">
-          {tabs.map((tab) => (
-            <div
-              key={tab.threadId}
-              className="flex-1"
-              style={{ display: tab.threadId === activeTabId ? 'flex' : 'none' }}
-            >
-              <ChatInterface
-                threadId={tab.threadId}
-                ownerUserId={tab.ownerUserId}
-                isFullscreen={isFullscreen}
-                onToggleFullscreen={() => setIsFullscreen((prev) => !prev)}
-                onStatusChange={(s) => handleStatusChange(tab.threadId, s)}
-                onTitleChange={(title) => handleTitleChange(tab.threadId, title)}
-              />
-            </div>
-          ))}
-        </div>
+    <div
+      className={cn(
+        isFullscreen
+          ? 'fixed inset-0 z-50 flex flex-col bg-background'
+          : 'flex flex-col h-[calc(100vh-theme(spacing.16))] overflow-hidden bg-background',
       )}
+    >
+      <ChatTabBar
+        tabs={tabs}
+        activeTabId={activeTabId}
+        onTabSelect={setActiveTabId}
+        onTabClose={handleCloseTab}
+        onNewChat={handleNewChat}
+        onThreadSelect={handleThreadSelect}
+        maxTabs={MAX_TABS}
+      />
 
-      {/* Normal layout */}
-      <div className="flex flex-col h-[calc(100vh-theme(spacing.16))] overflow-hidden bg-background">
-        <ChatTabBar
-          tabs={tabs}
-          activeTabId={activeTabId}
-          onTabSelect={setActiveTabId}
-          onTabClose={handleCloseTab}
-          onNewChat={handleNewChat}
-          onThreadSelect={handleThreadSelect}
-          maxTabs={MAX_TABS}
-        />
-
-        <div className="flex-1 relative overflow-hidden p-4">
-          {tabs.map((tab) => (
-            <div
-              key={tab.threadId}
-              className="absolute inset-4"
-              style={{ display: tab.threadId === activeTabId ? 'flex' : 'none' }}
-            >
-              <ChatInterface
-                threadId={tab.threadId}
-                ownerUserId={tab.ownerUserId}
-                isFullscreen={isFullscreen}
-                onToggleFullscreen={() => setIsFullscreen((prev) => !prev)}
-                onStatusChange={(s) => handleStatusChange(tab.threadId, s)}
-                onTitleChange={(title) => handleTitleChange(tab.threadId, title)}
-              />
-            </div>
-          ))}
-        </div>
+      <div className="flex-1 relative overflow-hidden p-4">
+        {tabs.map((tab) => (
+          <div
+            key={tab.threadId}
+            className="absolute inset-4"
+            style={{ display: tab.threadId === activeTabId ? 'flex' : 'none' }}
+          >
+            <ChatInterface
+              threadId={tab.threadId}
+              ownerUserId={tab.ownerUserId}
+              isFullscreen={isFullscreen}
+              onToggleFullscreen={() => setIsFullscreen((prev) => !prev)}
+              onStatusChange={(s) => handleStatusChange(tab.threadId, s)}
+              onTitleChange={(title) => handleTitleChange(tab.threadId, title)}
+            />
+          </div>
+        ))}
       </div>
-    </>
+    </div>
   );
 }

--- a/apps/web-ui/components/agent/chat-interface.tsx
+++ b/apps/web-ui/components/agent/chat-interface.tsx
@@ -48,10 +48,12 @@ import { toast } from "sonner";
 import { useDistillSkill } from "@/lib/queries/skills";
 import { SkillFormDialog } from "@/components/skills/skill-form-dialog";
 
-// Available modes
+// Available modes — must stay in sync with the modes the server accepts in
+// /api/chat (fast | plan | deep). "deep" runs the extended-thinking agent.
 const AGENT_MODES = [
   { id: "fast", label: "Fast (ReAct)" },
   { id: "plan", label: "Plan & Execute" },
+  { id: "deep", label: "Deep (Extended Thinking)" },
 ];
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -256,6 +258,70 @@ interface MessageRowProps {
   renderToolInvocation: (part: any, messageId: string, index: number) => React.ReactNode;
 }
 
+// Extract a plain image URL from a content part, tolerating the several shapes
+// history reconstruction can produce (data URL, {url}, or Bedrock {source}).
+function partImageUrl(part: any): string | undefined {
+  if (!part || typeof part !== "object") return undefined;
+  if (typeof part.image === "string") return part.image;
+  if (typeof part.url === "string") return part.url;
+  if (typeof part.image_url === "string") return part.image_url;
+  if (part.image_url && typeof part.image_url.url === "string") return part.image_url.url;
+  if (part.source?.data && part.source?.media_type) {
+    return `data:${part.source.media_type};base64,${part.source.data}`;
+  }
+  return undefined;
+}
+
+// Render a message whose `content` has no structured `parts` (legacy / history
+// rows). If content is a JSON-encoded array of parts, render its text and image
+// portions instead of dumping the raw JSON string as markdown text.
+function MessageContentFallback({ content }: { content: any }) {
+  let value: any = content;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed.startsWith("[") || trimmed.startsWith("{")) {
+      try {
+        value = JSON.parse(trimmed);
+      } catch {
+        // Not JSON — render the string as-is below.
+      }
+    }
+  }
+
+  if (Array.isArray(value)) {
+    return (
+      <>
+        {value.map((part: any, idx: number) => {
+          if (typeof part === "string") {
+            return <MarkdownContent key={idx} content={part} />;
+          }
+          if (part?.type === "text" && typeof part.text === "string") {
+            return <MarkdownContent key={idx} content={part.text} />;
+          }
+          const imageUrl = partImageUrl(part);
+          if (imageUrl) {
+            return (
+              <img
+                key={idx}
+                src={imageUrl}
+                alt={part?.name || "attachment"}
+                className="max-w-xs max-h-48 rounded border object-contain mb-2"
+              />
+            );
+          }
+          return null;
+        })}
+      </>
+    );
+  }
+
+  return (
+    <MarkdownContent
+      content={typeof value === "string" ? value : JSON.stringify(value)}
+    />
+  );
+}
+
 const MessageRow = React.memo(function MessageRow({ message, isLastMessage, isActivelyStreaming, renderPhaseBlock, renderToolInvocation }: MessageRowProps) {
   const isUser = message.role === "user";
   const parts: any[] = message.parts || [];
@@ -350,15 +416,9 @@ const MessageRow = React.memo(function MessageRow({ message, isLastMessage, isAc
             return null;
           })}
 
-        {/* Fallback for simple content */}
+        {/* Fallback for simple content (legacy / history rows without parts) */}
         {parts.length === 0 && message.content && (
-          <MarkdownContent
-            content={
-              typeof message.content === "string"
-                ? message.content
-                : JSON.stringify(message.content)
-            }
-          />
+          <MessageContentFallback content={message.content} />
         )}
       </div>
 
@@ -495,6 +555,9 @@ export function ChatInterface({
   const planStepCacheRef = useRef(new Map<string, string[]>());
   // rAF handle for debounced auto-scroll — cancelled if a new message arrives before the frame fires.
   const scrollRafRef = useRef<number | null>(null);
+  // Set once the user sends a message so a slow history fetch can't clobber the
+  // optimistic conversation with a stale (or empty) server snapshot.
+  const skipHistoryRef = useRef(false);
 
   // Scroll control state - track if user has manually scrolled up
   const [userHasScrolledUp, setUserHasScrolledUp] = useState(false);
@@ -716,11 +779,14 @@ export function ChatInterface({
     return "Processing";
   }, [isLoading, messages]);
 
-  // Fetch conversation history when component mounts (for existing threads)
+  // Fetch conversation history when component mounts (for existing threads).
+  // Guarded so a stale load (thread switch / unmount) or a send that races the
+  // fetch cannot setState late or clobber the optimistic conversation.
   useEffect(() => {
+    let cancelled = false;
+    const controller = new AbortController();
+
     async function fetchHistory() {
-      // Only fetch if this looks like an existing thread (not a new timestamp-based ID)
-      // We attempt to fetch history for all threads; if none exists, API returns empty array
       console.log(
         "[ChatInterface] Attempting to fetch history for thread:",
         threadId,
@@ -731,9 +797,13 @@ export function ChatInterface({
         const historyUrl = ownerUserId
           ? `/api/threads/${threadId}/history?ownerUserId=${encodeURIComponent(ownerUserId)}`
           : `/api/threads/${threadId}/history`;
-        const res = await fetch(historyUrl);
+        const res = await fetch(historyUrl, { signal: controller.signal });
+        // Bail if this load is no longer current, or a send has already
+        // populated the conversation for this thread.
+        if (cancelled || skipHistoryRef.current) return;
         if (res.ok) {
           const data = await res.json();
+          if (cancelled || skipHistoryRef.current) return;
           if (data.messages && data.messages.length > 0) {
             console.log(
               "[ChatInterface] Loaded",
@@ -749,14 +819,20 @@ export function ChatInterface({
           console.warn("[ChatInterface] Failed to fetch history:", res.status);
         }
       } catch (error) {
+        if ((error as any)?.name === "AbortError") return;
         console.error("[ChatInterface] Error fetching history:", error);
       } finally {
-        setIsLoadingHistory(false);
+        if (!cancelled) setIsLoadingHistory(false);
       }
     }
 
     fetchHistory();
-  }, [threadId, setMessages]);
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [threadId, ownerUserId, setMessages]);
 
   useEffect(() => {
     if (messages.length > 0) {
@@ -863,6 +939,9 @@ export function ChatInterface({
     setHasStarted(true);
     setWasStopped(false);
     setUserHasScrolledUp(false); // Reset scroll state on new message
+    // A send has taken over this thread — an in-flight history load must not
+    // overwrite the optimistic user message / streamed response.
+    skipHistoryRef.current = true;
 
     await sendMessage(
       {
@@ -905,14 +984,21 @@ export function ChatInterface({
   };
 
   // Handle tool approval - makes explicit API call to resume LangGraph execution
-  const handleToolApproval = async (toolCallId: string, approved: boolean) => {
+  const handleToolApproval = async (
+    toolCallId: string,
+    approved: boolean,
+    toolName: string,
+  ) => {
     console.log(
       `[ChatInterface] Tool ${approved ? "approved" : "rejected"}: ${toolCallId}`,
     );
 
-    // First, update local state via addToolResult (for UI feedback)
+    // First, update local state via addToolResult (for UI feedback).
+    // AI SDK v5 expects { tool, toolCallId, output } — passing the legacy
+    // `result` key left the tool output undefined so the approve/reject state
+    // wasn't reflected until the follow-up re-stream.
     const result = approved ? "Approved" : "Cancelled by user";
-    addToolResult({ toolCallId, result });
+    addToolResult({ tool: toolName, toolCallId, output: result });
 
     // Then, make explicit API call to resume the graph
     // We send the tool result as a message with role: 'tool'
@@ -1145,16 +1231,17 @@ export function ChatInterface({
     messageId: string,
     index: number,
   ) => {
-    // Extract tool name from multiple possible sources
-    // Priority: toolName > name > type (tool-name format) > fallback
-    let toolName = part.toolName || part.name;
-
-    if (!toolName && part.type?.startsWith('tool-')) {
-      // Extract from "tool-execute_command" → "execute_command"
-      toolName = part.type.replace('tool-', '').replace(/_/g, ' ');
+    // Raw tool identifier (as registered on the server) — used for addToolResult.
+    // Priority: toolName > name > type ("tool-execute_command" → "execute_command").
+    let rawToolName = part.toolName || part.name;
+    if (!rawToolName && part.type?.startsWith('tool-')) {
+      rawToolName = part.type.replace('tool-', '');
     }
+    rawToolName = rawToolName || "tool";
 
-    toolName = toolName || "tool";
+    // Human-friendly name for display (underscores → spaces).
+    const toolName = rawToolName.replace(/_/g, ' ');
+
     const args = part.args || part.input;
     const result = part.result || part.output;
     const state = part.state;
@@ -1163,13 +1250,23 @@ export function ChatInterface({
     // Show approval UI only when: not auto-approve AND tool is in "call" state without result
     const isPending = !autoApprove && isCall && !result && !isLoading;
 
+    const hasRealResult =
+      !!result && result !== "Approved" && result !== "Cancelled by user";
+
+    // A tool part with no result that is no longer streaming and is not awaiting
+    // approval means the run was aborted mid-tool. Surface a terminal state
+    // instead of a perpetual "pending" that never resolves (even after reload).
+    const isInterrupted = isCall && !result && !isLoading && !isPending;
+
     // Determine tool state for new component
     const toolState =
-      result && result !== "Approved" && result !== "Cancelled by user"
+      hasRealResult
         ? "complete"
         : isLoading && isCall && !result
           ? "running"
-          : "pending";
+          : isInterrupted
+            ? "error"
+            : "pending";
 
     // Determine approval state for Confirmation component
     const approvalState =
@@ -1208,14 +1305,14 @@ export function ChatInterface({
               <ConfirmationActions>
                 <ConfirmationAction
                   variant="outline"
-                  onClick={() => handleToolApproval(part.toolCallId, false)}
+                  onClick={() => handleToolApproval(part.toolCallId, false, rawToolName)}
                 >
                   <X className="w-3 h-3 mr-1" />
                   Reject
                 </ConfirmationAction>
                 <ConfirmationAction
                   variant="default"
-                  onClick={() => handleToolApproval(part.toolCallId, true)}
+                  onClick={() => handleToolApproval(part.toolCallId, true, rawToolName)}
                 >
                   <Check className="w-3 h-3 mr-1" />
                   Approve & Run
@@ -1240,16 +1337,20 @@ export function ChatInterface({
             </Confirmation>
           )}
 
-          {/* Output with loading state — truncated to TOOL_OUTPUT_TRUNCATE_BYTES if large */}
-          <ToolOutputWithTruncation
-            output={
-              result !== "Approved" && result !== "Cancelled by user"
-                ? result
-                : undefined
-            }
-            isLoading={isLoading && isCall && !result}
-            label="Output"
-          />
+          {/* Output with loading state — truncated to TOOL_OUTPUT_TRUNCATE_BYTES if large.
+              If the run was aborted mid-tool, show a terminal interrupted note. */}
+          {isInterrupted ? (
+            <ToolOutput
+              errorText="Execution interrupted — the run was stopped before this tool returned a result."
+              label="Output"
+            />
+          ) : (
+            <ToolOutputWithTruncation
+              output={hasRealResult ? result : undefined}
+              isLoading={isLoading && isCall && !result}
+              label="Output"
+            />
+          )}
         </ToolContent>
       </Tool>
     );
@@ -2028,7 +2129,9 @@ export function ChatInterface({
                 onClick={async () => {
                   const success = await copyToClipboard(messages);
                   if (success) {
-                    // Optional: Toast notification could go here
+                    toast.success("Copied to clipboard");
+                  } else {
+                    toast.error("Could not copy chat to clipboard");
                   }
                 }}
                 title="Copy chat to clipboard"

--- a/apps/web-ui/components/agent/file-upload.tsx
+++ b/apps/web-ui/components/agent/file-upload.tsx
@@ -4,6 +4,7 @@ import { useRef, useState } from "react";
 import { X, Paperclip, FileImage } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { toast } from "sonner";
 
 export interface FileAttachment {
   name: string;
@@ -20,11 +21,17 @@ interface FileUploadProps {
 }
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+const MAX_FILES = 5;
 const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"];
 
 export function FileUpload({ onFilesChange, files, disabled }: FileUploadProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [error, setError] = useState<string>("");
+
+  const reject = (message: string) => {
+    setError(message);
+    toast.error(message);
+  };
 
   const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const selectedFiles = Array.from(e.target.files || []);
@@ -33,13 +40,18 @@ export function FileUpload({ onFilesChange, files, disabled }: FileUploadProps) 
     const validFiles: FileAttachment[] = [];
 
     for (const file of selectedFiles) {
+      if (files.length + validFiles.length >= MAX_FILES) {
+        reject(`You can attach at most ${MAX_FILES} images`);
+        break;
+      }
+
       if (!ALLOWED_TYPES.includes(file.type)) {
-        setError(`${file.name}: Only images are supported`);
+        reject(`${file.name}: Only images are supported (JPEG, PNG, GIF, WebP)`);
         continue;
       }
 
       if (file.size > MAX_FILE_SIZE) {
-        setError(`${file.name}: File too large (max 5MB)`);
+        reject(`${file.name}: File too large (max 5MB)`);
         continue;
       }
 
@@ -53,7 +65,7 @@ export function FileUpload({ onFilesChange, files, disabled }: FileUploadProps) 
       });
     }
 
-    onFilesChange([...files, ...validFiles]);
+    if (validFiles.length > 0) onFilesChange([...files, ...validFiles]);
     if (inputRef.current) inputRef.current.value = "";
   };
 

--- a/apps/web-ui/components/agent/thread-sidebar.tsx
+++ b/apps/web-ui/components/agent/thread-sidebar.tsx
@@ -19,14 +19,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-
-interface Thread {
-    id: string;
-    title: string;
-    createdAt: number;
-    updatedAt: number;
-    ownerUserId?: string;
-}
+import { useThreads, useDeleteThread } from '@/lib/queries/threads';
 
 interface ThreadSidebarProps {
     className?: string;
@@ -43,10 +36,14 @@ export function ThreadSidebar({
     onThreadSelect,
     onNewChat
 }: ThreadSidebarProps) {
-    const [threads, setThreads] = useState<Thread[]>([]);
     const [searchQuery, setSearchQuery] = useState('');
-    const [isLoading, setIsLoading] = useState(true);
     const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+
+    // Threads list is server state — TanStack Query keeps it fresh (refetch on
+    // focus/remount) and mutations invalidate it, so the sidebar no longer goes
+    // stale after a thread is created/renamed/deleted elsewhere.
+    const { data: threads = [], isLoading } = useThreads();
+    const deleteThread = useDeleteThread();
 
     useEffect(() => {
         fetch('/api/auth/session')
@@ -55,41 +52,16 @@ export function ThreadSidebar({
             .catch(() => {});
     }, []);
 
-    const fetchThreads = async () => {
-        try {
-            const res = await fetch('/api/threads');
-            if (res.ok) {
-                const data = await res.json();
-                setThreads(data);
-            }
-        } catch (e) {
-            console.error("Failed to fetch threads", e);
-        } finally {
-            setIsLoading(false);
-        }
-    };
-
-    useEffect(() => {
-        fetchThreads();
-        // Poll for updates every 10s or relies on parent to trigger refresh?
-        // Simple polling for now
-        // const interval = setInterval(fetchThreads, 300000);
-        // return () => clearInterval(interval);
-    }, []);
-
-    const handleDeleteThread = async (e: React.MouseEvent, id: string) => {
+    const handleDeleteThread = (e: React.MouseEvent, id: string) => {
         e.stopPropagation();
-        try {
-            const res = await fetch(`/api/threads/${id}`, { method: 'DELETE' });
-            if (res.ok) {
-                setThreads(threads.filter(t => t.id !== id));
+        deleteThread.mutate(id, {
+            onSuccess: () => {
                 if (currentThreadId === id) {
                     onNewChat();
                 }
-            }
-        } catch (e) {
-            console.error("Failed to delete thread", e);
-        }
+            },
+            onError: (err) => console.error("Failed to delete thread", err),
+        });
     };
 
     const filteredThreads = threads.filter(t => 

--- a/apps/web-ui/lib/agent/agent-shared.ts
+++ b/apps/web-ui/lib/agent/agent-shared.ts
@@ -411,6 +411,51 @@ export function getRecentMessages(messages: BaseMessage[], maxMessages: number =
  *
  * Call this function immediately before invoking modelWithTools.
  */
+/**
+ * Detects an extended-thinking / reasoning content block in either the LangChain
+ * normalized shape (`type: 'thinking' | 'reasoning' | 'reasoning_content' | …`) or
+ * the raw Bedrock Converse shape (`{ reasoningContent: { reasoningText: … } }`).
+ */
+function isReasoningBlock(b: unknown): boolean {
+    if (!b || typeof b !== 'object') return false;
+    const block = b as Record<string, unknown>;
+    if ('reasoningContent' in block || 'reasoning_content' in block) return true;
+    const t = block.type;
+    return t === 'reasoning_content' || t === 'reasoning' || t === 'thinking'
+        || t === 'redacted_reasoning' || t === 'redacted_thinking';
+}
+
+/**
+ * Removes reasoning/thinking content blocks from an AI message's content array.
+ *
+ * Why: Bedrock Claude Sonnet 5 emits `reasoningContent` blocks, but these do not
+ * survive the checkpoint round-trip intact — on replay `reasoningText.text` comes
+ * back null, and Bedrock rejects the next invoke with
+ *   ValidationException: Value at 'messages.N.content.M.reasoningContent.reasoningText.text'
+ *   failed to satisfy constraint: Member must not be null
+ * Reasoning content is the model's own scratchpad, not required for context
+ * fidelity, and we do not explicitly enable extended thinking (so Bedrock does not
+ * require it on replay). Stripping it is the safe, standard mitigation. Returns the
+ * original message untouched when it carries no reasoning blocks.
+ */
+function stripReasoningBlocks(msg: BaseMessage): BaseMessage {
+    if (msg._getType() !== 'ai') return msg;
+    const ai = msg as AIMessage;
+    if (!Array.isArray(ai.content)) return msg;
+    const original = ai.content as unknown[];
+    const filtered = original.filter((b) => !isReasoningBlock(b));
+    if (filtered.length === original.length) return msg; // nothing to strip
+    return new AIMessage({
+        content: filtered as AIMessage['content'],
+        tool_calls: ai.tool_calls,
+        additional_kwargs: ai.additional_kwargs,
+        response_metadata: ai.response_metadata,
+        id: ai.id,
+        name: ai.name,
+        usage_metadata: ai.usage_metadata,
+    });
+}
+
 export function sanitizeMessagesForBedrock(messages: BaseMessage[]): BaseMessage[] {
     // Bedrock requires every toolResult to IMMEDIATELY follow the assistant
     // toolUse that owns it — "answered somewhere in the array" is not enough.
@@ -445,7 +490,10 @@ export function sanitizeMessagesForBedrock(messages: BaseMessage[]): BaseMessage
         // Skip ToolMessages here — they are re-emitted via their AI owner below.
         if (msg._getType() === 'tool') continue;
 
-        result.push(msg);
+        // Strip reasoning/thinking blocks from AI messages — they come back with a
+        // null reasoningText after a checkpoint round-trip and Bedrock rejects them.
+        const cleaned = stripReasoningBlocks(msg);
+        result.push(cleaned);
 
         if (msg._getType() !== 'ai') continue;
         const aiMsg = msg as AIMessage;

--- a/apps/web-ui/lib/agent/agent-shared.ts
+++ b/apps/web-ui/lib/agent/agent-shared.ts
@@ -519,10 +519,14 @@ export async function getActiveMCPTools(serverIds?: string[], tenantId?: string,
         return [];
     }
 
-    const { getMCPManager: getManager } = await import('./mcp-manager');
+    const { getMCPManager: getManager, tenantScopedKey } = await import('./mcp-manager');
     const { createMCPTools: createTools } = await import('./mcp-tools');
     const { mergeConfigs } = await import('./mcp-config');
     const manager = getManager();
+
+    // MCP connections are cached per tenant so no tenant reuses another's live
+    // subprocess/token. Fall back to 'default' only when no tenant is supplied.
+    const tid = tenantId || 'default';
 
     // Resolve server configs from DynamoDB + defaults
     let allConfigs;
@@ -548,7 +552,7 @@ export async function getActiveMCPTools(serverIds?: string[], tenantId?: string,
 
     // Connect regular servers (idempotent — skips already-connected)
     if (regularServerIds.length > 0) {
-        await manager.connectServers(regularServerIds, allConfigs);
+        await manager.connectServers(regularServerIds, allConfigs, tid);
     }
 
     // Connect credential-sensitive servers for ALL selected accounts
@@ -574,7 +578,7 @@ export async function getActiveMCPTools(serverIds?: string[], tenantId?: string,
                 };
                 for (const config of credentialServerConfigs) {
                     try {
-                        const scopedId = await manager.connectServerWithAwsCredentials(config, accountCtx.accountId, awsCredentials);
+                        const scopedId = await manager.connectServerWithAwsCredentials(config, accountCtx.accountId, awsCredentials, tid);
                         scopedInstanceIds.push(scopedId);
                     } catch (err: any) {
                         console.error(`[getActiveMCPTools] Failed to connect "${config.id}" for account ${accountCtx.accountId}:`, err.message);
@@ -586,7 +590,10 @@ export async function getActiveMCPTools(serverIds?: string[], tenantId?: string,
         }
     }
 
-    const allInstanceIds = [...regularServerIds, ...scopedInstanceIds];
+    // Regular tools are cached under the tenant-scoped key; map raw ids accordingly.
+    // (scopedInstanceIds are already fully-qualified keys returned by the manager.)
+    const regularInstanceIds = regularServerIds.map(id => tenantScopedKey(tid, id));
+    const allInstanceIds = [...regularInstanceIds, ...scopedInstanceIds];
     return createTools(manager, allInstanceIds);
 }
 

--- a/apps/web-ui/lib/agent/agent-shared.ts
+++ b/apps/web-ui/lib/agent/agent-shared.ts
@@ -19,6 +19,10 @@ export interface ResolvedModelConfig {
     baseUrl?: string;
     apiKey?: string;
     maxTokens?: number;
+    /** Sampling temperature. OMITTED by default — newer models (e.g. Bedrock Claude
+     *  Sonnet 5) reject any `temperature` parameter with a ValidationException, so we
+     *  only send one when a provider's model entry explicitly configures it. */
+    temperature?: number;
     /** Bedrock-only: region + explicit static credentials (when configured as a provider record). */
     region?: string;
     accessKeyId?: string;

--- a/apps/web-ui/lib/agent/aws-credentials-tool.ts
+++ b/apps/web-ui/lib/agent/aws-credentials-tool.ts
@@ -106,7 +106,7 @@ export function createGetAwsCredentialsTool(tenantId: string) {
                 // 3. Determine region (use first region from account, or default)
                 const region = account.regions?.[0] || env.AWS_REGION || env.NEXT_PUBLIC_AWS_REGION || 'us-east-1';
 
-                // 4. Create session profile
+                // 4. Create session profile in the tenant-isolated credentials file
                 const profile = await createSessionProfile(
                     accountId,
                     {
@@ -114,7 +114,8 @@ export function createGetAwsCredentialsTool(tenantId: string) {
                         secretAccessKey: credentials.SecretAccessKey!,
                         sessionToken: credentials.SessionToken!,
                         region: region
-                    }
+                    },
+                    tenantId
                 );
 
                 console.log(`[Tool] Created profile: ${profile.profileName} for account: ${accountId}`);

--- a/apps/web-ui/lib/agent/deep-agent.ts
+++ b/apps/web-ui/lib/agent/deep-agent.ts
@@ -27,7 +27,29 @@ export async function createDeepGraph(config: GraphConfig) {
     const { model: modelConfig, autoApprove, accounts, accountId, accountName, selectedSkill, mcpServerIds, tenantId, userId } = config as any;
     const modelId = modelConfig.modelId;
     const checkpointer = await getCheckpointer();
-    const store = await getStore();
+    const baseStore = await getStore();
+
+    // Tenant-bind the long-term store for this run. deepagents calls the
+    // config-less BaseStore methods (store.put/get/search), so the underlying
+    // batch() never receives the run config and would fall back to the shared
+    // tenant "default" pool — mixing every tenant's deep-agent store data. Wrap
+    // (never mutate) the singleton so batch() always carries THIS run's tenant.
+    const store = (tenantId
+        ? Object.assign(Object.create(baseStore), {
+            batch(ops: unknown[], config?: unknown) {
+                const cfg = (config as Record<string, unknown>) ?? {};
+                const merged = {
+                    ...cfg,
+                    configurable: {
+                        ...((cfg.configurable as Record<string, unknown>) ?? {}),
+                        tenant_id: tenantId,
+                        user_id: userId,
+                    },
+                };
+                return (baseStore as { batch: (o: unknown[], c: unknown) => Promise<unknown[]> }).batch(ops, merged);
+            },
+        })
+        : baseStore);
 
     // --- Skill loading (async DB lookup, tenant-scoped) ---
     let skillSection = '';
@@ -115,6 +137,20 @@ No explicit AWS account was provided. If the user asks to perform AWS operations
         ...mcpTools,
     ];
 
+    // --- HITL interrupt configuration ---
+    // When autoApprove=false, interrupt before mutation tools execute.
+    // IMPORTANT: deepagents (v1.10.5) does NOT propagate the top-level `interruptOn`
+    // into subagents — `interruptOn` is a per-subagent field. The mutation tools
+    // actually live inside the aws-ops (execute_command) and code-iac
+    // (write_file/edit_file/execute_command) subagents, so the same config must be
+    // attached to each of those specs or HITL is silently bypassed for exactly the
+    // destructive actions it is meant to gate.
+    const interruptOn = autoApprove ? undefined : {
+        execute_command: true,
+        write_file: true,
+        edit_file: true,
+    };
+
     // --- Subagent Definitions ---
     const awsOpsSubagent: SubAgent = {
         name: "aws-ops",
@@ -136,6 +172,7 @@ ${accountContext}
 - Use --no-paginate for small result sets; use pagination loops for large ones
 - Verify current resource state before any mutation command`,
         tools: [executeCommandTool, getAwsCredentialsTool, listAwsAccountsTool],
+        interruptOn,
     };
 
     const researchSubagent: SubAgent = {
@@ -168,6 +205,7 @@ Always cite the source URL when returning findings.`,
 
 Always read existing files before editing them to understand the current state.`,
         tools: [readFileTool, writeFileTool, editFileTool, lsTool, globTool, grepTool, executeCommandTool],
+        interruptOn,
     };
 
     // --- System Prompt ---
@@ -211,15 +249,8 @@ ${accountContext}
     console.log(`   Subagents: aws-ops, research, code-iac`);
     console.log(`================================================================================\n`);
 
-    // --- HITL interrupt configuration ---
-    // When autoApprove=false, interrupt before mutation tools execute
-    const interruptOn = autoApprove ? undefined : {
-        execute_command: true,
-        write_file: true,
-        edit_file: true,
-    };
-
-    // Create Deep Agent
+    // Create Deep Agent — orchestrator's own tools gated by the top-level
+    // interruptOn; subagents gated by their per-spec interruptOn (see above).
     const agent = createDeepAgent({
         model: model,
         tools: allTools,

--- a/apps/web-ui/lib/agent/mcp-config.ts
+++ b/apps/web-ui/lib/agent/mcp-config.ts
@@ -399,6 +399,90 @@ export function validateMcpConfig(config: unknown): { ok: true } | { ok: false; 
     return { ok: true };
 }
 
+// ─── Secret masking ──────────────────────────────────────────────────────────
+//
+// GET /api/mcp-servers must never return stored secrets (bearer tokens in
+// headers, API keys in env) in plaintext. We replace secret-looking values with
+// a sentinel placeholder in responses, keeping the stored copy intact. On save,
+// any field still equal to the placeholder is restored from the stored config,
+// so editing a server without re-typing its secret preserves it.
+
+/** Sentinel returned in place of a secret value. The UI shows it read-only. */
+export const MCP_SECRET_MASK = '__NUCLEUS_SECRET_UNCHANGED__';
+
+/** True for map keys that name a secret (API key, token, password, Authorization…). */
+function isSecretKey(key: string): boolean {
+    return /(secret|token|password|passwd|credential|authorization|auth\b|api[_-]?key|access[_-]?key|_key$|^key$)/i.test(key);
+}
+
+function maskValueMap(map: Record<string, string> | undefined): Record<string, string> | undefined {
+    if (!map) return map;
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(map)) {
+        out[k] = v && isSecretKey(k) ? MCP_SECRET_MASK : v;
+    }
+    return out;
+}
+
+function restoreValueMap(
+    incoming: Record<string, string> | undefined,
+    stored: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+    if (!incoming) return incoming;
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(incoming)) {
+        if (v === MCP_SECRET_MASK) {
+            // Unchanged secret: restore the stored value; drop the field entirely
+            // if there is nothing to restore (never persist the placeholder literal).
+            if (stored && stored[k] !== undefined) out[k] = stored[k];
+        } else {
+            out[k] = v;
+        }
+    }
+    return out;
+}
+
+/** Mask secret values in the resolved server list (GET response). */
+export function maskServerConfigs(servers: MCPServerConfig[]): MCPServerConfig[] {
+    return servers.map(s => ({
+        ...s,
+        env: maskValueMap(s.env),
+        headers: maskValueMap(s.headers),
+    }));
+}
+
+/** Mask secret values in the editor JSON (GET response). */
+export function maskMcpConfigJson(json: MCPConfigJson): MCPConfigJson {
+    const masked: MCPConfigJson = { mcpServers: {} };
+    for (const [id, entry] of Object.entries(json.mcpServers)) {
+        if (isRemoteEntry(entry)) {
+            masked.mcpServers[id] = { ...entry, headers: maskValueMap(entry.headers) };
+        } else {
+            masked.mcpServers[id] = { ...entry, env: maskValueMap(entry.env) };
+        }
+    }
+    return masked;
+}
+
+/**
+ * Restore masked secrets in an incoming config against what is currently stored,
+ * so a save that left placeholders in place keeps the existing secrets.
+ */
+export function restoreMaskedSecrets(incoming: MCPConfigJson, stored: MCPConfigJson | null): MCPConfigJson {
+    const result: MCPConfigJson = { mcpServers: {} };
+    for (const [id, entry] of Object.entries(incoming.mcpServers)) {
+        const prev = stored?.mcpServers?.[id];
+        if (isRemoteEntry(entry)) {
+            const prevHeaders = prev && isRemoteEntry(prev) ? prev.headers : undefined;
+            result.mcpServers[id] = { ...entry, headers: restoreValueMap(entry.headers, prevHeaders) };
+        } else {
+            const prevEnv = prev && !isRemoteEntry(prev) ? prev.env : undefined;
+            result.mcpServers[id] = { ...entry, env: restoreValueMap(entry.env, prevEnv) };
+        }
+    }
+    return result;
+}
+
 /**
  * Get a specific MCP server config by ID from defaults.
  */

--- a/apps/web-ui/lib/agent/mcp-manager.ts
+++ b/apps/web-ui/lib/agent/mcp-manager.ts
@@ -171,6 +171,32 @@ function extractDockerEnvVars(args: string[]): Record<string, string> {
 }
 
 /**
+ * Build the stdio subprocess environment.
+ *
+ * A tenant-authored MCP server command runs as a child process. Spreading the
+ * full parent `process.env` would hand it every application secret (DATABASE_URL,
+ * NEXTAUTH_SECRET, COGNITO_*, provider API keys, LANGFUSE_*, …). We instead pass
+ * an explicit allowlist plus the server-specific `config.env` (which is where the
+ * server's own credentials, e.g. GRAFANA_TOKEN, are intentionally provided).
+ */
+function buildStdioEnv(configEnv?: Record<string, string>): Record<string, string> {
+    const ALLOWED_KEYS = [
+        'PATH', 'HOME', 'LANG', 'LC_ALL', 'LC_CTYPE', 'TZ', 'TERM', 'SHELL', 'USER', 'LOGNAME', 'TMPDIR',
+        'AWS_REGION', 'AWS_DEFAULT_REGION', 'AWS_STS_REGIONAL_ENDPOINTS', 'AWS_CA_BUNDLE',
+        // uv/uvx + node runtime knobs the MCP server processes rely on.
+        'NODE_EXTRA_CA_CERTS', 'UV_CACHE_DIR', 'XDG_CACHE_HOME', 'XDG_CONFIG_HOME', 'NPM_CONFIG_CACHE',
+    ];
+    const env: Record<string, string> = {};
+    for (const key of ALLOWED_KEYS) {
+        const val = process.env[key];
+        if (val !== undefined) env[key] = val;
+    }
+    // Server-specific env wins (credentials, log level, and any AWS_PROFILE /
+    // AWS_SHARED_CREDENTIALS_FILE injected for credential-scoped servers).
+    return { ...env, ...(configEnv || {}) };
+}
+
+/**
  * Build the MCP client transport for a server config.
  * Pure + side-effect free (constructs the transport object) — unit tested.
  */
@@ -192,10 +218,7 @@ export function buildTransport(config: MCPServerConfig): Transport {
     return new StdioClientTransport({
         command: config.command,
         args: config.args,
-        env: {
-            ...process.env as Record<string, string>,
-            ...(config.env || {}),
-        },
+        env: buildStdioEnv(config.env),
     });
 }
 
@@ -207,6 +230,22 @@ export interface MCPToolInfo {
     inputSchema: any;
 }
 
+/**
+ * Separator between the tenant prefix and the logical server id in a connection
+ * cache key. Distinct from the account separator ('::') so tool-name derivation
+ * in mcp-tools.ts can strip the tenant prefix without disturbing account scoping.
+ *
+ * Key shapes:
+ *   regular         → `<tenantId>##<serverId>`
+ *   account-scoped  → `<tenantId>##<serverId>::<accountId>`
+ */
+export const TENANT_SEP = '##';
+
+/** Build the tenant-scoped connection cache key for a (regular) server. */
+export function tenantScopedKey(tenantId: string, serverId: string): string {
+    return `${tenantId || 'default'}${TENANT_SEP}${serverId}`;
+}
+
 export class MCPServerManager {
     private clients: Map<string, Client> = new Map();
     private transports: Map<string, Transport> = new Map();
@@ -215,30 +254,37 @@ export class MCPServerManager {
     private probeCounter = 0;
 
     /**
-     * Connect to a specific MCP server by config.
-     * Returns immediately if already connected.
+     * Connect to a specific MCP server by config, isolated per tenant.
+     * Returns immediately if this tenant already has the server connected.
      * Uses a connecting lock to prevent duplicate connections.
+     *
+     * The connection is cached under a tenant-scoped key so one tenant can never
+     * reuse another tenant's live subprocess/session (e.g. two tenants both
+     * defining a server id "grafana" get separate connections + tokens).
      */
-    async connectServer(config: MCPServerConfig): Promise<void> {
-        if (this.clients.has(config.id)) {
-            console.log(`[MCPManager] Server "${config.name}" (${config.id}) already connected`);
+    async connectServer(config: MCPServerConfig, tenantId: string = 'default'): Promise<void> {
+        const key = tenantScopedKey(tenantId, config.id);
+
+        if (this.clients.has(key)) {
+            console.log(`[MCPManager] Server "${config.name}" (${key}) already connected`);
             return;
         }
 
         // Prevent duplicate concurrent connections
-        if (this.connecting.has(config.id)) {
-            console.log(`[MCPManager] Server "${config.name}" (${config.id}) connection in progress, waiting...`);
-            await this.connecting.get(config.id);
+        if (this.connecting.has(key)) {
+            console.log(`[MCPManager] Server "${config.name}" (${key}) connection in progress, waiting...`);
+            await this.connecting.get(key);
             return;
         }
 
-        const connectPromise = this._doConnect(config);
-        this.connecting.set(config.id, connectPromise);
+        // _doConnect stores under the config's `id`; give it the tenant-scoped key.
+        const connectPromise = this._doConnect({ ...config, id: key });
+        this.connecting.set(key, connectPromise);
 
         try {
             await connectPromise;
         } finally {
-            this.connecting.delete(config.id);
+            this.connecting.delete(key);
         }
     }
 
@@ -330,41 +376,42 @@ export class MCPServerManager {
     async connectServerWithAwsCredentials(
         config: MCPServerConfig,
         accountId: string,
-        credentials: { accessKeyId: string; secretAccessKey: string; sessionToken: string; region: string }
+        credentials: { accessKeyId: string; secretAccessKey: string; sessionToken: string; region: string },
+        tenantId: string = 'default'
     ): Promise<string> {
         // Remote transports never use AWS credential injection — connect normally.
         if ((config.transport ?? 'stdio') !== 'stdio') {
-            await this.connectServer(config);
-            return config.id;
+            await this.connectServer(config, tenantId);
+            return tenantScopedKey(tenantId, config.id);
         }
 
-        const scopedId = `${config.id}::${accountId}`;
+        // Tenant-scoped + account-scoped key: `<tenantId>##<serverId>::<accountId>`.
+        const scopedId = `${tenantScopedKey(tenantId, config.id)}::${accountId}`;
 
         if (this.clients.has(scopedId)) {
             console.log(`[MCPManager] Account-scoped server "${config.name}" for account ${accountId} already connected`);
             return scopedId;
         }
 
-        // Write STS credentials to a named profile in ~/.aws/credentials so Python's boto3
-        // uses the correct account credentials regardless of what AWS_PROFILE the parent
-        // process has set (e.g. an SSO profile like STX-CLOUD-PLATFORM-ADMIN).
-        // Setting AWS_PROFILE in the subprocess env overrides the parent's profile.
-        // This is the same mechanism used by get_aws_credentials for CLI commands.
+        // Write STS credentials to a named profile in this tenant's ISOLATED
+        // credentials file so boto3 uses the correct account credentials regardless
+        // of the parent process's AWS_PROFILE. The file lives outside the agent
+        // file-tool jail and is per-tenant, so no cross-tenant credential leak.
         const { createSessionProfile } = await import('./session-manager');
-        const sessionProfile = await createSessionProfile(accountId, credentials);
+        const sessionProfile = await createSessionProfile(accountId, credentials, tenantId);
         console.log(`[MCPManager] Created session profile "${sessionProfile.profileName}" for account-scoped MCP server`);
 
-        // Build subprocess env: merge parent env, then override with server-specific vars,
-        // then force AWS_PROFILE to our named profile (overriding any SSO profile).
+        // Build subprocess env: server-specific vars, then force AWS_PROFILE to our
+        // named profile and point AWS_SHARED_CREDENTIALS_FILE at the tenant file so
+        // the subprocess resolves the profile from there (not the shared ~/.aws file).
         const scopedConfig: MCPServerConfig = {
             ...config,
             id: scopedId,
             env: {
                 ...(config.env || {}),
-                // Point boto3 at the named profile written to ~/.aws/credentials above.
-                // This overrides AWS_PROFILE=<sso-profile> from the parent process.
                 AWS_PROFILE: sessionProfile.profileName,
                 AWS_DEFAULT_PROFILE: sessionProfile.profileName,
+                AWS_SHARED_CREDENTIALS_FILE: sessionProfile.credentialsFile,
                 AWS_DEFAULT_REGION: credentials.region,
             },
         };
@@ -418,22 +465,36 @@ export class MCPServerManager {
      * Useful for credential rotation or cleanup.
      */
     async disconnectAccountScopedServers(baseServerId: string): Promise<void> {
-        const prefix = `${baseServerId}::`;
-        const scopedIds = Array.from(this.clients.keys()).filter(id => id.startsWith(prefix));
+        // Matches `<tenantId>##<baseServerId>::<accountId>` across all tenants.
+        const marker = `${TENANT_SEP}${baseServerId}::`;
+        const scopedIds = Array.from(this.clients.keys()).filter(id => id.includes(marker) || id.startsWith(`${baseServerId}::`));
         console.log(`[MCPManager] Disconnecting ${scopedIds.length} account-scoped instances of "${baseServerId}"`);
         await Promise.allSettled(scopedIds.map(id => this.disconnectServer(id)));
+    }
+
+    /**
+     * Disconnect every server instance opened for a tenant (regular + account-scoped).
+     * Call this on run end / abort so a run's MCP subprocesses and their live tokens
+     * do not outlive the run. Safe to call when nothing is connected.
+     */
+    async disconnectTenantServers(tenantId: string): Promise<void> {
+        const prefix = `${tenantId || 'default'}${TENANT_SEP}`;
+        const ids = Array.from(this.clients.keys()).filter(id => id.startsWith(prefix));
+        if (ids.length === 0) return;
+        console.log(`[MCPManager] Disconnecting ${ids.length} server instance(s) for tenant "${tenantId}"`);
+        await Promise.allSettled(ids.map(id => this.disconnectServer(id)));
     }
 
     /**
      * Connect to multiple MCP servers by their IDs.
      * If allConfigs is provided (from DynamoDB), uses those; otherwise falls back to DEFAULT_MCP_SERVERS.
      */
-    async connectServers(serverIds: string[], allConfigs?: MCPServerConfig[]): Promise<void> {
+    async connectServers(serverIds: string[], allConfigs?: MCPServerConfig[], tenantId: string = 'default'): Promise<void> {
         const source = allConfigs || DEFAULT_MCP_SERVERS;
         const configs = source.filter(s => serverIds.includes(s.id));
 
         const results = await Promise.allSettled(
-            configs.map(config => this.connectServer(config))
+            configs.map(config => this.connectServer(config, tenantId))
         );
 
         for (let i = 0; i < results.length; i++) {

--- a/apps/web-ui/lib/agent/mcp-test-handler.ts
+++ b/apps/web-ui/lib/agent/mcp-test-handler.ts
@@ -7,12 +7,20 @@ import {
 } from '@/lib/agent/mcp-config';
 import { getMCPManager } from '@/lib/agent/mcp-manager';
 import { getSessionTenantId } from '@/lib/auth-session';
+import { authorize } from '@/lib/rbac/authorize';
 
 /**
  * Shared "Test connection" handler for both MCP settings surfaces.
  * Probes a single server entry (connect → listTools → disconnect). No persistence.
  */
 export async function handleMcpTest(req: Request): Promise<NextResponse> {
+    // Testing a connection spawns a subprocess / opens an outbound connection — gate
+    // it behind the AI Ops module (same surface that owns MCP config).
+    const authError = await authorize('read', 'AIOps');
+    if (authError) {
+        return NextResponse.json({ success: false, error: 'Forbidden' }, { status: authError.status });
+    }
+
     try {
         await getSessionTenantId();
     } catch {

--- a/apps/web-ui/lib/agent/mcp-tools.ts
+++ b/apps/web-ui/lib/agent/mcp-tools.ts
@@ -10,7 +10,19 @@
 
 import { tool } from '@langchain/core/tools';
 import { z } from 'zod';
-import { MCPServerManager, MCPToolInfo } from './mcp-manager';
+import { MCPServerManager, MCPToolInfo, TENANT_SEP } from './mcp-manager';
+import { AuditService } from '@/lib/audit-service';
+
+/**
+ * Strip the tenant prefix (`<tenantId>##`) from a connection key, leaving the
+ * logical server id — either `<serverId>` or `<serverId>::<accountId>`.
+ * Tool names/descriptions are derived from the logical id so they stay stable
+ * and human-readable regardless of the tenant the run belongs to.
+ */
+function logicalServerId(mcpServerId: string): string {
+    const idx = mcpServerId.indexOf(TENANT_SEP);
+    return idx >= 0 ? mcpServerId.slice(idx + TENANT_SEP.length) : mcpServerId;
+}
 
 /**
  * Convert a JSON Schema property type to a Zod schema.
@@ -190,17 +202,19 @@ export function createMCPTools(
     console.log(`[MCPTools] Converting ${mcpTools.length} MCP tools to LangChain format`);
 
     const langchainTools = mcpTools.map(mcpTool => {
-        // For account-scoped servers (serverId contains ::accountId), include last 4 digits
-        // of the account ID in the tool name so the LLM can target specific accounts.
-        // Bedrock enforces a 64-char tool name limit — truncate if needed.
+        // Derive the tool name from the tenant-stripped logical id.
+        // For account-scoped servers (logicalId contains ::accountId), include last 4
+        // digits of the account ID in the tool name so the LLM can target specific
+        // accounts. Bedrock enforces a 64-char tool name limit — truncate if needed.
+        const logicalId = logicalServerId(mcpTool.mcpServerId);
         let namespacedName: string;
-        if (mcpTool.mcpServerId.includes('::')) {
-            const [baseServerId, accountId] = mcpTool.mcpServerId.split('::');
+        if (logicalId.includes('::')) {
+            const [baseServerId, accountId] = logicalId.split('::');
             const accountSuffix = accountId.slice(-4);
             const raw = `mcp_${baseServerId}_${accountSuffix}_${mcpTool.name}`.replace(/[^a-zA-Z0-9_-]/g, '_');
             namespacedName = raw.slice(0, 64);
         } else {
-            namespacedName = `mcp_${mcpTool.mcpServerId}_${mcpTool.name}`.replace(/[^a-zA-Z0-9_-]/g, '_');
+            namespacedName = `mcp_${logicalId}_${mcpTool.name}`.replace(/[^a-zA-Z0-9_-]/g, '_');
         }
 
         // Convert MCP input schema to Zod
@@ -213,13 +227,40 @@ export function createMCPTools(
         }
 
         // Prefix description with server name + account context for clarity in the LLM prompt
-        const accountId = mcpTool.mcpServerId.includes('::') ? mcpTool.mcpServerId.split('::')[1] : undefined;
+        const accountId = logicalId.includes('::') ? logicalId.split('::')[1] : undefined;
         const description = accountId
             ? `[MCP: ${mcpTool.mcpServerName} | Account: ${accountId}] ${mcpTool.description || mcpTool.name}`
             : `[MCP: ${mcpTool.mcpServerName}] ${mcpTool.description || mcpTool.name}`;
 
         return tool(
-            async (input: any) => {
+            async (input: any, config?: any) => {
+                // Tenant/user context arrives via the LangGraph RunnableConfig
+                // ({ configurable: { tenant_id, user_id } }) set by the chat/agent-ops routes.
+                const configurable = config?.configurable ?? {};
+                const auditTenantId = (configurable.tenant_id as string | undefined) ?? undefined;
+                const auditUserId = (configurable.user_id as string | undefined) ?? undefined;
+
+                const audit = (status: 'success' | 'error') => {
+                    // MCP tools call out to customer AWS/integrations — audit every invocation.
+                    // Fire-and-forget: never block or fail tool execution on audit write.
+                    AuditService.logResourceAction({
+                        eventType: 'agent.tool.mcp',
+                        action: 'mcp_tool_call',
+                        resourceType: 'mcp_tool',
+                        resourceId: namespacedName,
+                        resourceName: `${mcpTool.mcpServerName} / ${mcpTool.name}`,
+                        status,
+                        details: `Agent invoked MCP tool "${mcpTool.name}" on server "${mcpTool.mcpServerName}"${accountId ? ` (account ${accountId})` : ''}`,
+                        user: auditUserId || 'agent',
+                        userType: auditUserId ? 'user' : 'system',
+                        source: 'agent',
+                        severity: 'medium',
+                        ...(auditTenantId ? { tenantId: auditTenantId } : {}),
+                        ...(accountId ? { accountId } : {}),
+                        metadata: { tenantId: auditTenantId, mcpServer: mcpTool.mcpServerName, tool: mcpTool.name, accountId },
+                    }).catch(() => {});
+                };
+
                 try {
                     const coercedInput = coerceInputToSchema(input, mcpTool.inputSchema);
                     console.log(`[MCPTools] Executing MCP tool: ${mcpTool.name} on server: ${mcpTool.mcpServerId}`);
@@ -233,10 +274,12 @@ export function createMCPTools(
                     const formatted = formatMCPResult(result);
                     console.log(`[MCPTools] MCP tool ${mcpTool.name} completed. Result length: ${formatted.length}`);
 
+                    audit('success');
                     return formatted;
                 } catch (error: any) {
                     const errorMsg = `Error executing MCP tool "${mcpTool.name}": ${error.message}`;
                     console.error(`[MCPTools] ${errorMsg}`);
+                    audit('error');
                     return errorMsg;
                 }
             },
@@ -277,7 +320,7 @@ export function getMCPToolsDescription(mcpManager: MCPServerManager, serverIds?:
     for (const [serverName, serverTools] of grouped) {
         desc += `  [${serverName}]:\n`;
         for (const t of serverTools) {
-            desc += `  - mcp_${t.mcpServerId}_${t.name}: ${(t.description || t.name).slice(0, 100)}\n`;
+            desc += `  - mcp_${logicalServerId(t.mcpServerId)}_${t.name}: ${(t.description || t.name).slice(0, 100)}\n`;
         }
     }
 

--- a/apps/web-ui/lib/agent/memory-nodes.ts
+++ b/apps/web-ui/lib/agent/memory-nodes.ts
@@ -272,13 +272,21 @@ Extract memories to save.`
             } else {
                 console.log(`🧠 [MEMORY SAVE] Saving ${toSave.length} memories (reconcile disabled)...`);
                 for (const mem of toSave) {
-                    if (mem.kind === 'PROCEDURAL') {
-                        console.log(`   ⏭️ Skipped procedural rule ${mem.key} (reconcile disabled)`);
-                        continue;
-                    }
                     try {
-                        await saveMemory(tenantId, userId, mem.namespace, mem.key, mem.value as Record<string, unknown>);
-                        console.log(`   ✅ Saved: ${mem.namespace.join("/")}/${mem.key}`);
+                        if (mem.kind === 'PROCEDURAL') {
+                            // Persist with the PROCEDURAL kind (saveMemory hardcodes SEMANTIC),
+                            // matching how the reconcile-on path stores rules. Without this,
+                            // procedural memory silently never works unless reconcile is also on,
+                            // even though recall/extraction/skill-synthesis all still run.
+                            await getMemoryService().remember({
+                                tenantId, userId, kind: 'PROCEDURAL',
+                                namespace: mem.namespace, key: mem.key,
+                                value: mem.value as Record<string, unknown>,
+                            });
+                        } else {
+                            await saveMemory(tenantId, userId, mem.namespace, mem.key, mem.value as Record<string, unknown>);
+                        }
+                        console.log(`   ✅ Saved: ${mem.namespace.join("/")}/${mem.key}${mem.kind === 'PROCEDURAL' ? ' [PROCEDURAL]' : ''}`);
                     } catch (err: any) {
                         console.warn(`   ⚠️ Failed to save ${mem.key}: ${err?.message ?? err}`);
                     }

--- a/apps/web-ui/lib/agent/memory/memory-service.ts
+++ b/apps/web-ui/lib/agent/memory/memory-service.ts
@@ -51,8 +51,14 @@ export class MemoryService {
         try {
             const emb = await this.getEmbeddings(m.tenantId);
             vec = await emb.embedQuery(JSON.stringify(m.value));
-        } catch {
-            // provider missing / embedding failure is non-fatal
+        } catch (err) {
+            // Provider missing / embedding failure is non-fatal: the memory is still
+            // stored (below, via the null-embedding ORM path), so recency recall can
+            // surface it — but it is unreachable by vector similarity search until
+            // re-embedded. Surface it at warn level with tenant context.
+            console.warn(
+                `[MemoryService] Embedding failed for tenant=${m.tenantId} namespace=${m.namespace.join('/')} key=${m.key} — storing without embedding (vector recall will miss it): ${(err as { message?: string })?.message ?? err}`,
+            );
         }
 
         if (vec) {
@@ -133,6 +139,7 @@ export class MemoryService {
                 FROM agent_memories
                 WHERE "tenantId" = ${p.tenantId}
                   AND "supersededById" IS NULL
+                  AND "expiresAt" > NOW()
                   AND (${nsPrefix} = '' OR "namespace" LIKE ${nsPrefix + '%'})
                   AND (${kindList}::text[] IS NULL OR "kind"::text = ANY(${kindList}::text[]))
                 ORDER BY embedding <=> ${vecStr}::vector
@@ -144,6 +151,7 @@ export class MemoryService {
                 FROM agent_memories
                 WHERE "tenantId" = ${p.tenantId}
                   AND "supersededById" IS NULL
+                  AND "expiresAt" > NOW()
                   AND (${nsPrefix} = '' OR "namespace" LIKE ${nsPrefix + '%'})
                   AND (${kindList}::text[] IS NULL OR "kind"::text = ANY(${kindList}::text[]))
                 ORDER BY "createdAt" DESC
@@ -151,12 +159,15 @@ export class MemoryService {
             `;
         }
 
-        // Reinforcement signal — best-effort, non-blocking.
-        const keys = rows.map((r) => r.key);
-        if (keys.length) {
+        // Reinforcement signal — best-effort, non-blocking. Bump ONLY the rows actually
+        // recalled (by id), not every row sharing a key string: a key like "prod-region"
+        // recurs across namespaces and superseded rows, and skill-synthesis matures rules
+        // at accessCount >= threshold, so a key-scoped UPDATE would inflate maturity.
+        const ids = rows.map((r) => r.id);
+        if (ids.length) {
             prisma.$executeRaw`
                 UPDATE agent_memories SET "lastAccessedAt" = NOW(), "accessCount" = "accessCount" + 1
-                WHERE "tenantId" = ${p.tenantId} AND "key" = ANY(${keys}::text[])
+                WHERE "tenantId" = ${p.tenantId} AND "id" = ANY(${ids}::text[])
             `.catch(() => {});
         }
 

--- a/apps/web-ui/lib/agent/memory/reconcile.ts
+++ b/apps/web-ui/lib/agent/memory/reconcile.ts
@@ -171,9 +171,20 @@ export async function reconcileMemories(params: {
                         value: item.fact.value as unknown as Record<string, unknown>,
                         sourceThreadId,
                     });
-                    await svc.supersede(tenantId, d.targetId!, newId);
-                    summary.superseded++;
-                    summary.added++;
+                    if (newId !== d.targetId!) {
+                        await svc.supersede(tenantId, d.targetId!, newId);
+                        summary.superseded++;
+                        summary.added++;
+                    } else {
+                        // remember() upserted ONTO the very row the judge wanted superseded
+                        // (they share namespace+key — the "same fact, value changed" case).
+                        // The ON CONFLICT DO UPDATE already replaced the value in place, so the
+                        // fact is current. Calling supersede() here would set the row's
+                        // supersededById to itself and recall's `supersededById IS NULL` filter
+                        // would drop it — data loss. In-place update is the correct outcome.
+                        console.log(`🧠 [JUDGE] ${item.fact.key}: SUPERSEDE collapsed to in-place update (new row == target ${d.targetId})`);
+                        summary.updated++;
+                    }
                     break;
                 }
                 case 'REINFORCE':

--- a/apps/web-ui/lib/agent/memory/working-memory.ts
+++ b/apps/web-ui/lib/agent/memory/working-memory.ts
@@ -14,9 +14,20 @@ export function workingMemoryEnabled(): boolean {
     return !(v === 'false' || v === '0');
 }
 
+// Legacy default when neither an env override nor a model-derived budget is available.
+const DEFAULT_TOKEN_BUDGET = 60000;
+
+// Explicit operator override via env, or null when unset/invalid. When set it wins over
+// any model-derived budget passed by the caller — a deliberate kill-switch / escape hatch.
+export function tokenBudgetOverride(): number | null {
+    const raw = process.env.WORKING_MEMORY_TOKEN_BUDGET;
+    if (raw === undefined || raw === '') return null;
+    const n = Number(raw);
+    return Number.isFinite(n) && n > 0 ? n : null;
+}
+
 export function tokenBudget(): number {
-    const n = Number(process.env.WORKING_MEMORY_TOKEN_BUDGET);
-    return Number.isFinite(n) && n > 0 ? n : 60000;
+    return tokenBudgetOverride() ?? DEFAULT_TOKEN_BUDGET;
 }
 
 export function keepRecent(): number {
@@ -146,6 +157,13 @@ export interface PrepareContextDeps {
     reflectorModel: BaseChatModel;
     tenantId?: string;
     threadId?: string;
+    /** Model-derived input-token budget (provider context window minus reserved output
+     *  tokens). Used when no explicit WORKING_MEMORY_TOKEN_BUDGET env override is set, so
+     *  small/local models (8k–32k) aren't over-budgeted by the legacy 60k default. */
+    budgetTokens?: number;
+    /** Rough token cost of the always-on system prompt, subtracted from the budget so the
+     *  window accounting reflects the real per-call input, not just message tokens. */
+    systemPromptTokens?: number;
 }
 export interface PreparedContext {
     windowMessages: BaseMessage[];
@@ -169,7 +187,12 @@ export async function prepareContext(
         };
     }
 
-    const budget = tokenBudget();
+    // Budget resolution: explicit env override wins; otherwise the caller's model-derived
+    // budget; otherwise the legacy default. The always-on system prompt is charged against
+    // the budget so the message window accounts for the real per-call input, not just
+    // message tokens (a small/local model's context is spent on the system prompt too).
+    const inputCapacity = tokenBudgetOverride() ?? deps.budgetTokens ?? DEFAULT_TOKEN_BUDGET;
+    const budget = Math.max(1, inputCapacity - (deps.systemPromptTokens ?? 0));
     const keep = keepRecent();
     const total = estimateMessagesTokens(messages);
 

--- a/apps/web-ui/lib/agent/model-factory.ts
+++ b/apps/web-ui/lib/agent/model-factory.ts
@@ -38,6 +38,40 @@ export interface AgentModels {
     reflector: BaseChatModel;
 }
 
+/** Conservative default output-token cap when a provider record doesn't specify one.
+ *  4096 is safe across small/local models and matches the Anthropic/Bedrock defaults —
+ *  the previous 40000 OpenAI-path default overflowed 8k–32k context windows. */
+export const DEFAULT_MAX_OUTPUT_TOKENS = 4096;
+
+/** Provider-level context-window estimates (tokens). The ProviderModel schema has no
+ *  per-model context-window field, so we approximate at the provider family level — no
+ *  model-ID assumptions. Self-hosted families are sized conservatively for small local
+ *  models; operators can still override the derived working-memory budget via
+ *  WORKING_MEMORY_TOKEN_BUDGET. */
+const PROVIDER_CONTEXT_WINDOW: Record<ResolvedModelConfig["provider"], number> = {
+    bedrock: 200_000,
+    anthropic: 200_000,
+    openai: 128_000,
+    "openai-compatible": 16_000,
+    ollama: 16_000,
+    vllm: 16_000,
+    litellm: 16_000,
+    lmstudio: 16_000,
+};
+
+/**
+ * Derives a safe input-token budget for working-memory compaction from the resolved
+ * model config: the provider's context window minus the model's output-token
+ * reservation and a safety margin, floored to a usable minimum. Fed to prepareContext
+ * so small/local models aren't over-budgeted by the legacy 60k default.
+ */
+export function deriveInputTokenBudget(config: ResolvedModelConfig): number {
+    const contextWindow = PROVIDER_CONTEXT_WINDOW[config.provider] ?? 16_000;
+    const outputReserve = config.maxTokens || DEFAULT_MAX_OUTPUT_TOKENS;
+    const SAFETY_MARGIN = 2_000;
+    return Math.max(8_000, contextWindow - outputReserve - SAFETY_MARGIN);
+}
+
 /**
  * Creates the main and reflector model instances for a given resolved config.
  * Routes to ChatBedrockConverse (AWS) or ChatOpenAI (self-hosted) based on provider.
@@ -65,7 +99,7 @@ export function createAgentModels(config: ResolvedModelConfig): AgentModels {
         return {
             main: new ChatOpenAI({
                 ...openaiConfig,
-                maxTokens: config.maxTokens || 40000,
+                maxTokens: config.maxTokens || DEFAULT_MAX_OUTPUT_TOKENS,
                 streaming: true,
             }),
             reflector: new ChatOpenAI({
@@ -85,7 +119,7 @@ export function createAgentModels(config: ResolvedModelConfig): AgentModels {
             temperature: 0,
             ...(config.baseUrl ? { anthropicApiUrl: config.baseUrl } : {}),
         };
-        const defaultMaxTokens = config.maxTokens || 4096;
+        const defaultMaxTokens = config.maxTokens || DEFAULT_MAX_OUTPUT_TOKENS;
         return {
             main: new ChatAnthropic({
                 ...anthropicConfig,
@@ -117,7 +151,7 @@ export function createAgentModels(config: ResolvedModelConfig): AgentModels {
             secretAccessKey: config.secretAccessKey,
         },
     };
-    const defaultMaxTokens = config.maxTokens || 4096;
+    const defaultMaxTokens = config.maxTokens || DEFAULT_MAX_OUTPUT_TOKENS;
     return {
         main: new ChatBedrockConverse({
             ...bedrockConfig,

--- a/apps/web-ui/lib/agent/model-factory.ts
+++ b/apps/web-ui/lib/agent/model-factory.ts
@@ -94,7 +94,9 @@ export function createAgentModels(config: ResolvedModelConfig): AgentModels {
                 baseURL: normalizeOpenAICompatibleBaseUrl(config.provider, config.baseUrl),
                 apiKey: config.apiKey || "not-needed",
             },
-            temperature: 0,
+            // Only send temperature when the model explicitly configures one — newer
+            // models reject the parameter outright (see ResolvedModelConfig.temperature).
+            ...(config.temperature !== undefined ? { temperature: config.temperature } : {}),
         };
         return {
             main: new ChatOpenAI({
@@ -116,7 +118,7 @@ export function createAgentModels(config: ResolvedModelConfig): AgentModels {
         const anthropicConfig = {
             model: config.modelId,
             apiKey: config.apiKey,
-            temperature: 0,
+            ...(config.temperature !== undefined ? { temperature: config.temperature } : {}),
             ...(config.baseUrl ? { anthropicApiUrl: config.baseUrl } : {}),
         };
         const defaultMaxTokens = config.maxTokens || DEFAULT_MAX_OUTPUT_TOKENS;
@@ -145,7 +147,9 @@ export function createAgentModels(config: ResolvedModelConfig): AgentModels {
     const bedrockConfig = {
         region: config.region,
         model: config.modelId,
-        temperature: 0,
+        // Only send temperature when explicitly configured — Bedrock Claude Sonnet 5
+        // (and other newer models) reject any temperature with a ValidationException.
+        ...(config.temperature !== undefined ? { temperature: config.temperature } : {}),
         credentials: {
             accessKeyId: config.accessKeyId,
             secretAccessKey: config.secretAccessKey,

--- a/apps/web-ui/lib/agent/model-resolver.ts
+++ b/apps/web-ui/lib/agent/model-resolver.ts
@@ -26,7 +26,7 @@ async function loadRecordModel(providerRecordId: string, modelId: string, tenant
     if (!record || !record.isEnabled) {
         throw new Error('Provider not found or disabled');
     }
-    const models = record.models as Array<{ id: string; label: string; maxTokens?: number }>;
+    const models = record.models as Array<{ id: string; label: string; maxTokens?: number; temperature?: number }>;
     const modelEntry = models.find((m) => m.id === modelId);
     if (!modelEntry) {
         throw new Error(`Model "${modelId}" is not available on provider "${record.name}"`);
@@ -45,6 +45,7 @@ function toResolvedConfig(
     config: Pick<ProviderRuntimeConfig, 'region' | 'accessKeyId' | 'secretAccessKey' | 'baseUrl' | 'apiKey'>,
     modelId: string,
     maxTokens?: number,
+    temperature?: number,
 ): ResolvedModelConfig {
     if (provider === 'bedrock') {
         return {
@@ -54,6 +55,7 @@ function toResolvedConfig(
             accessKeyId: config.accessKeyId,
             secretAccessKey: config.secretAccessKey,
             maxTokens,
+            temperature,
         };
     }
     return {
@@ -62,6 +64,7 @@ function toResolvedConfig(
         baseUrl: config.baseUrl,
         apiKey: config.apiKey,
         maxTokens,
+        temperature,
     };
 }
 
@@ -94,7 +97,7 @@ export async function resolveModelConfig(
         const { record, modelEntry } = await loadRecordModel(last, modelId, tenantId);
         const config = await ProviderModelService.getConfigById(record.id, tenantId);
         if (!config) throw new ProviderConfigError('Provider not found or disabled');
-        return toResolvedConfig('bedrock', config, modelId, modelEntry.maxTokens);
+        return toResolvedConfig('bedrock', config, modelId, modelEntry.maxTokens, modelEntry.temperature);
     }
 
     // Record-backed providers (anthropic + the OpenAI-compatible family).
@@ -106,7 +109,7 @@ export async function resolveModelConfig(
         // Secrets live in the encrypted `credentials` blob — resolve via getConfigById (decrypts).
         const config = await ProviderModelService.getConfigById(record.id, tenantId);
         if (!config) throw new ProviderConfigError('Provider not found or disabled');
-        return toResolvedConfig(providerType, config, modelId, modelEntry.maxTokens);
+        return toResolvedConfig(providerType, config, modelId, modelEntry.maxTokens, modelEntry.temperature);
     }
 
     throw new ProviderConfigError(
@@ -128,6 +131,8 @@ export async function resolveDefaultModelConfig(tenantId: string): Promise<Resol
             'The default LLM provider has no chat model selected. Pick a chat model on the provider in Settings → Providers.',
         );
     }
-    const modelEntry = config.models.find((m) => m.id === config.chatModel);
-    return toResolvedConfig(config.provider, config, config.chatModel, modelEntry?.maxTokens);
+    const modelEntry = config.models.find((m) => m.id === config.chatModel) as
+        | { id: string; maxTokens?: number; temperature?: number }
+        | undefined;
+    return toResolvedConfig(config.provider, config, config.chatModel, modelEntry?.maxTokens, modelEntry?.temperature);
 }

--- a/apps/web-ui/lib/agent/planning-agent.ts
+++ b/apps/web-ui/lib/agent/planning-agent.ts
@@ -26,10 +26,10 @@ import {
     buildOperationalWorkflows,
     CORE_PRINCIPLES,
 } from "./prompt-templates";
-import { createAgentModels, assembleTools } from "./model-factory";
+import { createAgentModels, assembleTools, deriveInputTokenBudget } from "./model-factory";
 import { createMemoryRecallNode, createMemorySaveNode } from "./memory-nodes";
 import { autoSkillSelectionEnabled } from "./auto-skill-select";
-import { prepareContext, buildWorkingMemorySection } from "./memory/working-memory";
+import { prepareContext, buildWorkingMemorySection, estimateTokens } from "./memory/working-memory";
 
 // Factory function to create a configured reflection graph
 export async function createReflectionGraph(config: GraphConfig) {
@@ -76,7 +76,15 @@ export async function createReflectionGraph(config: GraphConfig) {
     const memorySaveNode = createMemorySaveNode(memoryDeps);
 
     // Working-memory deps — threadId is read per-node from the runtime config.
-    const wmDeps = { reflectorModel, tenantId, userId: config.userId };
+    // budgetTokens is derived from the resolved model so small/local context windows
+    // trigger compaction correctly; systemPromptTokens charges the always-on prompt
+    // (identity + skill + principles + workflows + account context) against that budget.
+    const budgetTokens = deriveInputTokenBudget(modelConfig);
+    const systemPromptTokens = estimateTokens(
+        baseIdentity + effectiveSkillSection + CORE_PRINCIPLES + awsCliStandards +
+        reportStrategy + autoApproveGuidance + operationalWorkflows + accountContext,
+    );
+    const wmDeps = { reflectorModel, tenantId, userId: config.userId, budgetTokens, systemPromptTokens };
 
     // ---------------------------------------------------------------------------
     // PLANNER NODE
@@ -134,8 +142,16 @@ Only return the JSON array, nothing else.`);
 
         const _auditInputs_plan = [plannerSystemPrompt, lastMessage];
         const _auditStart_plan = Date.now();
-        const response = await model.invoke(_auditInputs_plan);
-        llmAuditLog('PLANNER', _auditInputs_plan, response, _auditStart_plan);
+        let response: AIMessage;
+        try {
+            response = await model.invoke(_auditInputs_plan) as AIMessage;
+            llmAuditLog('PLANNER', _auditInputs_plan, response, _auditStart_plan);
+        } catch (err: any) {
+            // A provider hiccup while planning must not abort the run — fall back to a
+            // trivial single-step plan (the empty content flows through the parse fallback below).
+            console.error(`[Planner] LLM invoke failed, falling back to single-step plan: ${err?.message ?? err}`);
+            response = new AIMessage({ content: '' });
+        }
 
         let planSteps: PlanStep[] = [];
         try {
@@ -232,8 +248,16 @@ ${accountContext}
         const safeMessages = sanitizeMessagesForBedrock(recentMessages);
         const _auditInputs_exec = [executorSystemPrompt, ...safeMessages];
         const _auditStart_exec = Date.now();
-        const response = await modelWithTools.invoke(_auditInputs_exec);
-        llmAuditLog('EXECUTOR', _auditInputs_exec, response, _auditStart_exec);
+        let response: AIMessage;
+        try {
+            response = await modelWithTools.invoke(_auditInputs_exec) as AIMessage;
+            llmAuditLog('EXECUTOR', _auditInputs_exec, response, _auditStart_exec);
+        } catch (err: any) {
+            // Provider error mid-step: don't crash the run. Emit a text note (no tool calls)
+            // so the graph routes on to reflection/finalization with whatever was gathered.
+            console.error(`⚠️ [EXECUTOR] LLM invoke failed: ${err?.message ?? err}`);
+            response = new AIMessage({ content: `⚠️ This step could not be executed due to a model/provider error (${err?.message ?? err}). Proceeding with the information gathered so far.` });
+        }
 
         if ('tool_calls' in response && response.tool_calls && response.tool_calls.length > 0) {
             console.log(`\n🛠️ [EXECUTOR] Tool Calls Generated:`);
@@ -388,8 +412,21 @@ ${plan.map((s, i) => `${i + 1}. [${s.status}] ${s.step}`).join('\n')}`
 
         const _auditInputs_ref = [reflectorSystemPrompt, summaryInput];
         const _auditStart_ref = Date.now();
-        const response = await reflectorModel.invoke(_auditInputs_ref);
-        llmAuditLog('REFLECTOR', _auditInputs_ref, response, _auditStart_ref);
+        let response: Awaited<ReturnType<typeof reflectorModel.invoke>>;
+        try {
+            response = await reflectorModel.invoke(_auditInputs_ref);
+            llmAuditLog('REFLECTOR', _auditInputs_ref, response, _auditStart_ref);
+        } catch (err: any) {
+            // If the reflector fails (throttle, context overflow, parse-impossible), treat the
+            // work as complete and force finalization rather than aborting the whole run.
+            console.warn(`⚠️ [REFLECTOR] invoke failed, forcing finalization: ${err?.message ?? err}`);
+            return {
+                messages: [tagMessagePhase(new AIMessage({ content: "🔍 Reflection skipped due to a model/provider error — finalizing with the results gathered so far." }), 'reflection')],
+                reflection: state.reflection || "Reflection unavailable (provider error).",
+                isComplete: true,
+                nextAction: "complete",
+            };
+        }
 
         let analysis = "";
         let issues = "None";
@@ -485,7 +522,7 @@ ${suggestions !== "None" ? `💡 **Suggestions:** ${suggestions}` : ""}
     // REVISER NODE
     // ---------------------------------------------------------------------------
     async function reviseNode(state: ReflectionState, runtimeConfig?: any): Promise<Partial<ReflectionState>> {
-        const { messages, reflection, errors } = state;
+        const { messages, reflection, errors, iterationCount } = state;
 
         const threadId = runtimeConfig?.configurable?.thread_id as string | undefined;
         const { windowMessages, workingMemorySection, stateUpdate } =
@@ -526,12 +563,21 @@ ${accountContext}`);
         const safeMessages = sanitizeMessagesForBedrock(recentMessages);
         const _auditInputs_rev = [reviserSystemPrompt, ...safeMessages];
         const _auditStart_rev = Date.now();
-        const response = await modelWithTools.invoke(_auditInputs_rev);
-        llmAuditLog('REVISER', _auditInputs_rev, response, _auditStart_rev);
+        let response: AIMessage;
+        try {
+            response = await modelWithTools.invoke(_auditInputs_rev) as AIMessage;
+            llmAuditLog('REVISER', _auditInputs_rev, response, _auditStart_rev);
+        } catch (err: any) {
+            // Provider error while revising: emit a text note (no tool calls) so the graph
+            // routes back to reflection and can finalize instead of aborting.
+            console.error(`⚠️ [REVISER] LLM invoke failed: ${err?.message ?? err}`);
+            response = new AIMessage({ content: `⚠️ Revision could not be completed due to a model/provider error (${err?.message ?? err}).` });
+        }
 
-        if ('tool_calls' in response && response.tool_calls && response.tool_calls.length > 0) {
+        const revHasToolCalls = 'tool_calls' in response && !!response.tool_calls && response.tool_calls.length > 0;
+        if (revHasToolCalls) {
             console.log(`\n🛠️ [REVISER] Tool Calls Generated:`);
-            for (const toolCall of response.tool_calls) {
+            for (const toolCall of response.tool_calls!) {
                 console.log(`   → Tool: ${toolCall.name}`);
             }
         }
@@ -539,6 +585,12 @@ ${accountContext}`);
         return {
             messages: [tagMessagePhase(response, 'revision')],
             nextAction: "generate",
+            // Advance the iteration counter on the prose reflect→revise→reflect cycle. The
+            // executor only increments when it runs, so a reviser returning prose (no tool
+            // calls) would otherwise ping-pong reflect↔revise until GraphRecursionError. When
+            // the reviser emits tool_calls the tools→generate path increments as before, so
+            // we leave the counter untouched there to avoid double-counting.
+            ...(revHasToolCalls ? {} : { iterationCount: iterationCount + 1 }),
             ...stateUpdate,
         };
     }
@@ -580,11 +632,27 @@ Write for an engineer audience. Be specific — include resource IDs, account na
         });
         const _auditInputs_fin = [summarySystemPrompt, summaryInput];
         const _auditStart_fin = Date.now();
-        const summaryResponse = await model.invoke(_auditInputs_fin);
-        llmAuditLog('FINAL', _auditInputs_fin, summaryResponse, _auditStart_fin);
-        const summaryContent = typeof summaryResponse.content === 'string'
-            ? summaryResponse.content
-            : JSON.stringify(summaryResponse.content);
+        let summaryContent: string;
+        try {
+            const summaryResponse = await model.invoke(_auditInputs_fin);
+            llmAuditLog('FINAL', _auditInputs_fin, summaryResponse, _auditStart_fin);
+            summaryContent = typeof summaryResponse.content === 'string'
+                ? summaryResponse.content
+                : JSON.stringify(summaryResponse.content);
+        } catch (err: any) {
+            // A finalize failure must never crash the run — assemble a best-effort summary
+            // from the tool results and review notes already captured in state.
+            console.error(`⚠️ [FINAL] Summary synthesis failed: ${err?.message ?? err}`);
+            const toolDigest = toolResults.length > 0
+                ? toolResults.slice(-3).map(e => `[${e.isError ? '❌' : '✅'} ${e.toolName}]\n${truncateOutput(e.output, 500)}`).join('\n\n---\n\n')
+                : '(no tool output was captured)';
+            summaryContent = `⚠️ I could not generate a polished summary due to a model/provider error (${err?.message ?? err}), but here is what was gathered:
+
+**Key tool outputs:**
+${toolDigest}
+
+**Review notes:** ${reflection || 'None'}`;
+        }
 
         const finalMessage = `✅ **Task Complete**
 

--- a/apps/web-ui/lib/agent/sanitize-bedrock.test.ts
+++ b/apps/web-ui/lib/agent/sanitize-bedrock.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
+import { sanitizeMessagesForBedrock } from './agent-shared';
+
+describe('sanitizeMessagesForBedrock — reasoning content', () => {
+    it('strips a Bedrock reasoningContent block with null text (the crash case)', () => {
+        const ai = new AIMessage({
+            content: [
+                { reasoningContent: { reasoningText: { text: null, signature: 'sig' } } } as any,
+                { type: 'text', text: 'Here is the answer.' } as any,
+            ],
+        });
+        const [out] = sanitizeMessagesForBedrock([new HumanMessage('hi'), ai]).slice(1);
+        expect(Array.isArray(out.content)).toBe(true);
+        const blocks = out.content as any[];
+        expect(blocks.some((b) => 'reasoningContent' in b)).toBe(false);
+        expect(blocks).toEqual([{ type: 'text', text: 'Here is the answer.' }]);
+    });
+
+    it('strips normalized thinking/reasoning blocks but keeps text + tool_use', () => {
+        const ai = new AIMessage({
+            content: [
+                { type: 'thinking', thinking: 'let me think' } as any,
+                { type: 'text', text: 'calling tool' } as any,
+                { type: 'tool_use', id: 't1', name: 'do_it', input: {} } as any,
+            ],
+            tool_calls: [{ id: 't1', name: 'do_it', args: {}, type: 'tool_call' }],
+        });
+        const out = sanitizeMessagesForBedrock([ai, new ToolMessage({ content: 'ok', tool_call_id: 't1' })]);
+        const cleanedAi = out[0];
+        const blocks = cleanedAi.content as any[];
+        expect(blocks.some((b) => b.type === 'thinking')).toBe(false);
+        expect(blocks.some((b) => b.type === 'text')).toBe(true);
+        expect(blocks.some((b) => b.type === 'tool_use')).toBe(true);
+        // tool result still re-emitted immediately after its owning AI message
+        expect(out[1]._getType()).toBe('tool');
+        // tool_calls metadata preserved on the clone
+        expect((cleanedAi as AIMessage).tool_calls?.[0]?.id).toBe('t1');
+    });
+
+    it('leaves messages without reasoning blocks untouched (same reference)', () => {
+        const ai = new AIMessage({ content: 'plain answer' });
+        const input = [new HumanMessage('q'), ai];
+        const out = sanitizeMessagesForBedrock(input);
+        expect(out[1]).toBe(ai);
+    });
+});

--- a/apps/web-ui/lib/agent/session-manager.ts
+++ b/apps/web-ui/lib/agent/session-manager.ts
@@ -4,13 +4,24 @@ import * as os from 'os';
 
 /**
  * AWS Session Profile Manager
- * 
- * Manages temporary AWS profiles stored in ~/.aws/credentials for agent sessions.
+ *
+ * Manages temporary AWS profiles for agent sessions.
  * Profile naming convention: nucleus_agent_<accountId>_<timestamp>
- * 
+ *
+ * SECURITY — per-tenant credential file isolation:
+ * Each tenant's temporary STS credentials are written to a dedicated credentials
+ * file under a private root (`<tmpdir>/nucleus-aws-creds/<tenantId>/credentials`)
+ * that lives OUTSIDE the agent file-tool jail (see AGENT_WORKDIR in tools.ts).
+ * The file-tools cannot resolve a path into this root, so one tenant's agent can
+ * no longer read another tenant's live session credentials via read_file/ls/grep.
+ * Callers point the AWS CLI/SDK at the right file via AWS_SHARED_CREDENTIALS_FILE.
+ *
+ * A caller that does not pass a tenantId falls back to the legacy shared
+ * `~/.aws/credentials` file (preserved for non-tenant-scoped local usage).
+ *
  * Features:
- * - Creates profiles per AWS account
- * - Cleans up all agent profiles on server restart
+ * - Creates profiles per AWS account, isolated per tenant
+ * - Cleans up all agent credentials on server restart
  */
 
 export interface SessionProfile {
@@ -19,6 +30,8 @@ export interface SessionProfile {
     region: string;
     createdAt: Date;
     expiresAt: Date;
+    /** Absolute path to the credentials file this profile was written to. */
+    credentialsFile: string;
 }
 
 export interface AwsCredentials {
@@ -28,11 +41,26 @@ export interface AwsCredentials {
     region: string;
 }
 
-// AWS credentials file path
-const AWS_CREDENTIALS_FILE = path.join(os.homedir(), '.aws', 'credentials');
+// Legacy shared AWS credentials file (used only when no tenantId is supplied).
+const LEGACY_AWS_CREDENTIALS_FILE = path.join(os.homedir(), '.aws', 'credentials');
+
+// Private root for per-tenant credential files. Deliberately a SIBLING of the
+// agent file-tool jail (AGENT_WORKDIR, default <tmpdir>/nucleus-agent) so file
+// tools cannot resolve a path into it.
+const TENANT_CREDS_ROOT = path.join(os.tmpdir(), 'nucleus-aws-creds');
 
 // Profile name prefix for identification during cleanup
 const PROFILE_PREFIX = 'nucleus_agent_';
+
+/**
+ * Resolve the absolute credentials-file path for a tenant.
+ * Deterministic so execute_command (which only has the tenantId) can point
+ * AWS_SHARED_CREDENTIALS_FILE at the same file this module writes to.
+ */
+export function getTenantCredentialsFilePath(tenantId: string): string {
+    const sanitized = tenantId.replace(/[^a-zA-Z0-9_-]/g, '_') || 'default';
+    return path.join(TENANT_CREDS_ROOT, sanitized, 'credentials');
+}
 
 /**
  * Generate a unique profile name
@@ -45,9 +73,9 @@ function generateProfileName(accountId: string): string {
 /**
  * Read the current AWS credentials file
  */
-async function readCredentialsFile(): Promise<string> {
+async function readCredentialsFile(filePath: string): Promise<string> {
     try {
-        return await fs.readFile(AWS_CREDENTIALS_FILE, 'utf-8');
+        return await fs.readFile(filePath, 'utf-8');
     } catch (error: any) {
         if (error.code === 'ENOENT') {
             return '';
@@ -59,10 +87,10 @@ async function readCredentialsFile(): Promise<string> {
 /**
  * Write to the AWS credentials file
  */
-async function writeCredentialsFile(content: string): Promise<void> {
-    const awsDir = path.dirname(AWS_CREDENTIALS_FILE);
-    await fs.mkdir(awsDir, { recursive: true });
-    await fs.writeFile(AWS_CREDENTIALS_FILE, content, { mode: 0o600 });
+async function writeCredentialsFile(filePath: string, content: string): Promise<void> {
+    const dir = path.dirname(filePath);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(filePath, content, { mode: 0o600 });
 }
 
 /**
@@ -104,26 +132,32 @@ function serializeCredentialsFile(profiles: Map<string, Map<string, string>>): s
 }
 
 /**
- * Create a new AWS session profile
+ * Create a new AWS session profile.
+ *
+ * When tenantId is provided the profile is written to that tenant's isolated
+ * credentials file; otherwise it falls back to the legacy shared file.
  */
 export async function createSessionProfile(
     accountId: string,
-    credentials: AwsCredentials
+    credentials: AwsCredentials,
+    tenantId?: string
 ): Promise<SessionProfile> {
-    console.log(`[SessionManager] Creating profile for account: ${accountId}`);
+    console.log(`[SessionManager] Creating profile for account: ${accountId}${tenantId ? ` (tenant: ${tenantId})` : ''}`);
 
     const profileName = generateProfileName(accountId);
+    const credentialsFile = tenantId ? getTenantCredentialsFilePath(tenantId) : LEGACY_AWS_CREDENTIALS_FILE;
 
     const profile: SessionProfile = {
         profileName,
         accountId,
         region: credentials.region,
         createdAt: new Date(),
-        expiresAt: new Date(Date.now() + 15 * 60 * 1000) // 15 minutes
+        expiresAt: new Date(Date.now() + 15 * 60 * 1000), // 15 minutes
+        credentialsFile,
     };
 
     // Read current credentials file
-    const content = await readCredentialsFile();
+    const content = await readCredentialsFile(credentialsFile);
     const profiles = parseCredentialsFile(content);
 
     // Add new profile
@@ -135,21 +169,45 @@ export async function createSessionProfile(
     profiles.set(profileName, profileCreds);
 
     // Write back to file
-    await writeCredentialsFile(serializeCredentialsFile(profiles));
+    await writeCredentialsFile(credentialsFile, serializeCredentialsFile(profiles));
 
-    console.log(`[SessionManager] Created profile: ${profileName}`);
+    console.log(`[SessionManager] Created profile: ${profileName} in ${credentialsFile}`);
 
     return profile;
 }
 
 /**
- * Cleanup all agent profiles (called on server startup)
+ * Remove a single tenant's credentials file (called on run end / credential rotation).
+ */
+export async function cleanupTenantCredentials(tenantId: string): Promise<void> {
+    const filePath = getTenantCredentialsFilePath(tenantId);
+    try {
+        await fs.rm(path.dirname(filePath), { recursive: true, force: true });
+        console.log(`[SessionManager] Removed credentials for tenant ${tenantId}`);
+    } catch (error) {
+        console.error(`[SessionManager] Error removing tenant ${tenantId} credentials:`, error);
+    }
+}
+
+/**
+ * Cleanup all agent profiles (called on server startup).
+ * Removes the entire per-tenant credentials root AND strips agent profiles
+ * from the legacy shared file.
  */
 export async function cleanupAllAgentProfiles(): Promise<void> {
     console.log('[SessionManager] Cleaning up all agent profiles...');
 
+    // 1. Nuke the per-tenant credentials root wholesale.
     try {
-        const content = await readCredentialsFile();
+        await fs.rm(TENANT_CREDS_ROOT, { recursive: true, force: true });
+    } catch (error) {
+        console.error('[SessionManager] Error removing per-tenant credentials root:', error);
+    }
+
+    // 2. Strip agent-created profiles from the legacy shared file (leave any
+    //    user/SSO profiles untouched).
+    try {
+        const content = await readCredentialsFile(LEGACY_AWS_CREDENTIALS_FILE);
         const profiles = parseCredentialsFile(content);
 
         let removedCount = 0;
@@ -161,10 +219,10 @@ export async function cleanupAllAgentProfiles(): Promise<void> {
         }
 
         if (removedCount > 0) {
-            await writeCredentialsFile(serializeCredentialsFile(profiles));
-            console.log(`[SessionManager] Removed ${removedCount} stale agent profiles`);
+            await writeCredentialsFile(LEGACY_AWS_CREDENTIALS_FILE, serializeCredentialsFile(profiles));
+            console.log(`[SessionManager] Removed ${removedCount} stale agent profiles from legacy file`);
         } else {
-            console.log('[SessionManager] No stale agent profiles found');
+            console.log('[SessionManager] No stale agent profiles found in legacy file');
         }
     } catch (error) {
         console.error('[SessionManager] Error during cleanup:', error);

--- a/apps/web-ui/lib/agent/text-to-sql/__tests__/sql-validator.test.ts
+++ b/apps/web-ui/lib/agent/text-to-sql/__tests__/sql-validator.test.ts
@@ -44,6 +44,29 @@ describe('validateSQL', () => {
         expect(result.error).toMatch(/tenant/i);
     });
 
+    it('rejects the "$1 IS NOT NULL" tenant-predicate bypass', () => {
+        // References $1 but applies no real tenant filter — must be rejected.
+        const result = validateSQL("SELECT * FROM inventory_resources WHERE $1 IS NOT NULL");
+        expect(result.valid).toBe(false);
+        expect(result.error).toMatch(/tenant/i);
+    });
+
+    it('rejects $1 used only in a non-tenant predicate', () => {
+        const result = validateSQL("SELECT * FROM inventory_resources WHERE account_id = $1");
+        expect(result.valid).toBe(false);
+        expect(result.error).toMatch(/tenant/i);
+    });
+
+    it('accepts a genuine tenant_id = $1 predicate', () => {
+        const result = validateSQL("SELECT * FROM inventory_resources WHERE tenant_id = $1 AND region = 'us-east-1'");
+        expect(result.valid).toBe(true);
+    });
+
+    it('accepts a table-qualified tenant_id = $1 predicate', () => {
+        const result = validateSQL("SELECT * FROM inventory_resources WHERE inventory_resources.tenant_id = $1");
+        expect(result.valid).toBe(true);
+    });
+
     it('rejects queries referencing other tables', () => {
         const result = validateSQL("SELECT * FROM auth_users WHERE tenant_id = $1");
         expect(result.valid).toBe(false);

--- a/apps/web-ui/lib/agent/text-to-sql/sql-validator.ts
+++ b/apps/web-ui/lib/agent/text-to-sql/sql-validator.ts
@@ -37,9 +37,17 @@ export function validateSQL(rawSQL: string): ValidationResult {
         }
     }
 
-    // Must reference $1 for tenant_id
-    if (!sql.includes('$1')) {
-        return { valid: false, sql: rawSQL, error: 'Query must include $1 parameter for tenant_id isolation.' };
+    // Must contain a genuine tenant-id equality predicate bound to $1.
+    // A bare `$1` reference is NOT enough — e.g. `WHERE $1 IS NOT NULL` references
+    // $1 but returns every tenant's rows. Require `tenant_id = $1` (optionally
+    // table-qualified, or the camelCase "tenantId" column), in either operand order.
+    const TENANT_PREDICATE = /(?:\btenant_id\b|"tenantId")\s*=\s*\$1\b|\$1\s*=\s*(?:\btenant_id\b|"tenantId")/i;
+    if (!TENANT_PREDICATE.test(sql)) {
+        return {
+            valid: false,
+            sql: rawSQL,
+            error: 'Query must filter by tenant with a tenant_id = $1 equality predicate for tenant isolation.',
+        };
     }
 
     // Block system catalog access

--- a/apps/web-ui/lib/agent/thread-lock.ts
+++ b/apps/web-ui/lib/agent/thread-lock.ts
@@ -1,0 +1,62 @@
+import { randomUUID } from 'crypto';
+import { getPrismaClient } from '@/lib/db/pg-config';
+
+/**
+ * Cross-instance per-thread execution lock (chat_thread_locks table).
+ *
+ * The web-ui service autoscales to multiple ECS tasks, so the previous
+ * module-level `Map` only prevented duplicate LangGraph runs within a single
+ * task. Two requests on the same thread routed to different tasks would both
+ * run — doubling LLM cost and interleaving checkpoint writes on the same
+ * thread_id (lost-update corruption). This lock is shared across all tasks.
+ *
+ * Uses raw SQL (not tenant-intercepted) keyed by the full threadId, which
+ * already embeds the tenant. `expiresAt` (TTL) lets a crashed holder's lock be
+ * reclaimed; `holder` ensures release() only removes the lock this request owns.
+ */
+
+// TTL must exceed the route's maxDuration (300s) so a long-but-live run isn't
+// reclaimed mid-flight, with a small buffer for post-run persistence.
+const LOCK_TTL_SECONDS = 360;
+
+/**
+ * Attempt to acquire the lock for `threadId`. Returns a holder token on success
+ * (pass it to release), or null if another live request holds the lock.
+ */
+export async function acquireThreadLock(threadId: string): Promise<string | null> {
+    const prisma = getPrismaClient();
+    const token = randomUUID();
+    try {
+        // Fresh insert acquires; on conflict we only reclaim if the existing
+        // lock has expired (crashed holder). A live lock leaves 0 rows → null.
+        const rows = await prisma.$queryRaw<Array<{ threadId: string }>>`
+            INSERT INTO chat_thread_locks ("threadId", "holder", "acquiredAt", "expiresAt")
+            VALUES (${threadId}, ${token}, NOW(), NOW() + (${LOCK_TTL_SECONDS} * INTERVAL '1 second'))
+            ON CONFLICT ("threadId") DO UPDATE
+                SET "holder" = EXCLUDED."holder",
+                    "acquiredAt" = NOW(),
+                    "expiresAt" = EXCLUDED."expiresAt"
+                WHERE chat_thread_locks."expiresAt" < NOW()
+            RETURNING "threadId"
+        `;
+        return rows.length > 0 ? token : null;
+    } catch (e) {
+        // If the lock table is unavailable, fail OPEN (allow the request) rather
+        // than hard-blocking chat — matches the prior in-memory behaviour on any
+        // internal error. Logged so the misconfiguration is visible.
+        console.error('[thread-lock] acquire failed, proceeding without lock:', e);
+        return token;
+    }
+}
+
+/** Release the lock iff this request still holds it (matches on holder token). */
+export async function releaseThreadLock(threadId: string, token: string): Promise<void> {
+    const prisma = getPrismaClient();
+    try {
+        await prisma.$executeRaw`
+            DELETE FROM chat_thread_locks WHERE "threadId" = ${threadId} AND "holder" = ${token}
+        `;
+    } catch (e) {
+        console.error('[thread-lock] release failed (lock will expire via TTL):', e);
+    }
+}

--- a/apps/web-ui/lib/agent/tools.ts
+++ b/apps/web-ui/lib/agent/tools.ts
@@ -4,14 +4,80 @@ import { exec } from 'child_process';
 import { promisify } from 'util';
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import * as os from 'os';
 import { S3Client, PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
 import { Readable } from 'stream';
 import { env } from '@/env';
+import { getTenantCredentialsFilePath } from './session-manager';
+import { AuditService } from '@/lib/audit-service';
 
 // Re-export AWS credentials tool factories
 export { createGetAwsCredentialsTool, createListAwsAccountsTool } from './aws-credentials-tool';
 
 const execAsync = promisify(exec);
+
+// --- File-tool path jail (defense-in-depth) ---
+// All file tools (read/write/edit/ls/glob/grep) confine their paths to a single
+// working directory so the agent cannot read or write outside it — e.g.
+// /proc/self/environ, ~/.aws/credentials, or another tenant's files. Configurable
+// via AGENT_WORKDIR; defaults to a directory under the OS temp dir.
+const AGENT_WORKDIR = path.resolve(process.env.AGENT_WORKDIR || path.join(os.tmpdir(), 'nucleus-agent'));
+
+let workdirReady: Promise<void> | null = null;
+function ensureWorkdir(): Promise<void> {
+    if (!workdirReady) {
+        workdirReady = fs.mkdir(AGENT_WORKDIR, { recursive: true }).then(() => undefined);
+    }
+    return workdirReady;
+}
+
+/**
+ * Resolve a model-supplied path inside the jail. Relative paths resolve against
+ * the jail root; absolute paths must already fall within it. Returns null when
+ * the resolved path escapes the jail (caller returns an error string, never throws).
+ */
+function resolveInJail(inputPath: string): string | null {
+    const resolved = path.resolve(AGENT_WORKDIR, inputPath && inputPath.length > 0 ? inputPath : '.');
+    if (resolved === AGENT_WORKDIR || resolved.startsWith(AGENT_WORKDIR + path.sep)) {
+        return resolved;
+    }
+    return null;
+}
+
+const JAIL_ERROR = (p: string) =>
+    `Error: path "${p}" is outside the agent working directory (${AGENT_WORKDIR}). ` +
+    `File tools may only access paths within that directory.`;
+
+/**
+ * Build an explicit environment allowlist for execute_command.
+ *
+ * DEFENSE-IN-DEPTH ONLY. execute_command runs an arbitrary shell, so this does
+ * NOT sandbox the command — a determined command can still reach the container's
+ * filesystem and network. What it DOES do is stop the application's own secrets
+ * (DATABASE_URL, NEXTAUTH_SECRET, COGNITO_*, TAVILY_API_KEY, LANGFUSE_*, and any
+ * *_SECRET / *_KEY) from being inherited into the child's environment, where a
+ * simple `env`/`printenv` would otherwise dump them. Full OS/container sandboxing
+ * (seccomp, read-only rootfs, network egress policy, dropped capabilities) is a
+ * separate infrastructure follow-up tracked outside this change.
+ */
+function buildCommandEnv(tenantId?: string): Record<string, string> {
+    const ALLOWED_KEYS = [
+        'PATH', 'HOME', 'LANG', 'LC_ALL', 'LC_CTYPE', 'TZ', 'TERM', 'SHELL', 'USER', 'LOGNAME', 'TMPDIR',
+        'AWS_REGION', 'AWS_DEFAULT_REGION', 'AWS_PROFILE', 'AWS_DEFAULT_PROFILE',
+        'AWS_CONFIG_FILE', 'AWS_SHARED_CREDENTIALS_FILE', 'AWS_STS_REGIONAL_ENDPOINTS', 'AWS_CA_BUNDLE',
+    ];
+    const childEnv: Record<string, string> = {};
+    for (const key of ALLOWED_KEYS) {
+        const val = process.env[key];
+        if (val !== undefined) childEnv[key] = val;
+    }
+    // Point the AWS CLI/SDK at this tenant's isolated credentials file so profiles
+    // created by get_aws_credentials resolve — without exposing other tenants' files.
+    if (tenantId) {
+        childEnv.AWS_SHARED_CREDENTIALS_FILE = getTenantCredentialsFilePath(tenantId);
+    }
+    return childEnv;
+}
 
 // Helper to truncate large tool outputs to prevent prompt token limits
 const MAX_OUTPUT_LENGTH = 100000;
@@ -33,23 +99,51 @@ const formatSize = (bytes: number) => {
 
 // --- Execute Command Tool ---
 export const executeCommandTool = tool(
-    async ({ command }: { command: string }) => {
+    async ({ command }: { command: string }, config?: any) => {
         console.log(`[Tool] Executing command: ${command}`);
+
+        // Tenant/user context arrives via the LangGraph RunnableConfig set in
+        // app/api/chat/route.ts ({ configurable: { tenant_id, user_id } }).
+        const configurable = config?.configurable ?? {};
+        const tenantId = configurable.tenant_id as string | undefined;
+        const userId = configurable.user_id as string | undefined;
+
+        const audit = (status: 'success' | 'error') => {
+            // Fire-and-forget: never block or fail tool execution on audit write.
+            AuditService.logResourceAction({
+                eventType: 'agent.tool.execute_command',
+                action: 'execute_command',
+                resourceType: 'agent_tool',
+                resourceId: 'execute_command',
+                resourceName: 'Agent Shell Command',
+                status,
+                details: `Agent executed shell command: ${command}`.slice(0, 2000),
+                user: userId || 'agent',
+                userType: userId ? 'user' : 'system',
+                source: 'agent',
+                severity: 'medium',
+                ...(tenantId ? { tenantId } : {}),
+                metadata: { tenantId, command },
+            }).catch(() => {});
+        };
 
         try {
             const { stdout, stderr } = await execAsync(command, {
                 shell: '/bin/bash',
                 timeout: 120000, // 2 minute timeout for long-running AWS CLI commands
                 maxBuffer: 1024 * 1024 * 10, // 10MB buffer
+                env: buildCommandEnv(tenantId) as NodeJS.ProcessEnv,
             });
 
             const output = stdout || stderr || 'Command executed successfully (no output)';
             console.log(`[Tool] Command Output Length: ${output.length}`);
 
+            audit('success');
             return truncateToolOutput(output);
         } catch (error: any) {
             const errorMsg = `Command failed: ${error.message}\n${error.stderr || ''}`;
             console.error(`[Tool] Command Error:`, errorMsg);
+            audit('error');
             return errorMsg;
         }
     },
@@ -67,7 +161,9 @@ export const lsTool = tool(
     async ({ path: dirPath }: { path: string }) => {
         console.log(`[Tool] Listing contents: ${dirPath}`);
         try {
-            const fullPath = path.resolve(dirPath);
+            await ensureWorkdir();
+            const fullPath = resolveInJail(dirPath);
+            if (!fullPath) return JAIL_ERROR(dirPath);
             const stats = await fs.stat(fullPath);
 
             if (!stats.isDirectory()) {
@@ -123,7 +219,10 @@ export const readFileTool = tool(
         console.log(`[Tool] Reading file: ${file_path}`);
 
         try {
-            const content = await fs.readFile(file_path, 'utf-8');
+            await ensureWorkdir();
+            const fullPath = resolveInJail(file_path);
+            if (!fullPath) return JAIL_ERROR(file_path);
+            const content = await fs.readFile(fullPath, 'utf-8');
             const lines = content.split('\n');
 
             let result = content;
@@ -182,12 +281,16 @@ export const writeFileTool = tool(
         }
 
         try {
-            const dir = path.dirname(file_path);
+            await ensureWorkdir();
+            const fullPath = resolveInJail(file_path);
+            if (!fullPath) return JAIL_ERROR(file_path);
+
+            const dir = path.dirname(fullPath);
             if (dir && dir !== '.') {
                 await fs.mkdir(dir, { recursive: true });
             }
 
-            await fs.writeFile(file_path, content, 'utf-8');
+            await fs.writeFile(fullPath, content, 'utf-8');
             console.log(`[Tool] File written successfully`);
             return `Successfully written to '${file_path}'.`;
         } catch (error: any) {
@@ -212,7 +315,10 @@ export const editFileTool = tool(
         console.log(`[Tool] Editing file: ${file_path} with ${edits.length} edits`);
 
         try {
-            let content = await fs.readFile(file_path, 'utf-8');
+            await ensureWorkdir();
+            const fullPath = resolveInJail(file_path);
+            if (!fullPath) return JAIL_ERROR(file_path);
+            let content = await fs.readFile(fullPath, 'utf-8');
             let updatedContent = content;
 
             for (const edit of edits) {
@@ -231,7 +337,7 @@ export const editFileTool = tool(
             }
 
             if (!dry_run) {
-                await fs.writeFile(file_path, updatedContent, 'utf-8');
+                await fs.writeFile(fullPath, updatedContent, 'utf-8');
                 console.log(`[Tool] File updated successfully`);
                 return `Successfully applied ${edits.length} edit(s) to ${file_path}.`;
             } else {
@@ -263,14 +369,19 @@ export const globTool = tool(
         console.log(`[Tool] Glob search: ${pattern} in ${basePath || '.'}`);
 
         try {
-            const searchPath = basePath || '.';
+            await ensureWorkdir();
+            const searchPath = resolveInJail(basePath || '.');
+            if (!searchPath) return JAIL_ERROR(basePath || '.');
             try {
                 await fs.access(searchPath);
             } catch {
-                return `Error: Directory '${searchPath}' does not exist.`;
+                return `Error: Directory '${basePath || '.'}' does not exist.`;
             }
 
-            const command = `find "${searchPath}" -name "${pattern}" -not -path '*/node_modules/*' -maxdepth 10`;
+            // Pattern is a filename glob only (no slashes per the schema) — pass it as a
+            // literal -name argument so it cannot break out of the find invocation.
+            const safePattern = pattern.replace(/["`$\\]/g, '');
+            const command = `find "${searchPath}" -name "${safePattern}" -not -path '*/node_modules/*' -maxdepth 10`;
 
             const { stdout, stderr } = await execAsync(command);
 
@@ -311,6 +422,24 @@ export const grepTool = tool(
         console.log(`[Tool] Grep: "${pattern}"`);
 
         try {
+            await ensureWorkdir();
+
+            // Confine every search target to the jail. Runs with cwd = AGENT_WORKDIR
+            // so bare defaults ('.' / '*') and any provided paths stay inside it.
+            let targetStr: string;
+            if (file_paths && file_paths.length > 0) {
+                const resolvedTargets: string[] = [];
+                for (const p of file_paths) {
+                    const resolved = resolveInJail(p);
+                    if (!resolved) return JAIL_ERROR(p);
+                    resolvedTargets.push(resolved);
+                }
+                targetStr = resolvedTargets.map(p => `"${p}"`).join(' ');
+            } else {
+                // Left unquoted so the shell expands '*' relative to cwd (the jail root).
+                targetStr = recursive ? '.' : '*';
+            }
+
             let command = 'grep';
 
             if (include_lines) command += ' -n';
@@ -323,15 +452,9 @@ export const grepTool = tool(
 
             const safePattern = pattern.replace(/"/g, '\\"');
             command += ` "${safePattern}"`;
+            command += ` ${targetStr}`;
 
-            if (file_paths && file_paths.length > 0) {
-                command += ` ${file_paths.map(p => `"${p}"`).join(' ')}`;
-            } else {
-                if (recursive) command += ' .';
-                else command += ' *';
-            }
-
-            const { stdout, stderr } = await execAsync(command);
+            const { stdout, stderr } = await execAsync(command, { cwd: AGENT_WORKDIR });
 
             if (!stdout && !stderr) return "No matches found.";
 

--- a/apps/web-ui/lib/queries/query-keys.ts
+++ b/apps/web-ui/lib/queries/query-keys.ts
@@ -82,4 +82,8 @@ export const queryKeys = {
         details: () => [...queryKeys.skills.all, 'detail'] as const,
         detail: (id: string) => [...queryKeys.skills.details(), id] as const,
     },
+    threads: {
+        all: ['threads'] as const,
+        lists: () => [...queryKeys.threads.all, 'list'] as const,
+    },
 } as const;

--- a/apps/web-ui/lib/queries/threads.ts
+++ b/apps/web-ui/lib/queries/threads.ts
@@ -1,0 +1,66 @@
+'use client';
+
+/**
+ * TanStack Query hooks for chat threads (list + delete + rename).
+ *
+ * The sidebar previously hand-rolled useState + fetch with no invalidation, so
+ * it went stale after a thread was created/renamed/deleted elsewhere. Routing
+ * the list through TanStack Query gives us refetch-on-focus for free and lets
+ * mutations invalidate the list so every consumer refreshes together.
+ */
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '@/lib/queries/query-keys';
+
+export interface Thread {
+    id: string;
+    title: string;
+    createdAt: number;
+    updatedAt: number;
+    model?: string;
+    ownerUserId?: string;
+}
+
+export function useThreads() {
+    return useQuery({
+        queryKey: queryKeys.threads.lists(),
+        queryFn: async (): Promise<Thread[]> => {
+            const res = await fetch('/api/threads');
+            if (!res.ok) throw new Error('Failed to fetch threads');
+            return res.json();
+        },
+    });
+}
+
+export function useDeleteThread() {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async (id: string) => {
+            const res = await fetch(`/api/threads/${id}`, { method: 'DELETE' });
+            if (!res.ok) {
+                const data = await res.json().catch(() => ({}));
+                throw new Error(data.error ?? 'Failed to delete thread');
+            }
+            return res.json().catch(() => ({}));
+        },
+        onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.threads.all }),
+    });
+}
+
+export function useRenameThread() {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async ({ id, title }: { id: string; title: string }) => {
+            const res = await fetch(`/api/threads/${id}`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ title }),
+            });
+            if (!res.ok) {
+                const data = await res.json().catch(() => ({}));
+                throw new Error(data.error ?? 'Failed to rename thread');
+            }
+            return res.json().catch(() => ({}));
+        },
+        onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.threads.all }),
+    });
+}

--- a/apps/web-ui/lib/store/thread-store.ts
+++ b/apps/web-ui/lib/store/thread-store.ts
@@ -9,6 +9,11 @@ export interface Thread {
     ownerUserId?: string;
 }
 
+// ChatSession is NOT registered in TENANT_SCOPED_MODELS (its unique key is the
+// global `sessionId`, which is incompatible with the tenant extension's
+// findUnique injection). Every method here therefore scopes on tenantId
+// MANUALLY — do not switch to getTenantClient without also solving the
+// findUnique/upsert unique-key constraint.
 export class ThreadStore {
     async listThreads(tenantId: string): Promise<Thread[]> {
         const prisma = getPrismaClient();
@@ -27,9 +32,9 @@ export class ThreadStore {
         }));
     }
 
-    async getThread(sessionId: string): Promise<Thread | undefined> {
+    async getThread(sessionId: string, tenantId: string): Promise<Thread | undefined> {
         const prisma = getPrismaClient();
-        const s = await prisma.chatSession.findUnique({ where: { sessionId } });
+        const s = await prisma.chatSession.findFirst({ where: { sessionId, tenantId } });
         if (!s) return undefined;
         return {
             id: s.sessionId,
@@ -49,10 +54,21 @@ export class ThreadStore {
         userId?: string
     ): Promise<Thread> {
         const prisma = getPrismaClient();
+        const resolvedTenantId = tenantId ?? "default";
+
+        // Guard against cross-tenant collision on the globally-unique sessionId:
+        // if a row with this sessionId already exists under a DIFFERENT tenant,
+        // refuse rather than clobber it (bare/un-namespaced IDs could otherwise
+        // let one tenant overwrite another tenant's session title/metadata).
+        const existing = await prisma.chatSession.findUnique({ where: { sessionId } });
+        if (existing && existing.tenantId !== resolvedTenantId) {
+            throw new Error("Thread ID belongs to another tenant");
+        }
+
         const s = await prisma.chatSession.upsert({
             where: { sessionId },
             create: {
-                tenantId: tenantId ?? "default",
+                tenantId: resolvedTenantId,
                 sessionId,
                 userId: userId ?? "default",
                 title,
@@ -70,37 +86,30 @@ export class ThreadStore {
         };
     }
 
-    async updateThread(sessionId: string, updates: Partial<{ title: string; model: string }>): Promise<Thread | undefined> {
+    async updateThread(
+        sessionId: string,
+        tenantId: string,
+        updates: Partial<{ title: string; model: string }>
+    ): Promise<Thread | undefined> {
         const prisma = getPrismaClient();
-        try {
-            const s = await prisma.chatSession.update({
-                where: { sessionId },
-                data: {
-                    ...(updates.title !== undefined && { title: updates.title }),
-                    ...(updates.model !== undefined && { model: updates.model }),
-                },
-            });
-            return {
-                id: s.sessionId,
-                title: s.title,
-                createdAt: s.createdAt.getTime(),
-                updatedAt: s.updatedAt.getTime(),
-                model: s.model ?? undefined,
-                ownerUserId: s.userId,
-            };
-        } catch {
-            return undefined;
-        }
+        // updateMany scopes on the (non-unique) tenantId filter and returns a count,
+        // so a cross-tenant sessionId simply matches zero rows instead of updating.
+        const res = await prisma.chatSession.updateMany({
+            where: { sessionId, tenantId },
+            data: {
+                ...(updates.title !== undefined && { title: updates.title }),
+                ...(updates.model !== undefined && { model: updates.model }),
+                updatedAt: new Date(),
+            },
+        });
+        if (res.count === 0) return undefined;
+        return this.getThread(sessionId, tenantId);
     }
 
-    async deleteThread(sessionId: string): Promise<boolean> {
+    async deleteThread(sessionId: string, tenantId: string): Promise<boolean> {
         const prisma = getPrismaClient();
-        try {
-            await prisma.chatSession.delete({ where: { sessionId } });
-            return true;
-        } catch {
-            return false;
-        }
+        const res = await prisma.chatSession.deleteMany({ where: { sessionId, tenantId } });
+        return res.count > 0;
     }
 }
 

--- a/libs/prisma/migrations/20260709120000_chat_thread_lock/migration.sql
+++ b/libs/prisma/migrations/20260709120000_chat_thread_lock/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "chat_thread_locks" (
+    "threadId" TEXT NOT NULL,
+    "holder" TEXT NOT NULL,
+    "acquiredAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "chat_thread_locks_pkey" PRIMARY KEY ("threadId")
+);
+
+-- CreateIndex
+CREATE INDEX "chat_thread_locks_expiresAt_idx" ON "chat_thread_locks"("expiresAt");

--- a/libs/prisma/schema.prisma
+++ b/libs/prisma/schema.prisma
@@ -495,6 +495,22 @@ model ScheduledTaskLock {
   @@map("scheduled_task_locks")
 }
 
+// ChatThreadLock — cross-instance per-thread execution lock for the AI chat.
+// Replaces the in-memory Map in app/api/chat/route.ts, which only guards a
+// single ECS task (web-ui autoscales), so concurrent requests on the same
+// thread could otherwise run two graphs and interleave checkpoint writes.
+// `holder` is a per-request token so release only deletes the lock we hold;
+// `expiresAt` lets a crashed holder's stale lock be reclaimed.
+model ChatThreadLock {
+  threadId   String   @id
+  holder     String
+  acquiredAt DateTime @default(now())
+  expiresAt  DateTime
+
+  @@index([expiresAt])
+  @@map("chat_thread_locks")
+}
+
 enum MemoryKind {
   SEMANTIC
   EPISODIC

--- a/scripts/cleanup-expired.ts
+++ b/scripts/cleanup-expired.ts
@@ -6,8 +6,10 @@
  * PostgreSQL does not have built-in row expiry. This script deletes expired records.
  *
  * Tables cleaned:
- *   - audit_logs:           expiresAt < NOW() (30-day retention)
- *   - schedule_executions:  expiresAt < NOW() (90-day retention)
+ *   - audit_logs:            expiresAt < NOW() (30-day retention)
+ *   - schedule_executions:   expiresAt < NOW() (90-day retention)
+ *   - agent_memories:        expiresAt < NOW() (90-day retention)
+ *   - agent_working_memory:  expiresAt < NOW() (per-thread scratchpad TTL)
  *
  * Run manually or on a schedule (EventBridge + Lambda or pg_cron in production).
  * Idempotent: safe to run multiple times — rows already deleted won't re-appear.
@@ -56,11 +58,22 @@ async function main(): Promise<void> {
         where: { expiresAt: { lt: now } },
     });
     console.log(`cleanup-expired: schedule_executions with expiresAt < NOW(): ${expiredExecCount}`);
+
+    // ── Step 2b: Count expired agent memories (long-term + per-thread working memory) ──
+    const expiredMemoryCount = await prisma.agentMemory.count({
+        where: { expiresAt: { lt: now } },
+    });
+    console.log(`cleanup-expired: agent_memories with expiresAt < NOW(): ${expiredMemoryCount}`);
+
+    const expiredWorkingMemoryCount = await prisma.agentWorkingMemory.count({
+        where: { expiresAt: { lt: now } },
+    });
+    console.log(`cleanup-expired: agent_working_memory with expiresAt < NOW(): ${expiredWorkingMemoryCount}`);
     console.log('');
 
     if (DRY_RUN) {
         console.log('cleanup-expired: DRY_RUN=true — no rows deleted.');
-        console.log(`  Would delete: ${expiredAuditCount} audit_logs, ${expiredExecCount} schedule_executions`);
+        console.log(`  Would delete: ${expiredAuditCount} audit_logs, ${expiredExecCount} schedule_executions, ${expiredMemoryCount} agent_memories, ${expiredWorkingMemoryCount} agent_working_memory`);
         return;
     }
 
@@ -76,9 +89,21 @@ async function main(): Promise<void> {
     });
     console.log(`cleanup-expired: deleted ${deletedExec.count} expired schedule_executions`);
 
+    // ── Step 5: Delete expired agent memories ─────────────────────────────────
+    const deletedMemory = await prisma.agentMemory.deleteMany({
+        where: { expiresAt: { lt: now } },
+    });
+    console.log(`cleanup-expired: deleted ${deletedMemory.count} expired agent_memories`);
+
+    // ── Step 6: Delete expired agent working memory ───────────────────────────
+    const deletedWorkingMemory = await prisma.agentWorkingMemory.deleteMany({
+        where: { expiresAt: { lt: now } },
+    });
+    console.log(`cleanup-expired: deleted ${deletedWorkingMemory.count} expired agent_working_memory`);
+
     console.log('');
     console.log(
-        `cleanup-expired: complete. audit_logs deleted: ${deletedAudit.count}, schedule_executions deleted: ${deletedExec.count}`
+        `cleanup-expired: complete. audit_logs deleted: ${deletedAudit.count}, schedule_executions deleted: ${deletedExec.count}, agent_memories deleted: ${deletedMemory.count}, agent_working_memory deleted: ${deletedWorkingMemory.count}`
     );
 }
 


### PR DESCRIPTION
## Summary

Review-driven production-hardening pass on the **AIOps** multi-turn agentic chatbot (chat API, LangGraph agents, tools/MCP, memory, frontend). Fixes cross-tenant data-exposure holes, hardens the tool-execution surface, and removes a guaranteed infinite-loop crash — the blockers to running this autonomously for multiple orgs/users.

**Verification:** full-tree `tsc` at 183 errors (≤ the 184 pre-existing baseline — zero net new); Prisma schema validates; ~155 targeted vitest pass across the changed subsystems.

## Critical
- **Cross-tenant thread IDOR** — `thread-store.ts` tenant-scopes every read/mutate (`updateMany`/`deleteMany`/`findFirst` with `{sessionId, tenantId}`); `DELETE`/`PATCH`/history routes resolve the session tenant, reject cross-tenant embedded IDs, and audit the real user. History reads gate on a tenant-scoped ownership check that also closes the previously-unscoped checkpoint fallback.
- **`execute_command` hardening (defense-in-depth)** — path jail on all file tools, env allowlist that strips app secrets, per-tenant AWS credential files (no more single shared `~/.aws/credentials`).
- **Planning-agent infinite loop** — `reviseNode` increments `iterationCount` on the prose path so the reflect↔revise cycle terminates instead of running to `GraphRecursionError`.
- **Memory** — kept **tenant-shared by design** (no userId scoping); fixed the SUPERSEDE self-collision (data loss) and the over-broad reinforcement `UPDATE`.

## High
Distributed thread lock (new `chat_thread_locks` table + migration, replaces the single-instance `Map`); planning-agent provider-error resilience; structural `tenant_id = $1` SQL predicate; MCP tenant-keyed connections + subprocess env allowlist + route RBAC + secret masking + teardown on config change; tool audit logging; deep-agent HITL bypass (per-subagent `interruptOn`) + store tenant-binding; frontend fullscreen double-mount.

## Medium/Low
Provider-aware token budget (system prompt charged); memory TTL cleanup + recall `expiresAt` guard; procedural-memory gating; server+client attachment validation; `addToolResult` v5 shape; deep mode exposed (now safe); interrupted tool-card state; TanStack Query sidebar; multimodal history rendering; copy toast; `fetchHistory` race guard.

## ⚠️ Migration
Ships `20260709120000_chat_thread_lock` (applied automatically by the deploy entrypoint's `prisma migrate deploy`). The distributed thread lock is inert until it runs.

## Deferred follow-ups (documented, intentionally out of scope)
1. **Full OS/container sandbox for `execute_command`** (seccomp / read-only rootfs / egress policy / dropped caps). Current hardening is defense-in-depth; the *shell* vector can still read the deterministic per-tenant creds root — the *file-tool* vector is fully closed.
2. **Account-scoped MCP stale STS creds** — cached connections have no TTL refresh (~15-min expiry mid-session). Teardown-on-config-change is wired; time-based refresh in `mcp-manager` remains.
3. **`ChatMessage` DB idempotency key** — the distributed lock removes the concurrent-double-run cause; a unique constraint would also close retry-based dupes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)