### PR TITLE
fix(workers): drive health heartbeat per-replica to stop multi-replica flap

### DIFF
--- a/apps/workers/src/env.ts
+++ b/apps/workers/src/env.ts
@@ -76,6 +76,15 @@ export const env = createEnv({
         // Health server port (ECS container health check probes this). Default 8080.
         HEALTH_PORT: z.string().optional(),
 
+        // Per-replica local heartbeat cadence (ms). The health endpoint reports
+        // unhealthy when the heartbeat goes stale (> HEALTH_STALENESS_MS, see
+        // index.ts). This interval advances the heartbeat independently of
+        // pg-boss's singleton monitor-states event, so every replica in an
+        // autoscaled fleet stays healthy — not just the one holding the monitor
+        // lock. Default 30s (4 ticks within the 120s staleness budget). See
+        // health.ts.
+        HEALTH_HEARTBEAT_INTERVAL_MS: z.string().optional(),
+
         // Misc
         PORT: z.string().optional(),
         TENANT_ID: z.string().optional(),

--- a/apps/workers/src/index.ts
+++ b/apps/workers/src/index.ts
@@ -1,7 +1,7 @@
 import { createBoss } from './boss.js';
 import { createExecutor } from './executor/index.js';
 import { createLogger } from './lib/logger.js';
-import { startHealthServer, markReady } from './lib/health.js';
+import { startHealthServer, markReady, startLocalHeartbeat, stopLocalHeartbeat } from './lib/health.js';
 import type { Server } from 'node:http';
 import { registerDeadLetterQueue, registerMonitoring, registerErrorTripwire } from './lib/observability.js';
 import { register as registerSchedulerJobs } from './jobs/scheduler/index.js';
@@ -25,6 +25,12 @@ const HEALTH_PORT = parseInt(env.HEALTH_PORT ?? '8080', 10);
 // monitor-states ticks every 30s (see boss.ts). Allow ~4 missed ticks before we
 // declare the supervisor wedged, so a single slow tick does not flap the task.
 const HEALTH_STALENESS_MS = 120_000;
+// Per-replica local heartbeat cadence. Default 30s = 4 ticks within the 120s
+// staleness budget, so a single missed tick never flaps the task. This is the
+// load-bearing liveness signal across a multi-replica / autoscaled fleet — pg-boss
+// monitor-states is a singleton and can't drive every replica's heartbeat. See
+// lib/health.ts.
+const HEALTH_HEARTBEAT_INTERVAL_MS = parseInt(env.HEALTH_HEARTBEAT_INTERVAL_MS ?? '30000', 10);
 
 let healthServer: Server | undefined;
 
@@ -41,7 +47,9 @@ async function shutdown(signal: string): Promise<void> {
     // Stop scheduling new agent-ops ticks BEFORE draining, so the sweeper interval
     // cannot enqueue against a stopping boss during the drain window.
     stopAgentOpsSweeper();
-    // Fail the health check immediately so ECS/LB stops routing to this task.
+    // Stop advancing the heartbeat and fail the health check immediately so ECS
+    // stops routing work to a draining task.
+    stopLocalHeartbeat();
     healthServer?.close();
     try {
         // Give in-flight handlers time to finish. Must stay below the ECS task
@@ -64,9 +72,13 @@ async function main() {
 
     // Health server first so ECS gets a fast /live even while queues register.
     healthServer = startHealthServer({ port: HEALTH_PORT, stalenessMs: HEALTH_STALENESS_MS });
+    // Local heartbeat drives liveness per-replica (not via pg-boss's singleton
+    // monitor-states) — correct for HA / autoscale. See lib/health.ts.
+    startLocalHeartbeat(HEALTH_HEARTBEAT_INTERVAL_MS);
 
-    // Error tripwire + monitoring replace the bare error log: sustained errors now
-    // exit the process (ECS restarts), and monitor-states drives the heartbeat.
+    // Error tripwire + monitoring: sustained boss 'error' bursts exit the process
+    // (ECS restarts), and monitor-states / wip / maintenance bump the heartbeat as
+    // a bonus on top of the per-replica local timer above.
     registerErrorTripwire(boss, log, { threshold: 10, windowMs: 60_000 });
     registerMonitoring(boss, log);
 

--- a/apps/workers/src/lib/health.test.ts
+++ b/apps/workers/src/lib/health.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import http from 'node:http';
+import {
+    startHealthServer,
+    markReady,
+    startLocalHeartbeat,
+    stopLocalHeartbeat,
+} from './health.js';
+
+/**
+ * Regression coverage for the multi-replica liveness flap (see health.ts header):
+ * pg-boss monitor-states is a per-database singleton, so a liveness check driven
+ * only by that event starves every non-leader replica. The local heartbeat must
+ * keep a replica healthy on its own clock, with no monitor-states / wip /
+ * maintenance events ever firing — exactly the situation a healthy non-leader
+ * replica is in.
+ *
+ * Real timers (short, with wide margins) rather than fake timers, because the
+ * assertion goes through the real HTTP server and mixing fake timers with live
+ * I/O is flaky. Total runtime ~1s.
+ */
+
+function get(port: number, path: string): Promise<{ status: number; body: string }> {
+    return new Promise((resolve, reject) => {
+        const req = http.get(`http://127.0.0.1:${port}${path}`, (res) => {
+            let data = '';
+            res.on('data', (c) => (data += c));
+            res.on('end', () => resolve({ status: res.statusCode ?? 0, body: data }));
+        });
+        req.on('error', reject);
+    });
+}
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe('health — per-replica local heartbeat', () => {
+    const servers: http.Server[] = [];
+
+    afterEach(() => {
+        servers.forEach((s) => s.close());
+        servers.length = 0;
+        stopLocalHeartbeat();
+    });
+
+    /** Bind an ephemeral health server; return the actual port. */
+    function start(stalenessMs = 200): number {
+        const s = startHealthServer({ port: 0, stalenessMs });
+        servers.push(s);
+        const addr = s.address();
+        return typeof addr === 'object' && addr ? addr.port : 0;
+    }
+
+    it('stays healthy on the local heartbeat alone (non-leader replica: no monitor-states)', async () => {
+        const port = start(200);
+        markReady();
+        // Local heartbeat ONLY — never call the monitor-states / wip / maintenance
+        // path. This is the non-leader replica that lost the singleton lock.
+        startLocalHeartbeat(50);
+        // Wait well past the 200ms staleness window; the local timer keeps it fresh.
+        await wait(350);
+        const res = await get(port, '/health');
+        expect(res.status).toBe(200);
+        expect(JSON.parse(res.body).status).toBe('ok');
+    });
+
+    it('goes unhealthy once the local heartbeat stops (simulated wedge)', async () => {
+        const port = start(200);
+        markReady();
+        startLocalHeartbeat(50);
+        await wait(150); // healthy while ticking
+        stopLocalHeartbeat();
+        await wait(350); // now stale → unhealthy
+        const res = await get(port, '/health');
+        expect(res.status).toBe(503);
+        expect(JSON.parse(res.body).status).toBe('unhealthy');
+    });
+
+    it('/live is always 200 once the process is up', async () => {
+        const port = start(200);
+        const res = await get(port, '/live');
+        expect(res.status).toBe(200);
+        expect(res.body).toBe('ok');
+    });
+});

--- a/apps/workers/src/lib/health.ts
+++ b/apps/workers/src/lib/health.ts
@@ -8,11 +8,29 @@
 // discovery, right-sizing and agent-ops crons silently stop. That is the opposite
 // of a zero-downtime guarantee.
 //
-// This exposes an HTTP endpoint that an ECS container health check probes. It goes
-// unhealthy when the pg-boss monitoring loop stops emitting (see observability.ts,
-// which calls heartbeat() on every monitor-states tick) — proving the supervisor
-// is alive end-to-end, not merely that the process exists. ECS then replaces the
-// task, which is our recovery mechanism.
+// This exposes an HTTP endpoint that an ECS container health check probes. /health
+// is healthy while (a) the boss has finished starting (markReady) and (b) the
+// heartbeat is fresh (see startLocalHeartbeat + observability.ts). ECS then
+// replaces a task whose heartbeat goes stale — that is our recovery mechanism.
+//
+// Multi-replica / autoscale note — why the heartbeat is driven locally:
+// pg-boss's monitor-states event is a per-database SINGLETON. onMonitor() only
+// emits after winning a row lock (trySetMonitorTimeCommand), so across N replicas
+// sharing one database exactly one replica emits monitor-states each tick. A
+// liveness check driven solely by that event therefore starves every non-leader
+// replica's heartbeat → /health goes unhealthy on healthy tasks → ECS kills and
+// replaces them → the replacement races the lock again → a ~5min flap cycle that
+// leaves you ~1 effective replica. (This was the production symptom on
+// desiredCount:2.)
+//
+// The fix: startLocalHeartbeat() ticks on a per-replica setInterval, advancing the
+// heartbeat as long as this replica's own event loop turns over — the real
+// "wedged process" signal, independent of the singleton. monitor-states / wip /
+// maintenance (observability.ts) still bump the heartbeat as a bonus when they
+// fire. DB / supervisor *faults* (as opposed to a wedged loop) are caught
+// separately by the boss 'error' tripwire (registerErrorTripwire), which exits the
+// process for ECS to restart. So the two failure modes are covered by distinct
+// mechanisms and neither depends on holding the singleton monitor lock.
 
 import http from 'node:http';
 import { createLogger } from './logger.js';
@@ -33,6 +51,38 @@ export function markReady(): void {
     heartbeat();
 }
 
+let heartbeatTimer: NodeJS.Timeout | undefined;
+
+/**
+ * Start a per-replica local heartbeat on a setInterval, advancing
+ * `lastHeartbeat` independently of pg-boss's singleton monitor-states event.
+ *
+ * This is what makes the liveness check correct across an autoscaled fleet:
+ * every replica's heartbeat stays fresh on its own clock, not just the one
+ * replica holding the monitor lock (see the module header for the full
+ * rationale). A wedged event loop stops the interval → heartbeat goes stale →
+ * ECS replaces the task.
+ *
+ * Idempotent — calling twice replaces the previous timer. The timer is
+ * `.unref()`-ed so it never keeps the process alive on its own; callers should
+ * `stopLocalHeartbeat()` during graceful shutdown.
+ */
+export function startLocalHeartbeat(intervalMs: number): void {
+    if (heartbeatTimer) clearInterval(heartbeatTimer);
+    heartbeatTimer = setInterval(() => {
+        lastHeartbeat = Date.now();
+    }, intervalMs);
+    heartbeatTimer.unref?.();
+}
+
+/** Stop the local heartbeat interval (graceful shutdown). */
+export function stopLocalHeartbeat(): void {
+    if (heartbeatTimer) {
+        clearInterval(heartbeatTimer);
+        heartbeatTimer = undefined;
+    }
+}
+
 export interface HealthServerOptions {
     port: number;
     /** Max age of the last heartbeat before /health reports unhealthy. */
@@ -50,7 +100,9 @@ export function startHealthServer(opts: HealthServerOptions): http.Server {
             return;
         }
 
-        // Health/readiness: the pg-boss supervisor loop is actively ticking.
+        // Health/readiness: the boss is ready and the heartbeat is fresh. The
+        // heartbeat is advanced per-replica (startLocalHeartbeat) plus bonus bumps
+        // from pg-boss monitor-states / wip / maintenance (observability.ts).
         const age = Date.now() - lastHeartbeat;
         const healthy = ready && age <= opts.stalenessMs;
         res.writeHead(healthy ? 200 : 503, { 'content-type': 'application/json' });

--- a/infra/compute/index.ts
+++ b/infra/compute/index.ts
@@ -1349,6 +1349,13 @@ const workersTaskDef = new aws.ecs.TaskDefinition("workers-task-def", {
             { name: "USE_PG_SCHEDULES", value: "true" },
             { name: "LOG_LEVEL", value: "info" },
             { name: "HEALTH_PORT", value: "8080" },
+            // Per-replica local heartbeat cadence for the container health check.
+            // Drives liveness independently of pg-boss's singleton monitor-states
+            // event, so every replica in an autoscaled fleet stays healthy — not
+            // just the one holding the monitor lock. 30s = 4 ticks within the
+            // 120s staleness budget (HEALTH_STALENESS_MS in index.ts). See
+            // apps/workers/src/lib/health.ts.
+            { name: "HEALTH_HEARTBEAT_INTERVAL_MS", value: "30000" },
             // The workers -> web-ui internal trigger reaches the app via the public
             // CloudFront URL (NAT egress). The ALB is internet-facing and its SG
             // only admits CloudFront's prefix list, so a private-subnet worker


### PR DESCRIPTION
## Summary

The workers ECS container health check was flapping every ~5 min in prod: tasks started, reached steady state, then "failed container health checks" and got replaced. One replica stayed healthy; the other had zero monitor activity for its whole life and got killed.

## Root cause

The liveness heartbeat was driven **solely by pg-boss `monitor-states`**, which is a per-database **singleton** — `onMonitor()` only emits after winning a row lock (`trySetMonitorTimeCommand`). With `desiredCount: 2`, the replica losing the monitor lock never received a heartbeat → `/health` went unhealthy after the 120s staleness window → ECS killed + replaced it → the replacement raced the lock again → oscillation → ~1 effective replica.

Job *execution* across replicas was always fine (SKIP LOCKED + singletonKeys); only *liveness* was wrongly tied to the singleton. This was a regression from combining the monitor-driven liveness check with `desiredCount: 2` (pg-boss hardening pass).

Evidence: `aws ecs describe-services` events showed a repeating `failed container health checks → replaced unhealthy → steady state → repeat` cycle every ~5 min; the dead task's log stream had an empty 5-min gap between "All jobs registered" and SIGTERM while its sibling emitted `queue-depth` every 30s.

## Fix — per-replica heartbeat (future-proof for autoscale)

Add `startLocalHeartbeat()` — a per-replica `setInterval` (default 30s, 4 ticks within the 120s staleness budget) that advances the heartbeat on this replica's own clock, **independent of the singleton monitor lock**.

- Adding/removing replicas at runtime just works — no cross-replica coordination.
- A truly wedged event loop stops the timer → heartbeat stale → ECS replaces the task (wedge detection preserved).
- DB/supervisor *faults* stay covered by the separate `registerErrorTripwire` (exits the process). The two failure modes use distinct mechanisms; neither needs the monitor lock.
- `monitor-states`/`wip`/`maintenance` remain as bonus heartbeat bumps.

## Changes

| File | Change |
|------|--------|
| `apps/workers/src/lib/health.ts` | `startLocalHeartbeat`/`stopLocalHeartbeat` (`unref`-ed, idempotent) + rewritten module header |
| `apps/workers/src/index.ts` | start after health server, stop on shutdown, add `HEALTH_HEARTBEAT_INTERVAL_MS` (default `30000`) |
| `apps/workers/src/env.ts` | optional `HEALTH_HEARTBEAT_INTERVAL_MS` |
| `infra/compute/index.ts` | surface env in workers task def (parity with `HEALTH_PORT`) |
| `apps/workers/src/lib/health.test.ts` | regression test (3): non-leader stays healthy on local heartbeat alone; goes unhealthy once it stops; `/live` always 200 |

## Verification

- `tsc --noEmit` clean (workers + `infra/compute`)
- Workers tests: **212 passed** (was 209 → +3 new), 5 pre-existing discovery failures unchanged, **no regressions**
- New health tests: 3/3 pass

## Known limitation (out of scope)

Queue-depth logs and CloudWatch metrics remain singleton-bound — only the monitor leader emits them. That's an observability gap, not a liveness one; a separate non-singleton emitter would address it.

## Deploy & verify

```bash
cd infra/compute && AWS_PROFILE=STX-CLOUD-PLATFORM pulumi up --stack prod --yes
```
Confirm the flap stops over ~20 min:
```bash
aws ecs describe-services --profile STX-CLOUD-PLATFORM \
  --cluster arn:aws:ecs:ap-south-1:970547372609:cluster/nucleus-cloud-ops-ecs-cluster \
  --services nucleus-cloud-ops-workers-service \
  --query 'services[0].events[0:10].[createdAt,message]' --output table
```
Both desired tasks should stay `HEALTHY`/`Running` with no more `failed container health checks` entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)