### PR TITLE
feat(agent-ops): wire internal-key scheduler auth + raise autonomous iteration budget

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -157,8 +157,13 @@ LANGFUSE_HOST=https://cloud.langfuse.com
 # Skip audit DB writes in local dev
 # SKIP_AUDIT_LOGGING=true
 
-# Internal worker<->web-ui auth key (must match across both apps)
-# INTERNAL_API_KEY=internal-worker-key
+# Internal worker<->web-ui auth key (must match across both apps).
+# REQUIRED for the agent-ops scheduler to work: the workers process sends this
+# as x-internal-key when triggering a scheduled task, and web-ui only trusts the
+# call when this is set AND matches. If unset, the worker fails closed (the tick
+# throws + dead-letters) and no scheduled run ever fires. Use any value locally;
+# in prod it is injected from Secrets Manager.
+INTERNAL_API_KEY=internal-worker-key
 
 # Maintenance / one-off scripts
 # DRY_RUN=true
@@ -180,3 +185,6 @@ LANGFUSE_HOST=https://cloud.langfuse.com
 # DOCDB_PASSWORD=your-password
 # DEEP_AGENT_DB_NAME=nucleus
 # DEEP_AGENT_LOG_LEVEL=debug
+# Iteration budget for autonomous Agent Ops runs (scheduled/channel-triggered).
+# Separate from the interactive chat agents (MAX_ITERATIONS=30). Default 150 when unset.
+# AGENT_OPS_MAX_ITERATIONS=150

