### PR TITLE
feat(agent-ops): connector-grade channels + autonomous scheduled-agent hardening

### DIFF
--- a/apps/web-ui/app/api/agent-memories/route.ts
+++ b/apps/web-ui/app/api/agent-memories/route.ts
@@ -6,7 +6,7 @@ import type { MemoryCategory } from '@/lib/agent-memory/category';
 import type { AgentMemorySortField, SortDirection } from '@/lib/db/repositories/agent-memory/interface';
 
 const VALID_CATEGORIES = new Set<MemoryCategory>(['infra', 'user', 'patterns', 'errors', 'other']);
-const VALID_SORT_FIELDS = new Set<AgentMemorySortField>(['category', 'key', 'createdAt', 'expiresAt']);
+const VALID_SORT_FIELDS = new Set<AgentMemorySortField>(['category', 'key', 'createdAt', 'updatedAt', 'expiresAt']);
 
 export async function GET(request: NextRequest) {
     try {

--- a/apps/web-ui/app/api/agent-ops/scheduled-tasks/[taskId]/route.ts
+++ b/apps/web-ui/app/api/agent-ops/scheduled-tasks/[taskId]/route.ts
@@ -9,7 +9,9 @@ import {
     getScheduledTask,
     updateScheduledTask,
     deleteScheduledTask,
+    validateScheduleInput,
 } from '@/lib/agent-ops/scheduled-task-service';
+import type { UpdateScheduledTaskParams } from '@/lib/db/repositories/scheduled-task/interface';
 import { registerTask, unregisterTask } from '@/lib/agent-ops/scheduler-engine';
 import { cancelActiveRunsForTask } from '@/lib/agent-ops/agent-ops-service';
 import { getSessionTenantId, getAuthSession } from '@/lib/auth-session';
@@ -39,7 +41,39 @@ export async function PATCH(req: Request, { params }: Ctx) {
         const existing = await getScheduledTask(tenantId, taskId);
         if (!existing) return NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 });
 
-        const task = await updateScheduledTask(tenantId, taskId, body);
+        // Whitelist the mutable fields — a raw pass-through would let clients
+        // set lifecycle columns (runCount, taskStatus, nextRunAt, …) directly.
+        // mode is intentionally NOT accepted: Agent Ops is plan-mode only.
+        const updates: UpdateScheduledTaskParams = {};
+        if (body.name !== undefined) updates.name = body.name;
+        if (body.description !== undefined) updates.description = body.description;
+        if (body.scheduleType !== undefined) updates.scheduleType = body.scheduleType;
+        if (body.cronExpression !== undefined) updates.cronExpression = body.cronExpression;
+        if (body.intervalMinutes !== undefined) updates.intervalMinutes = body.intervalMinutes;
+        if (body.timezone !== undefined) updates.timezone = body.timezone;
+        if (body.autoApprove !== undefined) updates.autoApprove = body.autoApprove;
+        if (body.model !== undefined) updates.model = body.model;
+        if (body.accountId !== undefined) updates.accountId = body.accountId;
+        if (body.accountName !== undefined) updates.accountName = body.accountName;
+        if (body.mcpServerIds !== undefined) updates.mcpServerIds = body.mcpServerIds;
+        if (body.knowledgeBaseIds !== undefined) updates.knowledgeBaseIds = body.knowledgeBaseIds;
+        if (body.notification !== undefined) updates.notification = body.notification;
+
+        // Validate the schedule as it will look AFTER the update.
+        if (updates.scheduleType !== undefined || updates.cronExpression !== undefined || updates.intervalMinutes !== undefined) {
+            const merged = {
+                scheduleType: updates.scheduleType ?? existing.scheduleType,
+                cronExpression: updates.cronExpression ?? existing.cronExpression,
+                intervalMinutes: updates.intervalMinutes ?? existing.intervalMinutes,
+            };
+            const scheduleError = validateScheduleInput(merged);
+            if (scheduleError) {
+                return NextResponse.json({ error: scheduleError }, { status: 400 });
+            }
+            if (merged.scheduleType === 'interval') updates.cronExpression = '';
+        }
+
+        const task = await updateScheduledTask(tenantId, taskId, updates);
         if (!task) return NextResponse.json({ error: 'Not found' }, { status: 404 });
         // Re-register with updated cron if task is active
         if (task.taskStatus === 'active') registerTask(task);

--- a/apps/web-ui/app/api/agent-ops/scheduled-tasks/route.ts
+++ b/apps/web-ui/app/api/agent-ops/scheduled-tasks/route.ts
@@ -4,7 +4,7 @@
  */
 
 import { NextResponse } from 'next/server';
-import { listScheduledTasks, createScheduledTask } from '@/lib/agent-ops/scheduled-task-service';
+import { listScheduledTasks, createScheduledTask, validateScheduleInput } from '@/lib/agent-ops/scheduled-task-service';
 import { registerTask } from '@/lib/agent-ops/scheduler-engine';
 import { getSessionTenantId, getAuthSession } from '@/lib/auth-session';
 import { AuditService } from '@/lib/audit-service';
@@ -23,13 +23,24 @@ export async function POST(req: Request) {
     try {
         const tenantId = await getSessionTenantId();
         const body = await req.json();
+
+        const scheduleError = validateScheduleInput(body);
+        if (scheduleError) {
+            return NextResponse.json({ error: scheduleError }, { status: 400 });
+        }
+        const scheduleType = body.scheduleType === 'interval' ? 'interval' as const : 'cron' as const;
+
         const task = await createScheduledTask({
             tenantId,
             name: body.name,
             description: body.description,
-            cronExpression: body.cronExpression,
+            scheduleType,
+            cronExpression: scheduleType === 'interval' ? '' : body.cronExpression,
+            intervalMinutes: scheduleType === 'interval' ? Number(body.intervalMinutes) : undefined,
             timezone: body.timezone || 'UTC',
-            mode: body.mode || 'plan',
+            // Agent Ops is plan-mode only — autonomous runs always take the
+            // planner → final → memory_save path regardless of what the client sends.
+            mode: 'plan',
             autoApprove: body.autoApprove ?? false,
             model: body.model,
             accountId: body.accountId,

--- a/apps/web-ui/app/api/agent-ops/settings/defaults/route.ts
+++ b/apps/web-ui/app/api/agent-ops/settings/defaults/route.ts
@@ -1,0 +1,102 @@
+/**
+ * AgentOps Default Configuration API Route
+ *
+ * GET /api/agent-ops/settings/defaults — Returns the tenant's Agent Ops defaults
+ *   (default model + graph iteration limit), or configured:false when unset.
+ * PUT /api/agent-ops/settings/defaults — Validates and saves the defaults.
+ *   Both fields are required. New runs for the tenant use these defaults.
+ */
+
+import { NextResponse } from 'next/server';
+import { TenantConfigService } from '@/lib/tenant-config-service';
+import { getSessionTenantId, getAuthSession } from '@/lib/auth-session';
+import { AuditService } from '@/lib/audit-service';
+import { authorize } from '@/lib/rbac/authorize';
+import {
+    AGENT_OPS_DEFAULTS_KEY,
+    FALLBACK_MAX_ITERATIONS,
+    validateAgentOpsDefaults,
+} from '@/lib/agent-ops/agent-ops-defaults';
+import type { AgentOpsDefaultsConfig } from '@/lib/agent-ops/types';
+
+export async function GET() {
+    try {
+        const tenantId = await getSessionTenantId();
+        const config = await TenantConfigService.getConfig<AgentOpsDefaultsConfig>(AGENT_OPS_DEFAULTS_KEY, tenantId);
+
+        if (!config) {
+            // Not configured yet — surface the effective fallback iteration limit
+            // so the form can pre-fill a sensible value.
+            return NextResponse.json({
+                configured: false,
+                defaultModel: '',
+                maxIterations: FALLBACK_MAX_ITERATIONS,
+            });
+        }
+
+        return NextResponse.json({
+            configured: true,
+            defaultModel: config.defaultModel,
+            maxIterations: config.maxIterations,
+        });
+    } catch (error: any) {
+        console.error('[API /agent-ops/settings/defaults] GET error:', error);
+        return NextResponse.json(
+            { error: error.message || 'Failed to fetch Agent Ops defaults' },
+            { status: 500 }
+        );
+    }
+}
+
+export async function PUT(req: Request) {
+    try {
+        const authError = await authorize('update', 'Agent');
+        if (authError) return authError;
+
+        const tenantId = await getSessionTenantId();
+        const body = (await req.json()) as Partial<AgentOpsDefaultsConfig>;
+
+        const validationError = validateAgentOpsDefaults(body);
+        if (validationError) {
+            return NextResponse.json({ error: validationError }, { status: 400 });
+        }
+
+        const config: AgentOpsDefaultsConfig = {
+            defaultModel: body.defaultModel!.trim(),
+            maxIterations: Math.round(Number(body.maxIterations)),
+        };
+
+        await TenantConfigService.saveConfig(AGENT_OPS_DEFAULTS_KEY, config, tenantId);
+        console.log('[API /agent-ops/settings/defaults] Saved Agent Ops defaults');
+
+        const session = await getAuthSession();
+        AuditService.logUserAction({
+            eventType: 'agent.settings.defaults_updated',
+            severity: 'medium',
+            apiRoute: 'PUT /api/agent-ops/settings/defaults',
+            httpMethod: 'PUT',
+            action: 'Updated Agent Ops Defaults',
+            resourceType: 'agent',
+            resourceId: 'agent-ops-defaults',
+            resourceName: 'Agent Ops Defaults',
+            user: session?.user?.email || 'unknown',
+            userType: 'user',
+            status: 'success',
+            details: `Set default model to "${config.defaultModel}" and graph limit to ${config.maxIterations}`,
+            metadata: { tenantId },
+        }).catch(() => {});
+
+        return NextResponse.json({
+            success: true,
+            configured: true,
+            defaultModel: config.defaultModel,
+            maxIterations: config.maxIterations,
+        });
+    } catch (error: any) {
+        console.error('[API /agent-ops/settings/defaults] PUT error:', error);
+        return NextResponse.json(
+            { error: error.message || 'Failed to save Agent Ops defaults' },
+            { status: 500 }
+        );
+    }
+}

--- a/apps/web-ui/app/api/agent-ops/settings/jira/test/route.ts
+++ b/apps/web-ui/app/api/agent-ops/settings/jira/test/route.ts
@@ -1,0 +1,91 @@
+/**
+ * AgentOps Jira Connection Test API Route
+ *
+ * POST /api/agent-ops/settings/jira/test — Verifies Base URL + User Email +
+ * API Token by calling Jira's /rest/api/3/myself. Values from the request
+ * body (unsaved form input) win; blank fields fall back to the stored tenant
+ * config. Returns the authenticated account's displayName and accountId so
+ * the UI can auto-fill the Bot Account ID field. Secrets are never echoed.
+ */
+
+import { NextResponse } from 'next/server';
+import { TenantConfigService } from '@/lib/tenant-config-service';
+import { getSessionTenantId } from '@/lib/auth-session';
+import { authorize } from '@/lib/rbac/authorize';
+import type { JiraIntegrationConfig } from '@/lib/agent-ops/types';
+
+const CONFIG_KEY = 'agent-ops-jira';
+
+export async function POST(req: Request) {
+    try {
+        const authError = await authorize('update', 'Agent');
+        if (authError) return authError;
+
+        const tenantId = await getSessionTenantId();
+        const body = (await req.json().catch(() => ({}))) as {
+            baseUrl?: string;
+            userEmail?: string;
+            apiToken?: string;
+        };
+
+        const existing = await TenantConfigService.getConfig<JiraIntegrationConfig>(CONFIG_KEY, tenantId);
+
+        const baseUrl = (body.baseUrl?.trim() || existing?.baseUrl || '').replace(/\/+$/, '');
+        const userEmail = body.userEmail?.trim() || existing?.userEmail;
+        const apiToken = body.apiToken?.trim() || existing?.apiToken;
+
+        if (!baseUrl || !userEmail || !apiToken) {
+            return NextResponse.json(
+                { success: false, error: 'Base URL, User Email, and API Token are all required to test the connection.' },
+                { status: 400 }
+            );
+        }
+        if (!baseUrl.startsWith('https://')) {
+            return NextResponse.json(
+                { success: false, error: 'Base URL must start with https:// (e.g. https://your-org.atlassian.net).' },
+                { status: 400 }
+            );
+        }
+
+        const auth = Buffer.from(`${userEmail}:${apiToken}`).toString('base64');
+        const res = await fetch(`${baseUrl}/rest/api/3/myself`, {
+            headers: { Authorization: `Basic ${auth}`, Accept: 'application/json' },
+            signal: AbortSignal.timeout(10_000),
+        });
+
+        if (res.status === 401 || res.status === 403) {
+            return NextResponse.json(
+                { success: false, error: 'Jira rejected the credentials — check the User Email and API Token.' },
+                { status: 400 }
+            );
+        }
+        if (!res.ok) {
+            return NextResponse.json(
+                { success: false, error: `Jira returned HTTP ${res.status} — check the Base URL.` },
+                { status: 400 }
+            );
+        }
+
+        const me = (await res.json().catch(() => ({}))) as {
+            displayName?: string;
+            accountId?: string;
+            emailAddress?: string;
+        };
+
+        return NextResponse.json({
+            success: true,
+            data: {
+                displayName: me.displayName || '',
+                accountId: me.accountId || '',
+                emailAddress: me.emailAddress || '',
+            },
+        });
+    } catch (error: any) {
+        console.error('[API /agent-ops/settings/jira/test] POST error:', error);
+        const message =
+            error?.name === 'TimeoutError' || error?.name === 'AbortError'
+                ? 'Jira did not respond within 10 seconds — check the Base URL'
+                : error.message || 'Connection test failed';
+        return NextResponse.json({ success: false, error: message }, { status: 500 });
+    }
+}

--- a/apps/web-ui/app/api/agent-ops/settings/slack/test/route.ts
+++ b/apps/web-ui/app/api/agent-ops/settings/slack/test/route.ts
@@ -1,0 +1,70 @@
+/**
+ * AgentOps Slack Connection Test API Route
+ *
+ * POST /api/agent-ops/settings/slack/test — Verifies a bot token against
+ * Slack's auth.test endpoint. Uses the token from the request body when the
+ * user has typed a new (unsaved) value, otherwise falls back to the stored
+ * tenant config. The token itself is never echoed back.
+ */
+
+import { NextResponse } from 'next/server';
+import { TenantConfigService } from '@/lib/tenant-config-service';
+import { getSessionTenantId } from '@/lib/auth-session';
+import { authorize } from '@/lib/rbac/authorize';
+import type { SlackIntegrationConfig } from '@/lib/agent-ops/types';
+
+const CONFIG_KEY = 'agent-ops-slack';
+
+export async function POST(req: Request) {
+    try {
+        const authError = await authorize('update', 'Agent');
+        if (authError) return authError;
+
+        const tenantId = await getSessionTenantId();
+        const body = (await req.json().catch(() => ({}))) as { botToken?: string };
+
+        let botToken = body.botToken?.trim();
+        if (!botToken) {
+            const config = await TenantConfigService.getConfig<SlackIntegrationConfig>(CONFIG_KEY, tenantId);
+            botToken = config?.botToken;
+        }
+
+        if (!botToken) {
+            return NextResponse.json(
+                { success: false, error: 'No Bot Token to test. Enter a Bot Token above or save one first.' },
+                { status: 400 }
+            );
+        }
+
+        const res = await fetch('https://slack.com/api/auth.test', {
+            method: 'POST',
+            headers: { Authorization: `Bearer ${botToken}` },
+            signal: AbortSignal.timeout(10_000),
+        });
+        const data = (await res.json().catch(() => ({}))) as {
+            ok?: boolean;
+            error?: string;
+            team?: string;
+            user?: string;
+        };
+
+        if (!data.ok) {
+            return NextResponse.json(
+                { success: false, error: `Slack rejected the token: ${data.error || 'unknown error'}` },
+                { status: 400 }
+            );
+        }
+
+        return NextResponse.json({
+            success: true,
+            data: { team: data.team || '', botUser: data.user || '' },
+        });
+    } catch (error: any) {
+        console.error('[API /agent-ops/settings/slack/test] POST error:', error);
+        const message =
+            error?.name === 'TimeoutError' || error?.name === 'AbortError'
+                ? 'Slack API did not respond within 10 seconds'
+                : error.message || 'Connection test failed';
+        return NextResponse.json({ success: false, error: message }, { status: 500 });
+    }
+}

--- a/apps/web-ui/app/api/agent-ops/settings/telegram/test/route.ts
+++ b/apps/web-ui/app/api/agent-ops/settings/telegram/test/route.ts
@@ -1,0 +1,90 @@
+/**
+ * AgentOps Telegram Connection Test API Route
+ *
+ * POST /api/agent-ops/settings/telegram/test — Verifies a bot token against
+ * Telegram's getMe endpoint and reports the current webhook status via
+ * getWebhookInfo. Uses the token from the request body when the user has typed
+ * a new (unsaved) value, otherwise falls back to the stored tenant config. The
+ * token itself is never echoed back.
+ */
+
+import { NextResponse } from 'next/server';
+import { TenantConfigService } from '@/lib/tenant-config-service';
+import { getSessionTenantId } from '@/lib/auth-session';
+import { authorize } from '@/lib/rbac/authorize';
+import type { TelegramIntegrationConfig } from '@/lib/agent-ops/types';
+
+const CONFIG_KEY = 'agent-ops-telegram';
+
+export async function POST(req: Request) {
+    try {
+        const authError = await authorize('update', 'Agent');
+        if (authError) return authError;
+
+        const tenantId = await getSessionTenantId();
+        const body = (await req.json().catch(() => ({}))) as { botToken?: string };
+
+        let botToken = body.botToken?.trim();
+        if (!botToken) {
+            const config = await TenantConfigService.getConfig<TelegramIntegrationConfig>(CONFIG_KEY, tenantId);
+            botToken = config?.botToken;
+        }
+
+        if (!botToken) {
+            return NextResponse.json(
+                { success: false, error: 'No Bot Token to test. Enter a Bot Token above or save one first.' },
+                { status: 400 }
+            );
+        }
+
+        const meRes = await fetch(`https://api.telegram.org/bot${botToken}/getMe`, {
+            signal: AbortSignal.timeout(10_000),
+        });
+        const me = (await meRes.json().catch(() => ({}))) as {
+            ok?: boolean;
+            description?: string;
+            result?: { username?: string };
+        };
+
+        if (!me.ok) {
+            return NextResponse.json(
+                { success: false, error: `Telegram rejected the token: ${me.description || 'unknown error'}` },
+                { status: 400 }
+            );
+        }
+
+        const infoRes = await fetch(`https://api.telegram.org/bot${botToken}/getWebhookInfo`, {
+            signal: AbortSignal.timeout(10_000),
+        });
+        const info = (await infoRes.json().catch(() => ({}))) as {
+            ok?: boolean;
+            result?: {
+                url?: string;
+                last_error_message?: string;
+                pending_update_count?: number;
+            };
+        };
+
+        const webhook = info.result || {};
+
+        return NextResponse.json({
+            success: true,
+            data: {
+                botUsername: me.result?.username || '',
+                webhook: {
+                    url: webhook.url || '',
+                    isSet: Boolean(webhook.url),
+                    lastErrorMessage: webhook.last_error_message || '',
+                    pendingUpdateCount: webhook.pending_update_count ?? 0,
+                },
+            },
+        });
+    } catch (error: any) {
+        console.error('[API /agent-ops/settings/telegram/test] POST error:', error);
+        const message =
+            error?.name === 'TimeoutError' || error?.name === 'AbortError'
+                ? 'Telegram API did not respond within 10 seconds'
+                : error.message || 'Connection test failed';
+        return NextResponse.json({ success: false, error: message }, { status: 500 });
+    }
+}

--- a/apps/web-ui/app/api/agent-ops/settings/telegram/webhook/route.ts
+++ b/apps/web-ui/app/api/agent-ops/settings/telegram/webhook/route.ts
@@ -1,0 +1,95 @@
+/**
+ * AgentOps Telegram Webhook Registration API Route
+ *
+ * POST /api/agent-ops/settings/telegram/webhook — Registers the webhook with
+ * Telegram on the user's behalf (one-click alternative to the manual setWebhook
+ * curl). Uses the token/secret from the request body when the user has typed
+ * new (unsaved) values, otherwise falls back to the stored tenant config.
+ * Telegram requires an HTTPS URL, so this cannot target localhost.
+ */
+
+import { NextResponse } from 'next/server';
+import { TenantConfigService } from '@/lib/tenant-config-service';
+import { getSessionTenantId, getAuthSession } from '@/lib/auth-session';
+import { AuditService } from '@/lib/audit-service';
+import { authorize } from '@/lib/rbac/authorize';
+import type { TelegramIntegrationConfig } from '@/lib/agent-ops/types';
+
+const CONFIG_KEY = 'agent-ops-telegram';
+
+export async function POST(req: Request) {
+    try {
+        const authError = await authorize('update', 'Agent');
+        if (authError) return authError;
+
+        const tenantId = await getSessionTenantId();
+        const body = (await req.json().catch(() => ({}))) as {
+            webhookUrl?: string;
+            botToken?: string;
+            secretToken?: string;
+        };
+
+        const existing = await TenantConfigService.getConfig<TelegramIntegrationConfig>(CONFIG_KEY, tenantId);
+
+        const webhookUrl = body.webhookUrl?.trim() || '';
+        const botToken = body.botToken?.trim() || existing?.botToken;
+        const secretToken = body.secretToken?.trim() || existing?.secretToken;
+
+        if (!botToken || !secretToken) {
+            return NextResponse.json(
+                { success: false, error: 'Bot Token and Secret Token are both required. Enter them above or save them first.' },
+                { status: 400 }
+            );
+        }
+        if (!webhookUrl.startsWith('https://')) {
+            return NextResponse.json(
+                { success: false, error: "Telegram requires an HTTPS webhook URL — this won't work from localhost." },
+                { status: 400 }
+            );
+        }
+
+        const res = await fetch(`https://api.telegram.org/bot${botToken}/setWebhook`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ url: webhookUrl, secret_token: secretToken }),
+            signal: AbortSignal.timeout(10_000),
+        });
+        const data = (await res.json().catch(() => ({}))) as {
+            ok?: boolean;
+            description?: string;
+        };
+
+        if (!data.ok) {
+            return NextResponse.json(
+                { success: false, error: `Telegram rejected the webhook: ${data.description || 'unknown error'}` },
+                { status: 400 }
+            );
+        }
+
+        const session = await getAuthSession();
+        AuditService.logUserAction({
+            eventType: 'agent.settings.telegram_webhook_registered',
+            severity: 'medium',
+            apiRoute: 'POST /api/agent-ops/settings/telegram/webhook',
+            httpMethod: 'POST',
+            action: 'Registered Telegram Webhook',
+            resourceType: 'agent',
+            resourceId: 'telegram-integration',
+            resourceName: 'Telegram Integration',
+            user: session?.user?.email || 'unknown',
+            userType: 'user',
+            status: 'success',
+            details: 'Registered Telegram webhook with Telegram',
+            metadata: { tenantId },
+        }).catch(() => {});
+
+        return NextResponse.json({ success: true, data: { url: webhookUrl } });
+    } catch (error: any) {
+        console.error('[API /agent-ops/settings/telegram/webhook] POST error:', error);
+        const message =
+            error?.name === 'TimeoutError' || error?.name === 'AbortError'
+                ? 'Telegram API did not respond within 10 seconds'
+                : error.message || 'Failed to register webhook';
+        return NextResponse.json({ success: false, error: message }, { status: 500 });
+    }
+}

--- a/apps/web-ui/app/app/agent-ops/page.tsx
+++ b/apps/web-ui/app/app/agent-ops/page.tsx
@@ -132,6 +132,9 @@ export default function AgentOpsPage() {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={() => router.push("/app/agent-ops/settings")}>
+                  <Settings2 className="h-4 w-4 mr-2" /> Agent Defaults
+                </DropdownMenuItem>
                 <DropdownMenuItem onClick={() => router.push("/app/agent-ops/slack-settings")}>
                   <MessageSquare className="h-4 w-4 mr-2" /> Slack
                 </DropdownMenuItem>

--- a/apps/web-ui/app/app/agent-ops/scheduled-tasks/[taskId]/page.tsx
+++ b/apps/web-ui/app/app/agent-ops/scheduled-tasks/[taskId]/page.tsx
@@ -171,7 +171,11 @@ export default function ScheduledTaskDetailPage() {
                         </div>
                         <div>
                             <dt className="text-muted-foreground text-xs">Schedule</dt>
-                            <dd className="mt-0.5 font-mono text-xs">{task.cronExpression}</dd>
+                            <dd className="mt-0.5 font-mono text-xs">
+                                {task.scheduleType === "interval"
+                                    ? `every ${task.intervalMinutes ?? "?"} min`
+                                    : task.cronExpression}
+                            </dd>
                         </div>
                         <div>
                             <dt className="text-muted-foreground text-xs">Timezone</dt>

--- a/apps/web-ui/app/app/agent-ops/scheduled-tasks/page.tsx
+++ b/apps/web-ui/app/app/agent-ops/scheduled-tasks/page.tsx
@@ -88,6 +88,12 @@ export default function ScheduledTasksPage() {
         ? formatDateTime(iso, 'shortDateTime', timezone)
         : "—"
 
+    const formatSchedule = (t: ScheduledTask) => t.scheduleType === "interval"
+        ? (t.intervalMinutes && t.intervalMinutes % 60 === 0
+            ? `every ${t.intervalMinutes / 60}h`
+            : `every ${t.intervalMinutes ?? "?"}m`)
+        : t.cronExpression
+
     const stats = {
         active: tasks.filter(t => t.taskStatus === "active").length,
         paused: tasks.filter(t => t.taskStatus === "paused").length,
@@ -176,7 +182,7 @@ export default function ScheduledTasksPage() {
                                             <div className="flex-1 min-w-0">
                                                 <p className="font-medium text-sm truncate">{task.name}</p>
                                                 <div className="flex items-center gap-2 mt-0.5 text-xs text-muted-foreground flex-wrap">
-                                                    <span className="font-mono">{task.cronExpression}</span>
+                                                    <span className="font-mono">{formatSchedule(task)}</span>
                                                     <span>•</span>
                                                     <span>{task.timezone}</span>
                                                     <span>•</span>

--- a/apps/web-ui/app/app/agent-ops/settings/page.tsx
+++ b/apps/web-ui/app/app/agent-ops/settings/page.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { AgentOpsSettingsForm } from '@/components/agent-ops/agent-ops-settings-form';
+
+export default function AgentOpsSettingsPage() {
+    return (
+        <div className="flex-1 bg-background">
+            <AgentOpsSettingsForm />
+        </div>
+    );
+}

--- a/apps/web-ui/app/app/channels/page.tsx
+++ b/apps/web-ui/app/app/channels/page.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import { useChannelStatus } from '@/lib/queries/channels';
+import { useToggleChannelEnabled } from '@/lib/queries/channel-settings';
 import Link from 'next/link';
-import { Cable, CheckCircle2, Loader2, Settings2, Webhook } from 'lucide-react';
+import { Cable, CheckCircle2, Loader2, PauseCircle, Power, PowerOff, Settings2, Webhook } from 'lucide-react';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -48,12 +50,43 @@ function TelegramIcon({ className }: { className?: string }) {
 }
 
 
+function channelBadge(status: { configured: boolean; enabled: boolean } | null) {
+    if (!status) return null;
+    if (!status.configured) {
+        return <Badge variant="outline" className="text-xs text-muted-foreground">Not configured</Badge>;
+    }
+    if (!status.enabled) {
+        return (
+            <Badge variant="outline" className="gap-1 text-xs text-amber-600 dark:text-amber-500 border-amber-500/40">
+                <PauseCircle className="h-3 w-3" />
+                Deactivated
+            </Badge>
+        );
+    }
+    return (
+        <Badge variant="secondary" className="gap-1 text-xs">
+            <CheckCircle2 className="h-3 w-3 text-green-500" />
+            Active
+        </Badge>
+    );
+}
+
 export default function ChannelsPage() {
     const channelQuery = useChannelStatus();
     const status = channelQuery.data ?? {
         slack: null, jira: null, discord: null, telegram: null, webhook: null, mcp: null, providers: null,
     };
     const loading = channelQuery.isLoading;
+    const toggleMutation = useToggleChannelEnabled();
+
+    const handleToggle = async (channel: { id: string; name: string }, enabled: boolean) => {
+        try {
+            await toggleMutation.mutateAsync({ channel: channel.id, enabled });
+            toast.success(`${channel.name} integration ${enabled ? 'activated' : 'deactivated'}`);
+        } catch (error: any) {
+            toast.error(error.message || `Failed to ${enabled ? 'activate' : 'deactivate'} ${channel.name}`);
+        }
+    };
 
     const channels = [
         {
@@ -62,11 +95,7 @@ export default function ChannelsPage() {
             description: 'Receive Agent Ops commands via Slack slash commands and get results posted back to your channels.',
             href: '/app/channels/slack-settings',
             icon: <SlackIcon className="h-8 w-8 text-[#4A154B] dark:text-[#E8B4E8]" />,
-            statusBadge: status.slack
-                ? status.slack.configured
-                    ? <Badge variant="secondary" className="gap-1 text-xs"><CheckCircle2 className="h-3 w-3 text-green-500" />Configured</Badge>
-                    : <Badge variant="outline" className="text-xs text-muted-foreground">Not configured</Badge>
-                : null,
+            status: status.slack,
         },
         {
             id: 'jira',
@@ -74,11 +103,7 @@ export default function ChannelsPage() {
             description: 'Trigger agent runs from Jira Automation rules and receive results as issue comments.',
             href: '/app/channels/jira-settings',
             icon: <JiraIcon className="h-8 w-8" />,
-            statusBadge: status.jira
-                ? status.jira.configured
-                    ? <Badge variant="secondary" className="gap-1 text-xs"><CheckCircle2 className="h-3 w-3 text-green-500" />Configured</Badge>
-                    : <Badge variant="outline" className="text-xs text-muted-foreground">Not configured</Badge>
-                : null,
+            status: status.jira,
         },
         {
             id: 'discord',
@@ -86,11 +111,7 @@ export default function ChannelsPage() {
             description: 'Run agent commands via Discord slash commands with rich embeds and real-time streaming updates.',
             href: '/app/channels/discord-settings',
             icon: <DiscordIcon className="h-8 w-8 text-[#5865F2]" />,
-            statusBadge: status.discord
-                ? status.discord.configured
-                    ? <Badge variant="secondary" className="gap-1 text-xs"><CheckCircle2 className="h-3 w-3 text-green-500" />Configured</Badge>
-                    : <Badge variant="outline" className="text-xs text-muted-foreground">Not configured</Badge>
-                : null,
+            status: status.discord,
         },
         {
             id: 'telegram',
@@ -98,11 +119,7 @@ export default function ChannelsPage() {
             description: 'Trigger agent runs from Telegram bot commands with inline keyboard approvals and streaming.',
             href: '/app/channels/telegram-settings',
             icon: <TelegramIcon className="h-8 w-8 text-[#26A5E4]" />,
-            statusBadge: status.telegram
-                ? status.telegram.configured
-                    ? <Badge variant="secondary" className="gap-1 text-xs"><CheckCircle2 className="h-3 w-3 text-green-500" />Configured</Badge>
-                    : <Badge variant="outline" className="text-xs text-muted-foreground">Not configured</Badge>
-                : null,
+            status: status.telegram,
         },
         {
             id: 'webhook',
@@ -110,11 +127,7 @@ export default function ChannelsPage() {
             description: 'Generic HTTP webhook for any external system. Send tasks via POST and receive results at your callback URL.',
             href: '/app/channels/webhook-settings',
             icon: <Webhook className="h-8 w-8 text-orange-500" />,
-            statusBadge: status.webhook
-                ? status.webhook.configured
-                    ? <Badge variant="secondary" className="gap-1 text-xs"><CheckCircle2 className="h-3 w-3 text-green-500" />Configured</Badge>
-                    : <Badge variant="outline" className="text-xs text-muted-foreground">Not configured</Badge>
-                : null,
+            status: status.webhook,
         },
     ];
 
@@ -135,30 +148,59 @@ export default function ChannelsPage() {
                     </div>
                 ) : (
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                        {channels.map(channel => (
-                            <Card key={channel.id} className="flex flex-col hover:border-primary/50 transition-colors">
-                                <CardHeader className="pb-3">
-                                    <div className="flex items-start justify-between">
-                                        <div className="p-2 rounded-lg bg-muted/50">
-                                            {channel.icon}
+                        {channels.map(channel => {
+                            const configured = channel.status?.configured ?? false;
+                            const enabled = channel.status?.enabled ?? false;
+                            const toggling =
+                                toggleMutation.isPending && toggleMutation.variables?.channel === channel.id;
+                            return (
+                                <Card key={channel.id} className="flex flex-col hover:border-primary/50 transition-colors">
+                                    <CardHeader className="pb-3">
+                                        <div className="flex items-start justify-between">
+                                            <div className="p-2 rounded-lg bg-muted/50">
+                                                {channel.icon}
+                                            </div>
+                                            {channelBadge(channel.status)}
                                         </div>
-                                        {channel.statusBadge}
-                                    </div>
-                                    <CardTitle className="text-base mt-3">{channel.name}</CardTitle>
-                                    <CardDescription className="text-sm leading-relaxed">
-                                        {channel.description}
-                                    </CardDescription>
-                                </CardHeader>
-                                <CardContent className="mt-auto pt-0">
-                                    <Link href={channel.href}>
-                                        <Button variant="outline" size="sm" className="w-full gap-2">
-                                            <Settings2 className="h-3.5 w-3.5" />
-                                            Configure
-                                        </Button>
-                                    </Link>
-                                </CardContent>
-                            </Card>
-                        ))}
+                                        <CardTitle className="text-base mt-3">{channel.name}</CardTitle>
+                                        <CardDescription className="text-sm leading-relaxed">
+                                            {channel.description}
+                                        </CardDescription>
+                                    </CardHeader>
+                                    <CardContent className="mt-auto pt-0">
+                                        <div className="flex items-center gap-2">
+                                            <Link href={channel.href} className="flex-1">
+                                                <Button variant="outline" size="sm" className="w-full gap-2">
+                                                    <Settings2 className="h-3.5 w-3.5" />
+                                                    {configured ? 'Reconfigure' : 'Configure'}
+                                                </Button>
+                                            </Link>
+                                            {configured && (
+                                                <Button
+                                                    variant="outline"
+                                                    size="sm"
+                                                    className={`gap-2 ${enabled ? 'text-amber-600 dark:text-amber-500' : 'text-green-600 dark:text-green-500'}`}
+                                                    disabled={toggling}
+                                                    onClick={() => handleToggle(channel, !enabled)}
+                                                    title={enabled
+                                                        ? 'Deactivate — incoming requests and outgoing notifications stop; credentials are kept'
+                                                        : 'Activate — resume the integration with the stored credentials'}
+                                                >
+                                                    {toggling ? (
+                                                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                                    ) : enabled ? (
+                                                        <PowerOff className="h-3.5 w-3.5" />
+                                                    ) : (
+                                                        <Power className="h-3.5 w-3.5" />
+                                                    )}
+                                                    {enabled ? 'Deactivate' : 'Activate'}
+                                                </Button>
+                                            )}
+                                        </div>
+                                    </CardContent>
+                                </Card>
+                            );
+                        })}
                     </div>
                 )}
             </div>

--- a/apps/web-ui/components/agent-ops/agent-ops-settings-form.tsx
+++ b/apps/web-ui/components/agent-ops/agent-ops-settings-form.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { ArrowLeft, CheckCircle2, Cpu, Gauge, Loader2, Save } from 'lucide-react';
+import { toast } from 'sonner';
+import { useAgentOpsDefaults, useSaveAgentOpsDefaults } from '@/lib/queries/agent-ops-settings';
+import { useProviderModels } from '@/lib/queries/providers';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+
+// Keep in sync with lib/agent-ops/agent-ops-defaults.ts.
+const MIN_MAX_ITERATIONS = 10;
+const MAX_MAX_ITERATIONS = 500;
+
+interface AgentOpsSettingsFormProps {
+    backHref?: string;
+    backLabel?: string;
+}
+
+export function AgentOpsSettingsForm({
+    backHref = '/app/agent-ops',
+    backLabel = 'Back to Agent Ops',
+}: AgentOpsSettingsFormProps) {
+    const router = useRouter();
+    const { data, isLoading } = useAgentOpsDefaults();
+    const { data: models, isLoading: modelsLoading } = useProviderModels();
+    const saveMutation = useSaveAgentOpsDefaults();
+    const saving = saveMutation.isPending;
+
+    const [defaultModel, setDefaultModel] = useState('');
+    const [maxIterations, setMaxIterations] = useState<number>(150);
+    const [saved, setSaved] = useState(false);
+    const [error, setError] = useState('');
+
+    // Hydrate the form once the stored config arrives.
+    useEffect(() => {
+        if (data) {
+            setDefaultModel(data.defaultModel || '');
+            setMaxIterations(data.maxIterations || 150);
+        }
+    }, [data]);
+
+    if (isLoading) {
+        return (
+            <div className="flex-1 flex items-center justify-center">
+                <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+        );
+    }
+
+    const configured = data?.configured ?? false;
+    const noModels = !modelsLoading && (!models || models.length === 0);
+    // A previously-saved model that is no longer offered by any provider — keep
+    // it selectable so the admin sees what's stored and can consciously change it.
+    const staleModel = defaultModel && models && !models.some(m => m.id === defaultModel);
+
+    const handleSave = async () => {
+        if (!defaultModel) {
+            setError('Select a default model');
+            return;
+        }
+        if (!Number.isInteger(maxIterations) || maxIterations < MIN_MAX_ITERATIONS || maxIterations > MAX_MAX_ITERATIONS) {
+            setError(`Graph limit must be a whole number between ${MIN_MAX_ITERATIONS} and ${MAX_MAX_ITERATIONS}`);
+            return;
+        }
+        setError('');
+        try {
+            await saveMutation.mutateAsync({ defaultModel, maxIterations });
+            setSaved(true);
+            toast.success('Agent Ops defaults saved — new runs will use this configuration');
+            setTimeout(() => setSaved(false), 3000);
+        } catch (err: any) {
+            setError(err.message || 'Failed to save');
+            toast.error(err.message || 'Failed to save Agent Ops defaults');
+        }
+    };
+
+    return (
+        <div className="flex-1 bg-background max-w-3xl mx-auto space-y-6">
+            <div>
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    className="gap-2 text-muted-foreground hover:text-foreground -ml-2"
+                    onClick={() => router.push(backHref)}
+                >
+                    <ArrowLeft className="h-4 w-4" />
+                    {backLabel}
+                </Button>
+            </div>
+
+            <div className="flex items-center justify-between">
+                <div>
+                    <h1 className="text-2xl font-bold">Agent Ops Defaults</h1>
+                    <p className="text-muted-foreground mt-1">
+                        Default execution configuration applied to every new Agent Ops run for this organization.
+                        A run that specifies its own model still overrides the default.
+                    </p>
+                </div>
+                {configured && (
+                    <Badge variant="secondary" className="gap-1">
+                        <CheckCircle2 className="h-3.5 w-3.5 text-green-500" />
+                        Configured
+                    </Badge>
+                )}
+            </div>
+
+            {noModels && (
+                <Alert>
+                    <AlertDescription>
+                        No models are available yet. Configure an LLM provider under{' '}
+                        <button
+                            className="text-blue-500 hover:underline"
+                            onClick={() => router.push('/app/settings/providers')}
+                        >
+                            Settings → Providers
+                        </button>{' '}
+                        first, then choose a default model here.
+                    </AlertDescription>
+                </Alert>
+            )}
+
+            <Card>
+                <CardHeader>
+                    <CardTitle className="text-base flex items-center gap-2">
+                        <Cpu className="h-4 w-4" />
+                        Default Model
+                    </CardTitle>
+                    <CardDescription>
+                        The LLM used for planning, execution, and reflection when a run does not select its own model.
+                        Models come from your configured providers.
+                    </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-2">
+                    <Label htmlFor="defaultModel">
+                        Model <span className="text-destructive">*</span>
+                    </Label>
+                    <Select value={defaultModel} onValueChange={setDefaultModel} disabled={noModels}>
+                        <SelectTrigger id="defaultModel">
+                            <SelectValue placeholder={modelsLoading ? 'Loading models…' : 'Select a model'} />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {staleModel && (
+                                <SelectItem value={defaultModel}>
+                                    {defaultModel} (not currently available)
+                                </SelectItem>
+                            )}
+                            {(models ?? []).map(m => (
+                                <SelectItem key={m.id} value={m.id}>
+                                    {m.label}
+                                    <span className="text-muted-foreground"> · {m.provider}</span>
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                    {staleModel && (
+                        <p className="text-xs text-amber-600 dark:text-amber-500">
+                            The saved model is no longer offered by any provider. Pick a current model and save.
+                        </p>
+                    )}
+                </CardContent>
+            </Card>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle className="text-base flex items-center gap-2">
+                        <Gauge className="h-4 w-4" />
+                        Graph Iteration Limit
+                    </CardTitle>
+                    <CardDescription>
+                        Maximum number of reasoning/tool iterations a single run may take before it is force-completed.
+                        This caps both the executor loop and LangGraph&apos;s recursion limit. Higher values allow more
+                        complex autonomous tasks but cost more tokens.
+                    </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-2">
+                    <Label htmlFor="maxIterations">
+                        Max iterations <span className="text-destructive">*</span>
+                    </Label>
+                    <Input
+                        id="maxIterations"
+                        type="number"
+                        min={MIN_MAX_ITERATIONS}
+                        max={MAX_MAX_ITERATIONS}
+                        value={maxIterations}
+                        onChange={e => setMaxIterations(Number(e.target.value))}
+                        className="w-40"
+                    />
+                    <p className="text-xs text-muted-foreground">
+                        Between {MIN_MAX_ITERATIONS} and {MAX_MAX_ITERATIONS}. Default is 150.
+                    </p>
+                </CardContent>
+            </Card>
+
+            {error && (
+                <Alert variant="destructive">
+                    <AlertDescription>{error}</AlertDescription>
+                </Alert>
+            )}
+
+            <Button
+                onClick={handleSave}
+                disabled={saving || noModels}
+                className={saved ? 'bg-green-600 hover:bg-green-700' : ''}
+            >
+                {saving ? (
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                ) : saved ? (
+                    <CheckCircle2 className="h-4 w-4 mr-2" />
+                ) : (
+                    <Save className="h-4 w-4 mr-2" />
+                )}
+                {saved ? 'Saved' : 'Save Defaults'}
+            </Button>
+        </div>
+    );
+}

--- a/apps/web-ui/components/agent-ops/run-timeline/build-steps.ts
+++ b/apps/web-ui/components/agent-ops/run-timeline/build-steps.ts
@@ -88,6 +88,15 @@ export function buildSteps(events: AgentOpsEvent[], runStatus: AgentOpsStatus): 
       case "error":
         flat.push({ kind: "error", event: e });
         break;
+      case "notification":
+        // Scheduled digest delivery marker — a failed delivery is surfaced as an
+        // error step so it's impossible to miss; successful delivery is a quiet step.
+        if ((e.metadata as { status?: string } | undefined)?.status === "failed") {
+          flat.push({ kind: "error", event: e });
+        } else {
+          flat.push({ kind: "thinking", event: e });
+        }
+        break;
       default:
         flat.push({ kind: "thinking", event: e as AgentOpsEvent });
         break;

--- a/apps/web-ui/components/agent-ops/scheduled-task-dialog.tsx
+++ b/apps/web-ui/components/agent-ops/scheduled-task-dialog.tsx
@@ -36,15 +36,26 @@ interface ScheduledTaskDialogProps {
 const DEFAULT_FORM = {
     name: "",
     description: "",
+    scheduleType: "cron" as "cron" | "interval",
     cronExpression: "0 9 * * *",
+    intervalValue: 4,
+    intervalUnit: "hours" as "minutes" | "hours",
     timezone: "UTC",
-    mode: "plan" as const,
     autoApprove: false,
     notificationType: "none" as "none" | "slack" | "jira" | "telegram",
     channelId: "",
     channelName: "",
     chatId: "",
     issueKey: "",
+}
+
+const MIN_INTERVAL_MINUTES = 5
+
+function splitIntervalMinutes(minutes: number | undefined): { intervalValue: number; intervalUnit: "minutes" | "hours" } {
+    const m = minutes ?? 240
+    return m >= 60 && m % 60 === 0
+        ? { intervalValue: m / 60, intervalUnit: "hours" }
+        : { intervalValue: m, intervalUnit: "minutes" }
 }
 
 export function ScheduledTaskDialog({ tenantId = "default", task, onSaved, trigger }: ScheduledTaskDialogProps) {
@@ -54,9 +65,10 @@ export function ScheduledTaskDialog({ tenantId = "default", task, onSaved, trigg
     const [form, setForm] = useState(() => task ? {
         name: task.name,
         description: task.description,
-        cronExpression: task.cronExpression,
+        scheduleType: task.scheduleType ?? "cron",
+        cronExpression: task.cronExpression || DEFAULT_FORM.cronExpression,
+        ...splitIntervalMinutes(task.intervalMinutes),
         timezone: task.timezone,
-        mode: task.mode,
         autoApprove: task.autoApprove,
         notificationType: task.notification.type,
         channelId: task.notification.channelId || "",
@@ -67,9 +79,15 @@ export function ScheduledTaskDialog({ tenantId = "default", task, onSaved, trigg
 
     const set = (k: string, v: unknown) => setForm(f => ({ ...f, [k]: v }))
 
+    const intervalMinutes = form.intervalUnit === "hours" ? form.intervalValue * 60 : form.intervalValue
+
     const handleSave = async () => {
         if (!form.name.trim() || !form.description.trim()) {
             setError("Name and description are required")
+            return
+        }
+        if (form.scheduleType === "interval" && (!Number.isInteger(intervalMinutes) || intervalMinutes < MIN_INTERVAL_MINUTES)) {
+            setError(`Interval must be at least ${MIN_INTERVAL_MINUTES} minutes`)
             return
         }
         setError(null)
@@ -77,12 +95,14 @@ export function ScheduledTaskDialog({ tenantId = "default", task, onSaved, trigg
         try {
             // tenantId is resolved server-side from the session — never sent by the
             // client (a stale/placeholder value here would re-home the task's tenant).
+            // Mode is not sent: Agent Ops runs are always plan-mode.
             const body = {
                 name: form.name.trim(),
                 description: form.description.trim(),
-                cronExpression: form.cronExpression,
+                scheduleType: form.scheduleType,
+                cronExpression: form.scheduleType === "cron" ? form.cronExpression : "",
+                intervalMinutes: form.scheduleType === "interval" ? intervalMinutes : undefined,
                 timezone: form.timezone,
-                mode: form.mode,
                 autoApprove: form.autoApprove,
                 notification: {
                     type: form.notificationType,
@@ -154,41 +174,63 @@ export function ScheduledTaskDialog({ tenantId = "default", task, onSaved, trigg
 
                     <div className="space-y-1.5">
                         <Label>Schedule</Label>
-                        <CronPicker
-                            value={form.cronExpression}
-                            timezone={form.timezone}
-                            onValueChange={v => set("cronExpression", v)}
-                            onTimezoneChange={v => set("timezone", v)}
-                        />
+                        <Select value={form.scheduleType} onValueChange={v => set("scheduleType", v)}>
+                            <SelectTrigger>
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="cron">Cron schedule (specific times)</SelectItem>
+                                <SelectItem value="interval">Fixed interval (every N minutes/hours)</SelectItem>
+                            </SelectContent>
+                        </Select>
+                        {form.scheduleType === "cron" ? (
+                            <CronPicker
+                                value={form.cronExpression}
+                                timezone={form.timezone}
+                                onValueChange={v => set("cronExpression", v)}
+                                onTimezoneChange={v => set("timezone", v)}
+                            />
+                        ) : (
+                            <div className="space-y-1.5 pt-1">
+                                <div className="flex items-center gap-2">
+                                    <span className="text-sm text-muted-foreground">Every</span>
+                                    <Input
+                                        type="number"
+                                        min={1}
+                                        className="w-24"
+                                        value={form.intervalValue}
+                                        onChange={e => set("intervalValue", Number(e.target.value))}
+                                    />
+                                    <Select value={form.intervalUnit} onValueChange={v => set("intervalUnit", v)}>
+                                        <SelectTrigger className="w-32">
+                                            <SelectValue />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            <SelectItem value="minutes">minutes</SelectItem>
+                                            <SelectItem value="hours">hours</SelectItem>
+                                        </SelectContent>
+                                    </Select>
+                                </div>
+                                <p className="text-xs text-muted-foreground">
+                                    The next run fires this long after the previous run finishes. Minimum {MIN_INTERVAL_MINUTES} minutes.
+                                </p>
+                            </div>
+                        )}
                     </div>
 
-                    <div className="grid grid-cols-2 gap-4">
-                        <div className="space-y-1.5">
-                            <Label>Mode</Label>
-                            <Select value={form.mode} onValueChange={v => set("mode", v)}>
-                                <SelectTrigger>
-                                    <SelectValue />
-                                </SelectTrigger>
-                                <SelectContent>
-                                    <SelectItem value="plan">Plan (with approval)</SelectItem>
-                                    <SelectItem value="fast">Fast (direct execution)</SelectItem>
-                                </SelectContent>
-                            </Select>
-                        </div>
-                        <div className="space-y-1.5">
-                            <Label>Notification</Label>
-                            <Select value={form.notificationType} onValueChange={v => set("notificationType", v)}>
-                                <SelectTrigger>
-                                    <SelectValue />
-                                </SelectTrigger>
-                                <SelectContent>
-                                    <SelectItem value="none">None (web UI only)</SelectItem>
-                                    <SelectItem value="slack">Slack channel</SelectItem>
-                                    <SelectItem value="telegram">Telegram chat</SelectItem>
-                                    <SelectItem value="jira">Jira issue comment</SelectItem>
-                                </SelectContent>
-                            </Select>
-                        </div>
+                    <div className="space-y-1.5">
+                        <Label>Notification</Label>
+                        <Select value={form.notificationType} onValueChange={v => set("notificationType", v)}>
+                            <SelectTrigger>
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="none">None (web UI only)</SelectItem>
+                                <SelectItem value="slack">Slack channel</SelectItem>
+                                <SelectItem value="telegram">Telegram chat</SelectItem>
+                                <SelectItem value="jira">Jira issue comment</SelectItem>
+                            </SelectContent>
+                        </Select>
                     </div>
 
                     {form.notificationType === "slack" && (

--- a/apps/web-ui/components/channels/jira-settings-form.tsx
+++ b/apps/web-ui/components/channels/jira-settings-form.tsx
@@ -3,7 +3,8 @@
 import { useState } from 'react';
 import { useChannelSettings, useSaveChannelSettings, revealChannelSecrets } from '@/lib/queries/channel-settings';
 import { useRouter } from 'next/navigation';
-import { ArrowLeft, CheckCircle2, Copy, ExternalLink, Eye, EyeOff, Loader2, Save } from 'lucide-react';
+import { ArrowLeft, CheckCircle2, Copy, ExternalLink, Eye, EyeOff, Loader2, PlugZap, RefreshCw, Save } from 'lucide-react';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -11,6 +12,7 @@ import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
+import { SetupSteps } from '@/components/channels/setup-steps';
 
 interface JiraSettingsForm {
     webhookSecret: string;
@@ -25,6 +27,36 @@ interface JiraSettingsFormProps {
     backHref?: string;
     backLabel?: string;
 }
+
+const EXAMPLE_PAYLOAD = {
+    taskDescription: 'Check Lambda memory usage in prod',
+    accountId: '123456789012',
+    selectedSkill: 'aws-cost-optimization',
+    issue: {
+        key: 'OPS-42',
+        fields: {
+            summary: 'High Lambda costs detected',
+            project: { key: 'OPS' },
+            reporter: { displayName: 'Jane Doe' },
+            issuetype: { name: 'Task' },
+        },
+    },
+};
+
+// Template using Jira Automation smart values — paste directly into the
+// "Send web request" action's custom body so the payload fills itself per issue.
+const SMART_VALUE_PAYLOAD = `{
+  "taskDescription": "{{issue.summary}}",
+  "issue": {
+    "key": "{{issue.key}}",
+    "fields": {
+      "summary": "{{issue.summary}}",
+      "project": { "key": "{{project.key}}" },
+      "reporter": { "displayName": "{{issue.reporter.displayName}}" },
+      "issuetype": { "name": "{{issue.issueType.name}}" }
+    }
+  }
+}`;
 
 export function JiraSettingsForm(props: JiraSettingsFormProps) {
     const { data, isLoading } = useChannelSettings('jira');
@@ -71,6 +103,7 @@ function JiraSettingsFormInner({
     const [showSecret, setShowSecret] = useState(false);
     const [showApiToken, setShowApiToken] = useState(false);
     const [revealed, setRevealed] = useState(false);
+    const [testing, setTesting] = useState(false);
     const [copied, setCopied] = useState<string | null>(null);
 
     // Lazily pull the stored plaintext secrets into the form the first time the
@@ -100,6 +133,15 @@ function JiraSettingsFormInner({
             ? `${window.location.origin}/api/v1/trigger/jira`
             : '/api/v1/trigger/jira';
 
+    const generateSecret = () => {
+        const bytes = new Uint8Array(32);
+        crypto.getRandomValues(bytes);
+        const secret = Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
+        setForm(prev => ({ ...prev, webhookSecret: secret }));
+        setShowSecret(true);
+        toast.success('Webhook secret generated — save it here, then use the same value in your Jira Automation rule header');
+    };
+
     const handleSave = async () => {
         if (!configured && !form.webhookSecret.trim()) {
             setErrorMessage('Webhook Secret is required');
@@ -126,6 +168,35 @@ function JiraSettingsFormInner({
         } catch (error: any) {
             setErrorMessage(error.message || 'Failed to save');
             setSaveStatus('error');
+        }
+    };
+
+    const handleTestConnection = async () => {
+        setTesting(true);
+        try {
+            const res = await fetch('/api/agent-ops/settings/jira/test', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    baseUrl: form.baseUrl.trim() || undefined,
+                    userEmail: form.userEmail.trim() || undefined,
+                    apiToken: form.apiToken.trim() || undefined,
+                }),
+            });
+            const data = await res.json().catch(() => ({}));
+            if (res.ok && data.success) {
+                toast.success(`Connected to Jira as ${data.data.displayName}`);
+                if (!form.botAccountId.trim() && data.data.accountId) {
+                    setForm(prev => ({ ...prev, botAccountId: data.data.accountId }));
+                    toast.info('Bot Account ID auto-filled from the authenticated account — remember to save.');
+                }
+            } else {
+                toast.error(data.error || 'Connection test failed');
+            }
+        } catch {
+            toast.error('Connection test failed — network error');
+        } finally {
+            setTesting(false);
         }
     };
 
@@ -202,7 +273,7 @@ function JiraSettingsFormInner({
                     <CardDescription>
                         {configured
                             ? 'Enter new values to update stored credentials. Leave blank to keep existing values.'
-                            : 'Configure your Jira integration credentials. These are stored securely in DynamoDB.'}
+                            : 'Configure your Jira integration credentials. These are stored securely for your organization.'}
                     </CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-5">
@@ -211,37 +282,47 @@ function JiraSettingsFormInner({
                         <Label htmlFor="webhookSecret">
                             Webhook Secret <span className="text-destructive">*</span>
                         </Label>
-                        <div className="relative">
-                            <Input
-                                id="webhookSecret"
-                                type={showSecret ? 'text' : 'password'}
-                                placeholder={configured ? '••••••••••••' : 'Enter shared secret'}
-                                value={form.webhookSecret}
-                                onChange={e => setForm(prev => ({ ...prev, webhookSecret: e.target.value }))}
-                                className="pr-10 font-mono"
-                            />
-                            <Button
-                                type="button"
-                                variant="ghost"
-                                size="icon"
-                                className="absolute right-1 top-1/2 -translate-y-1/2 h-7 w-7"
-                                onClick={async () => {
-                                    if (!showSecret) await revealSecrets();
-                                    setShowSecret(v => !v);
-                                }}
-                            >
-                                {showSecret ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+                        <div className="flex items-center gap-2">
+                            <div className="relative flex-1">
+                                <Input
+                                    id="webhookSecret"
+                                    type={showSecret ? 'text' : 'password'}
+                                    placeholder={configured ? '••••••••••••' : 'Enter or generate a shared secret'}
+                                    value={form.webhookSecret}
+                                    onChange={e => setForm(prev => ({ ...prev, webhookSecret: e.target.value }))}
+                                    className="pr-10 font-mono"
+                                />
+                                <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="icon"
+                                    className="absolute right-1 top-1/2 -translate-y-1/2 h-7 w-7"
+                                    onClick={async () => {
+                                        if (!showSecret) await revealSecrets();
+                                        setShowSecret(v => !v);
+                                    }}
+                                >
+                                    {showSecret ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+                                </Button>
+                            </div>
+                            <Button type="button" variant="outline" size="sm" onClick={generateSecret}>
+                                <RefreshCw className="h-3.5 w-3.5 mr-2" />
+                                Generate
                             </Button>
                         </div>
                         <p className="text-xs text-muted-foreground">
-                            A secret you generate and then set as a custom header in your Jira Automation rule.
+                            A shared secret that authenticates incoming webhooks. Click{' '}
+                            <strong>Generate</strong> to create a strong one, then use the <em>same value</em> as the{' '}
+                            <code className="bg-muted px-1 rounded">Authorization: Bearer &lt;secret&gt;</code> header in
+                            your Jira Automation rule.
                         </p>
                     </div>
 
                     {/* Base URL */}
                     <div className="space-y-2">
                         <Label htmlFor="baseUrl">
-                            Jira Base URL <span className="text-muted-foreground text-xs">(optional)</span>
+                            Jira Base URL{' '}
+                            <span className="text-muted-foreground text-xs">(required to post results back)</span>
                         </Label>
                         <Input
                             id="baseUrl"
@@ -252,14 +333,16 @@ function JiraSettingsFormInner({
                             className="font-mono text-sm"
                         />
                         <p className="text-xs text-muted-foreground">
-                            Required to post run results back to Jira issues as comments.
+                            Your Jira Cloud site URL — the part before <code className="bg-muted px-1 rounded">/browse/…</code>{' '}
+                            when viewing any issue. Needed to post run results back to issues as comments.
                         </p>
                     </div>
 
                     {/* User Email */}
                     <div className="space-y-2">
                         <Label htmlFor="userEmail">
-                            User Email <span className="text-muted-foreground text-xs">(optional)</span>
+                            User Email{' '}
+                            <span className="text-muted-foreground text-xs">(required to post results back)</span>
                         </Label>
                         <Input
                             id="userEmail"
@@ -269,14 +352,16 @@ function JiraSettingsFormInner({
                             onChange={e => setForm(prev => ({ ...prev, userEmail: e.target.value }))}
                         />
                         <p className="text-xs text-muted-foreground">
-                            Atlassian account email used for API authentication.
+                            Email of the Atlassian account that owns the API token below. Comments will appear as this
+                            user — a dedicated bot/service account is recommended.
                         </p>
                     </div>
 
                     {/* API Token */}
                     <div className="space-y-2">
                         <Label htmlFor="apiToken">
-                            API Token <span className="text-muted-foreground text-xs">(optional)</span>
+                            API Token{' '}
+                            <span className="text-muted-foreground text-xs">(required to post results back)</span>
                         </Label>
                         <div className="relative">
                             <Input
@@ -300,15 +385,19 @@ function JiraSettingsFormInner({
                                 {showApiToken ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
                             </Button>
                         </div>
-                        <a
-                            href="https://id.atlassian.com/manage-profile/security/api-tokens"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="inline-flex items-center gap-1 text-xs text-blue-500 hover:underline"
-                        >
-                            Generate an Atlassian API token
-                            <ExternalLink className="h-3 w-3" />
-                        </a>
+                        <p className="text-xs text-muted-foreground">
+                            Sign in as the account above, then create a token at{' '}
+                            <a
+                                href="https://id.atlassian.com/manage-profile/security/api-tokens"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="inline-flex items-center gap-1 text-blue-500 hover:underline"
+                            >
+                                id.atlassian.com → Security → API tokens
+                                <ExternalLink className="h-3 w-3" />
+                            </a>{' '}
+                            → <strong>Create API token</strong>. Copy it immediately — Atlassian shows it only once.
+                        </p>
                     </div>
 
                     {/* Bot Account ID */}
@@ -326,8 +415,10 @@ function JiraSettingsFormInner({
                         />
                         <p className="text-xs text-muted-foreground">
                             Jira account ID of the bot user. Used to detect <code className="bg-muted px-1 rounded">@bot</code> mentions
-                            and prevent the bot from triggering itself on its own comments.
-                            Find it at <code className="bg-muted px-1 rounded">Jira → Profile → Account ID</code>.
+                            and prevent the bot from triggering itself on its own comments. Easiest way to fill it: enter
+                            the credentials above and click <strong>Test Connection</strong> — it is detected
+                            automatically. (Manual: open the bot user&apos;s profile in Jira; the ID is the last part of
+                            the profile URL after <code className="bg-muted px-1 rounded">/people/</code>.)
                         </p>
                     </div>
 
@@ -353,21 +444,43 @@ function JiraSettingsFormInner({
                         </Alert>
                     )}
 
-                    {/* Save button */}
-                    <Button
-                        onClick={handleSave}
-                        disabled={saving}
-                        className={saveStatus === 'saved' ? 'bg-green-600 hover:bg-green-700' : ''}
-                    >
-                        {saving ? (
-                            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                        ) : saveStatus === 'saved' ? (
-                            <CheckCircle2 className="h-4 w-4 mr-2" />
-                        ) : (
-                            <Save className="h-4 w-4 mr-2" />
-                        )}
-                        {saveStatus === 'saved' ? 'Saved' : 'Save Settings'}
-                    </Button>
+                    {/* Actions */}
+                    <div className="flex items-center gap-2">
+                        <Button
+                            onClick={handleSave}
+                            disabled={saving || testing}
+                            className={saveStatus === 'saved' ? 'bg-green-600 hover:bg-green-700' : ''}
+                        >
+                            {saving ? (
+                                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                            ) : saveStatus === 'saved' ? (
+                                <CheckCircle2 className="h-4 w-4 mr-2" />
+                            ) : (
+                                <Save className="h-4 w-4 mr-2" />
+                            )}
+                            {saveStatus === 'saved' ? 'Saved' : 'Save Settings'}
+                        </Button>
+                        <Button
+                            variant="outline"
+                            onClick={handleTestConnection}
+                            disabled={
+                                saving ||
+                                testing ||
+                                (!configured && !(form.baseUrl.trim() && form.userEmail.trim() && form.apiToken.trim()))
+                            }
+                        >
+                            {testing ? (
+                                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                            ) : (
+                                <PlugZap className="h-4 w-4 mr-2" />
+                            )}
+                            Test Connection
+                        </Button>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                        Test Connection verifies Base URL, User Email, and API Token against Jira and auto-fills the Bot
+                        Account ID on success.
+                    </p>
                 </CardContent>
             </Card>
 
@@ -380,88 +493,196 @@ function JiraSettingsFormInner({
                         <code className="bg-muted px-1 rounded">taskDescription</code> are optional.
                     </CardDescription>
                 </CardHeader>
-                <CardContent className="space-y-3">
-                    <pre className="bg-muted rounded-md p-4 text-xs overflow-x-auto">
-{`{
-  "taskDescription": "Check Lambda memory usage in prod",
-  "accountId": "123456789012",
-  "selectedSkill": "aws-cost-optimization",
-  "mode": "fast",
-  "issue": {
-    "key": "OPS-42",
-    "fields": {
-      "summary": "High Lambda costs detected",
-      "project": { "key": "OPS" },
-      "reporter": { "displayName": "Jane Doe" },
-      "issuetype": { "name": "Task" }
-    }
-  }
-}`}
-                    </pre>
-                    <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() =>
-                            copyToClipboard(
-                                JSON.stringify(
-                                    {
-                                        taskDescription: 'Check Lambda memory usage in prod',
-                                        accountId: '123456789012',
-                                        selectedSkill: 'aws-cost-optimization',
-                                        mode: 'fast',
-                                        issue: {
-                                            key: 'OPS-42',
-                                            fields: {
-                                                summary: 'High Lambda costs detected',
-                                                project: { key: 'OPS' },
-                                                reporter: { displayName: 'Jane Doe' },
-                                                issuetype: { name: 'Task' },
-                                            },
-                                        },
-                                    },
-                                    null,
-                                    2
-                                ),
-                                'payload'
-                            )
-                        }
-                    >
-                        {copied === 'payload' ? (
-                            <CheckCircle2 className="h-4 w-4 mr-2 text-green-500" />
-                        ) : (
-                            <Copy className="h-4 w-4 mr-2" />
-                        )}
-                        Copy example payload
-                    </Button>
+                <CardContent className="space-y-4">
+                    <div className="space-y-2">
+                        <p className="text-sm font-medium text-foreground">
+                            Automation template{' '}
+                            <span className="text-xs font-normal text-muted-foreground">
+                                — uses Jira smart values; paste as-is into the &quot;Send web request&quot; custom body
+                            </span>
+                        </p>
+                        <pre className="bg-muted rounded-md p-4 text-xs overflow-x-auto">{SMART_VALUE_PAYLOAD}</pre>
+                        <Button variant="outline" size="sm" onClick={() => copyToClipboard(SMART_VALUE_PAYLOAD, 'smart')}>
+                            {copied === 'smart' ? (
+                                <CheckCircle2 className="h-4 w-4 mr-2 text-green-500" />
+                            ) : (
+                                <Copy className="h-4 w-4 mr-2" />
+                            )}
+                            Copy automation template
+                        </Button>
+                    </div>
+                    <div className="space-y-2">
+                        <p className="text-sm font-medium text-foreground">
+                            Example resolved payload{' '}
+                            <span className="text-xs font-normal text-muted-foreground">
+                                — what the webhook receives; useful for testing with curl
+                            </span>
+                        </p>
+                        <pre className="bg-muted rounded-md p-4 text-xs overflow-x-auto">
+                            {JSON.stringify(EXAMPLE_PAYLOAD, null, 2)}
+                        </pre>
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => copyToClipboard(JSON.stringify(EXAMPLE_PAYLOAD, null, 2), 'payload')}
+                        >
+                            {copied === 'payload' ? (
+                                <CheckCircle2 className="h-4 w-4 mr-2 text-green-500" />
+                            ) : (
+                                <Copy className="h-4 w-4 mr-2" />
+                            )}
+                            Copy example payload
+                        </Button>
+                    </div>
                 </CardContent>
             </Card>
 
             {/* Setup Guide */}
             <Card>
                 <CardHeader>
-                    <CardTitle className="text-base">Setup Guide</CardTitle>
+                    <CardTitle className="text-base">Step-by-step Setup Guide</CardTitle>
+                    <CardDescription>
+                        Part 1 wires Jira → Agent Ops (trigger runs). Part 2 wires Agent Ops → Jira (result comments).
+                    </CardDescription>
                 </CardHeader>
-                <CardContent>
-                    <ol className="space-y-3 text-sm text-muted-foreground list-decimal list-inside">
-                        <li>Generate a random secret and enter it as the <strong className="text-foreground">Webhook Secret</strong> above.</li>
-                        <li>
-                            In Jira, go to <strong className="text-foreground">Project Settings → Automation</strong> and create a new rule.
-                        </li>
-                        <li>Add a trigger (e.g. "Issue created" or "Issue transitioned").</li>
-                        <li>
-                            Add a <strong className="text-foreground">Send web request</strong> action with the webhook URL above,
-                            method POST, and the JSON payload.
-                        </li>
-                        <li>
-                            Add a custom header <code className="bg-muted px-1 rounded text-foreground">Authorization</code> with value{' '}
-                            <code className="bg-muted px-1 rounded text-foreground">Bearer {'<your-secret>'}</code>.
-                        </li>
-                        <li>
-                            Optionally fill in <strong className="text-foreground">Base URL</strong>, <strong className="text-foreground">User Email</strong>,
-                            and <strong className="text-foreground">API Token</strong> above to enable result comments on Jira issues.
-                        </li>
-                        <li>Save and test the rule — results appear in Agent Ops and as issue comments.</li>
-                    </ol>
+                <CardContent className="space-y-6">
+                    <div className="space-y-4">
+                        <p className="text-sm font-semibold text-foreground">Part 1 — Trigger runs from Jira (required)</p>
+                        <SetupSteps
+                            steps={[
+                                {
+                                    title: 'Generate and save the Webhook Secret',
+                                    detail: (
+                                        <>
+                                            Click <strong className="text-foreground">Generate</strong> next to the
+                                            Webhook Secret field above, copy the value somewhere safe, and click{' '}
+                                            <strong className="text-foreground">Save Settings</strong>.
+                                        </>
+                                    ),
+                                },
+                                {
+                                    title: 'Create a Jira Automation rule',
+                                    detail: (
+                                        <>
+                                            In Jira, open{' '}
+                                            <strong className="text-foreground">Project settings → Automation</strong>{' '}
+                                            (or <strong className="text-foreground">Settings → System → Automation</strong>{' '}
+                                            for a global rule) and click{' '}
+                                            <strong className="text-foreground">Create rule</strong>.
+                                        </>
+                                    ),
+                                },
+                                {
+                                    title: 'Choose a trigger',
+                                    detail: (
+                                        <>
+                                            For example <strong className="text-foreground">Issue created</strong>,{' '}
+                                            <strong className="text-foreground">Issue transitioned</strong>, or{' '}
+                                            <strong className="text-foreground">Manually triggered</strong>. Optionally add
+                                            a condition (e.g. label = <code className="bg-muted px-1 rounded">agent-ops</code>)
+                                            so only selected issues trigger runs.
+                                        </>
+                                    ),
+                                },
+                                {
+                                    title: 'Add a "Send web request" action',
+                                    detail: (
+                                        <ul className="list-disc list-inside space-y-1">
+                                            <li>
+                                                <strong className="text-foreground">Web request URL</strong>: the Webhook
+                                                Endpoint shown at the top of this page
+                                            </li>
+                                            <li>
+                                                <strong className="text-foreground">HTTP method</strong>:{' '}
+                                                <code className="bg-muted px-1 rounded">POST</code>
+                                            </li>
+                                            <li>
+                                                <strong className="text-foreground">Web request body</strong>: Custom data →
+                                                paste the <em>Automation template</em> from the Webhook Payload card
+                                            </li>
+                                            <li>
+                                                <strong className="text-foreground">Headers</strong>: add{' '}
+                                                <code className="bg-muted px-1 rounded">Authorization</code> ={' '}
+                                                <code className="bg-muted px-1 rounded">Bearer &lt;your-secret&gt;</code>{' '}
+                                                (the Webhook Secret from step 1)
+                                            </li>
+                                        </ul>
+                                    ),
+                                },
+                                {
+                                    title: 'Publish and test the rule',
+                                    detail: (
+                                        <>
+                                            Use the rule&apos;s <strong className="text-foreground">Validate</strong>{' '}
+                                            button or create a test issue — the run appears under{' '}
+                                            <strong className="text-foreground">Agent Ops → Runs</strong> with source{' '}
+                                            <code className="bg-muted px-1 rounded">jira</code>.
+                                        </>
+                                    ),
+                                },
+                            ]}
+                        />
+                    </div>
+                    <div className="space-y-4">
+                        <p className="text-sm font-semibold text-foreground">
+                            Part 2 — Post results back to issues (recommended)
+                        </p>
+                        <SetupSteps
+                            startAt={6}
+                            steps={[
+                                {
+                                    title: 'Pick the bot account',
+                                    detail: (
+                                        <>
+                                            Use a dedicated Atlassian service account (recommended) or your own — run
+                                            results are posted as comments by this user.
+                                        </>
+                                    ),
+                                },
+                                {
+                                    title: 'Create an API token',
+                                    detail: (
+                                        <>
+                                            Signed in as that account, open{' '}
+                                            <a
+                                                href="https://id.atlassian.com/manage-profile/security/api-tokens"
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                className="inline-flex items-center gap-1 text-blue-500 hover:underline"
+                                            >
+                                                Atlassian account → Security → API tokens
+                                                <ExternalLink className="h-3 w-3" />
+                                            </a>{' '}
+                                            and click <strong className="text-foreground">Create API token</strong>. Copy
+                                            it right away — it is shown only once.
+                                        </>
+                                    ),
+                                },
+                                {
+                                    title: 'Fill in Base URL, User Email, and API Token',
+                                    detail: (
+                                        <>
+                                            Base URL is your site, e.g.{' '}
+                                            <code className="bg-muted px-1 rounded">https://your-org.atlassian.net</code>;
+                                            User Email is the bot account&apos;s email; API Token is the value from the
+                                            previous step.
+                                        </>
+                                    ),
+                                },
+                                {
+                                    title: 'Test and save',
+                                    detail: (
+                                        <>
+                                            Click <strong className="text-foreground">Test Connection</strong> — on
+                                            success the <strong className="text-foreground">Bot Account ID</strong> is
+                                            auto-filled (it prevents the bot from reacting to its own comments). Then
+                                            click <strong className="text-foreground">Save Settings</strong>.
+                                        </>
+                                    ),
+                                },
+                            ]}
+                        />
+                    </div>
                 </CardContent>
             </Card>
         </div>

--- a/apps/web-ui/components/channels/setup-steps.tsx
+++ b/apps/web-ui/components/channels/setup-steps.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+export interface SetupStep {
+    title: ReactNode;
+    detail?: ReactNode;
+}
+
+/**
+ * Numbered setup-guide step list shared by the channel settings pages.
+ * `startAt` lets a guide split into sections while keeping one running
+ * step sequence (e.g. Part 1 steps 1–5, Part 2 steps 6–9).
+ */
+export function SetupSteps({ steps, startAt = 1 }: { steps: SetupStep[]; startAt?: number }) {
+    return (
+        <ol className="space-y-4">
+            {steps.map((step, i) => (
+                <li key={i} className="flex gap-3">
+                    <span className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
+                        {startAt + i}
+                    </span>
+                    <div className="min-w-0 space-y-1">
+                        <div className="text-sm font-medium text-foreground">{step.title}</div>
+                        {step.detail && <div className="text-sm text-muted-foreground">{step.detail}</div>}
+                    </div>
+                </li>
+            ))}
+        </ol>
+    );
+}

--- a/apps/web-ui/components/channels/slack-settings-form.tsx
+++ b/apps/web-ui/components/channels/slack-settings-form.tsx
@@ -3,7 +3,8 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useChannelSettings, useSaveChannelSettings, revealChannelSecrets } from '@/lib/queries/channel-settings';
-import { ArrowLeft, CheckCircle2, Copy, Eye, EyeOff, Loader2, Save } from 'lucide-react';
+import { ArrowLeft, CheckCircle2, Copy, Eye, EyeOff, Loader2, PlugZap, Save } from 'lucide-react';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -11,6 +12,7 @@ import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
+import { SetupSteps } from '@/components/channels/setup-steps';
 
 interface SlackSettingsState {
     signingSecret: string;
@@ -56,7 +58,8 @@ function SlackSettingsFormInner({
     const [showSigningSecret, setShowSigningSecret] = useState(false);
     const [showBotToken, setShowBotToken] = useState(false);
     const [revealed, setRevealed] = useState(false);
-    const [copied, setCopied] = useState(false);
+    const [testing, setTesting] = useState(false);
+    const [copied, setCopied] = useState<string | null>(null);
 
     // Lazily pull the stored plaintext secrets into the form the first time the
     // user reveals a field (only when already configured and untouched).
@@ -77,10 +80,43 @@ function SlackSettingsFormInner({
         enabled: initialEnabled,
     });
 
-    const webhookUrl =
-        typeof window !== 'undefined'
-            ? `${window.location.origin}/api/v1/trigger/slack`
-            : '/api/v1/trigger/slack';
+    const origin = typeof window !== 'undefined' ? window.location.origin : '';
+    const webhookUrl = `${origin}/api/v1/trigger/slack`;
+    const interactionsUrl = `${origin}/api/v1/gateway/slack/interactions`;
+
+    // App manifest pre-wires the slash command, bot scopes, and interactivity
+    // endpoint so "Create app → From a manifest" needs zero manual configuration.
+    const appManifest = JSON.stringify(
+        {
+            display_information: {
+                name: 'Nucleus Cloud Ops',
+                description: 'AI Ops agent — trigger cloud operations tasks and receive results in Slack',
+            },
+            features: {
+                bot_user: { display_name: 'nucleus-cloud-ops', always_online: true },
+                slash_commands: [
+                    {
+                        command: '/cloud-ops',
+                        url: webhookUrl,
+                        description: 'Run an Agent Ops task',
+                        usage_hint: 'check EC2 costs in prod',
+                        should_escape: false,
+                    },
+                ],
+            },
+            oauth_config: {
+                scopes: { bot: ['commands', 'chat:write', 'chat:write.public'] },
+            },
+            settings: {
+                interactivity: { is_enabled: true, request_url: interactionsUrl },
+                org_deploy_enabled: false,
+                socket_mode_enabled: false,
+                token_rotation_enabled: false,
+            },
+        },
+        null,
+        2
+    );
 
     const handleSave = async () => {
         if (!configured && !form.signingSecret.trim()) {
@@ -108,10 +144,31 @@ function SlackSettingsFormInner({
         }
     };
 
-    const copyToClipboard = (text: string) => {
+    const handleTestConnection = async () => {
+        setTesting(true);
+        try {
+            const res = await fetch('/api/agent-ops/settings/slack/test', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ botToken: form.botToken.trim() || undefined }),
+            });
+            const data = await res.json().catch(() => ({}));
+            if (res.ok && data.success) {
+                toast.success(`Connected to workspace "${data.data.team}" as @${data.data.botUser}`);
+            } else {
+                toast.error(data.error || 'Connection test failed');
+            }
+        } catch {
+            toast.error('Connection test failed — network error');
+        } finally {
+            setTesting(false);
+        }
+    };
+
+    const copyToClipboard = (text: string, key: string) => {
         navigator.clipboard.writeText(text);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
+        setCopied(key);
+        setTimeout(() => setCopied(null), 2000);
     };
 
     return (
@@ -132,7 +189,8 @@ function SlackSettingsFormInner({
                 <div>
                     <h1 className="text-2xl font-bold">Slack Integration</h1>
                     <p className="text-muted-foreground mt-1">
-                        Configure your Slack app to trigger Agent Ops runs via slash commands.
+                        Trigger Agent Ops runs via slash commands and receive results, scheduled digests, and approval
+                        requests in your channels.
                     </p>
                 </div>
                 {configured && (
@@ -154,13 +212,35 @@ function SlackSettingsFormInner({
                 <CardContent>
                     <div className="flex items-center gap-2">
                         <Input readOnly value={webhookUrl} className="font-mono text-sm" />
-                        <Button variant="outline" size="icon" onClick={() => copyToClipboard(webhookUrl)}>
-                            {copied ? <CheckCircle2 className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
+                        <Button variant="outline" size="icon" onClick={() => copyToClipboard(webhookUrl, 'webhook')}>
+                            {copied === 'webhook' ? <CheckCircle2 className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
                         </Button>
                     </div>
                     <p className="text-xs text-muted-foreground mt-2">
                         Method: <code className="bg-muted px-1 rounded">POST</code>
                     </p>
+                </CardContent>
+            </Card>
+
+            {/* App Manifest */}
+            <Card>
+                <CardHeader>
+                    <CardTitle className="text-base">App Manifest — quick create</CardTitle>
+                    <CardDescription>
+                        The fastest way to set up: create your Slack app <strong>from this manifest</strong> and the
+                        slash command, bot scopes, and interactivity endpoint are configured automatically.
+                    </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                    <pre className="bg-muted rounded-md p-4 text-xs overflow-x-auto max-h-64">{appManifest}</pre>
+                    <Button variant="outline" size="sm" onClick={() => copyToClipboard(appManifest, 'manifest')}>
+                        {copied === 'manifest' ? (
+                            <CheckCircle2 className="h-4 w-4 mr-2 text-green-500" />
+                        ) : (
+                            <Copy className="h-4 w-4 mr-2" />
+                        )}
+                        Copy app manifest
+                    </Button>
                 </CardContent>
             </Card>
 
@@ -171,7 +251,7 @@ function SlackSettingsFormInner({
                     <CardDescription>
                         {configured
                             ? 'Enter new values to update the stored credentials. Leave blank to keep existing values.'
-                            : 'Enter your Slack app credentials. These are encrypted and stored securely.'}
+                            : 'Enter your Slack app credentials. These are stored securely for your organization.'}
                     </CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-5">
@@ -203,14 +283,15 @@ function SlackSettingsFormInner({
                             </Button>
                         </div>
                         <p className="text-xs text-muted-foreground">
-                            Found in your Slack app under <strong>Basic Information → App Credentials</strong>.
+                            Verifies that incoming requests really come from Slack. Found in your Slack app under{' '}
+                            <strong>Basic Information → App Credentials → Signing Secret</strong>.
                         </p>
                     </div>
 
                     {/* Bot Token */}
                     <div className="space-y-2">
                         <Label htmlFor="botToken">
-                            Bot Token <span className="text-muted-foreground text-xs">(optional)</span>
+                            Bot Token <span className="text-muted-foreground text-xs">(recommended)</span>
                         </Label>
                         <div className="relative">
                             <Input
@@ -235,7 +316,11 @@ function SlackSettingsFormInner({
                             </Button>
                         </div>
                         <p className="text-xs text-muted-foreground">
-                            Required only for proactive messages. Found under <strong>OAuth & Permissions → Bot User OAuth Token</strong>.
+                            Needed to post run results, scheduled-task digests, and approval buttons back to Slack
+                            (requires the <code className="bg-muted px-1 rounded">chat:write</code> scope). After
+                            installing the app, copy it from <strong>OAuth &amp; Permissions → Bot User OAuth Token</strong>{' '}
+                            (starts with <code className="bg-muted px-1 rounded">xoxb-</code>). Without it, only
+                            ephemeral replies to slash commands work.
                         </p>
                     </div>
 
@@ -261,41 +346,135 @@ function SlackSettingsFormInner({
                         </Alert>
                     )}
 
-                    {/* Save button */}
-                    <Button
-                        onClick={handleSave}
-                        disabled={saving}
-                        className={saveStatus === 'saved' ? 'bg-green-600 hover:bg-green-700' : ''}
-                    >
-                        {saving ? (
-                            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                        ) : saveStatus === 'saved' ? (
-                            <CheckCircle2 className="h-4 w-4 mr-2" />
-                        ) : (
-                            <Save className="h-4 w-4 mr-2" />
-                        )}
-                        {saveStatus === 'saved' ? 'Saved' : 'Save Settings'}
-                    </Button>
+                    {/* Actions */}
+                    <div className="flex items-center gap-2">
+                        <Button
+                            onClick={handleSave}
+                            disabled={saving || testing}
+                            className={saveStatus === 'saved' ? 'bg-green-600 hover:bg-green-700' : ''}
+                        >
+                            {saving ? (
+                                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                            ) : saveStatus === 'saved' ? (
+                                <CheckCircle2 className="h-4 w-4 mr-2" />
+                            ) : (
+                                <Save className="h-4 w-4 mr-2" />
+                            )}
+                            {saveStatus === 'saved' ? 'Saved' : 'Save Settings'}
+                        </Button>
+                        <Button
+                            variant="outline"
+                            onClick={handleTestConnection}
+                            disabled={saving || testing || (!configured && !form.botToken.trim())}
+                        >
+                            {testing ? (
+                                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                            ) : (
+                                <PlugZap className="h-4 w-4 mr-2" />
+                            )}
+                            Test Connection
+                        </Button>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                        Test Connection verifies the Bot Token against Slack&apos;s{' '}
+                        <code className="bg-muted px-1 rounded">auth.test</code> API — enter a token above or save one
+                        first.
+                    </p>
                 </CardContent>
             </Card>
 
             {/* Setup Guide */}
             <Card>
                 <CardHeader>
-                    <CardTitle className="text-base">Setup Guide</CardTitle>
+                    <CardTitle className="text-base">Step-by-step Setup Guide</CardTitle>
+                    <CardDescription>From zero to a working Slack integration in about five minutes.</CardDescription>
                 </CardHeader>
                 <CardContent>
-                    <ol className="space-y-3 text-sm text-muted-foreground list-decimal list-inside">
-                        <li>
-                            Go to <a href="https://api.slack.com/apps" target="_blank" rel="noopener noreferrer" className="text-blue-500 hover:underline">api.slack.com/apps</a> and create a new app.
-                        </li>
-                        <li>Under <strong className="text-foreground">Basic Information</strong>, copy the <strong className="text-foreground">Signing Secret</strong> and paste it above.</li>
-                        <li>
-                            Under <strong className="text-foreground">Slash Commands</strong>, create a new command (e.g. <code className="bg-muted px-1 rounded text-foreground">/cloud-ops</code>).
-                        </li>
-                        <li>Set the <strong className="text-foreground">Request URL</strong> to the Slash Command URL shown above.</li>
-                        <li>Install the app to your workspace and test the slash command.</li>
-                    </ol>
+                    <SetupSteps
+                        steps={[
+                            {
+                                title: 'Create the Slack app',
+                                detail: (
+                                    <>
+                                        Go to{' '}
+                                        <a
+                                            href="https://api.slack.com/apps"
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="text-blue-500 hover:underline"
+                                        >
+                                            api.slack.com/apps
+                                        </a>{' '}
+                                        → <strong className="text-foreground">Create New App</strong> →{' '}
+                                        <strong className="text-foreground">From a manifest</strong>. Pick your
+                                        workspace, choose JSON, and paste the App Manifest from the card above — this
+                                        auto-configures the slash command, bot scopes, and interactivity endpoint.
+                                    </>
+                                ),
+                            },
+                            {
+                                title: 'Copy the Signing Secret',
+                                detail: (
+                                    <>
+                                        In the app&apos;s settings, open{' '}
+                                        <strong className="text-foreground">Basic Information</strong>, scroll to{' '}
+                                        <strong className="text-foreground">App Credentials</strong>, click{' '}
+                                        <strong className="text-foreground">Show</strong> next to Signing Secret, and
+                                        paste it into the field above.
+                                    </>
+                                ),
+                            },
+                            {
+                                title: 'Install the app to your workspace',
+                                detail: (
+                                    <>
+                                        Open <strong className="text-foreground">Install App</strong> in the sidebar and
+                                        click <strong className="text-foreground">Install to Workspace</strong>, then
+                                        authorize the requested scopes (
+                                        <code className="bg-muted px-1 rounded">commands</code>,{' '}
+                                        <code className="bg-muted px-1 rounded">chat:write</code>,{' '}
+                                        <code className="bg-muted px-1 rounded">chat:write.public</code>).
+                                    </>
+                                ),
+                            },
+                            {
+                                title: 'Copy the Bot Token',
+                                detail: (
+                                    <>
+                                        After installation, go to{' '}
+                                        <strong className="text-foreground">OAuth &amp; Permissions</strong> and copy the{' '}
+                                        <strong className="text-foreground">Bot User OAuth Token</strong> (starts with{' '}
+                                        <code className="bg-muted px-1 rounded">xoxb-</code>) into the field above.
+                                    </>
+                                ),
+                            },
+                            {
+                                title: 'Invite the bot to your channel',
+                                detail: (
+                                    <>
+                                        In the Slack channel that should receive results or scheduled digests, run{' '}
+                                        <code className="bg-muted px-1 rounded">/invite @nucleus-cloud-ops</code>. To get
+                                        the <strong className="text-foreground">Channel ID</strong> (needed when
+                                        configuring a scheduled task&apos;s Slack notification): click the channel name
+                                        → scroll to the bottom of the About tab → copy the ID starting with{' '}
+                                        <code className="bg-muted px-1 rounded">C</code>.
+                                    </>
+                                ),
+                            },
+                            {
+                                title: 'Save, test, and run',
+                                detail: (
+                                    <>
+                                        Click <strong className="text-foreground">Save Settings</strong>, then{' '}
+                                        <strong className="text-foreground">Test Connection</strong> to verify the bot
+                                        token. Finally, try{' '}
+                                        <code className="bg-muted px-1 rounded">/cloud-ops check EC2 costs in prod</code>{' '}
+                                        in Slack.
+                                    </>
+                                ),
+                            },
+                        ]}
+                    />
                 </CardContent>
             </Card>
         </div>

--- a/apps/web-ui/components/channels/telegram-settings-form.tsx
+++ b/apps/web-ui/components/channels/telegram-settings-form.tsx
@@ -3,7 +3,8 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useChannelSettings, useSaveChannelSettings, revealChannelSecrets } from '@/lib/queries/channel-settings';
-import { ArrowLeft, CheckCircle2, Copy, Eye, EyeOff, Loader2, Save } from 'lucide-react';
+import { ArrowLeft, CheckCircle2, Copy, Eye, EyeOff, Loader2, PlugZap, RefreshCw, Save, Webhook } from 'lucide-react';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -11,6 +12,7 @@ import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
+import { SetupSteps } from '@/components/channels/setup-steps';
 
 interface TelegramSettingsState {
     botToken: string;
@@ -57,6 +59,8 @@ function TelegramSettingsFormInner({
     const [showSecretToken, setShowSecretToken] = useState(false);
     const [revealed, setRevealed] = useState(false);
     const [copied, setCopied] = useState(false);
+    const [testing, setTesting] = useState(false);
+    const [registering, setRegistering] = useState(false);
 
     // Lazily pull the stored plaintext secrets into the form the first time the
     // user reveals a field (only when already configured and untouched).
@@ -81,6 +85,16 @@ function TelegramSettingsFormInner({
         typeof window !== 'undefined'
             ? `${window.location.origin}/api/v1/gateway/telegram`
             : '/api/v1/gateway/telegram';
+
+    // Telegram secret tokens allow only A-Z a-z 0-9 _ - — hex satisfies that.
+    const generateSecret = () => {
+        const bytes = new Uint8Array(32);
+        crypto.getRandomValues(bytes);
+        const secret = Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
+        setForm(prev => ({ ...prev, secretToken: secret }));
+        setShowSecretToken(true);
+        toast.success('Secret token generated — save it here, then it verifies incoming Telegram webhook requests');
+    };
 
     const handleSave = async () => {
         // When already configured, blank fields keep existing stored values.
@@ -116,6 +130,57 @@ function TelegramSettingsFormInner({
         }
     };
 
+    const handleTestConnection = async () => {
+        setTesting(true);
+        try {
+            const res = await fetch('/api/agent-ops/settings/telegram/test', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ botToken: form.botToken.trim() || undefined }),
+            });
+            const data = await res.json().catch(() => ({}));
+            if (res.ok && data.success) {
+                toast.success(`Connected as @${data.data.botUsername}`);
+                if (!data.data.webhook.isSet) {
+                    toast.info('Webhook not registered yet — click "Register Webhook" below.');
+                } else if (data.data.webhook.lastErrorMessage) {
+                    toast.warning(`Telegram reported a webhook error: ${data.data.webhook.lastErrorMessage}`);
+                }
+            } else {
+                toast.error(data.error || 'Connection test failed');
+            }
+        } catch {
+            toast.error('Connection test failed — network error');
+        } finally {
+            setTesting(false);
+        }
+    };
+
+    const handleRegisterWebhook = async () => {
+        setRegistering(true);
+        try {
+            const res = await fetch('/api/agent-ops/settings/telegram/webhook', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    webhookUrl,
+                    botToken: form.botToken.trim() || undefined,
+                    secretToken: form.secretToken.trim() || undefined,
+                }),
+            });
+            const data = await res.json().catch(() => ({}));
+            if (res.ok && data.success) {
+                toast.success('Webhook registered with Telegram');
+            } else {
+                toast.error(data.error || 'Failed to register webhook');
+            }
+        } catch {
+            toast.error('Failed to register webhook — network error');
+        } finally {
+            setRegistering(false);
+        }
+    };
+
     const copyToClipboard = (text: string) => {
         navigator.clipboard.writeText(text);
         setCopied(true);
@@ -140,7 +205,8 @@ function TelegramSettingsFormInner({
                 <div>
                     <h1 className="text-2xl font-bold">Telegram Integration</h1>
                     <p className="text-muted-foreground mt-1">
-                        Configure your Telegram bot to trigger Agent Ops runs via messages.
+                        Trigger Agent Ops runs by messaging your bot and receive scheduled-task digests and approval
+                        requests in Telegram.
                     </p>
                 </div>
                 {configured && (
@@ -159,16 +225,35 @@ function TelegramSettingsFormInner({
                         Use this URL when setting up the Telegram bot webhook.
                     </CardDescription>
                 </CardHeader>
-                <CardContent>
+                <CardContent className="space-y-3">
                     <div className="flex items-center gap-2">
                         <Input readOnly value={webhookUrl} className="font-mono text-sm" />
                         <Button variant="outline" size="icon" onClick={() => copyToClipboard(webhookUrl)}>
                             {copied ? <CheckCircle2 className="h-4 w-4 text-green-500" /> : <Copy className="h-4 w-4" />}
                         </Button>
                     </div>
-                    <p className="text-xs text-muted-foreground mt-2">
+                    <p className="text-xs text-muted-foreground">
                         Method: <code className="bg-muted px-1 rounded">POST</code>
                     </p>
+                    <div>
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={handleRegisterWebhook}
+                            disabled={saving || registering || (!configured && !(form.botToken.trim() && form.secretToken.trim()))}
+                        >
+                            {registering ? (
+                                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                            ) : (
+                                <Webhook className="h-4 w-4 mr-2" />
+                            )}
+                            Register Webhook
+                        </Button>
+                        <p className="text-xs text-muted-foreground mt-2">
+                            One-click registration with Telegram. Works only after the Bot Token and Secret Token are
+                            saved (or typed above), and the app must be reachable over HTTPS.
+                        </p>
+                    </div>
                 </CardContent>
             </Card>
 
@@ -179,7 +264,7 @@ function TelegramSettingsFormInner({
                     <CardDescription>
                         {configured
                             ? 'Enter new values to update the stored credentials. Leave blank to keep existing values.'
-                            : 'Enter your Telegram bot credentials. These are encrypted and stored securely.'}
+                            : 'Enter your Telegram bot credentials. These are stored securely for your organization.'}
                     </CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-5">
@@ -192,7 +277,7 @@ function TelegramSettingsFormInner({
                             <Input
                                 id="botToken"
                                 type={showBotToken ? 'text' : 'password'}
-                                placeholder={configured ? '••••••••••••' : 'Enter bot token'}
+                                placeholder={configured ? '••••••••••••' : '123456789:AA...'}
                                 value={form.botToken}
                                 onChange={e => setForm(prev => ({ ...prev, botToken: e.target.value }))}
                                 className="pr-10 font-mono"
@@ -211,7 +296,8 @@ function TelegramSettingsFormInner({
                             </Button>
                         </div>
                         <p className="text-xs text-muted-foreground">
-                            Get this from <strong>@BotFather</strong> on Telegram.
+                            Get this from <strong>@BotFather</strong> when you create a bot (looks like{' '}
+                            <code className="bg-muted px-1 rounded">123456789:AA...</code>).
                         </p>
                     </div>
 
@@ -220,30 +306,40 @@ function TelegramSettingsFormInner({
                         <Label htmlFor="secretToken">
                             Secret Token <span className="text-destructive">*</span>
                         </Label>
-                        <div className="relative">
-                            <Input
-                                id="secretToken"
-                                type={showSecretToken ? 'text' : 'password'}
-                                placeholder={configured ? '••••••••••••' : 'Enter secret token'}
-                                value={form.secretToken}
-                                onChange={e => setForm(prev => ({ ...prev, secretToken: e.target.value }))}
-                                className="pr-10 font-mono"
-                            />
-                            <Button
-                                type="button"
-                                variant="ghost"
-                                size="icon"
-                                className="absolute right-1 top-1/2 -translate-y-1/2 h-7 w-7"
-                                onClick={async () => {
-                                    if (!showSecretToken) await revealSecrets();
-                                    setShowSecretToken(v => !v);
-                                }}
-                            >
-                                {showSecretToken ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+                        <div className="flex items-center gap-2">
+                            <div className="relative flex-1">
+                                <Input
+                                    id="secretToken"
+                                    type={showSecretToken ? 'text' : 'password'}
+                                    placeholder={configured ? '••••••••••••' : 'Enter or generate a secret token'}
+                                    value={form.secretToken}
+                                    onChange={e => setForm(prev => ({ ...prev, secretToken: e.target.value }))}
+                                    className="pr-10 font-mono"
+                                />
+                                <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="icon"
+                                    className="absolute right-1 top-1/2 -translate-y-1/2 h-7 w-7"
+                                    onClick={async () => {
+                                        if (!showSecretToken) await revealSecrets();
+                                        setShowSecretToken(v => !v);
+                                    }}
+                                >
+                                    {showSecretToken ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+                                </Button>
+                            </div>
+                            <Button type="button" variant="outline" size="sm" onClick={generateSecret}>
+                                <RefreshCw className="h-3.5 w-3.5 mr-2" />
+                                Generate
                             </Button>
                         </div>
                         <p className="text-xs text-muted-foreground">
-                            Used to verify webhook requests. Choose any random string.
+                            Telegram echoes this back in the{' '}
+                            <code className="bg-muted px-1 rounded">X-Telegram-Bot-Api-Secret-Token</code> header on every
+                            webhook request, so the platform can verify the request genuinely came from Telegram. Click{' '}
+                            <strong>Generate</strong> for a strong value. Allowed characters:{' '}
+                            <code className="bg-muted px-1 rounded">A-Z a-z 0-9 _ -</code>.
                         </p>
                     </div>
 
@@ -269,49 +365,147 @@ function TelegramSettingsFormInner({
                         </Alert>
                     )}
 
-                    {/* Save button */}
-                    <Button
-                        onClick={handleSave}
-                        disabled={saving}
-                        className={saveStatus === 'saved' ? 'bg-green-600 hover:bg-green-700' : ''}
-                    >
-                        {saving ? (
-                            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                        ) : saveStatus === 'saved' ? (
-                            <CheckCircle2 className="h-4 w-4 mr-2" />
-                        ) : (
-                            <Save className="h-4 w-4 mr-2" />
-                        )}
-                        {saveStatus === 'saved' ? 'Saved' : 'Save Settings'}
-                    </Button>
+                    {/* Actions */}
+                    <div className="flex items-center gap-2">
+                        <Button
+                            onClick={handleSave}
+                            disabled={saving || testing}
+                            className={saveStatus === 'saved' ? 'bg-green-600 hover:bg-green-700' : ''}
+                        >
+                            {saving ? (
+                                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                            ) : saveStatus === 'saved' ? (
+                                <CheckCircle2 className="h-4 w-4 mr-2" />
+                            ) : (
+                                <Save className="h-4 w-4 mr-2" />
+                            )}
+                            {saveStatus === 'saved' ? 'Saved' : 'Save Settings'}
+                        </Button>
+                        <Button
+                            variant="outline"
+                            onClick={handleTestConnection}
+                            disabled={saving || testing || (!configured && !form.botToken.trim())}
+                        >
+                            {testing ? (
+                                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                            ) : (
+                                <PlugZap className="h-4 w-4 mr-2" />
+                            )}
+                            Test Connection
+                        </Button>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                        Test Connection verifies the Bot Token against Telegram&apos;s{' '}
+                        <code className="bg-muted px-1 rounded">getMe</code> API and reports whether the webhook is
+                        registered — enter a token above or save one first.
+                    </p>
                 </CardContent>
             </Card>
 
             {/* Setup Guide */}
             <Card>
                 <CardHeader>
-                    <CardTitle className="text-base">Setup Guide</CardTitle>
+                    <CardTitle className="text-base">Step-by-step Setup Guide</CardTitle>
+                    <CardDescription>From zero to a working Telegram integration in a few minutes.</CardDescription>
                 </CardHeader>
                 <CardContent>
-                    <ol className="space-y-3 text-sm text-muted-foreground list-decimal list-inside">
-                        <li>
-                            Open Telegram and message <strong className="text-foreground">@BotFather</strong>.
-                        </li>
-                        <li>
-                            Send <code className="bg-muted px-1 rounded text-foreground">/newbot</code> and follow the prompts to create a bot.
-                        </li>
-                        <li>Copy the <strong className="text-foreground">Bot Token</strong> provided by BotFather and paste it above.</li>
-                        <li>Choose a <strong className="text-foreground">Secret Token</strong> (any random string) for webhook verification and enter it above.</li>
-                        <li>
-                            Set the webhook URL by calling:{' '}
-                            <code className="bg-muted px-1 rounded text-foreground text-xs break-all">
-                                https://api.telegram.org/bot&#123;YOUR_TOKEN&#125;/setWebhook?url=&#123;WEBHOOK_URL&#125;&secret_token=&#123;SECRET_TOKEN&#125;
-                            </code>
-                        </li>
-                        <li>
-                            Test by sending <code className="bg-muted px-1 rounded text-foreground">/cloudops Check Lambda configs</code> to your bot.
-                        </li>
-                    </ol>
+                    <SetupSteps
+                        steps={[
+                            {
+                                title: 'Create the bot',
+                                detail: (
+                                    <>
+                                        Open Telegram and message{' '}
+                                        <a
+                                            href="https://t.me/BotFather"
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="text-blue-500 hover:underline"
+                                        >
+                                            @BotFather
+                                        </a>
+                                        , send <code className="bg-muted px-1 rounded">/newbot</code>, and follow the
+                                        prompts to name your bot and pick a username.
+                                    </>
+                                ),
+                            },
+                            {
+                                title: 'Copy the Bot Token',
+                                detail: (
+                                    <>
+                                        BotFather replies with a token like{' '}
+                                        <code className="bg-muted px-1 rounded">123456789:AA...</code> — paste it into the{' '}
+                                        <strong className="text-foreground">Bot Token</strong> field above.
+                                    </>
+                                ),
+                            },
+                            {
+                                title: 'Generate a Secret Token',
+                                detail: (
+                                    <>
+                                        Click <strong className="text-foreground">Generate</strong> next to the Secret
+                                        Token field to create a strong value used to verify incoming webhook requests.
+                                    </>
+                                ),
+                            },
+                            {
+                                title: 'Save Settings',
+                                detail: (
+                                    <>
+                                        Click <strong className="text-foreground">Save Settings</strong> to store the Bot
+                                        Token and Secret Token for your organization.
+                                    </>
+                                ),
+                            },
+                            {
+                                title: 'Register the webhook',
+                                detail: (
+                                    <>
+                                        Click <strong className="text-foreground">Register Webhook</strong> in the Webhook
+                                        URL card above to register it with Telegram automatically. If you prefer to do it
+                                        manually, open this URL in a browser (replace the placeholders):
+                                        <code className="mt-2 block bg-muted px-1 rounded text-xs break-all">
+                                            https://api.telegram.org/bot&#123;YOUR_TOKEN&#125;/setWebhook?url=&#123;WEBHOOK_URL&#125;&secret_token=&#123;SECRET_TOKEN&#125;
+                                        </code>
+                                    </>
+                                ),
+                            },
+                            {
+                                title: 'Get your Chat ID',
+                                detail: (
+                                    <>
+                                        Needed when a scheduled task should send its digest to Telegram: message the bot
+                                        (or add it to a group), then open{' '}
+                                        <code className="bg-muted px-1 rounded text-xs break-all">
+                                            https://api.telegram.org/bot&#123;TOKEN&#125;/getUpdates
+                                        </code>{' '}
+                                        and read <code className="bg-muted px-1 rounded">message.chat.id</code> (group IDs
+                                        are negative). Alternatively, message{' '}
+                                        <a
+                                            href="https://t.me/userinfobot"
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="text-blue-500 hover:underline"
+                                        >
+                                            @userinfobot
+                                        </a>{' '}
+                                        for your personal chat ID.
+                                    </>
+                                ),
+                            },
+                            {
+                                title: 'Test',
+                                detail: (
+                                    <>
+                                        Click <strong className="text-foreground">Test Connection</strong> to verify the
+                                        token, then send{' '}
+                                        <code className="bg-muted px-1 rounded">/cloudops Check Lambda configs</code> to the
+                                        bot.
+                                    </>
+                                ),
+                            },
+                        ]}
+                    />
                 </CardContent>
             </Card>
         </div>

--- a/apps/web-ui/components/memory/memory-client-component.tsx
+++ b/apps/web-ui/components/memory/memory-client-component.tsx
@@ -41,9 +41,19 @@ function confidenceVariant(c: string | null): "default" | "secondary" | "outline
     return "outline";
 }
 
+function formatDateTime(iso: string): string {
+    return new Date(iso).toLocaleString(undefined, {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+    });
+}
+
 export function MemoryClientComponent() {
     const [pagination, setPagination] = useState<PaginationState>({ pageIndex: 0, pageSize: 10 });
-    const [sorting, setSorting] = useState<SortingState>([]);
+    const [sorting, setSorting] = useState<SortingState>([{ id: 'createdAt', desc: true }]);
     const [searchInput, setSearchInput] = useState("");
     const search = useDebounce(searchInput, 300);
     const [categories, setCategories] = useState<MemoryCategory[]>([]);
@@ -147,7 +157,16 @@ export function MemoryClientComponent() {
                 header: ({ column }) => <DataTableColumnHeader column={column} title="Created" />,
                 cell: ({ row }) => (
                     <span className="whitespace-nowrap text-sm text-muted-foreground">
-                        {new Date(row.original.createdAt).toLocaleDateString()}
+                        {formatDateTime(row.original.createdAt)}
+                    </span>
+                ),
+            },
+            {
+                accessorKey: "updatedAt",
+                header: ({ column }) => <DataTableColumnHeader column={column} title="Updated" />,
+                cell: ({ row }) => (
+                    <span className="whitespace-nowrap text-sm text-muted-foreground">
+                        {formatDateTime(row.original.updatedAt)}
                     </span>
                 ),
             },
@@ -156,7 +175,7 @@ export function MemoryClientComponent() {
                 header: ({ column }) => <DataTableColumnHeader column={column} title="Expires" />,
                 cell: ({ row }) => (
                     <span className="whitespace-nowrap text-sm text-muted-foreground">
-                        {new Date(row.original.expiresAt).toLocaleDateString()}
+                        {formatDateTime(row.original.expiresAt)}
                     </span>
                 ),
             },

--- a/apps/web-ui/lib/agent-ops/agent-executor.ts
+++ b/apps/web-ui/lib/agent-ops/agent-executor.ts
@@ -14,6 +14,29 @@ import * as path from 'path';
 import { HumanMessage } from '@langchain/core/messages';
 import { createDynamicExecutorGraph } from './executor-graphs';
 import { resolveModelConfig, resolveDefaultModelConfig } from '../agent/model-resolver';
+import { getAgentOpsDefaults, resolveMaxIterations } from './agent-ops-defaults';
+import type { ResolvedModelConfig } from '../agent/agent-shared';
+
+/**
+ * Resolve the model for a run, honoring the Agent Ops per-tenant default:
+ *   1. explicit run.model (scheduled task / New Run dialog) — always wins
+ *   2. tenant Agent Ops default model (Settings → Agent Defaults)
+ *   3. tenant default provider's chat model (legacy fallback)
+ */
+async function resolveRunModel(runModel: string | undefined, tenantId: string): Promise<ResolvedModelConfig> {
+    if (runModel) return resolveModelConfig(runModel, tenantId);
+    const defaults = await getAgentOpsDefaults(tenantId);
+    if (defaults?.defaultModel) {
+        // A stale/removed default model would throw ProviderConfigError here; fall
+        // back to the provider default rather than failing the whole run.
+        try {
+            return await resolveModelConfig(defaults.defaultModel, tenantId);
+        } catch (err) {
+            console.warn(`[AgentExecutor] Agent Ops default model "${defaults.defaultModel}" failed to resolve — falling back to provider default:`, err);
+        }
+    }
+    return resolveDefaultModelConfig(tenantId);
+}
 import { agentOpsService } from './agent-ops-service';
 import { getMCPManager } from '../agent/mcp-manager';
 import { registerRun, cleanupRun, isAborted } from './run-manager';
@@ -98,11 +121,11 @@ export async function executeAgentRun(run: AgentOpsRun, eventBus?: GatewayEventB
         });
 
         // ── Build graph ───────────────────────────────────────────────────────
-        // Resolve the configured provider — no hardcoded Bedrock default.
+        // Model + graph iteration limit come from the run override or the
+        // tenant's Agent Ops defaults (Settings → Agent Defaults).
         const modelString = (run as any).model as string | undefined;
-        const resolvedModel = modelString
-            ? await resolveModelConfig(modelString, tenantId)
-            : await resolveDefaultModelConfig(tenantId);
+        const resolvedModel = await resolveRunModel(modelString, tenantId);
+        const maxIterations = await resolveMaxIterations(tenantId);
         const graphConfig = {
             model: resolvedModel,
             autoApprove,
@@ -113,6 +136,7 @@ export async function executeAgentRun(run: AgentOpsRun, eventBus?: GatewayEventB
             knowledgeBaseIds,
             tenantId,
             userId: deriveUserId(run),
+            maxIterations,
         };
 
         const graph = await createDynamicExecutorGraph(graphConfig);
@@ -122,7 +146,7 @@ export async function executeAgentRun(run: AgentOpsRun, eventBus?: GatewayEventB
         } catch { /* non-fatal */ }
 
         const graphInput = { messages: [new HumanMessage(taskDescription)] };
-        const graphRunConfig = { configurable: { thread_id: threadId }, recursionLimit: 150 };
+        const graphRunConfig = { configurable: { thread_id: threadId }, recursionLimit: maxIterations };
 
         // ── Event tracking ────────────────────────────────────────────────────
         const toolsUsed = new Set<string>();
@@ -562,9 +586,8 @@ export async function resumeApprovedRun(run: AgentOpsRun, eventBus?: GatewayEven
         }
 
         const modelString = (run as any).model as string | undefined;
-        const resolvedModel = modelString
-            ? await resolveModelConfig(modelString, tenantId)
-            : await resolveDefaultModelConfig(tenantId);
+        const resolvedModel = await resolveRunModel(modelString, tenantId);
+        const maxIterations = await resolveMaxIterations(tenantId);
         const graphConfig = {
             model: resolvedModel,
             autoApprove: false, // keep approval mode — tools still need approval
@@ -575,12 +598,14 @@ export async function resumeApprovedRun(run: AgentOpsRun, eventBus?: GatewayEven
             knowledgeBaseIds,
             tenantId,
             userId: deriveUserId(run),
+            maxIterations,
         };
 
         const graph = await createDynamicExecutorGraph(graphConfig);
-        // Match the initial-run recursionLimit; otherwise a resumed run would fall
-        // back to LangGraph's default of 25 (tighter than the initial 150).
-        const graphRunConfig = { configurable: { thread_id: threadId }, recursionLimit: 150 };
+        // Match the initial-run recursionLimit (the tenant's configured graph
+        // limit); otherwise a resumed run would fall back to LangGraph's default
+        // of 25, tighter than what the initial run used.
+        const graphRunConfig = { configurable: { thread_id: threadId }, recursionLimit: maxIterations };
 
         // Inject approvalStatus='approved' so routing skips both gates on resume
         await (graph as any).updateState(graphRunConfig, {

--- a/apps/web-ui/lib/agent-ops/agent-ops-defaults.ts
+++ b/apps/web-ui/lib/agent-ops/agent-ops-defaults.ts
@@ -1,0 +1,55 @@
+/**
+ * Agent Ops Defaults
+ *
+ * Per-tenant default execution config (default model + graph iteration limit)
+ * applied to every new run that carries no explicit override. Stored in
+ * TenantConfig under 'agent-ops-defaults'. This module owns the config key,
+ * validation bounds, and the read path used by the executor.
+ */
+import { TenantConfigService } from '@/lib/tenant-config-service';
+import { env } from '@/env';
+import type { AgentOpsDefaultsConfig } from './types';
+
+export const AGENT_OPS_DEFAULTS_KEY = 'agent-ops-defaults';
+
+// Iteration-budget bounds. The floor keeps a run useful; the ceiling protects
+// the LLM token budget and the executor from runaway loops.
+export const MIN_MAX_ITERATIONS = 10;
+export const MAX_MAX_ITERATIONS = 500;
+
+// Fallback when a tenant has not configured Agent Ops defaults yet. Mirrors the
+// historical env-driven default so behavior is unchanged until a tenant opts in.
+export const FALLBACK_MAX_ITERATIONS = Number(env.AGENT_OPS_MAX_ITERATIONS) || 150;
+
+/**
+ * Validate a defaults payload. Returns an error string (for a 400) or null.
+ * Both fields are required — this is the "all parameters required" contract.
+ */
+export function validateAgentOpsDefaults(input: {
+    defaultModel?: unknown;
+    maxIterations?: unknown;
+}): string | null {
+    if (typeof input.defaultModel !== 'string' || !input.defaultModel.trim()) {
+        return 'defaultModel is required';
+    }
+    const n = Number(input.maxIterations);
+    if (!Number.isInteger(n) || n < MIN_MAX_ITERATIONS || n > MAX_MAX_ITERATIONS) {
+        return `maxIterations must be an integer between ${MIN_MAX_ITERATIONS} and ${MAX_MAX_ITERATIONS}`;
+    }
+    return null;
+}
+
+/** Read a tenant's Agent Ops defaults, or null when none are configured. */
+export async function getAgentOpsDefaults(tenantId: string): Promise<AgentOpsDefaultsConfig | null> {
+    return TenantConfigService.getConfig<AgentOpsDefaultsConfig>(AGENT_OPS_DEFAULTS_KEY, tenantId).catch(() => null);
+}
+
+/**
+ * Resolve the effective graph iteration limit for a tenant: the configured
+ * value, clamped to the allowed range, else the fallback. Never throws.
+ */
+export async function resolveMaxIterations(tenantId: string): Promise<number> {
+    const config = await getAgentOpsDefaults(tenantId);
+    if (!config || !Number.isFinite(config.maxIterations)) return FALLBACK_MAX_ITERATIONS;
+    return Math.min(MAX_MAX_ITERATIONS, Math.max(MIN_MAX_ITERATIONS, Math.round(config.maxIterations)));
+}

--- a/apps/web-ui/lib/agent-ops/agent-ops-service.ts
+++ b/apps/web-ui/lib/agent-ops/agent-ops-service.ts
@@ -40,7 +40,10 @@ export async function createRun(params: {
     autoApprove?: boolean;
     model?: string;
 }): Promise<AgentOpsRun> {
-    const run = await getAgentOpsRunRepository().createRun(params);
+    // Agent Ops is plan-mode only — coerce whatever the channel payload carried
+    // ('fast' from old Jira Automation bodies, etc.) so every run is planned and
+    // its terminal path persists outcome memories.
+    const run = await getAgentOpsRunRepository().createRun({ ...params, mode: 'plan' });
     console.log(`[AgentOpsService] Created run: ${run.runId} (source: ${params.source})`);
     return run;
 }

--- a/apps/web-ui/lib/agent-ops/executor-graphs.ts
+++ b/apps/web-ui/lib/agent-ops/executor-graphs.ts
@@ -11,11 +11,14 @@
  *   - agent-shared.ts      → sanitizeMessagesForBedrock, getRecentMessages, truncateOutput, llmAuditLog
  *   - persistence.ts       → PostgreSQL checkpointer (short-term), PostgreSQL store (long-term memory)
  *
- * Graph flow:
+ * Graph flow (plan-mode only — fast mode retired for Agent Ops):
  *   evaluator → clarify (end)
- *             → generate (fast mode) → tools → reflect → generate | __end__
- *             → planner (plan mode)  → generate → tools → reflect → revise → tools | reflect
- *                                                                  → final → __end__
+ *             → planner → generate → tools → reflect → revise → tools | reflect
+ *                                                    → final → memory_save → __end__
+ *
+ * Every non-clarification run takes the planner path, so the terminal edge
+ * always passes through memory_save — autonomous runs reliably persist their
+ * outcome to long-term memory.
  */
 
 import { AIMessage, HumanMessage, SystemMessage } from "@langchain/core/messages";
@@ -56,7 +59,9 @@ import { env } from "@/env";
 // iteration budget — the interactive chat agents keep the shared MAX_ITERATIONS=30.
 // A multi-step unattended task (AWS auth → cost query → Slack report) needs more
 // headroom, especially when it must resolve the target account first.
-const AGENT_OPS_MAX_ITERATIONS = Number(env.AGENT_OPS_MAX_ITERATIONS) || 150;
+// This env value is now only the fallback default: the effective per-run budget
+// comes from the tenant's Agent Ops defaults, passed in via config.maxIterations.
+const AGENT_OPS_FALLBACK_MAX_ITERATIONS = Number(env.AGENT_OPS_MAX_ITERATIONS) || 150;
 
 // ============================================================================
 // AGENT OPS DYNAMIC EXECUTOR GRAPH
@@ -64,6 +69,10 @@ const AGENT_OPS_MAX_ITERATIONS = Number(env.AGENT_OPS_MAX_ITERATIONS) || 150;
 
 export async function createDynamicExecutorGraph(config: GraphConfig) {
     const { model: modelId, autoApprove, accounts, accountId, mcpServerIds, tenantId, userId, knowledgeBaseIds } = config as any;
+
+    // Per-tenant graph iteration budget (Settings → Agent Defaults), clamped by
+    // the caller; falls back to the env default when a run doesn't carry one.
+    const AGENT_OPS_MAX_ITERATIONS = Number(config.maxIterations) || AGENT_OPS_FALLBACK_MAX_ITERATIONS;
 
     // ── Persistence (PostgreSQL checkpointer + long-term memory store) ────────
     const checkpointer = await getCheckpointer();
@@ -162,7 +171,7 @@ ${skillsContext}
 
 Return a JSON object with this exact schema:
 {
-    "mode": "plan" | "fast" | "end",
+    "mode": "plan" | "end",
     "skillId": string | null,
     "accountId": string | null,
     "requiresApproval": boolean,
@@ -172,8 +181,7 @@ Return a JSON object with this exact schema:
 }
 
 Rules:
-- "plan" for complex multi-step tasks, infrastructure mutations, security audits
-- "fast" for simple read queries, status checks, how-to questions
+- "plan" for every executable task — all runs are planned, executed, and reflected on
 - "end" ONLY when genuinely ambiguous — always set clarificationQuestion in this case
 - requiresApproval=true for any create/update/delete/start/stop operations
 
@@ -185,8 +193,8 @@ Return only the JSON object.`);
         llmAuditLog('EVALUATOR', inputs, response, start);
 
         let evalResult: RequestEvaluation = {
-            mode: 'fast', skillId: null, accountId: null,
-            requiresApproval: false, reasoning: 'Fallback to fast mode.',
+            mode: 'plan', skillId: null, accountId: null,
+            requiresApproval: false, reasoning: 'Fallback to plan mode.',
             clarificationQuestion: null, missingInfo: null,
         };
 
@@ -196,7 +204,9 @@ Return only the JSON object.`);
             if (match) {
                 const parsed = JSON.parse(match[0]);
                 evalResult = {
-                    mode: parsed.mode || 'fast',
+                    // Plan-mode only: anything that isn't a clarification ("end")
+                    // is coerced to 'plan' — including legacy 'fast' responses.
+                    mode: parsed.mode === 'end' ? 'end' : 'plan',
                     skillId: parsed.skillId || null,
                     accountId: parsed.accountId || null,
                     requiresApproval: !!parsed.requiresApproval,
@@ -603,15 +613,11 @@ Be specific — include resource IDs, account names, and numeric values where av
     // ============================================================================
 
     function routeFromEvaluator(state: ReflectionState): 'planner' | 'generate' | 'clarify' {
-        if (!state.evaluation) return 'generate';
-        if (state.evaluation.mode === 'plan') return 'planner';
-        if (state.evaluation.mode === 'end') return 'clarify';
-        // Fast mode mutative tasks still need plan-level approval gate when autoApprove=false.
-        // Without this, "start EC2" (fast mode, requiresApproval=true) skips approval_gate entirely.
-        if (!autoApprove && state.evaluation.requiresApproval && state.approvalStatus !== 'approved') {
-            return 'planner';
-        }
-        return 'generate';
+        if (state.evaluation?.mode === 'end') return 'clarify';
+        // Plan-mode only: every executable run goes through the planner, which
+        // guarantees the terminal path is final → memory_save → END. Legacy
+        // 'fast' evaluations resumed from old checkpoints route here too.
+        return 'planner';
     }
 
     // After planner: if approval required and not yet approved, go to approval_gate; else generate

--- a/apps/web-ui/lib/agent-ops/scheduled-notifier.ts
+++ b/apps/web-ui/lib/agent-ops/scheduled-notifier.ts
@@ -2,13 +2,16 @@
  * Scheduled-run channel delivery — direct dispatch, unidirectional (server → channel).
  *
  * The adapter is resolved from task.notification.type; the destination comes
- * from task.notification (channelId / chatId); credentials load per-tenant
- * inside the adapter. Delivery is best-effort: nothing here ever throws.
+ * from task.notification (channelId / chatId / issueKey); credentials load
+ * per-tenant inside the adapter. Nothing here ever throws, but delivery is NOT
+ * silent: every attempt is recorded as a 'notification' event on the run, so a
+ * missing bot token or a rejected API call is visible in the run timeline.
  */
 import type { ScheduledTask, AgentOpsRun, AgentOpsStatus } from './types';
 import type { ChannelType, ScheduledOutcome } from '@/lib/gateway/types';
 import { getAdapterRegistry } from '@/lib/gateway';
 import { getScheduledTask, updateLastRun } from './scheduled-task-service';
+import { recordEvent } from './agent-ops-service';
 
 export function mapRunStatusToOutcome(status: AgentOpsStatus): ScheduledOutcome | null {
     switch (status) {
@@ -26,31 +29,52 @@ export function mapRunStatusToOutcome(status: AgentOpsStatus): ScheduledOutcome 
 }
 
 export async function notifyScheduledRunResult(task: ScheduledTask, run: AgentOpsRun): Promise<void> {
+    const type = task.notification?.type;
+    if (!type || type === 'none') return;
+
+    const outcome = mapRunStatusToOutcome(run.status);
+    if (!outcome) {
+        console.warn(`[ScheduledNotifier] Run ${run.runId} status '${run.status}' has no digest — skipping`);
+        return;
+    }
+
+    // recordEvent never throws, so these markers can't abort finalization.
+    const recordFailure = async (reason: string) => {
+        console.error(`[ScheduledNotifier] Digest delivery FAILED for run ${run.runId} via ${type}: ${reason}`);
+        await recordEvent({
+            runId: run.runId,
+            tenantId: run.tenantId,
+            eventType: 'notification',
+            node: 'scheduled_notifier',
+            content: `Scheduled digest delivery via ${type} failed: ${reason}`,
+            metadata: { channel: type, status: 'failed', outcome, error: reason, taskId: task.taskId },
+        });
+    };
+
     try {
-        const type = task.notification?.type;
-        if (!type || type === 'none') return;
-
-        const outcome = mapRunStatusToOutcome(run.status);
-        if (!outcome) {
-            console.warn(`[ScheduledNotifier] Run ${run.runId} status '${run.status}' has no digest — skipping`);
-            return;
-        }
-
         const registry = getAdapterRegistry();
         if (!registry.has(type as ChannelType)) {
-            console.warn(`[ScheduledNotifier] No adapter for notification type '${type}' — skipping`);
+            await recordFailure(`no adapter registered for channel '${type}'`);
             return;
         }
         const adapter = registry.get(type as ChannelType);
         if (!adapter.sendScheduledNotification) {
-            console.warn(`[ScheduledNotifier] Adapter '${type}' does not support scheduled notifications — skipping`);
+            await recordFailure(`channel '${type}' does not support scheduled notifications`);
             return;
         }
 
         await adapter.sendScheduledNotification(task, run, outcome);
         console.log(`[ScheduledNotifier] Delivered '${outcome}' digest for run ${run.runId} via ${type}`);
+        await recordEvent({
+            runId: run.runId,
+            tenantId: run.tenantId,
+            eventType: 'notification',
+            node: 'scheduled_notifier',
+            content: `Scheduled digest delivered via ${type}`,
+            metadata: { channel: type, status: 'sent', outcome, taskId: task.taskId },
+        });
     } catch (err) {
-        console.error('[ScheduledNotifier] Notification failed (non-fatal):', err);
+        await recordFailure(err instanceof Error ? err.message : String(err));
     }
 }
 

--- a/apps/web-ui/lib/agent-ops/scheduled-task-service.ts
+++ b/apps/web-ui/lib/agent-ops/scheduled-task-service.ts
@@ -6,26 +6,12 @@
  */
 
 import { getScheduledTaskRepository } from '@/lib/db/repository-factory';
-import type { ScheduledTask, AgentMode, AgentOpsStatus } from './types';
+import type { CreateScheduledTaskParams, UpdateScheduledTaskParams } from '@/lib/db/repositories/scheduled-task/interface';
+import type { ScheduledTask, AgentOpsStatus } from './types';
 
 // ─── CRUD ──────────────────────────────────────────────────────────────
 
-export async function createScheduledTask(params: {
-    tenantId: string;
-    name: string;
-    description: string;
-    cronExpression: string;
-    timezone: string;
-    mode: AgentMode;
-    autoApprove: boolean;
-    model?: string;
-    accountId?: string;
-    accountName?: string;
-    mcpServerIds?: string[];
-    knowledgeBaseIds?: string[];
-    notification: ScheduledTask['notification'];
-    createdBy: string;
-}): Promise<ScheduledTask> {
+export async function createScheduledTask(params: CreateScheduledTaskParams): Promise<ScheduledTask> {
     const task = await getScheduledTaskRepository().createScheduledTask(params);
     console.log(`[ScheduledTaskService] Created task: ${task.taskId}`);
     return task;
@@ -46,7 +32,7 @@ export async function listAllActiveTasks(): Promise<ScheduledTask[]> {
 export async function updateScheduledTask(
     tenantId: string,
     taskId: string,
-    updates: Partial<Pick<ScheduledTask, 'name' | 'description' | 'cronExpression' | 'timezone' | 'mode' | 'autoApprove' | 'model' | 'accountId' | 'accountName' | 'mcpServerIds' | 'knowledgeBaseIds' | 'notification'>>
+    updates: UpdateScheduledTaskParams
 ): Promise<ScheduledTask | null> {
     return getScheduledTaskRepository().updateScheduledTask(tenantId, taskId, updates);
 }
@@ -71,6 +57,37 @@ export async function updateLastRun(
     opts?: { incrementRunCount?: boolean }
 ): Promise<void> {
     return getScheduledTaskRepository().updateLastRun(tenantId, taskId, runId, status, opts);
+}
+
+// ─── Schedule Validation ───────────────────────────────────────────────
+
+export const MIN_INTERVAL_MINUTES = 5;          // floor — protects the sweeper + LLM budget
+export const MAX_INTERVAL_MINUTES = 7 * 24 * 60; // 1 week
+
+/**
+ * Validate the schedule fields of a create/update payload. Returns an error
+ * message (for a 400 response) or null when valid.
+ */
+export function validateScheduleInput(input: {
+    scheduleType?: string;
+    cronExpression?: string;
+    intervalMinutes?: unknown;
+}): string | null {
+    const scheduleType = input.scheduleType ?? 'cron';
+    if (scheduleType !== 'cron' && scheduleType !== 'interval') {
+        return `scheduleType must be 'cron' or 'interval'`;
+    }
+    if (scheduleType === 'interval') {
+        const minutes = Number(input.intervalMinutes);
+        if (!Number.isInteger(minutes) || minutes < MIN_INTERVAL_MINUTES || minutes > MAX_INTERVAL_MINUTES) {
+            return `intervalMinutes must be an integer between ${MIN_INTERVAL_MINUTES} and ${MAX_INTERVAL_MINUTES}`;
+        }
+        return null;
+    }
+    if (!input.cronExpression || !input.cronExpression.trim()) {
+        return 'cronExpression is required for cron schedules';
+    }
+    return null;
 }
 
 // ─── Execution Lock ────────────────────────────────────────────────────

--- a/apps/web-ui/lib/agent-ops/scheduler-engine.ts
+++ b/apps/web-ui/lib/agent-ops/scheduler-engine.ts
@@ -30,6 +30,14 @@ export async function registerTask(task: ScheduledTask): Promise<void> {
     const boss = await getBoss();
     const queue = queueName(task.taskId);
 
+    // Interval tasks have no cron expression — the workers sweeper fires them
+    // off nextRunAt. Drop any stale pg-boss schedule (e.g. a task switched from
+    // cron to interval) and skip registration.
+    if (task.scheduleType === 'interval') {
+        try { await boss.unschedule(queue); } catch { /* no existing schedule */ }
+        return;
+    }
+
     await boss.createQueue(queue);
 
     // Remove existing schedule before re-registering (idempotent)

--- a/apps/web-ui/lib/agent-ops/types.ts
+++ b/apps/web-ui/lib/agent-ops/types.ts
@@ -10,6 +10,10 @@ export type TriggerSource = 'slack' | 'jira' | 'discord' | 'telegram' | 'webhook
 
 export type AgentOpsStatus = 'queued' | 'in_progress' | 'awaiting_input' | 'awaiting_approval' | 'completed' | 'failed' | 'cancelled';
 
+// Agent Ops is plan-mode only: every run goes planner → execute → reflect →
+// final → memory_save, so autonomous runs always persist outcome memories.
+// 'fast' remains in the union solely so legacy rows/checkpoints still type-check;
+// nothing produces it anymore and the executor coerces it to 'plan'.
 export type AgentMode = 'plan' | 'fast';
 
 export type AgentEventType =
@@ -23,7 +27,8 @@ export type AgentEventType =
     | 'error'
     | 'memory_recall'
     | 'memory_save'
-    | 'evaluation';
+    | 'evaluation'
+    | 'notification';
 
 // ─── Trigger Metadata ──────────────────────────────────────────────────
 
@@ -154,6 +159,10 @@ export interface AgentOpsEvent {
 
 export type ScheduledTaskStatus = 'active' | 'paused' | 'deleted';
 
+// 'cron' fires on a cron expression (per-task timezone); 'interval' re-fires a
+// fixed number of minutes after the previous run, anchored on nextRunAt.
+export type ScheduleType = 'cron' | 'interval';
+
 export interface ScheduledTaskNotification {
     type: 'none' | 'slack' | 'jira' | 'telegram';
     channelId?: string;      // slack
@@ -172,7 +181,9 @@ export interface ScheduledTask {
     tenantId: string;
     name: string;
     description: string;
-    cronExpression: string;
+    scheduleType: ScheduleType;
+    cronExpression: string;      // empty string when scheduleType === 'interval'
+    intervalMinutes?: number;    // set when scheduleType === 'interval'
     timezone: string;
     taskStatus: ScheduledTaskStatus;
     mode: AgentMode;
@@ -284,4 +295,19 @@ export interface WebhookIntegrationConfig {
     webhookSecret: string;
     enabled: boolean;
     autoApprove?: boolean;
+}
+
+// ─── Agent Ops Defaults ─────────────────────────────────────────────────
+
+/**
+ * Per-tenant default execution configuration for Agent Ops runs. Applied to
+ * every new run that does not carry an explicit override. Stored in
+ * TenantConfig under the key 'agent-ops-defaults'.
+ */
+export interface AgentOpsDefaultsConfig {
+    // Composite model id ({provider}:{modelId}:{recordId}) from the provider
+    // model picker; resolved via resolveModelConfig at run time.
+    defaultModel: string;
+    // Graph iteration budget — caps the executor loop AND LangGraph's recursionLimit.
+    maxIterations: number;
 }

--- a/apps/web-ui/lib/agent/agent-shared.ts
+++ b/apps/web-ui/lib/agent/agent-shared.ts
@@ -559,6 +559,7 @@ export interface GraphConfig {
     tenantId?: string;
     userId?: string;  // For long-term memory store scoping
     knowledgeBaseIds?: string[] | null;
+    maxIterations?: number;  // Agent Ops per-tenant graph iteration limit (executor loop + recursionLimit)
 }
 
 // --- MCP Integration ---

--- a/apps/web-ui/lib/db/repositories/agent-memory/interface.ts
+++ b/apps/web-ui/lib/db/repositories/agent-memory/interface.ts
@@ -23,7 +23,7 @@ export interface AgentMemoryRecord {
 }
 
 /** Columns the list view can be sorted by (server-side). */
-export type AgentMemorySortField = 'category' | 'key' | 'createdAt' | 'expiresAt';
+export type AgentMemorySortField = 'category' | 'key' | 'createdAt' | 'updatedAt' | 'expiresAt';
 export type SortDirection = 'asc' | 'desc';
 
 export interface AgentMemoryFilters {

--- a/apps/web-ui/lib/db/repositories/agent-memory/postgres.test.ts
+++ b/apps/web-ui/lib/db/repositories/agent-memory/postgres.test.ts
@@ -146,12 +146,12 @@ describe('AgentMemoryPostgresRepository', () => {
         ]);
     });
 
-    it('listByTenant defaults to updatedAt desc when no sort is requested', async () => {
+    it('listByTenant defaults to createdAt desc when no sort is requested', async () => {
         const repo = new AgentMemoryPostgresRepository();
         await repo.listByTenant({ tenantId: 't1' });
 
         const arg = mockPrisma.agentMemory.findMany.mock.calls[0][0];
-        expect(arg.orderBy).toEqual({ updatedAt: 'desc' });
+        expect(arg.orderBy).toEqual({ createdAt: 'desc' });
     });
 
     it('listByTenant maps a sort field + direction to orderBy', async () => {
@@ -160,6 +160,14 @@ describe('AgentMemoryPostgresRepository', () => {
 
         const arg = mockPrisma.agentMemory.findMany.mock.calls[0][0];
         expect(arg.orderBy).toEqual({ createdAt: 'asc' });
+    });
+
+    it('listByTenant maps updatedAt sort to the updatedAt column', async () => {
+        const repo = new AgentMemoryPostgresRepository();
+        await repo.listByTenant({ tenantId: 't1', sortBy: 'updatedAt', sortDir: 'desc' });
+
+        const arg = mockPrisma.agentMemory.findMany.mock.calls[0][0];
+        expect(arg.orderBy).toEqual({ updatedAt: 'desc' });
     });
 
     it('listByTenant sorts category by the derived namespace column', async () => {

--- a/apps/web-ui/lib/db/repositories/agent-memory/postgres.ts
+++ b/apps/web-ui/lib/db/repositories/agent-memory/postgres.ts
@@ -80,7 +80,7 @@ function orderByClause(
     sortBy: AgentMemorySortField | undefined,
     sortDir: 'asc' | 'desc' | undefined
 ): Record<string, 'asc' | 'desc'> {
-    if (!sortBy) return { updatedAt: 'desc' };
+    if (!sortBy) return { createdAt: 'desc' };
     const dir = sortDir ?? 'asc';
     const column = sortBy === 'category' ? 'namespace' : sortBy;
     return { [column]: dir };

--- a/apps/web-ui/lib/db/repositories/scheduled-task/interface.ts
+++ b/apps/web-ui/lib/db/repositories/scheduled-task/interface.ts
@@ -5,13 +5,15 @@
  * Implemented by ScheduledTaskDynamoRepository and ScheduledTaskPostgresRepository.
  * The feature flag USE_PG_AGENT_OPS controls which implementation is active.
  */
-import type { ScheduledTask, AgentOpsStatus, AgentMode } from '@/lib/agent-ops/types';
+import type { ScheduledTask, AgentOpsStatus, AgentMode, ScheduleType } from '@/lib/agent-ops/types';
 
 export interface CreateScheduledTaskParams {
     tenantId: string;
     name: string;
     description: string;
-    cronExpression: string;
+    scheduleType?: ScheduleType;   // default 'cron'
+    cronExpression: string;        // empty string for interval tasks
+    intervalMinutes?: number;      // required when scheduleType === 'interval'
     timezone: string;
     mode: AgentMode;
     autoApprove: boolean;
@@ -27,7 +29,9 @@ export interface CreateScheduledTaskParams {
 export interface UpdateScheduledTaskParams {
     name?: string;
     description?: string;
+    scheduleType?: ScheduleType;
     cronExpression?: string;
+    intervalMinutes?: number | null;
     timezone?: string;
     mode?: AgentMode;
     autoApprove?: boolean;

--- a/apps/web-ui/lib/db/repositories/scheduled-task/postgres.ts
+++ b/apps/web-ui/lib/db/repositories/scheduled-task/postgres.ts
@@ -29,13 +29,34 @@ function computeNextRunAt(cronExpression: string, timezone: string): Date | null
     }
 }
 
+/**
+ * Schedule-aware next-run computation. Interval tasks anchor on "now" — the
+ * caller invokes this at create/resume/run-finalize time, so the next fire is
+ * always intervalMinutes after the most recent lifecycle event. The worker
+ * sweeper fires interval tasks when nextRunAt <= now and re-advances it.
+ */
+function computeNextRun(schedule: {
+    scheduleType: string;
+    cronExpression: string;
+    timezone: string;
+    intervalMinutes?: number | null;
+}): Date | null {
+    if (schedule.scheduleType === 'interval') {
+        const minutes = schedule.intervalMinutes ?? 0;
+        return minutes > 0 ? new Date(Date.now() + minutes * 60_000) : null;
+    }
+    return computeNextRunAt(schedule.cronExpression, schedule.timezone);
+}
+
 function toScheduledTask(r: {
     id: string;
     tenantId: string;
     taskId: string;
     name: string;
     description: string;
+    scheduleType: string;
     cronExpression: string;
+    intervalMinutes: number | null;
     timezone: string;
     taskStatus: string;
     mode: string;
@@ -64,7 +85,9 @@ function toScheduledTask(r: {
         tenantId: r.tenantId,
         name: r.name,
         description: r.description,
+        scheduleType: (r.scheduleType as ScheduledTask['scheduleType']) || 'cron',
         cronExpression: r.cronExpression,
+        intervalMinutes: r.intervalMinutes ?? undefined,
         timezone: r.timezone,
         taskStatus: r.taskStatus as ScheduledTask['taskStatus'],
         mode: r.mode as ScheduledTask['mode'],
@@ -89,7 +112,13 @@ function toScheduledTask(r: {
 export class ScheduledTaskPostgresRepository implements IScheduledTaskRepository {
     async createScheduledTask(params: CreateScheduledTaskParams): Promise<ScheduledTask> {
         const taskId = uuidv4();
-        const nextRunAt = computeNextRunAt(params.cronExpression, params.timezone);
+        const scheduleType = params.scheduleType ?? 'cron';
+        const nextRunAt = computeNextRun({
+            scheduleType,
+            cronExpression: params.cronExpression,
+            timezone: params.timezone,
+            intervalMinutes: params.intervalMinutes,
+        });
 
         const record = await getTenantClient(params.tenantId).scheduledTask.create({
             data: {
@@ -97,7 +126,9 @@ export class ScheduledTaskPostgresRepository implements IScheduledTaskRepository
                 taskId,
                 name: params.name,
                 description: params.description,
+                scheduleType,
                 cronExpression: params.cronExpression,
+                intervalMinutes: params.intervalMinutes ?? null,
                 timezone: params.timezone,
                 taskStatus: 'active',
                 mode: params.mode,
@@ -148,12 +179,22 @@ export class ScheduledTaskPostgresRepository implements IScheduledTaskRepository
     ): Promise<ScheduledTask | null> {
         const updateData: Record<string, unknown> = { ...updates };
 
-        if (updates.cronExpression || updates.timezone) {
+        const scheduleChanged =
+            updates.cronExpression !== undefined ||
+            updates.timezone !== undefined ||
+            updates.scheduleType !== undefined ||
+            updates.intervalMinutes !== undefined;
+        if (scheduleChanged) {
             const task = await this.getScheduledTask(tenantId, taskId);
             if (task) {
-                const cron = updates.cronExpression ?? task.cronExpression;
-                const tz = updates.timezone ?? task.timezone;
-                updateData.nextRunAt = computeNextRunAt(cron, tz);
+                updateData.nextRunAt = computeNextRun({
+                    scheduleType: updates.scheduleType ?? task.scheduleType,
+                    cronExpression: updates.cronExpression ?? task.cronExpression,
+                    timezone: updates.timezone ?? task.timezone,
+                    intervalMinutes: updates.intervalMinutes !== undefined
+                        ? updates.intervalMinutes
+                        : task.intervalMinutes,
+                });
             }
         }
 
@@ -178,7 +219,7 @@ export class ScheduledTaskPostgresRepository implements IScheduledTaskRepository
     async resumeScheduledTask(tenantId: string, taskId: string): Promise<ScheduledTask | null> {
         const task = await this.getScheduledTask(tenantId, taskId);
         if (!task) return null;
-        const nextRunAt = computeNextRunAt(task.cronExpression, task.timezone);
+        const nextRunAt = computeNextRun(task);
         await getTenantClient(tenantId).scheduledTask.updateMany({
             where: { tenantId, taskId },
             data: { taskStatus: 'active', nextRunAt: nextRunAt ?? null },
@@ -202,7 +243,8 @@ export class ScheduledTaskPostgresRepository implements IScheduledTaskRepository
     ): Promise<void> {
         const task = await this.getScheduledTask(tenantId, taskId);
         if (!task) return;
-        const nextRunAt = computeNextRunAt(task.cronExpression, task.timezone);
+        // Interval tasks re-anchor on run completion: next fire = run end + interval.
+        const nextRunAt = computeNextRun(task);
         const incrementRunCount = opts?.incrementRunCount ?? true;
         await getTenantClient(tenantId).scheduledTask.updateMany({
             where: { tenantId, taskId },

--- a/apps/web-ui/lib/gateway/adapters/api-adapter.ts
+++ b/apps/web-ui/lib/gateway/adapters/api-adapter.ts
@@ -59,7 +59,8 @@ export class ApiAdapter implements ChannelAdapter {
             channelType: 'api',
             tenantId,
             taskDescription: payload.taskDescription?.trim() || '',
-            mode: payload.mode || 'fast',
+            // Agent Ops is plan-mode only; createRun coerces regardless.
+            mode: 'plan',
             autoApprove: payload.autoApprove ?? false,
             accountId: payload.accountId,
             accountName: payload.accountName,

--- a/apps/web-ui/lib/gateway/adapters/jira-adapter.ts
+++ b/apps/web-ui/lib/gateway/adapters/jira-adapter.ts
@@ -10,7 +10,7 @@ import type { NextRequest } from 'next/server';
 import { TenantConfigService } from '@/lib/tenant-config-service';
 import { env } from '@/env';
 import { agentOpsService } from '@/lib/agent-ops/agent-ops-service';
-import { buildDashboardRespondUrl } from '@/lib/gateway/utils/dashboard-url';
+import { buildDashboardRespondUrl, buildDashboardRunUrl } from '@/lib/gateway/utils/dashboard-url';
 import type {
     ChannelAdapter,
     ChannelType,
@@ -18,12 +18,14 @@ import type {
     HilCapabilities,
     GatewayMessage,
     ReplyContext,
+    ScheduledOutcome,
 } from '@/lib/gateway/types';
 import type {
     AgentOpsRun,
     AgentOpsEvent,
     JiraIntegrationConfig,
     JiraTriggerMeta,
+    ScheduledTask,
 } from '@/lib/agent-ops/types';
 
 // ─── ADF node types ────────────────────────────────────────────────────
@@ -331,6 +333,63 @@ export class JiraAdapter implements ChannelAdapter {
         await this.postComment(issueKey, text, config);
     }
 
+    /**
+     * Scheduled-task digest → Jira issue comment. Unlike the interactive send*
+     * methods (which are best-effort), this THROWS on missing config or a
+     * failed Jira API call so the scheduled notifier can record the failure
+     * on the run instead of silently dropping the digest.
+     */
+    async sendScheduledNotification(
+        task: ScheduledTask,
+        run: AgentOpsRun,
+        outcome: ScheduledOutcome,
+    ): Promise<void> {
+        const issueKey = task.notification?.issueKey;
+        if (!issueKey) {
+            throw new Error('No Jira issueKey configured on the task notification');
+        }
+        const config = await this.loadConfig(run.tenantId);
+        if (config && config.enabled === false) {
+            throw new Error('Jira integration is deactivated — activate it under Channels → Jira');
+        }
+        const { baseUrl, userEmail, apiToken } = this.resolveApiConfig(config);
+        if (!baseUrl || !userEmail || !apiToken) {
+            throw new Error('Jira API credentials not configured (Base URL, User Email, and API Token are required)');
+        }
+
+        const dashboardUrl = buildDashboardRunUrl(run.runId);
+        const durationSec = Math.round((run.durationMs ?? 0) / 1000);
+
+        let header: string;
+        let detail: string;
+        if (outcome === 'result') {
+            header = `✅ Scheduled task "${task.name}" completed`;
+            const tools = run.result?.toolsUsed?.length
+                ? `\nTools: ${run.result.toolsUsed.join(', ')}`
+                : '';
+            detail = `${run.result?.summary ?? '(no summary)'}${tools}\nDuration: ${durationSec}s`;
+        } else if (outcome === 'failure') {
+            header = `❌ Scheduled task "${task.name}" ${run.status === 'cancelled' ? 'was cancelled' : 'failed'}`;
+            detail = run.error ?? 'Run did not complete.';
+        } else {
+            header = `⏸️ Scheduled task "${task.name}" needs your attention`;
+            detail = run.clarification?.question
+                ?? (run.approvalRequest
+                    ? `Approval required (${run.approvalRequest.approvalType}).`
+                    : `Run is ${run.status.replace('_', ' ')}.`);
+        }
+
+        const text = [
+            header,
+            '',
+            detail.slice(0, 6000),
+            '',
+            `Run ${run.runId} · ${dashboardUrl}`,
+        ].join('\n');
+
+        await this.postComment(issueKey, text, config, { strict: true });
+    }
+
     // ─── Config ───────────────────────────────────────────────────────
 
     async getConfig(tenantId: string): Promise<Record<string, unknown>> {
@@ -361,15 +420,19 @@ export class JiraAdapter implements ChannelAdapter {
 
     /**
      * Post a comment to a Jira issue using Atlassian Document Format (ADF).
+     * Best-effort by default (interactive replies must never crash a run);
+     * pass { strict: true } to surface failures to the caller (scheduled digests).
      */
     private async postComment(
         issueKey: string,
         bodyText: string,
         config: JiraIntegrationConfig | null,
+        opts?: { strict?: boolean },
     ): Promise<void> {
         const { baseUrl, userEmail, apiToken } = this.resolveApiConfig(config);
 
         if (!baseUrl || !userEmail || !apiToken) {
+            if (opts?.strict) throw new Error('Jira API credentials not configured');
             console.warn('[JiraAdapter] Jira API not configured — skipping comment post');
             return;
         }
@@ -401,9 +464,12 @@ export class JiraAdapter implements ChannelAdapter {
 
             if (!res.ok) {
                 const text = await res.text().catch(() => '');
-                console.error(`[JiraAdapter] Jira API error ${res.status}: ${text}`);
+                const message = `Jira API error ${res.status} posting comment to ${issueKey}: ${text.slice(0, 300)}`;
+                if (opts?.strict) throw new Error(message);
+                console.error(`[JiraAdapter] ${message}`);
             }
         } catch (err) {
+            if (opts?.strict) throw err;
             console.error('[JiraAdapter] Failed to post comment:', err);
         }
     }

--- a/apps/web-ui/lib/gateway/adapters/slack-adapter.ts
+++ b/apps/web-ui/lib/gateway/adapters/slack-adapter.ts
@@ -268,6 +268,11 @@ export class SlackAdapter implements ChannelAdapter {
         }
     }
 
+    /**
+     * Scheduled-task digest → Slack channel. THROWS on missing config or a
+     * failed Slack API call so the scheduled notifier can record the failure
+     * on the run instead of silently dropping the digest.
+     */
     async sendScheduledNotification(
         task: ScheduledTask,
         run: AgentOpsRun,
@@ -275,13 +280,14 @@ export class SlackAdapter implements ChannelAdapter {
     ): Promise<void> {
         const channelId = task.notification?.channelId;
         if (!channelId) {
-            console.warn('[SlackAdapter] sendScheduledNotification: no channelId on task notification');
-            return;
+            throw new Error('No Slack channelId configured on the task notification');
         }
         const config = await this.loadConfig(run.tenantId);
+        if (config && config.enabled === false) {
+            throw new Error('Slack integration is deactivated — activate it under Channels → Slack');
+        }
         if (!config?.botToken) {
-            console.warn('[SlackAdapter] sendScheduledNotification: no botToken configured');
-            return;
+            throw new Error('No Slack Bot Token configured — set it under Channels → Slack');
         }
 
         const dashboardUrl = buildDashboardRunUrl(run.runId);
@@ -317,21 +323,17 @@ export class SlackAdapter implements ChannelAdapter {
             },
         ];
 
-        try {
-            const res = await fetch('https://slack.com/api/chat.postMessage', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    Authorization: `Bearer ${config.botToken}`,
-                },
-                body: JSON.stringify({ channel: channelId, blocks, text: header }),
-            });
-            const data = await res.json();
-            if (!data.ok) {
-                console.warn('[SlackAdapter] sendScheduledNotification post failed:', data.error);
-            }
-        } catch (err) {
-            console.error('[SlackAdapter] sendScheduledNotification error:', err);
+        const res = await fetch('https://slack.com/api/chat.postMessage', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${config.botToken}`,
+            },
+            body: JSON.stringify({ channel: channelId, blocks, text: header }),
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!data.ok) {
+            throw new Error(`Slack chat.postMessage failed: ${data.error || `HTTP ${res.status}`}`);
         }
     }
 

--- a/apps/web-ui/lib/gateway/adapters/telegram-adapter.ts
+++ b/apps/web-ui/lib/gateway/adapters/telegram-adapter.ts
@@ -279,6 +279,11 @@ export class TelegramAdapter implements ChannelAdapter {
         }
     }
 
+    /**
+     * Scheduled-task digest → Telegram chat. THROWS on missing config or a
+     * failed Telegram API call so the scheduled notifier can record the
+     * failure on the run instead of silently dropping the digest.
+     */
     async sendScheduledNotification(
         task: ScheduledTask,
         run: AgentOpsRun,
@@ -286,8 +291,11 @@ export class TelegramAdapter implements ChannelAdapter {
     ): Promise<void> {
         const chatIdRaw = task.notification?.chatId;
         if (!chatIdRaw) {
-            console.warn('[TelegramAdapter] sendScheduledNotification: no chatId on task notification');
-            return;
+            throw new Error('No Telegram chatId configured on the task notification');
+        }
+        const config = await this.loadConfig(run.tenantId);
+        if (config && config.enabled === false) {
+            throw new Error('Telegram integration is deactivated — activate it under Channels → Telegram');
         }
         const chatId = Number(chatIdRaw);
         const dashboardUrl = buildDashboardRunUrl(run.runId);
@@ -339,7 +347,7 @@ export class TelegramAdapter implements ChannelAdapter {
             text = buildLines(`${rawDetail.slice(0, 1000)}…`).join('\n');
         }
 
-        await this.sendMessage(run, chatId, text);
+        await this.sendMessage(run, chatId, text, undefined, { strict: true });
     }
 
     // ─── Config ───────────────────────────────────────────────────────
@@ -454,16 +462,22 @@ export class TelegramAdapter implements ChannelAdapter {
         };
     }
 
+    /**
+     * Best-effort by default (interactive replies must never crash a run);
+     * pass { strict: true } to surface failures to the caller (scheduled digests).
+     */
     private async sendMessage(
         run: AgentOpsRun,
         chatId: number,
         text: string,
         replyMarkup?: Record<string, unknown>,
+        opts?: { strict?: boolean },
     ): Promise<void> {
         const config = await this.loadConfig(run.tenantId);
         const botToken = config?.botToken || env.TELEGRAM_BOT_TOKEN || '';
 
         if (!botToken) {
+            if (opts?.strict) throw new Error('No Telegram Bot Token configured — set it under Channels → Telegram');
             console.warn('[TelegramAdapter] Bot token not configured');
             return;
         }
@@ -486,9 +500,13 @@ export class TelegramAdapter implements ChannelAdapter {
 
             if (!res.ok) {
                 const responseText = await res.text();
+                if (opts?.strict) {
+                    throw new Error(`Telegram sendMessage failed (${res.status}): ${responseText.slice(0, 300)}`);
+                }
                 console.warn(`[TelegramAdapter] sendMessage failed (${res.status}):`, responseText);
             }
         } catch (err) {
+            if (opts?.strict) throw err;
             console.error('[TelegramAdapter] sendMessage error:', err);
         }
     }

--- a/apps/web-ui/lib/queries/agent-memories.ts
+++ b/apps/web-ui/lib/queries/agent-memories.ts
@@ -30,7 +30,7 @@ export interface MemoryRow {
     supersededAt: string | null;
 }
 
-export type MemorySortField = 'category' | 'key' | 'createdAt' | 'expiresAt';
+export type MemorySortField = 'category' | 'key' | 'createdAt' | 'updatedAt' | 'expiresAt';
 
 export interface MemoryFilters {
     category?: MemoryCategory;

--- a/apps/web-ui/lib/queries/agent-ops-settings.ts
+++ b/apps/web-ui/lib/queries/agent-ops-settings.ts
@@ -1,0 +1,48 @@
+'use client';
+
+/**
+ * TanStack Query hooks for the Agent Ops default execution config
+ * (default model + graph iteration limit), stored per-tenant.
+ */
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+export interface AgentOpsDefaults {
+    configured: boolean;
+    defaultModel: string;
+    maxIterations: number;
+}
+
+const key = ['agent-ops', 'defaults'] as const;
+
+export function useAgentOpsDefaults() {
+    return useQuery({
+        queryKey: key,
+        queryFn: async (): Promise<AgentOpsDefaults> => {
+            const res = await fetch('/api/agent-ops/settings/defaults');
+            const data = await res.json().catch(() => ({}));
+            if (!res.ok) throw new Error(data.error || 'Failed to load Agent Ops defaults');
+            return {
+                configured: data.configured ?? false,
+                defaultModel: data.defaultModel ?? '',
+                maxIterations: data.maxIterations ?? 150,
+            };
+        },
+    });
+}
+
+export function useSaveAgentOpsDefaults() {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async (body: { defaultModel: string; maxIterations: number }) => {
+            const res = await fetch('/api/agent-ops/settings/defaults', {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body),
+            });
+            const data = await res.json().catch(() => ({}));
+            if (!res.ok) throw new Error(data.error || 'Failed to save Agent Ops defaults');
+            return data as AgentOpsDefaults;
+        },
+        onSuccess: () => qc.invalidateQueries({ queryKey: key }),
+    });
+}

--- a/apps/web-ui/lib/queries/channel-settings.ts
+++ b/apps/web-ui/lib/queries/channel-settings.ts
@@ -57,3 +57,30 @@ export function useSaveChannelSettings(channel: string) {
         },
     });
 }
+
+/**
+ * Activate/deactivate a configured channel without touching its credentials.
+ * Safe because every settings PUT merges the body over the stored config, so
+ * an `{ enabled }`-only body keeps all existing secrets. Only call this for
+ * channels that are already configured (otherwise the PUT 400s on the
+ * required-credential check).
+ */
+export function useToggleChannelEnabled() {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async ({ channel, enabled }: { channel: string; enabled: boolean }) => {
+            const res = await fetch(`/api/agent-ops/settings/${channel}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ enabled }),
+            });
+            const data = await res.json().catch(() => ({}));
+            if (!res.ok) throw new Error(data.error || `Failed to ${enabled ? 'activate' : 'deactivate'} channel`);
+            return data;
+        },
+        onSuccess: (_data, { channel }) => {
+            qc.invalidateQueries({ queryKey: ['channel-settings', channel] });
+            qc.invalidateQueries({ queryKey: ['channels', 'status'] });
+        },
+    });
+}

--- a/apps/web-ui/tests/agent-ops/agent-ops-defaults.test.ts
+++ b/apps/web-ui/tests/agent-ops/agent-ops-defaults.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// getAgentOpsDefaults / resolveMaxIterations read TenantConfig; stub the service
+// so the resolver tests exercise clamping logic without a DB.
+const mockGetConfig = vi.fn();
+vi.mock('@/lib/tenant-config-service', () => ({
+    TenantConfigService: { getConfig: (...args: unknown[]) => mockGetConfig(...args) },
+}));
+
+import {
+    validateAgentOpsDefaults,
+    resolveMaxIterations,
+    MIN_MAX_ITERATIONS,
+    MAX_MAX_ITERATIONS,
+    FALLBACK_MAX_ITERATIONS,
+} from '../../lib/agent-ops/agent-ops-defaults';
+
+describe('validateAgentOpsDefaults', () => {
+    it('accepts a valid payload', () => {
+        expect(validateAgentOpsDefaults({ defaultModel: 'anthropic:claude:uuid', maxIterations: 150 })).toBeNull();
+    });
+
+    it('requires a non-empty defaultModel', () => {
+        expect(validateAgentOpsDefaults({ defaultModel: '', maxIterations: 150 })).toMatch(/defaultModel/);
+        expect(validateAgentOpsDefaults({ defaultModel: '   ', maxIterations: 150 })).toMatch(/defaultModel/);
+        expect(validateAgentOpsDefaults({ maxIterations: 150 })).toMatch(/defaultModel/);
+    });
+
+    it('rejects a non-integer or out-of-range maxIterations', () => {
+        expect(validateAgentOpsDefaults({ defaultModel: 'm', maxIterations: 1.5 })).toMatch(/maxIterations/);
+        expect(validateAgentOpsDefaults({ defaultModel: 'm', maxIterations: MIN_MAX_ITERATIONS - 1 })).toMatch(/maxIterations/);
+        expect(validateAgentOpsDefaults({ defaultModel: 'm', maxIterations: MAX_MAX_ITERATIONS + 1 })).toMatch(/maxIterations/);
+        expect(validateAgentOpsDefaults({ defaultModel: 'm' })).toMatch(/maxIterations/);
+    });
+
+    it('accepts the boundary values', () => {
+        expect(validateAgentOpsDefaults({ defaultModel: 'm', maxIterations: MIN_MAX_ITERATIONS })).toBeNull();
+        expect(validateAgentOpsDefaults({ defaultModel: 'm', maxIterations: MAX_MAX_ITERATIONS })).toBeNull();
+    });
+});
+
+describe('resolveMaxIterations', () => {
+    it('returns the fallback when no config is set', async () => {
+        mockGetConfig.mockResolvedValueOnce(null);
+        expect(await resolveMaxIterations('t1')).toBe(FALLBACK_MAX_ITERATIONS);
+    });
+
+    it('returns the configured value when in range', async () => {
+        mockGetConfig.mockResolvedValueOnce({ defaultModel: 'm', maxIterations: 200 });
+        expect(await resolveMaxIterations('t1')).toBe(200);
+    });
+
+    it('clamps an out-of-range configured value into the allowed band', async () => {
+        mockGetConfig.mockResolvedValueOnce({ defaultModel: 'm', maxIterations: 99999 });
+        expect(await resolveMaxIterations('t1')).toBe(MAX_MAX_ITERATIONS);
+        mockGetConfig.mockResolvedValueOnce({ defaultModel: 'm', maxIterations: 1 });
+        expect(await resolveMaxIterations('t1')).toBe(MIN_MAX_ITERATIONS);
+    });
+
+    it('falls back when the config read throws', async () => {
+        mockGetConfig.mockRejectedValueOnce(new Error('db down'));
+        expect(await resolveMaxIterations('t1')).toBe(FALLBACK_MAX_ITERATIONS);
+    });
+});

--- a/apps/web-ui/tests/agent-ops/agent-ops-service.test.ts
+++ b/apps/web-ui/tests/agent-ops/agent-ops-service.test.ts
@@ -102,7 +102,9 @@ describe('createRun', () => {
         expect(run.tenantId).toBe('T0001');
         expect(run.source).toBe('slack');
         expect(run.taskDescription).toBe('Check Lambda configs');
-        expect(run.mode).toBe('fast');
+        // Agent Ops is plan-mode only — createRun coerces whatever the channel
+        // payload carried (here legacy 'fast') so every run is planned.
+        expect(run.mode).toBe('plan');
         expect(run.createdAt).toBeTruthy();
         expect(run.updatedAt).toBeTruthy();
     });

--- a/apps/workers/src/jobs/agent-ops-scheduler/index.test.ts
+++ b/apps/workers/src/jobs/agent-ops-scheduler/index.test.ts
@@ -14,19 +14,31 @@ const mockBoss = {
 
 const mockFindMany = vi.fn();
 
+const mockUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
+
 vi.mock('@prisma/client', () => ({
     PrismaClient: vi.fn().mockImplementation(() => ({
-        scheduledTask: { findMany: mockFindMany },
+        scheduledTask: { findMany: mockFindMany, updateMany: mockUpdateMany },
     })),
 }));
 
-import { sweep, selectDueTasks } from './index.js';
+import { sweep, selectDueTasks, type ActiveTaskRow } from './index.js';
 
-const task = (over: Partial<{ taskId: string; tenantId: string; cronExpression: string; timezone: string }> = {}) => ({
+const task = (over: Partial<ActiveTaskRow> = {}): ActiveTaskRow => ({
     taskId: 't1',
     tenantId: 'ten-1',
+    scheduleType: 'cron',
     cronExpression: '* * * * *',
+    intervalMinutes: null,
     timezone: 'UTC',
+    nextRunAt: null,
+    ...over,
+});
+
+const intervalTask = (over: Partial<ActiveTaskRow> = {}): ActiveTaskRow => task({
+    scheduleType: 'interval',
+    cronExpression: '',
+    intervalMinutes: 60,
     ...over,
 });
 
@@ -50,12 +62,49 @@ describe('selectDueTasks', () => {
         const due = selectDueTasks([task({ taskId: 'bad', cronExpression: 'not-a-cron' })], now, 60_000);
         expect(due).toEqual([]);
     });
+
+    it('selects an interval task whose nextRunAt anchor has passed', () => {
+        const now = Date.UTC(2026, 0, 1, 12, 0, 0);
+        const due = selectDueTasks(
+            [intervalTask({ nextRunAt: new Date(now - 1_000) })],
+            now,
+            60_000,
+        );
+        expect(due.map((t) => t.taskId)).toEqual(['t1']);
+    });
+
+    it('selects an interval task with a null anchor (fires once, then advanced)', () => {
+        const now = Date.UTC(2026, 0, 1, 12, 0, 0);
+        const due = selectDueTasks([intervalTask({ nextRunAt: null })], now, 60_000);
+        expect(due.map((t) => t.taskId)).toEqual(['t1']);
+    });
+
+    it('excludes an interval task whose anchor is in the future', () => {
+        const now = Date.UTC(2026, 0, 1, 12, 0, 0);
+        const due = selectDueTasks(
+            [intervalTask({ nextRunAt: new Date(now + 60_000) })],
+            now,
+            60_000,
+        );
+        expect(due).toEqual([]);
+    });
+
+    it('skips an interval task without intervalMinutes (never throws)', () => {
+        const now = Date.UTC(2026, 0, 1, 12, 0, 0);
+        const due = selectDueTasks(
+            [intervalTask({ intervalMinutes: null, nextRunAt: new Date(now - 1_000) })],
+            now,
+            60_000,
+        );
+        expect(due).toEqual([]);
+    });
 });
 
 describe('sweep', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         mockSend.mockResolvedValue('job-1');
+        mockUpdateMany.mockResolvedValue({ count: 1 });
     });
 
     it('enqueues one tick per due task with a per-task de-dup key', async () => {
@@ -73,6 +122,29 @@ describe('sweep', () => {
         mockFindMany.mockResolvedValue([task({ cronExpression: '0 0 * * *' })]); // daily — not due right now
         await sweep(mockBoss);
         expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it('advances the interval anchor after enqueueing an interval tick', async () => {
+        mockFindMany.mockResolvedValue([
+            intervalTask({ taskId: 'i1', tenantId: 'ten-2', nextRunAt: new Date(Date.now() - 1_000) }),
+        ]);
+        await sweep(mockBoss);
+        expect(mockSend).toHaveBeenCalledWith(
+            'agent-ops-tick',
+            { taskId: 'i1', tenantId: 'ten-2' },
+            expect.objectContaining({ singletonKey: 'task:i1' }),
+        );
+        expect(mockUpdateMany).toHaveBeenCalledWith(expect.objectContaining({
+            where: { tenantId: 'ten-2', taskId: 'i1' },
+            data: { nextRunAt: expect.any(Date) },
+        }));
+    });
+
+    it('does not touch the anchor for cron tasks', async () => {
+        mockFindMany.mockResolvedValue([task({ cronExpression: '* * * * *' })]);
+        await sweep(mockBoss);
+        expect(mockSend).toHaveBeenCalled();
+        expect(mockUpdateMany).not.toHaveBeenCalled();
     });
 
     it('skips a concurrent sweep while one is still in flight', async () => {

--- a/apps/workers/src/jobs/agent-ops-scheduler/index.ts
+++ b/apps/workers/src/jobs/agent-ops-scheduler/index.ts
@@ -9,8 +9,11 @@ import { env } from '../../env.js';
 export interface ActiveTaskRow {
     taskId: string;
     tenantId: string;
-    cronExpression: string;
+    scheduleType: string;          // 'cron' | 'interval'
+    cronExpression: string;        // empty string for interval tasks
+    intervalMinutes: number | null; // set for interval tasks
     timezone: string;
+    nextRunAt: Date | null;        // fire anchor for interval tasks
 }
 
 const log = createLogger('agent-ops-scheduler');
@@ -100,18 +103,41 @@ async function loadActiveTasks(): Promise<ActiveTaskRow[]> {
     const prisma = await getPrisma();
     return prisma.scheduledTask.findMany({
         where: { taskStatus: 'active' },
-        select: { taskId: true, tenantId: true, cronExpression: true, timezone: true },
+        select: {
+            taskId: true,
+            tenantId: true,
+            scheduleType: true,
+            cronExpression: true,
+            intervalMinutes: true,
+            timezone: true,
+            nextRunAt: true,
+        },
     });
 }
 
 /**
- * Pure selection of which active tasks are due at `nowMs`. A task is due if its
- * most recent scheduled occurrence (per its cron + timezone) falls within
- * `windowMs` before now. A malformed cron expression is skipped (never throws).
+ * Pure selection of which active tasks are due at `nowMs`.
+ *
+ * Cron tasks: due if the most recent scheduled occurrence (per cron + timezone)
+ * falls within `windowMs` before now. A malformed cron is skipped (never throws).
+ *
+ * Interval tasks: due when their `nextRunAt` anchor has passed. The sweep
+ * advances the anchor by `intervalMinutes` immediately after enqueueing (see
+ * advanceIntervalAnchor) so subsequent sweeps don't re-fire while the run is
+ * still executing; run finalization re-anchors it again to run-end + interval.
+ * A null anchor (legacy row / just switched to interval) fires once and is then
+ * advanced normally.
  */
 export function selectDueTasks(tasks: ActiveTaskRow[], nowMs: number, windowMs: number): ActiveTaskRow[] {
     const ref = new Date(nowMs);
     return tasks.filter((t) => {
+        if (t.scheduleType === 'interval') {
+            if (!t.intervalMinutes || t.intervalMinutes <= 0) {
+                log.warn('Interval task without intervalMinutes — skipping', { taskId: t.taskId });
+                return false;
+            }
+            return t.nextRunAt === null || t.nextRunAt.getTime() <= nowMs;
+        }
         try {
             const cron = new Cron(t.cronExpression, { timezone: t.timezone });
             const prev = cron.previousRuns(1, ref)[0];
@@ -124,6 +150,21 @@ export function selectDueTasks(tasks: ActiveTaskRow[], nowMs: number, windowMs: 
             });
             return false;
         }
+    });
+}
+
+/**
+ * Push an interval task's nextRunAt forward so the next sweep doesn't re-fire
+ * it while its run is still executing. Concurrent sweeps racing here are
+ * harmless: the enqueue is de-duped by singletonKey, and both racers write
+ * approximately the same anchor.
+ */
+async function advanceIntervalAnchor(task: ActiveTaskRow, nowMs: number): Promise<void> {
+    if (task.scheduleType !== 'interval' || !task.intervalMinutes) return;
+    const prisma = await getPrisma();
+    await prisma.scheduledTask.updateMany({
+        where: { tenantId: task.tenantId, taskId: task.taskId },
+        data: { nextRunAt: new Date(nowMs + task.intervalMinutes * 60_000) },
     });
 }
 
@@ -212,8 +253,9 @@ export async function sweep(boss: PgBoss): Promise<void> {
     }
     sweepInFlight = true;
     try {
+        const nowMs = Date.now();
         const active = await loadActiveTasks();
-        const due = selectDueTasks(active, Date.now(), DUE_WINDOW_MS);
+        const due = selectDueTasks(active, nowMs, DUE_WINDOW_MS);
         for (const task of due) {
             try {
                 await boss.send(
@@ -229,6 +271,9 @@ export async function sweep(boss: PgBoss): Promise<void> {
                         expireInSeconds: 300,
                     },
                 );
+                // Interval tasks stay "due" until their anchor moves — advance it
+                // now so the next sweep (30s away) doesn't enqueue again.
+                await advanceIntervalAnchor(task, nowMs);
             } catch (err) {
                 log.error(`Failed to enqueue tick for task ${task.taskId}`, { error: String(err) });
             }

--- a/libs/prisma/migrations/20260711120000_agent_ops_interval_schedules/migration.sql
+++ b/libs/prisma/migrations/20260711120000_agent_ops_interval_schedules/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable: interval-based schedules for Agent Ops scheduled tasks
+-- scheduleType: 'cron' (default, existing behavior) | 'interval'
+-- intervalMinutes: fixed re-run interval, set when scheduleType = 'interval'
+ALTER TABLE "scheduled_tasks"
+    ADD COLUMN "scheduleType" TEXT NOT NULL DEFAULT 'cron',
+    ADD COLUMN "intervalMinutes" INTEGER;

--- a/libs/prisma/schema.prisma
+++ b/libs/prisma/schema.prisma
@@ -454,10 +454,12 @@ model ScheduledTask {
   taskId         String
   name           String
   description    String
-  cronExpression String
+  scheduleType   String    @default("cron") // cron|interval
+  cronExpression String // empty string when scheduleType=interval
+  intervalMinutes Int? // set when scheduleType=interval
   timezone       String
   taskStatus     String    @default("active") // active|paused|deleted — CHECK in migration SQL
-  mode           String    @default("plan") // plan|fast
+  mode           String    @default("plan") // always "plan" — fast mode retired for Agent Ops; legacy rows may still hold "fast"
   autoApprove    Boolean   @default(false)
   model          String?
   accountId      String?


### PR DESCRIPTION
## Summary

Closes the gaps between the current Agent Ops implementation and the target **scheduled-agent** scenario (cron/interval trigger → AWS creds → memories/skills/KB → channel digest → outcome memory), and upgrades the Slack/Jira/Telegram integrations to connector-grade UX with full lifecycle controls.

### Channels / connectors (`c7e009d7`)
- **Setup guides rebuilt** for Slack, Jira, and Telegram: numbered step-by-step instructions (shared `SetupSteps` component), field-level help, external doc links
- **Test Connection** on all three: Slack `auth.test`, Jira `/rest/api/3/myself` (auto-fills Bot Account ID), Telegram `getMe` + `getWebhookInfo`
- **Slack app-manifest quick-create** block — paste one JSON manifest and the slash command, bot scopes, and interactivity endpoint are configured automatically
- **Jira**: webhook-secret generator + smart-value Automation payload template
- **Telegram**: one-click **Register Webhook** (calls `setWebhook` server-side, audit-logged)
- **Catalog lifecycle**: Active / Deactivated / Not-configured badges, Reconfigure, and an Activate/Deactivate toggle that preserves stored credentials

### Agent Ops autonomy (`d69b7c10`)
- **Plan-mode only**: the evaluator classifies plan|clarify; `createRun` coerces all channel payloads to plan. Every run now ends `final → memory_save`, guaranteeing outcome memories for self-learning (previously fast-mode runs skipped the save)
- **Interval schedules**: `scheduleType` + `intervalMinutes` (migration included), "every N minutes/hours" picker in the task dialog, worker sweeper fires off a `nextRunAt` anchor with no overlap between runs
- **Scheduled digest delivery hardened**: Jira issue-comment digests implemented (the `jira` notification type was previously a silent no-op); Slack/Telegram/Jira senders now throw on missing config, deactivated integration, or API rejection; the notifier records `notification` events (sent/failed) on the run and failed deliveries render as error steps in the timeline
- **Per-tenant defaults**: new **Settings → Agent Defaults** page — required default model (from configured providers) + graph iteration limit (10–500) stored in `TenantConfig`; the executor applies them to every new run (explicit run model still wins) on both initial and resume paths
- Scheduled-task PATCH now whitelists mutable fields instead of writing the raw request body

## Test plan

- [x] Workers: typecheck clean; `agent-ops-scheduler` suite 12/12 (new interval due-selection + anchor-advance coverage)
- [x] Web-ui: typecheck at the pre-existing 183-error baseline (verified by diffing against a clean-HEAD run); no new errors
- [x] `tests/agent-ops` at the pre-existing baseline (19 legacy mock-harness failures in 2 files, unchanged); the createRun test updated to assert the plan-mode coercion contract
- [x] New unit tests: `agent-ops-defaults` 8/8 (validation, clamping, fallback); scheduled-task repo 13/13
- [x] Migration applied to local Postgres; prod picks it up via `prisma migrate deploy` at container boot
- [ ] Live end-to-end: create a 5-min interval task with a Slack notification on a dev tenant and watch trigger → run → digest → memory event round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)