--- a/apps/web-ui/components/agent-ops/scheduled-task-dialog.tsx
+++ b/apps/web-ui/components/agent-ops/scheduled-task-dialog.tsx
@@ -75,8 +75,9 @@ export function ScheduledTaskDialog({ tenantId = "default", task, onSaved, trigg
         setError(null)
         setLoading(true)
         try {
+            // tenantId is resolved server-side from the session — never sent by the
+            // client (a stale/placeholder value here would re-home the task's tenant).
             const body = {
-                tenantId,
                 name: form.name.trim(),
                 description: form.description.trim(),
                 cronExpression: form.cronExpression,

--- a/apps/web-ui/env.ts
+++ b/apps/web-ui/env.ts
@@ -96,6 +96,11 @@ export const env = createEnv({
         DUAL_WRITE_SCHEDULES: z.string().optional(),
         INTERNAL_API_KEY: z.string().optional(),
         DEFAULT_TENANT_ID: z.string().optional(),
+        // Iteration budget for autonomous Agent Ops runs (scheduled/channel-triggered).
+        // Decoupled from the shared MAX_ITERATIONS=30 used by the interactive chat
+        // agents, since unattended runs (e.g. AWS auth → cost query → Slack) need
+        // more steps. Defaults to 150 when unset.
+        AGENT_OPS_MAX_ITERATIONS: z.string().optional(),
     },
 
     /**

--- a/apps/web-ui/lib/agent-ops/agent-executor.ts
+++ b/apps/web-ui/lib/agent-ops/agent-executor.ts
@@ -117,7 +117,7 @@ export async function executeAgentRun(run: AgentOpsRun, eventBus?: GatewayEventB
         } catch { /* non-fatal */ }
 
         const graphInput = { messages: [new HumanMessage(taskDescription)] };
-        const graphRunConfig = { configurable: { thread_id: threadId }, recursionLimit: 50 };
+        const graphRunConfig = { configurable: { thread_id: threadId }, recursionLimit: 150 };
 
         // ── Event tracking ────────────────────────────────────────────────────
         const toolsUsed = new Set<string>();
@@ -539,7 +539,9 @@ export async function resumeApprovedRun(run: AgentOpsRun, eventBus?: GatewayEven
         };
 
         const graph = await createDynamicExecutorGraph(graphConfig);
-        const graphRunConfig = { configurable: { thread_id: threadId } };
+        // Match the initial-run recursionLimit; otherwise a resumed run would fall
+        // back to LangGraph's default of 25 (tighter than the initial 150).
+        const graphRunConfig = { configurable: { thread_id: threadId }, recursionLimit: 150 };
 
         // Inject approvalStatus='approved' so routing skips both gates on resume
         await (graph as any).updateState(graphRunConfig, {

--- a/apps/web-ui/lib/agent-ops/executor-graphs.ts
+++ b/apps/web-ui/lib/agent-ops/executor-graphs.ts
@@ -31,7 +31,6 @@ import {
     getActiveMCPTools,
     getMCPToolsDescription,
     getMCPManager,
-    MAX_ITERATIONS,
 } from "@/lib/agent/agent-shared";
 import {
     buildBaseIdentity,
@@ -51,6 +50,13 @@ import { resolveKnowledgeBaseIds } from "@/lib/agent/auto-kb-select";
 import { GraphConfig } from "@/lib/agent/agent-shared";
 import { ReflectionState, graphState, PlanStep, RequestEvaluation, ToolResultEntry } from "./executor-state";
 import { filterMutativeToolCalls } from "./tool-classifier";
+import { env } from "@/env";
+
+// Autonomous Agent Ops runs (scheduled / channel-triggered) get their own, larger
+// iteration budget — the interactive chat agents keep the shared MAX_ITERATIONS=30.
+// A multi-step unattended task (AWS auth → cost query → Slack report) needs more
+// headroom, especially when it must resolve the target account first.
+const AGENT_OPS_MAX_ITERATIONS = Number(env.AGENT_OPS_MAX_ITERATIONS) || 150;
 
 // ============================================================================
 // AGENT OPS DYNAMIC EXECUTOR GRAPH
@@ -304,7 +310,7 @@ Return ONLY a JSON array of step strings. Example:
     // ============================================================================
     async function generateNode(state: ReflectionState): Promise<Partial<ReflectionState>> {
         const { messages, plan, iterationCount, evaluation } = state;
-        console.log(`\n[EXECUTOR] Iteration ${iterationCount + 1}/${MAX_ITERATIONS}`);
+        console.log(`\n[EXECUTOR] Iteration ${iterationCount + 1}/${AGENT_OPS_MAX_ITERATIONS}`);
 
         const { skillSection, accountContext, mutationInstruction, mcpInstructions, memorySection, kbSection } = getDynamicContext(evaluation, state.memoryContext);
         const baseIdentity = buildBaseIdentity(evaluation?.skillId);
@@ -491,11 +497,11 @@ Otherwise list specific issues to fix. Do not generate the fixed answer.`);
                 messages: [new AIMessage({ content: `🔍 **Reflection:**\n${analysis}${issues !== 'None' ? `\n⚠️ Issues: ${issues}` : ''}` })],
                 reflection: analysis,
                 errors: issues !== 'None' ? [issues] : [],
-                isComplete: isComplete || iterationCount >= MAX_ITERATIONS,
+                isComplete: isComplete || iterationCount >= AGENT_OPS_MAX_ITERATIONS,
                 plan: updatedPlan.length > 0 ? updatedPlan : plan,
             };
         } else {
-            if (content.includes('COMPLETE') || iterationCount >= MAX_ITERATIONS) {
+            if (content.includes('COMPLETE') || iterationCount >= AGENT_OPS_MAX_ITERATIONS) {
                 return { messages: [response], isComplete: true };
             }
             return {
@@ -621,17 +627,17 @@ Be specific — include resource IDs, account names, and numeric values where av
         if (state.evaluation?.mode === 'plan') {
             return state.iterationCount <= 1 ? 'final' : 'reflect';
         }
-        if (state.iterationCount >= MAX_ITERATIONS) return '__end__';
+        if (state.iterationCount >= AGENT_OPS_MAX_ITERATIONS) return '__end__';
         return 'reflect';
     }
 
     function routeFromTools(state: ReflectionState): 'generate' | 'reflect' {
-        return state.iterationCount >= MAX_ITERATIONS ? 'reflect' : 'generate';
+        return state.iterationCount >= AGENT_OPS_MAX_ITERATIONS ? 'reflect' : 'generate';
     }
 
     function routeFromReflect(state: ReflectionState): 'revise' | 'generate' | 'final' | '__end__' {
         if (state.evaluation?.mode === 'plan') {
-            if (state.isComplete || state.iterationCount >= MAX_ITERATIONS) return 'final';
+            if (state.isComplete || state.iterationCount >= AGENT_OPS_MAX_ITERATIONS) return 'final';
             return 'revise';
         }
         if (state.isComplete) return '__end__';

--- a/apps/web-ui/lib/db/pg-config.ts
+++ b/apps/web-ui/lib/db/pg-config.ts
@@ -141,9 +141,16 @@ export function getTenantClient(tenantId: string) {
                         };
                     }
 
-                    // Updates: inject tenantId into WHERE
+                    // Updates: inject tenantId into WHERE. Also strip tenantId from
+                    // `data` so a request body can NEVER re-home a row to another
+                    // tenant (a client-supplied data.tenantId would otherwise pass
+                    // straight to SET, orphaning the row and breaking tenant scoping).
                     if (['update', 'updateMany'].includes(operation)) {
                         args = { ...args, where: { ...args.where, tenantId } };
+                        if (args.data && typeof args.data === 'object' && 'tenantId' in (args.data as Record<string, unknown>)) {
+                            const { tenantId: _dropTenantId, ...restData } = args.data as Record<string, unknown>;
+                            args = { ...args, data: restData };
+                        }
                     }
 
                     // Deletes: inject tenantId into WHERE

--- a/apps/web-ui/middleware.ts
+++ b/apps/web-ui/middleware.ts
@@ -45,6 +45,18 @@ export default withAuth(
         callbacks: {
             authorized: ({ token, req }) => {
                 const { pathname } = req.nextUrl;
+                // Internal worker -> web-ui call: the agent-ops scheduler triggers a
+                // scheduled task with a shared x-internal-key instead of a NextAuth
+                // session. Let it past the auth gate; the route's resolveTenantId still
+                // strictly validates the secret (and falls back to session auth if it
+                // does not match). Mirrors the api/v1/trigger matcher exemption.
+                if (
+                    pathname.startsWith("/api/agent-ops/scheduled-tasks/") &&
+                    pathname.endsWith("/trigger") &&
+                    req.headers.get("x-internal-key")
+                ) {
+                    return true;
+                }
                 // Public routes — no auth required
                 if (
                     pathname === "/login" ||

--- a/bun.lock
+++ b/bun.lock
@@ -221,6 +221,7 @@
         "@aws-sdk/lib-dynamodb": "^3.700.0",
         "@prisma/client": "^6.0.0",
         "@t3-oss/env-core": "^0.13.11",
+        "croner": "^10.0.1",
         "dayjs": "^1.11.13",
         "p-limit": "^7.3.0",
         "pdf-parse": "^1.1.1",

--- a/docs/agent-ops-architecture.md
+++ b/docs/agent-ops-architecture.md
@@ -1,0 +1,191 @@
+# Agent Ops Architecture
+
+A headless, multi-tenant agent runtime. Any trigger — Slack, Telegram, Jira, the
+in-app UI, or a cron schedule — funnels into one execution path. Understanding the
+scheduler is the fastest way to understand the whole system, because it reuses every
+part of it.
+
+| | |
+| --- | --- |
+| **Scope** | agent-ops runtime + scheduler |
+| **Services** | `apps/web-ui` · `apps/workers` |
+| **Persistence** | PostgreSQL · pg-boss |
+
+---
+
+## 1. The core idea
+
+Something submits a task → the system creates a **run** → a LangGraph agent executes
+it (with optional human gates) → the result is delivered back to wherever the task
+came from.
+
+The delivery target is deliberately pluggable. Slack, Telegram, Discord, Jira, a
+webhook, the in-app dashboard, and the cron scheduler are all just *front-ends* over
+the same run. A run only records *where* it came from via a `source` field — the
+machinery downstream is identical.
+
+| `apps/web-ui` — the brain (Next.js) | `apps/workers` — the clock (pg-boss) |
+| --- | --- |
+| Run creation & the executor graph | Cron sweeper (every 30s) |
+| Human-in-the-loop resume endpoints | Per-tenant fan-out & atomic claim |
+| Channel adapters & delivery | Fires HTTP triggers into web-ui |
+| Schedule CRUD | Never runs the agent itself |
+| pg-boss *producer only* | |
+
+Both share one PostgreSQL database and one pg-boss instance. The worker's only job is
+to decide *when*; web-ui decides *what* and *how*.
+
+---
+
+## 2. The run lifecycle
+
+A run is the central record — `AgentOpsRun` (`libs/prisma/schema.prisma:385`). Its
+status walks a fixed state machine:
+
+```
+queued ──▶ in_progress ──▶ ┌ awaiting_input     ┐ ──▶ ┌ completed ┐
+                           └ awaiting_approval  ┘      │ failed    │
+                                                       └ cancelled ┘
+```
+
+| State | Meaning |
+| --- | --- |
+| `queued` | enqueued, not started |
+| `in_progress` | agent executing |
+| `awaiting_input` / `awaiting_approval` | parked on a human |
+| `completed` | terminal success |
+| `failed` / `cancelled` | terminal stop |
+
+Alongside status, each run carries a `source`, a `mode` (`fast` or `plan`), an
+`autoApprove` flag, and a `threadId` keying its LangGraph checkpoint. As it runs it
+emits an ordered stream of `AgentOpsEvent` rows — `planning`, `tool_call`,
+`tool_result`, `reflection`, `final`. That event log is the single source the UI
+timeline and the channel digests both read from.
+
+---
+
+## 3. How a run executes
+
+Entry is the gateway (`lib/gateway/gateway-service.ts → handleInbound`): validate &
+parse via a channel adapter, `createRun`, subscribe the channel to the run's events,
+then fire-and-forget `executeAgentRun(run)`.
+
+Execution builds a **single dynamic graph** (`lib/agent-ops/executor-graphs.ts`) —
+distinct from the AI Ops fast/planning/deep agents. An `evaluator` node classifies
+each request into `fast`, `plan`, or `end` at runtime, so the mode is chosen
+dynamically rather than fixed up front. Long-term memory is wired as the **first**
+node (`memory_recall`) and **last** node (`memory_save`), so runs learn across time.
+
+```
+START → memory_recall → evaluator ─┬─ clarify → END          # needs input
+                                   ├─ planner → approval_gate → generate…
+                                   └─ generate → tools → reflect → revise → final
+generate/revise → mutative_approval_gate → END   # pauses on write
+final → memory_save → END
+```
+
+Read-only tools always run. *Mutating* tools (classified in `tool-classifier.ts`) hit
+a gate. When `autoApprove=false`, the graph is compiled with
+`interruptBefore: ["approval_gate", "mutative_approval_gate"]` — that interrupt is the
+mechanism behind the `awaiting_*` states.
+
+---
+
+## 4. Human-in-the-loop
+
+Two flavors of pause — and, importantly, they resume through *different* mechanisms.
+
+| State | Meaning | Resume endpoint | Resume mechanism |
+| --- | --- | --- | --- |
+| `awaiting_input` | Agent needs clarification from the user. | `POST /api/agent-ops/[runId]/resume` | **Fresh re-run** with an enriched task description. |
+| `awaiting_approval` | A plan or a mutating action needs sign-off. | `POST /api/agent-ops/[runId]/approve` | **True checkpoint resume** — reloads LangGraph state, injects approval, continues. |
+
+Both surface in two UI pages that must stay in sync: the in-app run detail
+(`app/app/agent-ops/[runId]/page.tsx`) and the channel deep-link fallback
+(`[runId]/respond/page.tsx`) for channels that can't render native approval buttons.
+
+---
+
+## 5. Delivery
+
+Delivery is event-driven. The `notification-router` listens for run events
+(`run:completed`, `hil:plan_approval`, …) and calls the source adapter's `sendResult`
+/ `sendApprovalRequest`.
+
+Each adapter formats for its medium — Slack Block Kit buttons, Telegram MarkdownV2
+with a hard **4096-character cap** (truncated on the raw detail so an escape sequence
+is never cut mid-way), Discord, Jira comments, generic webhooks. Because delivery is
+decoupled behind the event bus, adding a channel means adding an adapter, not touching
+the executor.
+
+---
+
+## 6. Scheduling — the best lens on all of it
+
+Here is the payoff: the scheduler adds almost *no* new machinery. It is just another
+trigger. That is exactly why walking it teaches you the whole architecture.
+
+A scheduled task (`ScheduledTask`, `libs/prisma/schema.prisma:451`) is a user-defined
+row: a `cronExpression`, `timezone`, the task prompt, `mode`, `autoApprove`, target
+MCP servers & knowledge bases, and a `notification` destination. The end-to-end flow:
+
+1. **Sweep — the worker.** `agent-ops-scheduler/index.ts` runs `sweep()` every 30s,
+   loads active tasks, and uses `croner` to find any due in the last 60s.
+2. **Enqueue — with dedup.** `boss.send('agent-ops-tick', …)` with
+   `singletonKey: 'task:<taskId>'` — the first dedup layer, collapsing concurrent
+   sweeps and replicas into one job.
+3. **Trigger — HTTP into web-ui.** The tick handler `POST`s to
+   `/scheduled-tasks/[taskId]/trigger` with `x-internal-key` + `x-tenant-id`. The
+   route re-checks the task is still `active` (stale-tick 409) and grabs a per-minute
+   `ScheduledTaskLock` — the second dedup layer.
+4. **Create + execute — the shared path.** The route calls the identical
+   `createRun({ source: 'scheduled', … })` and `executeAgentRun(run)` used by the UI
+   and Slack. Fire-and-forget; returns `{ runId, status }` immediately.
+5. **Finalize + deliver.** On completion, `finalizeScheduledRun` updates `lastRun*` /
+   `runCount` and hands the digest to the same channel adapters via
+   `sendScheduledNotification`.
+
+So a scheduled run produces the **same** `AgentOpsRun`, the **same** event stream, the
+**same** executor graph, the **same** HIL gates, and the **same** delivery adapters as
+any interactive run — distinguished only by `source='scheduled'`. It even shows up in
+the same run-history views.
+
+Which is why studying scheduling forces you to walk the entire spine of the system in
+one pass:
+
+| Scheduling concern | What it teaches about the core architecture |
+| --- | --- |
+| Cron sweep + `singletonKey` + `ScheduledTaskLock` | The worker↔web-ui split, and idempotency across multiple replicas. |
+| `x-internal-key` / `x-tenant-id` on the trigger | How multi-tenancy flows without a user session — `getTenantClient(tenantId)` auto-scopes every query. |
+| Reusing `createRun` + `executeAgentRun` | That triggers are interchangeable front-ends over one run pipeline. |
+| `autoApprove` on a schedule | Why the HIL gate design matters — an unattended run either auto-approves or parks in `awaiting_approval` and pings a channel. |
+| `notification.type` + adapters | The event-bus / adapter delivery decoupling. |
+
+---
+
+## 7. One caveat
+
+> **Likely vestigial code.** `lib/agent-ops/scheduler-engine.ts` still registers
+> per-task pg-boss schedules (`agent-ops-task:<taskId>`), but the worker wires **no
+> consumer** for those queues — the 30s sweeper is authoritative. This path looks dead
+> and is worth confirming before it's mistaken for a live mechanism.
+
+---
+
+## 8. File reference
+
+| Concern | Path |
+| --- | --- |
+| Types / models / statuses | `apps/web-ui/lib/agent-ops/types.ts` |
+| Executor (run + resume) | `apps/web-ui/lib/agent-ops/agent-executor.ts` |
+| LangGraph executor graph | `apps/web-ui/lib/agent-ops/executor-graphs.ts` |
+| Mutative-tool classifier | `apps/web-ui/lib/agent-ops/tool-classifier.ts` |
+| Gateway orchestrator | `apps/web-ui/lib/gateway/gateway-service.ts` |
+| Notification router | `apps/web-ui/lib/gateway/notification-router.ts` |
+| Channel adapters | `apps/web-ui/lib/gateway/adapters/*.ts` |
+| HIL pages | `apps/web-ui/app/app/agent-ops/[runId]/{page,respond}.tsx` |
+| Worker cron sweeper | `apps/workers/src/jobs/agent-ops-scheduler/index.ts` |
+| Atomic per-tenant claim | `apps/workers/src/jobs/scheduler/services/pg-service.ts` |
+| Trigger endpoint | `apps/web-ui/app/api/agent-ops/scheduled-tasks/[taskId]/trigger/route.ts` |
+| Digest delivery | `apps/web-ui/lib/agent-ops/scheduled-notifier.ts` |
+| Data models | `libs/prisma/schema.prisma:385-496` |


### PR DESCRIPTION
## Summary

Makes the **agent-ops scheduled-task trigger path work end-to-end** (worker → web-ui → infra) and hardens the surrounding tenant handling. The workers scheduler triggers a task by POSTing to the web-ui trigger endpoint with a shared `x-internal-key` instead of a NextAuth session; several pieces were needed for that call to actually succeed after deployment, plus a bump to the autonomous iteration budget.

## Changes

- **middleware** — exempt `/api/agent-ops/scheduled-tasks/*/trigger` from the NextAuth gate when `x-internal-key` is present. The route still *strictly* validates the secret against `env.INTERNAL_API_KEY` (and falls back to session auth if it doesn't match). Without this the worker's session-less call was blocked at the middleware, so **no scheduled run ever fired**.
- **`.env.example`** — document `INTERNAL_API_KEY` as **REQUIRED** for the scheduler; uncomment a local default. In prod it's injected from Secrets Manager.
- **iteration budget** — decouple autonomous Agent Ops runs from the interactive chat agents' `MAX_ITERATIONS=30` via a new `AGENT_OPS_MAX_ITERATIONS` (default **150**). Raise `recursionLimit` 50→150 on both initial *and* resumed runs (resume was silently falling back to LangGraph's default of 25).
- **tenant safety** — the scheduled-task dialog no longer sends `tenantId` (resolved server-side from the session); the tenant Prisma extension now strips a client-supplied `tenantId` from `update` `data`, so a row can never be re-homed to another tenant.
- **`bun.lock`** — re-sync the workers `croner` dependency (package.json had it; lock was stale).
- **docs** — add `docs/agent-ops-architecture.md`.

## `INTERNAL_API_KEY` — infra confirmation

The reviewer-flagged concern (must work post-deploy in ECS) is fully satisfied by **already-committed** `infra/compute/index.ts`:
- A per-stack random secret `${appName}/internal-api-key` in Secrets Manager.
- Injected as `INTERNAL_API_KEY` into **all three** task defs: web-ui, workers, ephemeral-workers — same value everywhere.
- ECS execution role granted `secretsmanager:GetSecretValue` on it.

Both the worker (sender) and web-ui (validator) read the same secret; there is **no hardcoded fallback** — the worker fails closed (throws → retries → dead-letters) and the route falls through to session auth if the key is unset/mismatched.

## Note for reviewers (non-blocking)

`recursionLimit` counts LangGraph **super-steps**, while `AGENT_OPS_MAX_ITERATIONS` counts logical iterations (each iteration spans ~2–3 nodes: generate→tools→reflect). So with both at 150, the effective ceiling is ~50–75 iterations, and a genuinely runaway run trips `recursionLimit` (→ status `failed`) *before* the graceful iteration-budget exit fires. This is still a strict improvement over the old 50/30 and real runs finish in far fewer steps, but if we want the 150-iteration budget to be reachable *gracefully*, `recursionLimit` should be scaled higher (~300+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)