### PR TITLE
fix(agent-ops): reflector text-shattering, stall detection, PDF/markdown export, DB constraint drift

### DIFF
--- a/apps/web-ui/app/api/agent-ops/[runId]/cancel/route.ts
+++ b/apps/web-ui/app/api/agent-ops/[runId]/cancel/route.ts
@@ -42,6 +42,7 @@ export async function POST(
         await agentOpsService.updateRunStatus(tenantId, runId, 'cancelled');
         await agentOpsService.recordEvent({
             runId,
+            tenantId,
             eventType: 'final',
             node: '__cancelled__',
             content: 'Run cancelled by user.',

--- a/apps/web-ui/app/api/agent-ops/[runId]/resume/route.ts
+++ b/apps/web-ui/app/api/agent-ops/[runId]/resume/route.ts
@@ -53,7 +53,11 @@ export async function POST(
         // Mark run as in_progress again before re-triggering
         await agentOpsService.updateRunStatus(tenantId, runId, 'in_progress');
 
-        // Re-execute with the enriched task description (new threadId = same LangGraph state reset)
+        // Re-execute with the enriched task description on the SAME thread — the
+        // checkpoint state (including the stale mode='end' evaluation) survives.
+        // evaluatorNode's isReusableEvaluation() guard handles this: a stale
+        // clarification evaluation is discarded and the enriched task (with the
+        // user's reply) is re-evaluated, so the run can't loop on the old question.
         const resumedRun = {
             ...run,
             taskDescription: enrichedTask,

--- a/apps/web-ui/app/app/agent-ops/[runId]/page.tsx
+++ b/apps/web-ui/app/app/agent-ops/[runId]/page.tsx
@@ -16,6 +16,7 @@ import { RunTimeline } from "@/components/agent-ops/run-timeline/timeline"
 import { useRunStream } from "@/components/agent-ops/run-timeline/use-run-stream"
 import { useAgentOpsRunDetail, useApproveRun, useCancelRun, useResumeRun } from "@/lib/queries/agent-ops"
 import { exportRunToPdf } from "@/lib/agent-ops/export-pdf"
+import { exportRunToMarkdown } from "@/lib/agent-ops/export-markdown"
 import { useTenant } from "@/lib/tenant-context"
 import { toast } from "sonner"
 
@@ -51,13 +52,22 @@ export default function RunDetailPage() {
     if (!run) return
     setExporting(true)
     try {
-      await exportRunToPdf(run, events)
+      await exportRunToPdf(run, events, timezone)
     } catch (err) {
       toast.error("PDF export failed", { description: (err as Error).message })
     } finally {
       setExporting(false)
     }
-  }, [run, events])
+  }, [run, events, timezone])
+
+  const handleExportMarkdown = useCallback(() => {
+    if (!run) return
+    try {
+      exportRunToMarkdown(run, events, timezone)
+    } catch (err) {
+      toast.error("Markdown export failed", { description: (err as Error).message })
+    }
+  }, [run, events, timezone])
 
   if (detail.isLoading) {
     return <div className="flex flex-1 items-center justify-center py-24"><Spinner /></div>
@@ -93,6 +103,7 @@ export default function RunDetailPage() {
         onCancel={() => cancelRun.mutate({ runId, body: { tenantId: run.tenantId } })}
         cancelling={cancelRun.isPending}
         onExportPdf={handleExportPdf}
+        onExportMarkdown={handleExportMarkdown}
         exporting={exporting}
         onBack={() => router.push("/app/agent-ops")}
       />

--- a/apps/web-ui/components/agent-ops/run-timeline/run-header.tsx
+++ b/apps/web-ui/components/agent-ops/run-timeline/run-header.tsx
@@ -1,11 +1,14 @@
 "use client";
 
 import {
-  ArrowLeft, CalendarClock, CheckCircle2, Cpu, Download, Globe, Loader2,
+  ArrowLeft, CalendarClock, CheckCircle2, ChevronDown, Cpu, Download, FileText, Globe, Loader2,
   MessageSquare, ShieldCheck, StopCircle, Timer, Wifi, XCircle, Zap,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 import type { AgentOpsRun, AgentOpsStatus } from "@/lib/agent-ops/types";
 
@@ -31,7 +34,7 @@ function fmtDuration(ms?: number): string {
 }
 
 export function RunHeader({
-  run, tokens, streaming, onCancel, cancelling, onExportPdf, exporting, onBack,
+  run, tokens, streaming, onCancel, cancelling, onExportPdf, onExportMarkdown, exporting, onBack,
 }: {
   run: AgentOpsRun;
   tokens: { input: number; output: number };
@@ -39,6 +42,7 @@ export function RunHeader({
   onCancel: () => void;
   cancelling: boolean;
   onExportPdf: () => void;
+  onExportMarkdown: () => void;
   exporting: boolean;
   onBack: () => void;
 }) {
@@ -64,10 +68,23 @@ export function RunHeader({
         )}
         <span className="ml-auto flex items-center gap-2">
           {run.status !== "queued" && run.status !== "in_progress" && (
-            <Button variant="outline" size="sm" onClick={onExportPdf} disabled={exporting}>
-              {exporting ? <Loader2 className="mr-1.5 size-3.5 animate-spin" /> : <Download className="mr-1.5 size-3.5" />}
-              PDF
-            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" size="sm" disabled={exporting}>
+                  {exporting ? <Loader2 className="mr-1.5 size-3.5 animate-spin" /> : <Download className="mr-1.5 size-3.5" />}
+                  Export
+                  <ChevronDown className="ml-1 size-3.5" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={onExportPdf}>
+                  <Download className="mr-2 size-3.5" /> PDF
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={onExportMarkdown}>
+                  <FileText className="mr-2 size-3.5" /> Markdown
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           )}
           {active && (
             <Button variant="destructive" size="sm" onClick={onCancel} disabled={cancelling}>

--- a/apps/web-ui/lib/agent-ops/agent-executor.ts
+++ b/apps/web-ui/lib/agent-ops/agent-executor.ts
@@ -147,7 +147,17 @@ export async function executeAgentRun(run: AgentOpsRun, eventBus?: GatewayEventB
         } catch { /* non-fatal */ }
 
         const graphInput = { messages: [new HumanMessage(taskDescription)] };
-        const graphRunConfig = { configurable: { thread_id: threadId }, recursionLimit: maxIterations };
+        // tenant_id/user_id MUST be in configurable: execute_command reads
+        // config.configurable.tenant_id at invoke time to point
+        // AWS_SHARED_CREDENTIALS_FILE at the tenant creds file where
+        // get_aws_credentials wrote the STS profile. Without it the AWS CLI
+        // falls back to the empty ~/.aws/credentials and every command fails
+        // with "The config profile could not be found". (Matches the AIOps
+        // chat route in app/api/chat/route.ts.)
+        const graphRunConfig = {
+            configurable: { thread_id: threadId, tenant_id: tenantId, user_id: deriveUserId(run) },
+            recursionLimit: maxIterations,
+        };
 
         // ── Event tracking ────────────────────────────────────────────────────
         const toolsUsed = new Set<string>();
@@ -486,15 +496,27 @@ async function processLangGraphEvent(
             if (typeof rawContent === 'string') {
                 textContent = rawContent.trim();
             } else if (Array.isArray(rawContent)) {
-                // Bedrock returns [{type:'text', text:'...'}, {type:'tool_use', ...}]
+                // Bedrock streaming yields content as an array of un-coalesced
+                // text deltas ([{type:'text',text:'The'},{type:'text',text:' request'}...]).
+                // Each delta carries its own leading space, so join with '' —
+                // join('\n') shatters the text one delta per line in the UI + PDF.
+                // (Matches getStringContent() in fast-agent.ts.)
                 textContent = rawContent
                     .filter((c: any) => c.type === 'text' && c.text?.trim())
                     .map((c: any) => c.text)
-                    .join('\n')
+                    .join('')
                     .trim();
             }
 
-            if (textContent) {
+            // planner/evaluator/reflect each emit a clean STRUCTURED event at
+            // on_chain_end (Plan created / evaluation / parsed reflection). Their
+            // raw model text here is a duplicate twin — recording it too double-
+            // lists every planning/reflection step in the timeline. Skip it; the
+            // token usage above is still captured. (generate/agent → execution,
+            // revise → revision, final → final have no structured twin, so keep.)
+            const STRUCTURED_TWIN_NODES = new Set(['planner', 'evaluator', 'reflect']);
+
+            if (textContent && !STRUCTURED_TWIN_NODES.has(node)) {
                 if (node === 'final' || (node === 'generate' && !toolCalls.length)) {
                     result.finalContent = textContent;
                 }
@@ -604,7 +626,12 @@ export async function resumeApprovedRun(run: AgentOpsRun, eventBus?: GatewayEven
         // Match the initial-run recursionLimit (the tenant's configured graph
         // limit); otherwise a resumed run would fall back to LangGraph's default
         // of 25, tighter than what the initial run used.
-        const graphRunConfig = { configurable: { thread_id: threadId }, recursionLimit: maxIterations };
+        // tenant_id/user_id in configurable are required for execute_command to
+        // resolve AWS credentials on resume too — see the initial-run comment above.
+        const graphRunConfig = {
+            configurable: { thread_id: threadId, tenant_id: tenantId, user_id: deriveUserId(run) },
+            recursionLimit: maxIterations,
+        };
 
         // Inject approvalStatus='approved' so routing skips both gates on resume
         await (graph as any).updateState(graphRunConfig, {

--- a/apps/web-ui/lib/agent-ops/executor-graphs.ts
+++ b/apps/web-ui/lib/agent-ops/executor-graphs.ts
@@ -34,6 +34,9 @@ import {
     getActiveMCPTools,
     getMCPToolsDescription,
     getMCPManager,
+    computeReflectionStall,
+    extractTextContent,
+    critiqueVerdict,
 } from "@/lib/agent/agent-shared";
 import {
     buildBaseIdentity,
@@ -51,7 +54,7 @@ import { resolveKnowledgeBaseIds } from "@/lib/agent/auto-kb-select";
 
 // ── Agent Ops-specific imports ────────────────────────────────────────────────
 import { GraphConfig } from "@/lib/agent/agent-shared";
-import { ReflectionState, graphState, PlanStep, RequestEvaluation, ToolResultEntry } from "./executor-state";
+import { ReflectionState, graphState, PlanStep, RequestEvaluation, ToolResultEntry, isReusableEvaluation } from "./executor-state";
 import { filterMutativeToolCalls } from "./tool-classifier";
 import { env } from "@/env";
 
@@ -151,7 +154,12 @@ export async function createDynamicExecutorGraph(config: GraphConfig) {
     // NODE: EVALUATOR — determines mode, skill, account, and whether clarification needed
     // ============================================================================
     async function evaluatorNode(state: ReflectionState): Promise<Partial<ReflectionState>> {
-        if (state.evaluation) return {}; // Already evaluated (e.g. resumed from checkpoint)
+        // Reuse a checkpointed PLAN evaluation (approval resume). A stale 'end'
+        // (clarification) evaluation must be re-evaluated: on clarification resume
+        // the user's reply is in the last message, and skipping the LLM here made
+        // routeFromEvaluator replay the old mode='end' → clarify → the run
+        // re-asked the identical question forever.
+        if (isReusableEvaluation(state.evaluation)) return {};
 
         const lastMessage = state.messages[state.messages.length - 1];
         const taskDescription = typeof lastMessage.content === 'string'
@@ -199,7 +207,7 @@ Return only the JSON object.`);
         };
 
         try {
-            const content = response.content as string;
+            const content = extractTextContent(response.content);
             const match = content.match(/\{[\s\S]*\}/);
             if (match) {
                 const parsed = JSON.parse(match[0]);
@@ -296,7 +304,7 @@ Return ONLY a JSON array of step strings. Example:
 
         let planSteps: PlanStep[] = [];
         try {
-            const match = (response.content as string).match(/\[[\s\S]*\]/);
+            const match = extractTextContent(response.content).match(/\[[\s\S]*\]/);
             if (match) {
                 planSteps = JSON.parse(match[0]).map((step: string) => ({ step, status: 'pending' as const }));
             }
@@ -490,10 +498,18 @@ Otherwise list specific issues to fix. Do not generate the fixed answer.`);
         const response = await reflectorModel.invoke(inputs);
         llmAuditLog('REFLECTOR', inputs, response, start);
 
-        const content = typeof response.content === 'string' ? response.content : JSON.stringify(response.content);
+        const content = extractTextContent(response.content);
 
         if (isComplex) {
             let analysis = '', issues = 'None', isComplete = false, updatedPlan: PlanStep[] = [];
+            // Empty reflector text (reasoning consumed the output budget) parses to
+            // nothing and would loop forever with issues='None' resetting the stall
+            // counter. Report it as a CONSTANT issue so consecutive repeats trip
+            // computeReflectionStall and the run finalizes instead of churning.
+            if (!content.trim()) {
+                analysis = 'Reflector returned no text output.';
+                issues = 'EMPTY_REFLECTION: reflector produced no text';
+            }
             try {
                 const match = content.match(/\{[\s\S]*\}/);
                 if (match) {
@@ -505,17 +521,34 @@ Otherwise list specific issues to fix. Do not generate the fixed answer.`);
                 }
             } catch { isComplete = false; }
 
-            console.log(`[REFLECTOR] Complete: ${isComplete} | Issues: ${issues !== 'None' ? issues : 'None'}`);
+            // Stall detection: if the reflector keeps reporting the SAME blocking
+            // issue, the revise loop isn't making progress. Bail to final rather
+            // than churning to AGENT_OPS_MAX_ITERATIONS (the Jira run burned 1.4M
+            // tokens repeating a single tool-arg error before the user cancelled).
+            const prevIssues = state.errors?.[0];
+            const { stallCount, stalled } = computeReflectionStall(
+                issues === 'None' ? '' : issues,
+                prevIssues,
+                state.reflectionStallCount ?? 0,
+            );
+            const analysisOut = stalled
+                ? `${analysis}\n\n⚠️ Reflection stalled: the issue "${issues}" persisted across multiple reflections without resolution — finalizing with current findings instead of retrying further.`
+                : analysis;
+
+            console.log(`[REFLECTOR] Complete: ${isComplete} | Issues: ${issues !== 'None' ? issues : 'None'}${stalled ? ` | STALLED (count=${stallCount})` : ''}`);
 
             return {
-                messages: [new AIMessage({ content: `🔍 **Reflection:**\n${analysis}${issues !== 'None' ? `\n⚠️ Issues: ${issues}` : ''}` })],
-                reflection: analysis,
+                messages: [new AIMessage({ content: `🔍 **Reflection:**\n${analysisOut}${issues !== 'None' ? `\n⚠️ Issues: ${issues}` : ''}` })],
+                reflection: analysisOut,
                 errors: issues !== 'None' ? [issues] : [],
-                isComplete: isComplete || iterationCount >= AGENT_OPS_MAX_ITERATIONS,
+                isComplete: isComplete || iterationCount >= AGENT_OPS_MAX_ITERATIONS || stalled,
                 plan: updatedPlan.length > 0 ? updatedPlan : plan,
+                reflectionStallCount: stallCount,
             };
         } else {
-            if (content.includes('COMPLETE') || iterationCount >= AGENT_OPS_MAX_ITERATIONS) {
+            // critiqueVerdict also accepts on an EMPTY critique — looping on empty
+            // reflector feedback burns iterations with nothing to fix.
+            if (critiqueVerdict(content) === 'accept' || iterationCount >= AGENT_OPS_MAX_ITERATIONS) {
                 return { messages: [response], isComplete: true };
             }
             return {
@@ -602,7 +635,7 @@ Be specific — include resource IDs, account names, and numeric values where av
         const response = await model.invoke(inputs);
         llmAuditLog('FINAL', inputs, response, start);
 
-        const summaryContent = typeof response.content === 'string' ? response.content : JSON.stringify(response.content);
+        const summaryContent = extractTextContent(response.content);
         const finalMessage = `✅ **Task Complete**\n\n**Original Task:** ${taskDescription}\n**Iterations:** ${iterationCount}\n\n---\n\n${summaryContent}`;
 
         return { messages: [new AIMessage({ content: finalMessage })], isComplete: true };

--- a/apps/web-ui/lib/agent-ops/executor-state.ts
+++ b/apps/web-ui/lib/agent-ops/executor-state.ts
@@ -46,6 +46,7 @@ export interface ReflectionState {
     clarificationQuestion: string | null;
     approvalStatus: 'pending' | 'approved' | 'rejected' | null;
     pendingToolApprovals: string[];  // tool names awaiting approval at mutative_approval_gate
+    reflectionStallCount?: number;   // consecutive unproductive reflections (stall detector)
 }
 
 export const graphState: StateGraphArgs<ReflectionState>["channels"] = {
@@ -84,6 +85,12 @@ export const graphState: StateGraphArgs<ReflectionState>["channels"] = {
         reducer: (_x: boolean, y: boolean) => y,
         default: () => false,
     },
+    // Stall detector: without this channel LangGraph silently DROPS the value the
+    // reflect node returns, so the counter never accumulates and the bail never fires.
+    reflectionStallCount: {
+        reducer: (x: number | undefined, y: number | undefined) => y ?? x ?? 0,
+        default: () => 0,
+    },
     toolResults: {
         reducer: (x: ToolResultEntry[], y: ToolResultEntry[]) => x.concat(y),
         default: () => [],
@@ -113,3 +120,19 @@ export const graphState: StateGraphArgs<ReflectionState>["channels"] = {
         default: () => [],
     },
 };
+
+/**
+ * Whether a checkpointed evaluation can be REUSED on a graph re-invoke.
+ *
+ * The clarification resume re-runs the graph on the SAME thread, so the
+ * previous run's evaluation survives in the checkpoint (the channel reducer
+ * keeps it). A plan-mode evaluation is a real execution decision — reusing it
+ * is correct (that's what the approval resume relies on). But a mode='end'
+ * (clarification) decision must NEVER be reused: the user's reply is now in
+ * the conversation and the evaluator has to actually read it — otherwise the
+ * stale decision routes straight back to clarify and the run re-asks the same
+ * question forever, no matter what the user answers.
+ */
+export function isReusableEvaluation(evaluation: RequestEvaluation | null | undefined): boolean {
+    return !!evaluation && evaluation.mode !== 'end';
+}

--- a/apps/web-ui/lib/agent-ops/export-markdown.ts
+++ b/apps/web-ui/lib/agent-ops/export-markdown.ts
@@ -1,0 +1,213 @@
+/**
+ * Agent Ops run → Markdown report.
+ *
+ * Companion to export-pdf.ts: same data, same buildSteps() step model as the
+ * on-screen timeline, rendered as a self-contained .md document (the pattern
+ * users know from the AI Ops chat export in lib/chat-export.ts).
+ *
+ * buildRunReportMarkdown() is pure (unit-tested); exportRunToMarkdown() wraps
+ * it in a Blob download.
+ */
+
+import type { AgentOpsRun, AgentOpsEvent } from "./types"
+import { formatDateTime } from '@/lib/date-utils';
+import { buildSteps, type TimelineStep } from "@/components/agent-ops/run-timeline/build-steps";
+
+function formatTime(iso: string, timeZone?: string) {
+    return formatDateTime(iso, 'longDateTime', timeZone);
+}
+
+function formatDuration(ms?: number) {
+    if (!ms) return "—"
+    if (ms < 1000) return `${ms}ms`
+    if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`
+    return `${(ms / 60000).toFixed(1)}m`
+}
+
+/**
+ * Wrap content in a code fence that cannot be terminated early: the fence is
+ * one backtick longer than the longest backtick run inside the content.
+ */
+function fence(content: string, lang = ""): string {
+    const longestRun = content.match(/`+/g)?.reduce((max, run) => Math.max(max, run.length), 0) ?? 0
+    const marker = "`".repeat(Math.max(3, longestRun + 1))
+    return `${marker}${lang}\n${content}\n${marker}`
+}
+
+const STEP_ICONS: Record<string, string> = {
+    memory: "🧠",
+    evaluation: "🧭",
+    planning: "📋",
+    thinking: "💭",
+    tool: "🔧",
+    reflection: "🔍",
+    final: "✅",
+    error: "❌",
+}
+
+export function buildRunReportMarkdown(
+    run: AgentOpsRun,
+    events: AgentOpsEvent[],
+    timeZone?: string,
+): string {
+    const lines: string[] = []
+    const push = (...ls: string[]) => { lines.push(...ls) }
+
+    const tokens = events.reduce(
+        (acc, e) => {
+            acc.input += (e.metadata?.inputTokens as number) || 0
+            acc.output += (e.metadata?.outputTokens as number) || 0
+            return acc
+        },
+        { input: 0, output: 0 },
+    )
+    const tokenStr = tokens.input + tokens.output > 0
+        ? `${tokens.input.toLocaleString()} in / ${tokens.output.toLocaleString()} out`
+        : "—"
+
+    // ── Header + metadata ───────────────────────────────────────────────────
+    push(
+        `# Agent Ops Run Report`,
+        ``,
+        `\`${run.runId}\` · **${run.status.replace(/_/g, " ").toUpperCase()}**`,
+        ``,
+        `| Source | Mode | Duration | Tokens | Events | Started |${run.completedAt ? " Completed |" : ""}`,
+        `|---|---|---|---|---|---|${run.completedAt ? "---|" : ""}`,
+        `| ${run.source} | ${run.mode} | ${formatDuration(run.durationMs)} | ${tokenStr} | ${events.length} | ${formatTime(run.createdAt, timeZone)} |${run.completedAt ? ` ${formatTime(run.completedAt, timeZone)} |` : ""}`,
+        ``,
+    )
+
+    // ── Task ────────────────────────────────────────────────────────────────
+    push(`## Task Description`, ``, run.taskDescription, ``)
+    const taskMeta = [
+        run.selectedSkill ? `**Skill:** ${run.selectedSkill}` : "",
+        run.accountName ? `**Account:** ${run.accountName}${run.accountId ? ` (${run.accountId})` : ""}` : "",
+    ].filter(Boolean)
+    if (taskMeta.length) push(taskMeta.join(" · "), ``)
+
+    // ── Result / Error ──────────────────────────────────────────────────────
+    if (run.result?.summary) {
+        push(`## Result`, ``, run.result.summary, ``)
+        if (run.result.toolsUsed?.length) push(`**Tools used:** ${run.result.toolsUsed.join(", ")}`, ``)
+        if (run.result.iterations) push(`*${run.result.iterations} iteration(s)*`, ``)
+    }
+    if (run.error) {
+        push(`## Error`, ``, fence(run.error), ``)
+    }
+
+    // ── Execution Timeline ──────────────────────────────────────────────────
+    // Same step model as the UI timeline and the PDF. Groups render EXPANDED:
+    // a document can't be clicked open, so every grouped tool call is inlined.
+    push(`## Execution Timeline (${events.length} events)`, ``)
+
+    const steps = buildSteps(events, run.status)
+    if (steps.length === 0) push(`*No events recorded.*`, ``)
+
+    const t = (e: AgentOpsEvent) => formatTime(e.createdAt, timeZone)
+
+    function renderStep(step: TimelineStep, depth: number) {
+        // Group children render one heading level deeper (#### instead of ###).
+        const h = "#".repeat(Math.min(3 + depth, 6))
+
+        switch (step.kind) {
+            case "group": {
+                const toolCount = step.steps.filter(s => s.kind === "tool").length
+                const dur = step.durationMs > 0 ? ` · ${formatDuration(step.durationMs)}` : ""
+                push(`${h} ⚙️ Worked — ${toolCount} tool call${toolCount === 1 ? "" : "s"}${dur}`, ``)
+                for (const s of step.steps) renderStep(s, depth + 1)
+                break
+            }
+            case "tool": {
+                const anchor = step.call ?? step.result
+                const statusMark = step.status === "error" ? "✗" : step.status === "running" ? "…" : "✓"
+                const dur = step.durationMs !== undefined ? ` ${formatDuration(step.durationMs)}` : ""
+                push(`${h} ${STEP_ICONS.tool} Tool: \`${step.toolName}\` ${statusMark}${dur}${anchor ? ` — ${t(anchor)}` : ""}`, ``)
+                const args = step.call?.toolArgs
+                const output = step.result?.toolOutput ?? step.result?.content
+                if (args && Object.keys(args).length > 0) {
+                    push(`**Arguments:**`, ``, fence(JSON.stringify(args, null, 2), "json"), ``)
+                }
+                if (output) {
+                    push(`**Output:**`, ``, fence(output), ``)
+                }
+                if (!args && !output) push(`*No detail captured.*`, ``)
+                break
+            }
+            case "planning":
+                push(`${h} ${STEP_ICONS.planning} Planning — ${t(step.event)}`, ``)
+                if (step.event.content) push(step.event.content, ``)
+                break
+            case "reflection":
+                push(`${h} ${STEP_ICONS.reflection} ${step.event.eventType === "revision" ? "Revision" : "Reflection"} — ${t(step.event)}`, ``)
+                if (step.event.content) push(step.event.content, ``)
+                break
+            case "thinking":
+                if (!step.event.content) break
+                push(`${h} ${STEP_ICONS.thinking} Thinking — ${t(step.event)}`, ``)
+                push(step.event.content, ``)
+                break
+            case "evaluation": {
+                const m = (step.event.metadata ?? {}) as Record<string, unknown>
+                const kbs = (m.knowledgeBaseIds as unknown[] | undefined) ?? []
+                const badges = [
+                    m.mode ? `${m.mode} mode` : "",
+                    (m.skillName || m.skillId) ? `skill: ${m.skillName ?? m.skillId}` : "",
+                    kbs.length ? `KB ×${kbs.length}` : "",
+                    m.requiresApproval ? "approval required" : "",
+                ].filter(Boolean).join(" · ")
+                push(`${h} ${STEP_ICONS.evaluation} Evaluated request — ${t(step.event)}`, ``)
+                if (badges) push(`*${badges}*`, ``)
+                if (step.event.content) push(step.event.content, ``)
+                break
+            }
+            case "memory": {
+                const m = (step.event.metadata ?? {}) as Record<string, unknown>
+                const title = step.event.content || (step.phase === "recall" ? "Memory recall" : "Memory save")
+                push(`${h} ${STEP_ICONS.memory} ${title} — ${t(step.event)}`, ``)
+                if (step.phase === "recall") {
+                    const parts = [
+                        (m.facts as unknown[])?.length ? `${(m.facts as unknown[]).length} fact(s)` : "",
+                        (m.rules as unknown[])?.length ? `${(m.rules as unknown[]).length} rule(s)` : "",
+                        (m.episodes as unknown[])?.length ? `${(m.episodes as unknown[]).length} episode(s)` : "",
+                    ].filter(Boolean).join(" · ")
+                    if (parts) push(`*${parts}*`, ``)
+                } else if (m.savedFacts !== undefined) {
+                    push(`*${m.savedFacts ?? 0} fact(s), ${m.savedRules ?? 0} rule(s) saved · episode: ${m.episodeCaptured ? "yes" : "no"}*`, ``)
+                }
+                break
+            }
+            case "final":
+                push(`${h} ${STEP_ICONS.final} ${step.event.node === "__cancelled__" ? "Run cancelled" : "Final summary"} — ${t(step.event)}`, ``)
+                if (step.event.content) push(step.event.content, ``)
+                break
+            case "error":
+                push(`${h} ${STEP_ICONS.error} Error — ${t(step.event)}`, ``)
+                if (step.event.content) push(fence(step.event.content), ``)
+                break
+        }
+    }
+
+    for (const step of steps) renderStep(step, 0)
+
+    push(`---`, ``, `*Generated ${formatDateTime(new Date(), 'longDateTime', timeZone)} · Nucleus Cloud Ops*`)
+
+    return lines.join("\n")
+}
+
+/** Build the report and trigger a browser download (same pattern as chat-export.ts). */
+export function exportRunToMarkdown(
+    run: AgentOpsRun,
+    events: AgentOpsEvent[],
+    timeZone?: string,
+): void {
+    const markdown = buildRunReportMarkdown(run, events, timeZone)
+    const blob = new Blob([markdown], { type: "text/markdown;charset=utf-8" })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement("a")
+    link.href = url
+    link.download = `agent-ops-run-${run.runId.slice(0, 8)}-${new Date().toISOString().slice(0, 10)}.md`
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+    URL.revokeObjectURL(url)
+}

--- a/apps/web-ui/lib/agent-ops/export-pdf.ts
+++ b/apps/web-ui/lib/agent-ops/export-pdf.ts
@@ -1,5 +1,6 @@
 import type { AgentOpsRun, AgentOpsEvent } from "./types"
 import { formatDateTime } from '@/lib/date-utils';
+import { buildSteps, type TimelineStep } from "@/components/agent-ops/run-timeline/build-steps";
 
 const EVENT_META: Record<string, { label: string; bg: string; color: string }> = {
     planning: { label: "Planning", bg: "#dbeafe", color: "#1d4ed8" },
@@ -173,9 +174,20 @@ export function buildRunReportHtml(run: AgentOpsRun, events: AgentOpsEvent[], ti
     }
     const statusStyle = statusColors[run.status] ?? "background:#f3f4f6;color:#374151;"
 
+    // The <title> becomes the browser's default "Save as PDF" filename.
+    const docTitle = `agent-ops-run-${run.runId.slice(0, 8)}`
+
     return `<!DOCTYPE html>
 <html>
-<head><meta charset="utf-8"/><title>Agent Ops Run Report</title></head>
+<head>
+  <meta charset="utf-8"/>
+  <title>${esc(docTitle)}</title>
+  <style>
+    @page { size: A4; margin: 8mm; }
+    /* Force badge/section background colors to print (they carry meaning). */
+    html, body { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  </style>
+</head>
 <body style="${S.body}">
 
   <!-- Header -->
@@ -240,57 +252,346 @@ export function buildRunReportHtml(run: AgentOpsRun, events: AgentOpsEvent[], ti
 </html>`
 }
 
-export async function exportRunToPdf(run: AgentOpsRun, events: AgentOpsEvent[]): Promise<void> {
-    const html2pdf = (await import("html2pdf.js")).default
+// hex "#rrggbb" → [r,g,b] for jsPDF's setFillColor/setTextColor.
+function hexToRgb(hex: string): [number, number, number] {
+    const m = /^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex)
+    if (!m) return [55, 65, 81]
+    return [parseInt(m[1], 16), parseInt(m[2], 16), parseInt(m[3], 16)]
+}
 
-    const html = buildRunReportHtml(run, events)
-    const filename = `agent-ops-run-${run.runId.slice(0, 8)}-${new Date().toISOString().slice(0, 10)}.pdf`
+/**
+ * Export a run to PDF using jsPDF's vector text API — NOT html2canvas.
+ *
+ * Two earlier approaches failed:
+ *  1. html2pdf/html2canvas rasterized the whole report into ONE canvas. Chrome
+ *     silently caps canvas height at 65,535 px (transparent, no error), so long
+ *     runs produced a blank PDF.
+ *  2. Native window.print() has no canvas limit but opens the OS print dialog,
+ *     which is dead-in-the-water on machines with no printer configured (macOS
+ *     shows "No Printer Selected" and hides Save-as-PDF in a small menu).
+ *
+ * jsPDF text rendering has neither problem: no raster canvas (no size limit),
+ * selectable text, tiny files, jsPDF.save() triggers a normal browser download
+ * with a real filename on every OS. We paginate manually via a y-cursor.
+ */
+export async function exportRunToPdf(
+    run: AgentOpsRun,
+    events: AgentOpsEvent[],
+    timeZone?: string
+): Promise<void> {
+    const { jsPDF } = await import("jspdf")
+    const doc = new jsPDF({ unit: "mm", format: "a4", orientation: "portrait" })
 
-    // html2pdf.js clones the source node (via snapdom's deepCloneBasic, which
-    // copies inline styles verbatim with cloneNode) and places the clone inside
-    // its own `height:auto` capture container, then runs html2canvas on that
-    // *container*. If the source node's inline style makes it out-of-flow
-    // (position: fixed/absolute, or off-screen coordinates), the clone is also
-    // out-of-flow and contributes zero height to the capture container — so
-    // html2canvas renders a 0-height canvas and jsPDF emits an empty PDF
-    // (verified: 1468x0 canvas → 3 KB blank PDF).
-    //
-    // Fix: keep the off-screen positioning on a WRAPPER that is never cloned,
-    // and leave the holder itself as an in-flow block carrying only the body's
-    // base styles (S.body). html2pdf clones the holder (not the wrapper), so
-    // the clone flows normally inside the capture container and the container
-    // gets the content's height (verified: 733x1161 → 1468x2324 canvas,
-    // ~1M non-white pixels → 370 KB PDF). All report styling is inline, so the
-    // clone needs no external stylesheets.
-    const wrapper = document.createElement("div")
-    wrapper.style.cssText = "position:fixed;top:0;left:-99999px;z-index:-9999;pointer-events:none;"
-    const holder = document.createElement("div")
-    holder.style.cssText = S.body
-    holder.innerHTML = new DOMParser().parseFromString(html, "text/html").body.innerHTML
-    wrapper.appendChild(holder)
-    document.body.appendChild(wrapper)
+    const M = 12                 // page margin (mm)
+    const PW = 210, PH = 297     // A4 (mm)
+    const CW = PW - M * 2        // content width (mm)
+    const PT = 0.352778          // 1 pt in mm
+    let y = M
 
-    // Let layout settle before capture.
-    await new Promise(r => setTimeout(r, 50))
+    const clean = (s: unknown) => String(s ?? "").replace(/\r/g, "").replace(/\t/g, "    ")
+    const ensure = (h: number) => { if (y + h > PH - M) { doc.addPage(); y = M } }
 
-    try {
-        await html2pdf()
-            .set({
-                margin: [8, 8, 8, 8],
-                filename,
-                image: { type: "jpeg", quality: 0.98 },
-                html2canvas: {
-                    scale: 2,
-                    useCORS: true,
-                    logging: false,
-                    windowWidth: 794,
-                    scrollY: 0,
-                },
-                jsPDF: { unit: "mm", format: "a4", orientation: "portrait" },
-            })
-            .from(holder)
-            .save()
-    } finally {
-        document.body.removeChild(wrapper)
+    // Wrapped paragraph. Returns nothing; advances y (paginating as needed).
+    function para(
+        text: string,
+        opts: { size?: number; color?: [number, number, number]; font?: string; style?: string; indent?: number; gap?: number } = {}
+    ) {
+        const { size = 9, color = [55, 65, 81], font = "helvetica", style = "normal", indent = 0, gap = 1.35 } = opts
+        doc.setFont(font, style)
+        doc.setFontSize(size)
+        doc.setTextColor(color[0], color[1], color[2])
+        const lh = size * PT * gap
+        const lines: string[] = doc.splitTextToSize(clean(text), CW - indent)
+        for (const ln of lines) {
+            ensure(lh)
+            doc.text(ln, M + indent, y + size * PT)  // baseline offset
+            y += lh
+        }
     }
+
+    // Small filled label chip. Draws at (x, y-top); returns its width (mm).
+    function chip(label: string, x: number, bgHex: string, fgHex: string): number {
+        const size = 7.5
+        doc.setFont("helvetica", "bold")
+        doc.setFontSize(size)
+        const w = doc.getTextWidth(label) + 3
+        const h = 4.2
+        const [br, bg, bb] = hexToRgb(bgHex)
+        const [fr, fg, fb] = hexToRgb(fgHex)
+        doc.setFillColor(br, bg, bb)
+        doc.roundedRect(x, y, w, h, 0.8, 0.8, "F")
+        doc.setTextColor(fr, fg, fb)
+        doc.text(label, x + 1.5, y + h - 1.3)
+        return w
+    }
+
+    function rule() {
+        ensure(3)
+        doc.setDrawColor(229, 231, 235)
+        doc.setLineWidth(0.2)
+        doc.line(M, y, PW - M, y)
+        y += 3
+    }
+
+    // ── Header ────────────────────────────────────────────────────────────
+    para("Agent Ops Run Report", { size: 18, style: "bold", color: [17, 24, 39], gap: 1.1 })
+    para(run.runId, { size: 9, font: "courier", color: [107, 114, 128] })
+    y += 1
+    const statusMeta: Record<string, [string, string]> = {
+        completed: ["#dcfce7", "#166534"], failed: ["#fee2e2", "#dc2626"],
+        in_progress: ["#dbeafe", "#1d4ed8"], cancelled: ["#f3f4f6", "#6b7280"],
+    }
+    const [sbg, sfg] = statusMeta[run.status] ?? ["#f3f4f6", "#374151"]
+    chip(run.status.replace(/_/g, " ").toUpperCase(), M, sbg, sfg)
+    y += 7
+
+    // ── Meta ──────────────────────────────────────────────────────────────
+    const tokenTotals = events.reduce(
+        (a, e) => {
+            if (e.metadata) {
+                a.input += (e.metadata.inputTokens as number) || 0
+                a.output += (e.metadata.outputTokens as number) || 0
+            }
+            return a
+        },
+        { input: 0, output: 0 }
+    )
+    const tokenStr = tokenTotals.input + tokenTotals.output > 0
+        ? `${tokenTotals.input.toLocaleString()} in / ${tokenTotals.output.toLocaleString()} out`
+        : "—"
+    const metaPairs: [string, string][] = [
+        ["Source", clean(run.source)],
+        ["Mode", clean(run.mode)],
+        ["Duration", formatDuration(run.durationMs)],
+        ["Tokens", tokenStr],
+        ["Events", String(events.length)],
+        ["Started", formatTime(run.createdAt, timeZone)],
+    ]
+    if (run.completedAt) metaPairs.push(["Completed", formatTime(run.completedAt, timeZone)])
+    for (const [k, v] of metaPairs) {
+        ensure(5)
+        doc.setFont("helvetica", "bold"); doc.setFontSize(9); doc.setTextColor(107, 114, 128)
+        doc.text(`${k}:`, M, y + 3)
+        doc.setFont("helvetica", "normal"); doc.setTextColor(17, 24, 39)
+        doc.text(clean(v), M + 26, y + 3)
+        y += 5
+    }
+    y += 3
+
+    // ── Task ──────────────────────────────────────────────────────────────
+    para("Task Description", { size: 12, style: "bold", color: [55, 65, 81] })
+    rule()
+    para(run.taskDescription, { size: 10, color: [17, 24, 39] })
+    if (run.selectedSkill) para(`Skill: ${run.selectedSkill}`, { size: 8, color: [107, 114, 128] })
+    if (run.accountName) para(`Account: ${run.accountName} (${run.accountId ?? ""})`, { size: 8, color: [107, 114, 128] })
+    y += 3
+
+    // ── Result / Error ──────────────────────────────────────────────────────
+    if (run.result?.summary) {
+        para("Result", { size: 12, style: "bold", color: [22, 101, 52] })
+        rule()
+        para(run.result.summary, { size: 9, color: [17, 24, 39] })
+        if (run.result.toolsUsed?.length) para(`Tools used: ${run.result.toolsUsed.join(", ")}`, { size: 8, color: [107, 114, 128] })
+        if (run.result.iterations) para(`${run.result.iterations} iteration(s)`, { size: 8, color: [107, 114, 128] })
+        y += 3
+    }
+    if (run.error) {
+        para("Error", { size: 12, style: "bold", color: [220, 38, 38] })
+        rule()
+        para(run.error, { size: 9, font: "courier", color: [220, 38, 38] })
+        y += 3
+    }
+
+    // ── Execution Timeline ──────────────────────────────────────────────────
+    // Reuse the SAME step model the web UI builds (run-timeline/build-steps.ts)
+    // so the PDF and the on-screen timeline never drift: tool_call + tool_result
+    // are paired into one Tool step (name, arguments, output, status, duration),
+    // and steps carry the same kinds/labels/colors as the UI. The ONE deliberate
+    // difference: the UI folds long work runs into collapsible "Worked — N tool
+    // calls" groups, but a PDF can't be clicked open, so groups are rendered
+    // EXPANDED here and every tool call shows its arguments + output inline.
+    para(`Execution Timeline (${events.length} events)`, { size: 12, style: "bold", color: [55, 65, 81] })
+    rule()
+
+    const steps = buildSteps(events, run.status)
+    if (steps.length === 0) {
+        para("No events recorded.", { size: 9, color: [156, 163, 175] })
+    }
+
+    const fmtDur = (ms?: number) =>
+        ms === undefined ? "" : ms < 1000 ? `${ms}ms` : ms < 60000 ? `${(ms / 1000).toFixed(1)}s` : `${(ms / 60000).toFixed(1)}m`
+    const firstLine = (t?: string, n = 110) => {
+        if (!t) return ""
+        const l = clean(t).split("\n").find((s) => s.trim()) ?? ""
+        return l.length > n ? `${l.slice(0, n)}…` : l
+    }
+
+    type Chip = { label: string; bg: string; fg: string }
+    const KIND: Record<string, Chip> = {
+        memory:     { label: "Memory",     bg: "#ede9fe", fg: "#6d28d9" },
+        evaluation: { label: "Evaluated",  bg: "#fef3c7", fg: "#b45309" },
+        planning:   { label: "Planning",   bg: "#dbeafe", fg: "#1d4ed8" },
+        thinking:   { label: "Thinking",   bg: "#f3f4f6", fg: "#6b7280" },
+        tool:       { label: "Tool",       bg: "#e0f2fe", fg: "#0369a1" },
+        reflection: { label: "Reflection", bg: "#f3e8ff", fg: "#7e22ce" },
+        final:      { label: "Final",      bg: "#dcfce7", fg: "#166534" },
+        error:      { label: "Error",      bg: "#fee2e2", fg: "#dc2626" },
+    }
+
+    // Header row for a step: chip + optional title (+ status) + right-aligned time.
+    function stepHead(
+        chipLabel: string,
+        c: Chip,
+        indent: number,
+        opts: { title?: string; titleMono?: boolean; status?: string; statusColor?: [number, number, number]; time?: string } = {}
+    ) {
+        ensure(6)
+        const x0 = M + indent
+        const cw = chip(chipLabel, x0, c.bg, c.fg)
+        let cx = x0 + cw + 2
+        const timeStr = opts.time ?? ""
+        let timeW = 0
+        if (timeStr) {
+            doc.setFont("helvetica", "normal"); doc.setFontSize(7.5)
+            timeW = doc.getTextWidth(timeStr)
+        }
+        const rightEdge = PW - M - (timeW ? timeW + 2 : 0)
+        if (opts.title) {
+            doc.setFont(opts.titleMono ? "courier" : "helvetica", opts.titleMono ? "normal" : "bold")
+            doc.setFontSize(9); doc.setTextColor(17, 24, 39)
+            const t = (doc.splitTextToSize(clean(opts.title), Math.max(20, rightEdge - cx - 2))[0] as string) ?? ""
+            doc.text(t, cx, y + 3)
+            cx += doc.getTextWidth(t) + 3
+        }
+        if (opts.status) {
+            doc.setFont("helvetica", "normal"); doc.setFontSize(8)
+            const sc = opts.statusColor ?? [107, 114, 128]
+            doc.setTextColor(sc[0], sc[1], sc[2])
+            doc.text(opts.status, cx, y + 3)
+        }
+        if (timeStr) {
+            doc.setFont("helvetica", "normal"); doc.setFontSize(7.5); doc.setTextColor(156, 163, 175)
+            doc.text(timeStr, PW - M - timeW, y + 3)
+        }
+        y += 6
+    }
+
+    function renderStep(step: TimelineStep, indent: number) {
+        const bodyIndent = indent + 4
+        const t = (e: AgentOpsEvent) => formatTime(e.createdAt, timeZone)
+
+        switch (step.kind) {
+            case "group": {
+                const toolCount = step.steps.filter((s) => s.kind === "tool").length
+                ensure(6)
+                doc.setFont("helvetica", "bold"); doc.setFontSize(8.5); doc.setTextColor(107, 114, 128)
+                const dur = step.durationMs > 0 ? `  ·  ${fmtDur(step.durationMs)}` : ""
+                doc.text(`Worked — ${toolCount} tool call${toolCount === 1 ? "" : "s"}${dur}`, M + indent, y + 3)
+                y += 6
+                for (const s of step.steps) renderStep(s, indent + 4)
+                y += 1
+                break
+            }
+            case "tool": {
+                const anchor = step.call ?? step.result
+                const statusLabel = step.status === "error" ? "failed" : step.status === "running" ? "running" : ""
+                const statusColor: [number, number, number] = step.status === "error" ? [220, 38, 38] : [107, 114, 128]
+                stepHead(KIND.tool.label, KIND.tool, indent, {
+                    title: step.toolName,
+                    titleMono: true,
+                    status: [statusLabel, step.durationMs !== undefined ? fmtDur(step.durationMs) : ""].filter(Boolean).join("  "),
+                    statusColor,
+                    time: anchor ? t(anchor) : undefined,
+                })
+                const args = step.call?.toolArgs
+                const output = step.result?.toolOutput ?? step.result?.content
+                if (args && Object.keys(args).length > 0) {
+                    para("ARGUMENTS", { size: 7, style: "bold", color: [107, 114, 128], indent: bodyIndent })
+                    para(JSON.stringify(args, null, 2), { size: 7.5, font: "courier", color: [55, 65, 81], indent: bodyIndent, gap: 1.25 })
+                }
+                if (output) {
+                    para("OUTPUT", { size: 7, style: "bold", color: [107, 114, 128], indent: bodyIndent })
+                    para(output, { size: 7.5, font: "courier", color: step.status === "error" ? [220, 38, 38] : [55, 65, 81], indent: bodyIndent, gap: 1.25 })
+                }
+                if (!args && !output) para("No detail captured.", { size: 8, color: [156, 163, 175], indent: bodyIndent })
+                y += 1.5
+                break
+            }
+            case "planning":
+                stepHead(KIND.planning.label, KIND.planning, indent, { title: firstLine(step.event.content) || "Planning", time: t(step.event) })
+                if (step.event.content) para(step.event.content, { size: 8.5, color: [55, 65, 81], indent: bodyIndent })
+                y += 1.5
+                break
+            case "reflection":
+                stepHead(step.event.eventType === "revision" ? "Revision" : "Reflection", KIND.reflection, indent, { time: t(step.event) })
+                if (step.event.content) para(step.event.content, { size: 8.5, color: [55, 65, 81], indent: bodyIndent })
+                y += 1.5
+                break
+            case "thinking":
+                if (!step.event.content) break
+                stepHead(KIND.thinking.label, KIND.thinking, indent, { time: t(step.event) })
+                para(step.event.content, { size: 8.5, color: [107, 114, 128], style: "italic", indent: bodyIndent })
+                y += 1.5
+                break
+            case "evaluation": {
+                const m = (step.event.metadata ?? {}) as Record<string, unknown>
+                const kbs = (m.knowledgeBaseIds as unknown[] | undefined) ?? []
+                const badges = [
+                    m.mode ? `${m.mode} mode` : "",
+                    (m.skillName || m.skillId) ? `skill: ${m.skillName ?? m.skillId}` : "",
+                    kbs.length ? `KB ×${kbs.length}` : "",
+                    m.requiresApproval ? "approval" : "",
+                ].filter(Boolean).join("    ·    ")
+                stepHead(KIND.evaluation.label, KIND.evaluation, indent, { title: "Evaluated request", time: t(step.event) })
+                if (badges) para(badges, { size: 7.5, color: [107, 114, 128], indent: bodyIndent })
+                if (step.event.content) para(step.event.content, { size: 8.5, color: [55, 65, 81], indent: bodyIndent })
+                y += 1.5
+                break
+            }
+            case "memory": {
+                const m = (step.event.metadata ?? {}) as Record<string, unknown>
+                stepHead(KIND.memory.label, KIND.memory, indent, {
+                    title: step.event.content || (step.phase === "recall" ? "Memory recall" : "Memory save"),
+                    time: t(step.event),
+                })
+                if (step.phase === "recall") {
+                    const parts = [
+                        (m.facts as unknown[])?.length ? `${(m.facts as unknown[]).length} fact(s)` : "",
+                        (m.rules as unknown[])?.length ? `${(m.rules as unknown[]).length} rule(s)` : "",
+                        (m.episodes as unknown[])?.length ? `${(m.episodes as unknown[]).length} episode(s)` : "",
+                    ].filter(Boolean).join("    ·    ")
+                    if (parts) para(parts, { size: 7.5, color: [107, 114, 128], indent: bodyIndent })
+                } else if (m.savedFacts !== undefined) {
+                    para(`${m.savedFacts ?? 0} fact(s), ${m.savedRules ?? 0} rule(s) saved · episode: ${m.episodeCaptured ? "yes" : "no"}`,
+                        { size: 7.5, color: [107, 114, 128], indent: bodyIndent })
+                }
+                y += 1.5
+                break
+            }
+            case "final":
+                stepHead(KIND.final.label, KIND.final, indent, { title: step.event.node === "__cancelled__" ? "Run cancelled" : "Final summary", time: t(step.event) })
+                if (step.event.content) para(step.event.content, { size: 9, color: [17, 24, 39], indent: bodyIndent })
+                y += 1.5
+                break
+            case "error":
+                stepHead(KIND.error.label, KIND.error, indent, { title: firstLine(step.event.content) || "Error", time: t(step.event) })
+                if (step.event.content) para(step.event.content, { size: 8, font: "courier", color: [220, 38, 38], indent: bodyIndent })
+                y += 1.5
+                break
+        }
+    }
+
+    for (const step of steps) renderStep(step, 0)
+
+    // ── Footer on every page ────────────────────────────────────────────────
+    const pages = doc.getNumberOfPages()
+    for (let p = 1; p <= pages; p++) {
+        doc.setPage(p)
+        doc.setFont("helvetica", "normal"); doc.setFontSize(7.5); doc.setTextColor(156, 163, 175)
+        const footer = `Nucleus Cloud Ops  ·  Page ${p} of ${pages}`
+        doc.text(footer, PW / 2 - doc.getTextWidth(footer) / 2, PH - 6)
+    }
+
+    const filename = `agent-ops-run-${run.runId.slice(0, 8)}-${new Date().toISOString().slice(0, 10)}.pdf`
+    doc.save(filename)
 }

--- a/apps/web-ui/lib/agent/agent-shared.ts
+++ b/apps/web-ui/lib/agent/agent-shared.ts
@@ -81,6 +81,7 @@ export interface ReflectionState {
     memoryStats: MemoryStats | null;
     runningSummary: string; // Phase 1: rolling summary of compacted turns
     scratchpad: Scratchpad; // Phase 1: structured working-memory scratchpad
+    reflectionStallCount?: number; // consecutive reflections with the same blocking issue (stall detector)
 }
 
 // --- Schema for StateGraph ---
@@ -150,10 +151,109 @@ export const graphState: StateGraphArgs<ReflectionState>["channels"] = {
         reducer: (x: Scratchpad, y: Scratchpad) => y || x,
         default: () => ({ openGoals: [], keyFindings: [], resourceIds: [], pendingSteps: [] }),
     },
+    reflectionStallCount: {
+        reducer: (x: number | undefined, y: number | undefined) => y ?? x ?? 0,
+        default: () => 0,
+    },
 };
+
+/**
+ * Extract the plain text of an LLM response, whatever shape it arrives in.
+ *
+ * Bedrock returns `AIMessage.content` as EITHER a string OR an array of content
+ * blocks ([{type:'text',text:'…'}, {type:'tool_use',…}]) — and under streaming
+ * the text blocks are un-coalesced per-delta. Casting that array `as string`
+ * (which several nodes used to do) is a lie TypeScript cannot catch: at runtime
+ * `content.match(...)` / `content.toLowerCase()` throw TypeError, and
+ * `String(content)` yields "[object Object],[object Object]".
+ *
+ * That crash silently broke plan parsing and, worse, made the reflector return
+ * isComplete=false forever — spinning the reflect→revise loop until
+ * MAX_ITERATIONS. ALWAYS route LLM content through this helper.
+ *
+ * Text deltas carry their own leading spaces, so blocks join with '' (never '\n',
+ * which shatters the prose one delta per line).
+ */
+export function extractTextContent(content: unknown): string {
+    if (content == null) return '';
+    if (typeof content === 'string') return content;
+    if (Array.isArray(content)) {
+        return content
+            .map((block: any) => {
+                if (typeof block === 'string') return block;
+                if (block?.type === 'text' && typeof block.text === 'string') return block.text;
+                return '';
+            })
+            .join('');
+    }
+    return typeof content === 'object' ? JSON.stringify(content) : String(content);
+}
+
+/**
+ * Decide what to do with a reflector critique.
+ *
+ * 'accept' when the critique says COMPLETE — or when it is EMPTY. An empty
+ * critique happens for real: Claude Sonnet 5 on Bedrock emits a
+ * reasoning_content block first, and if the reflector's output budget runs out
+ * mid-reasoning (stopReason max_tokens) there is no text at all. Feeding an
+ * empty "[REFLECTION FEEDBACK]" back to the agent just burns iterations — the
+ * agent has nothing to fix, so accept the answer instead.
+ */
+export function critiqueVerdict(critique: string): 'accept' | 'revise' {
+    const trimmed = critique.trim();
+    if (!trimmed) return 'accept';
+    if (trimmed.includes('COMPLETE')) return 'accept';
+    return 'revise';
+}
+
+/**
+ * Format the run's tool results as ground-truth evidence for the reflector.
+ *
+ * Takes ALL results (already capped at 10 by the toolResults reducer), not just
+ * the current iteration's: reflection usually runs an iteration or two AFTER
+ * the tool calls (on the no-tools text turn), and a per-iteration filter hands
+ * the reflector an empty log — which it reads as "no tools were run" and then
+ * falsely accuses the agent of fabricating data it genuinely fetched.
+ */
+export function buildToolExecutionLog(
+    toolResults: ToolResultEntry[] | undefined,
+): string {
+    if (!toolResults?.length) return '';
+    const entries = toolResults
+        .map(tr => `- [iteration ${tr.iterationIndex}] ${tr.toolName}: ${tr.isError ? 'ERROR' : 'OK'}\n  Output: ${tr.output}`)
+        .join('\n');
+    return `\n<TOOL_EXECUTION_LOG>\nThe following tools were executed during this run:\n${entries}\n</TOOL_EXECUTION_LOG>\n`;
+}
 
 // --- Constants ---
 export const MAX_ITERATIONS = 30;
+
+// Reflect→revise stall detection. If the reflector reports the SAME blocking
+// issue in this many consecutive reflections, the revise step isn't making
+// progress — finalize with current findings instead of churning to
+// MAX_ITERATIONS (which wastes tokens and leaves the run looking "hung").
+export const REFLECTION_STALL_LIMIT = 2;
+
+/**
+ * Decide whether the reflect→revise loop has stalled. A stall is the SAME
+ * non-empty blocking issue repeating across consecutive reflections: the
+ * revise attempts aren't resolving it. Any change in the issue (or an issue
+ * clearing to 'None'/'') resets the counter.
+ *
+ * Heuristic by design — it matches on the reflector's verbatim issues string,
+ * so a model that rephrases the same blocker each round won't trip it; the
+ * MAX_ITERATIONS cap remains the hard backstop for those cases.
+ */
+export function computeReflectionStall(
+    currentIssues: string,
+    prevIssues: string | undefined,
+    prevStallCount: number,
+): { stallCount: number; stalled: boolean } {
+    const hasIssue = !!currentIssues && currentIssues !== 'None';
+    const repeated = hasIssue && !!prevIssues && prevIssues === currentIssues;
+    const stallCount = repeated ? prevStallCount + 1 : 0;
+    return { stallCount, stalled: stallCount >= REFLECTION_STALL_LIMIT };
+}
 
 // ---------------------------------------------------------------------------
 // LLM Audit Logger

--- a/apps/web-ui/lib/agent/fast-agent.ts
+++ b/apps/web-ui/lib/agent/fast-agent.ts
@@ -13,6 +13,9 @@ import {
     tagMessagePhase,
     getCheckpointer,
     getStore,
+    extractTextContent,
+    critiqueVerdict,
+    buildToolExecutionLog,
 } from "./agent-shared";
 
 // Maximum number of reflection cycles before accepting the answer as-is.
@@ -177,15 +180,12 @@ Review the full conversation history before responding:
         const { messages, toolResults } = state;
         const lastMessage = messages[messages.length - 1];
 
-        // Build tool execution summary from the CURRENT iteration only (not stale prior iterations)
-        const currentIterationResults = toolResults?.filter(tr => tr.iterationIndex === state.iterationCount) ?? [];
-        let toolExecutionLog = '';
-        if (currentIterationResults.length > 0) {
-            const entries = currentIterationResults.map(tr =>
-                `- ${tr.toolName}: ${tr.isError ? 'ERROR' : 'OK'}\n  Output: ${tr.output}`
-            ).join('\n');
-            toolExecutionLog = `\n<TOOL_EXECUTION_LOG>\nThe following tools were executed:\n${entries}\n</TOOL_EXECUTION_LOG>\n`;
-        }
+        // Ground-truth evidence for the reflector: ALL of the run's tool results
+        // (reducer-capped at 10). Reflection typically runs an iteration or two
+        // AFTER the tool calls, so a current-iteration-only filter handed the
+        // reflector an empty log and it falsely accused the agent of fabricating
+        // data it had genuinely fetched.
+        const toolExecutionLog = buildToolExecutionLog(toolResults);
 
         // If only tool calls, skip reflection (need an answer to reflect on)
         if ((lastMessage as AIMessage).tool_calls && ((lastMessage as AIMessage).tool_calls?.length ?? 0) > 0) {
@@ -261,7 +261,7 @@ Please provide your critique.`
             console.warn(`⚠️ [FAST REFLECTOR] Skipping reflection due to model error: ${err?.message ?? err}`);
             return { isComplete: true };
         }
-        const content = typeof response.content === 'string' ? response.content : JSON.stringify(response.content);
+        const content = extractTextContent(response.content);
 
         if (!content) {
             console.log(`⚠️ [FAST REFLECTOR] Empty content received!`);
@@ -272,7 +272,11 @@ Please provide your critique.`
 
         console.log(`   Critique: ${truncateOutput(content, 200)}`);
 
-        if (content.includes("COMPLETE")) {
+        if (critiqueVerdict(content) === 'accept') {
+            // COMPLETE — or an EMPTY critique (reflector spent its whole budget on a
+            // reasoning block, stopReason max_tokens): looping on empty feedback gives
+            // the agent nothing to fix, so accept the answer.
+            if (!content.trim()) console.warn(`⚠️ [FAST REFLECTOR] Empty critique — accepting answer instead of looping.`);
             // Do NOT add the reflector's message to state — the agent's answer is already there.
             // Adding "COMPLETE" would overwrite the last message and leak to the UI.
             return { isComplete: true };
@@ -288,14 +292,9 @@ Please provide your critique.`
         };
     }
 
-    // Helper to safely extract string content
-    function getStringContent(content: string | any[]): string {
-        if (typeof content === 'string') return content;
-        if (Array.isArray(content)) {
-            return content.map(c => c.text || JSON.stringify(c)).join('');
-        }
-        return JSON.stringify(content);
-    }
+    // Kept as a thin alias — the canonical implementation is extractTextContent()
+    // in agent-shared.ts, which every graph now shares.
+    const getStringContent = extractTextContent;
 
     // ---------------------------------------------------------------------------
     // FINALIZE NODE

--- a/apps/web-ui/lib/agent/memory-nodes.ts
+++ b/apps/web-ui/lib/agent/memory-nodes.ts
@@ -8,7 +8,7 @@
 
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
-import { truncateOutput } from "./agent-shared";
+import { truncateOutput, extractTextContent } from "./agent-shared";
 import { saveMemory } from "./persistence";
 import { getMemoryService } from "./memory/memory-service";
 import { memoryLogVerbose } from "./memory/log";
@@ -90,9 +90,7 @@ ${memorySummary}
 Return only the relevant memories.`
                     });
                     const response = await reflectorModel.invoke([filterPrompt, filterInput]);
-                    const content = typeof response.content === "string"
-                        ? response.content
-                        : JSON.stringify(response.content);
+                    const content = extractTextContent(response.content);
                     factsSection = (content.trim() === "NONE") ? "" : content.trim();
                     console.log(`🧠 [RECALL:facts] LLM filter ${factsSection ? `kept:\n${factsSection}` : 'kept none (NONE)'}`);
                 } catch (err: any) {
@@ -248,9 +246,7 @@ Extract memories to save.`
 
         try {
             const response = await reflectorModel.invoke([extractPrompt, extractInput]);
-            const content = typeof response.content === "string"
-                ? response.content
-                : JSON.stringify(response.content);
+            const content = extractTextContent(response.content);
 
             const jsonMatch = content.match(/\[[\s\S]*\]/);
             if (!jsonMatch) {

--- a/apps/web-ui/lib/agent/model-factory.ts
+++ b/apps/web-ui/lib/agent/model-factory.ts
@@ -130,7 +130,11 @@ export function createAgentModels(config: ResolvedModelConfig): AgentModels {
             }),
             reflector: new ChatAnthropic({
                 ...anthropicConfig,
-                maxTokens: Math.min(defaultMaxTokens, 2048),
+                // Full budget, not min(…, 2048): Claude Sonnet 5 emits a reasoning
+                // block before its text, and a 2048 cap let reasoning consume the
+                // whole budget (stopReason max_tokens) — the reflector returned
+                // ZERO text and the reflection loop spun on empty critiques.
+                maxTokens: defaultMaxTokens,
                 streaming: false,
             }),
         };
@@ -164,7 +168,8 @@ export function createAgentModels(config: ResolvedModelConfig): AgentModels {
         }),
         reflector: new ChatBedrockConverse({
             ...bedrockConfig,
-            maxTokens: Math.min(defaultMaxTokens, 2048),
+            // Full budget, not min(…, 2048) — see the ChatAnthropic reflector note.
+            maxTokens: defaultMaxTokens,
             streaming: false,
         }),
     };

--- a/apps/web-ui/lib/agent/planning-agent.ts
+++ b/apps/web-ui/lib/agent/planning-agent.ts
@@ -15,6 +15,8 @@ import {
     llmAuditLog,
     getCheckpointer,
     getStore,
+    extractTextContent,
+    REFLECTION_STALL_LIMIT,
 } from "./agent-shared";
 import {
     buildBaseIdentity,
@@ -155,7 +157,7 @@ Only return the JSON array, nothing else.`);
 
         let planSteps: PlanStep[] = [];
         try {
-            const content = response.content as string;
+            const content = extractTextContent(response.content);
             const jsonMatch = content.match(/\[[\s\S]*\]/);
             if (jsonMatch) {
                 const parsed = JSON.parse(jsonMatch[0]);
@@ -434,9 +436,14 @@ ${plan.map((s, i) => `${i + 1}. [${s.status}] ${s.step}`).join('\n')}`
         let isComplete = false;
         let updatedPlan: PlanStep[] = [];
 
+        let parseFailed = false;
         try {
-            const content = response.content as string;
+            const content = extractTextContent(response.content);
             console.log(`[Reflector] Raw content: ${truncateOutput(content, 200)}`);
+            // Empty reflector text (reasoning consumed the whole output budget,
+            // stopReason max_tokens) — route through the parse-failure path so the
+            // consecutive-failure fail-safe below can force completion.
+            if (!content.trim()) throw new Error('reflector returned no text output');
 
             // Extract outermost JSON object using balanced-brace scan to avoid
             // greedy regex capturing embedded JSON strings in large tool outputs.
@@ -479,8 +486,22 @@ ${plan.map((s, i) => `${i + 1}. [${s.status}] ${s.step}`).join('\n')}`
             }
         } catch (e) {
             console.error("[Reflector] Parsing failed:", e);
+            parseFailed = true;
             analysis = "Reflection parsing failed. Continuing with next iteration.";
             isComplete = false;
+        }
+
+        // Fail-safe (defense in depth): a reflector we cannot parse must NEVER be
+        // able to spin the reflect→revise loop. Before this guard, a parse failure
+        // left isComplete=false every round, so the loop churned all the way to
+        // MAX_ITERATIONS burning an LLM call per lap. After REFLECTION_STALL_LIMIT
+        // consecutive unparseable reflections, finalize with what we already have.
+        const priorFailures = state.reflectionStallCount ?? 0;
+        const parseFailures = parseFailed ? priorFailures + 1 : 0;
+        if (parseFailed && parseFailures >= REFLECTION_STALL_LIMIT) {
+            isComplete = true;
+            analysis = `Reflection output could not be parsed ${parseFailures} times in a row — finalizing with the results gathered so far rather than retrying further.`;
+            console.warn(`⚠️ [REFLECTOR] ${parseFailures} consecutive parse failures — forcing completion.`);
         }
 
         console.log(`\n🧐 [REFLECTOR] Analysis Complete:`);
@@ -508,7 +529,8 @@ ${suggestions !== "None" ? `💡 **Suggestions:** ${suggestions}` : ""}
             reflection: analysis,
             errors: issues !== "None" ? [issues] : [],
             isComplete,
-            nextAction: isComplete ? "complete" : "revise"
+            nextAction: isComplete ? "complete" : "revise",
+            reflectionStallCount: parseFailures,
         };
 
         if (updatedPlan.length > 0) {
@@ -636,9 +658,7 @@ Write for an engineer audience. Be specific — include resource IDs, account na
         try {
             const summaryResponse = await model.invoke(_auditInputs_fin);
             llmAuditLog('FINAL', _auditInputs_fin, summaryResponse, _auditStart_fin);
-            summaryContent = typeof summaryResponse.content === 'string'
-                ? summaryResponse.content
-                : JSON.stringify(summaryResponse.content);
+            summaryContent = extractTextContent(summaryResponse.content);
         } catch (err: any) {
             // A finalize failure must never crash the run — assemble a best-effort summary
             // from the tool results and review notes already captured in state.

--- a/apps/web-ui/lib/agent/text-to-sql/nodes/generate-sql.ts
+++ b/apps/web-ui/lib/agent/text-to-sql/nodes/generate-sql.ts
@@ -1,4 +1,5 @@
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
+import { extractTextContent } from '@/lib/agent/agent-shared';
 import { buildSQLGenerationPrompt } from '../prompts';
 import { type TextToSQLState, requireModelConfig } from '../state';
 import { createAgentModels } from '@/lib/agent/model-factory';
@@ -33,9 +34,7 @@ export async function generateSQLNode(state: TextToSQLState): Promise<Partial<Te
     ]);
 
     // Extract SQL — strip markdown fences if present
-    let sql = typeof response.content === 'string'
-        ? response.content
-        : JSON.stringify(response.content);
+    let sql = extractTextContent(response.content);
     sql = sql.replace(/```sql\n?/gi, '').replace(/```\n?/g, '').trim();
 
     console.log(`[TextToSQL] Generated SQL (iteration ${state.iteration + 1}): ${sql}`);

--- a/apps/web-ui/lib/agent/text-to-sql/nodes/reflect.ts
+++ b/apps/web-ui/lib/agent/text-to-sql/nodes/reflect.ts
@@ -1,4 +1,5 @@
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
+import { extractTextContent } from '@/lib/agent/agent-shared';
 import { buildReflectionPrompt } from '../prompts';
 import { type TextToSQLState, requireModelConfig } from '../state';
 import { createAgentModels } from '@/lib/agent/model-factory';
@@ -33,9 +34,7 @@ export async function reflectNode(state: TextToSQLState): Promise<Partial<TextTo
         new HumanMessage(prompt),
     ]);
 
-    const content = typeof response.content === 'string'
-        ? response.content
-        : JSON.stringify(response.content);
+    const content = extractTextContent(response.content);
 
     // Parse JSON response
     let satisfied = true;

--- a/apps/web-ui/lib/agent/text-to-sql/nodes/synthesize.ts
+++ b/apps/web-ui/lib/agent/text-to-sql/nodes/synthesize.ts
@@ -1,4 +1,5 @@
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
+import { extractTextContent } from '@/lib/agent/agent-shared';
 import { buildSynthesisPrompt } from '../prompts';
 import { type TextToSQLState, requireModelConfig } from '../state';
 import { createAgentModels } from '@/lib/agent/model-factory';
@@ -28,9 +29,7 @@ export async function synthesizeNode(state: TextToSQLState): Promise<Partial<Tex
             new HumanMessage(prompt),
         ]);
 
-        const finalAnswer = typeof response.content === 'string'
-            ? response.content
-            : JSON.stringify(response.content);
+        const finalAnswer = extractTextContent(response.content);
 
         console.log(`[TextToSQL] Synthesized answer: ${finalAnswer.length} chars`);
         return { finalAnswer };

--- a/apps/web-ui/tests/agent-ops/agent-shared.test.ts
+++ b/apps/web-ui/tests/agent-ops/agent-shared.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { AIMessage, HumanMessage, ToolMessage, BaseMessage } from '@langchain/core/messages';
-import { sanitizeMessagesForBedrock, getRecentMessages, graphState, tagMessagePhase } from '../../lib/agent/agent-shared';
+import { sanitizeMessagesForBedrock, getRecentMessages, graphState, tagMessagePhase, computeReflectionStall, REFLECTION_STALL_LIMIT, extractTextContent, critiqueVerdict, buildToolExecutionLog } from '../../lib/agent/agent-shared';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -247,5 +247,133 @@ describe('executionOutput graphState reducer', () => {
     it('initialises to empty string', () => {
         const defaultFn = graphState.executionOutput?.default as () => string;
         expect(defaultFn()).toBe('');
+    });
+});
+
+describe('extractTextContent', () => {
+    it('returns a plain string unchanged', () => {
+        expect(extractTextContent('hello world')).toBe('hello world');
+    });
+
+    it('joins Bedrock text-delta blocks into the original prose (not "[object Object]")', () => {
+        // The runtime bug: `response.content as string` on this array yielded
+        // "[object Object],[object Object]" and blew up .match()/.toLowerCase().
+        const blocks = [
+            { type: 'text', text: '{"analysis":' },
+            { type: 'text', text: ' "looks good",' },
+            { type: 'text', text: ' "isComplete": true}' },
+        ];
+        const out = extractTextContent(blocks);
+        expect(out).toBe('{"analysis": "looks good", "isComplete": true}');
+        expect(out).not.toContain('[object Object]');
+        expect(() => JSON.parse(out)).not.toThrow();
+    });
+
+    it('keeps only text blocks, dropping tool_use blocks', () => {
+        const blocks = [
+            { type: 'text', text: 'thinking' },
+            { type: 'tool_use', id: 't1', name: 'foo', input: {} },
+        ];
+        expect(extractTextContent(blocks)).toBe('thinking');
+    });
+
+    it('returns a usable string (never throws) for empty / null content', () => {
+        expect(extractTextContent([])).toBe('');
+        expect(extractTextContent(null)).toBe('');
+        expect(extractTextContent(undefined)).toBe('');
+    });
+
+    it('produces output that supports the string ops the reflector calls', () => {
+        const blocks = [{ type: 'text', text: 'Task Complete' }];
+        const out = extractTextContent(blocks);
+        // These are exactly the calls that threw at planning-agent.ts:476 / :159
+        expect(out.toLowerCase()).toContain('task complete');
+        expect(out.indexOf('{')).toBe(-1);
+        expect(() => out.match(/\[[\s\S]*\]/)).not.toThrow();
+    });
+});
+
+describe('critiqueVerdict', () => {
+    it('accepts when the critique contains COMPLETE', () => {
+        expect(critiqueVerdict('COMPLETE')).toBe('accept');
+        expect(critiqueVerdict('The answer is good. COMPLETE')).toBe('accept');
+    });
+
+    it('accepts when the critique is empty — an empty critique must never drive a revision loop', () => {
+        // Live failure: reflector burned its whole output budget on a
+        // reasoning_content block (stopReason max_tokens) → no text → the agent
+        // received "[REFLECTION FEEDBACK]" with an empty issue list and looped.
+        expect(critiqueVerdict('')).toBe('accept');
+        expect(critiqueVerdict('   \n  ')).toBe('accept');
+    });
+
+    it('revises when the critique lists real issues', () => {
+        expect(critiqueVerdict('- Missing --output json on the CLI call')).toBe('revise');
+    });
+});
+
+describe('buildToolExecutionLog', () => {
+    it('includes tool results from ALL iterations, not just the current one', () => {
+        // Live failure: tools ran in iterations 1-2, reflection happened at
+        // iteration 3 → the per-iteration filter produced an empty log and the
+        // reflector falsely accused the agent of fabricating tool data.
+        const results = [
+            { toolName: 'searchJiraIssuesUsingJql', output: '{"issues":[...]}', isError: false, iterationIndex: 1 },
+            { toolName: 'getJiraIssue', output: '{"key":"DEVCHNMGM-817"}', isError: false, iterationIndex: 2 },
+        ];
+        const log = buildToolExecutionLog(results);
+        expect(log).toContain('searchJiraIssuesUsingJql');
+        expect(log).toContain('getJiraIssue');
+        expect(log).toContain('<TOOL_EXECUTION_LOG>');
+    });
+
+    it('returns empty string when no tools were executed', () => {
+        expect(buildToolExecutionLog([])).toBe('');
+        expect(buildToolExecutionLog(undefined)).toBe('');
+    });
+
+    it('marks errored tool calls', () => {
+        const log = buildToolExecutionLog([
+            { toolName: 'execute_command', output: 'Command failed', isError: true, iterationIndex: 1 },
+        ]);
+        expect(log).toContain('ERROR');
+    });
+});
+
+describe('computeReflectionStall', () => {
+    it('does not stall on the first reflection with an issue', () => {
+        const r = computeReflectionStall('AWS CLI missing --output json', undefined, 0);
+        expect(r.stallCount).toBe(0);
+        expect(r.stalled).toBe(false);
+    });
+
+    it('resets the count when the issue changes between reflections', () => {
+        const r = computeReflectionStall('new different issue', 'old issue', 1);
+        expect(r.stallCount).toBe(0);
+        expect(r.stalled).toBe(false);
+    });
+
+    it('resets the count when the current reflection reports no issues', () => {
+        const r = computeReflectionStall('None', 'some issue', 1);
+        expect(r.stallCount).toBe(0);
+        expect(r.stalled).toBe(false);
+    });
+
+    it('increments the count when the same blocking issue repeats', () => {
+        const r = computeReflectionStall('same issue', 'same issue', 0);
+        expect(r.stallCount).toBe(1);
+        expect(r.stalled).toBe(false);
+    });
+
+    it('flags stalled once the same issue persists to the limit', () => {
+        const r = computeReflectionStall('same issue', 'same issue', REFLECTION_STALL_LIMIT - 1);
+        expect(r.stallCount).toBe(REFLECTION_STALL_LIMIT);
+        expect(r.stalled).toBe(true);
+    });
+
+    it('treats empty-string issues as no issue (no false stall)', () => {
+        const r = computeReflectionStall('', '', 1);
+        expect(r.stallCount).toBe(0);
+        expect(r.stalled).toBe(false);
     });
 });

--- a/apps/web-ui/tests/agent-ops/clarification-resume.test.ts
+++ b/apps/web-ui/tests/agent-ops/clarification-resume.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Regression test for the clarification-resume loop.
+ *
+ * Live failure: a run asked a clarification (evaluation.mode='end'), the user
+ * answered, and the resume re-invoked the graph on the SAME thread. The
+ * evaluator's "already evaluated" guard saw the checkpointed evaluation and
+ * returned instantly — never calling the LLM, never reading the user's reply —
+ * and routeFromEvaluator routed to clarify again off the stale mode='end'.
+ * The run re-asked the identical question forever, whatever the user answered.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isReusableEvaluation } from '../../lib/agent-ops/executor-state';
+import type { RequestEvaluation } from '../../lib/agent-ops/executor-state';
+
+function evaluation(overrides: Partial<RequestEvaluation>): RequestEvaluation {
+    return {
+        mode: 'plan', skillId: null, accountId: null, requiresApproval: false,
+        reasoning: '', clarificationQuestion: null, missingInfo: null,
+        skillName: null, knowledgeBaseIds: [],
+        ...overrides,
+    } as RequestEvaluation;
+}
+
+describe('isReusableEvaluation', () => {
+    it('is false when there is no evaluation yet — evaluator must run', () => {
+        expect(isReusableEvaluation(null)).toBe(false);
+        expect(isReusableEvaluation(undefined as unknown as null)).toBe(false);
+    });
+
+    it('is true for an executable plan decision — approval resume reuses it', () => {
+        expect(isReusableEvaluation(evaluation({ mode: 'plan', requiresApproval: true }))).toBe(true);
+    });
+
+    it("is FALSE for a stale clarification decision (mode='end') — the user's reply must be re-evaluated", () => {
+        expect(isReusableEvaluation(evaluation({
+            mode: 'end',
+            clarificationQuestion: 'Could you clarify the purpose of this message?',
+        }))).toBe(false);
+    });
+});

--- a/apps/web-ui/tests/agent-ops/executor-event-coverage.test.ts
+++ b/apps/web-ui/tests/agent-ops/executor-event-coverage.test.ts
@@ -135,4 +135,43 @@ describe('executor event coverage', () => {
         const chatter = mockRecordEvent.mock.calls.find(c => c[0].node === 'memory_recall' && c[0].eventType !== 'memory_recall');
         expect(chatter).toBeUndefined();
     });
+
+    it('joins streamed text-delta content blocks without inserting newlines', async () => {
+        // Bedrock streaming yields on_chat_model_end content as an array of
+        // un-coalesced deltas; each delta already carries its own leading space.
+        // Joining with '\n' shatters the text one delta per line — join with ''.
+        mockCreateDynamicExecutorGraph.mockResolvedValue(makeGraph([
+            {
+                event: 'on_chat_model_end', metadata: { langgraph_node: 'generate' },
+                data: {
+                    output: {
+                        content: [
+                            { type: 'text', text: 'The' },
+                            { type: 'text', text: ' request' },
+                            { type: 'text', text: ' involves' },
+                        ],
+                    },
+                },
+            },
+        ]));
+        await executeAgentRun(makeRun());
+        const call = mockRecordEvent.mock.calls.find(c => c[0].node === 'generate' && c[0].content);
+        expect(call).toBeDefined();
+        expect(call![0].content).toBe('The request involves');
+        expect(call![0].content).not.toContain('\n');
+    });
+
+    it('does NOT record raw model text for nodes that emit a structured twin', async () => {
+        // planner/evaluator/reflect each record a clean structured event at
+        // on_chain_end; their raw on_chat_model_end text is a duplicate.
+        mockCreateDynamicExecutorGraph.mockResolvedValue(makeGraph([
+            {
+                event: 'on_chat_model_end', metadata: { langgraph_node: 'reflect' },
+                data: { output: { content: 'raw reflector JSON blob' } },
+            },
+        ]));
+        await executeAgentRun(makeRun());
+        const twin = mockRecordEvent.mock.calls.find(c => c[0].node === 'reflect');
+        expect(twin).toBeUndefined();
+    });
 });

--- a/apps/web-ui/tests/agent-ops/export-markdown.test.ts
+++ b/apps/web-ui/tests/agent-ops/export-markdown.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Unit tests for the Agent Ops run → Markdown report builder.
+ *
+ * buildRunReportMarkdown() is the pure core of the "Download Markdown" export.
+ * It reuses the SAME buildSteps() model as the UI timeline and the PDF export,
+ * so the three renderings never drift.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildRunReportMarkdown } from '../../lib/agent-ops/export-markdown';
+import type { AgentOpsRun, AgentOpsEvent } from '../../lib/agent-ops/types';
+
+let seq = 0;
+function makeEvent(overrides: Partial<AgentOpsEvent>): AgentOpsEvent {
+    seq += 1;
+    return {
+        id: `ev-${seq}`,
+        tenantId: 't1',
+        runId: 'run-1',
+        eventType: 'execution',
+        node: 'generate',
+        content: '',
+        createdAt: new Date(1700000000000 + seq * 1000).toISOString(),
+        ...overrides,
+    } as AgentOpsEvent;
+}
+
+function makeRun(overrides: Partial<AgentOpsRun> = {}): AgentOpsRun {
+    return {
+        id: 'row-1',
+        tenantId: 't1',
+        runId: '5fbe4722-dd12-4fae-8c17-f4b2922bcb8a',
+        source: 'api',
+        status: 'completed',
+        taskDescription: 'Check the cost anomaly and report in slack',
+        mode: 'plan',
+        autoApprove: false,
+        threadId: 'th-1',
+        createdAt: new Date(1700000000000).toISOString(),
+        ...overrides,
+    } as AgentOpsRun;
+}
+
+describe('buildRunReportMarkdown', () => {
+    it('renders header, status, and metadata', () => {
+        const md = buildRunReportMarkdown(makeRun(), []);
+        expect(md).toContain('# Agent Ops Run Report');
+        expect(md).toContain('5fbe4722-dd12-4fae-8c17-f4b2922bcb8a');
+        expect(md).toContain('COMPLETED');
+        expect(md).toContain('| Source |');
+        expect(md).toContain('| api |');
+    });
+
+    it('renders the task description with skill and account', () => {
+        const md = buildRunReportMarkdown(
+            makeRun({ selectedSkill: 'cost-analyser', accountName: 'STX-MTSL', accountId: '590183986748' }),
+            [],
+        );
+        expect(md).toContain('## Task Description');
+        expect(md).toContain('Check the cost anomaly and report in slack');
+        expect(md).toContain('cost-analyser');
+        expect(md).toContain('STX-MTSL');
+    });
+
+    it('renders result summary and tools used', () => {
+        const md = buildRunReportMarkdown(
+            makeRun({ result: { summary: 'July trending 39% above June', toolsUsed: ['execute_command', 'get_aws_credentials'], iterations: 4 } as any }),
+            [],
+        );
+        expect(md).toContain('## Result');
+        expect(md).toContain('July trending 39% above June');
+        expect(md).toContain('execute_command');
+    });
+
+    it('renders the error section for failed runs', () => {
+        const md = buildRunReportMarkdown(makeRun({ status: 'failed', error: 'ValidationException: boom' }), []);
+        expect(md).toContain('## Error');
+        expect(md).toContain('ValidationException: boom');
+        expect(md).toContain('FAILED');
+    });
+
+    it('renders a paired tool step with fenced arguments and output', () => {
+        const events = [
+            makeEvent({ eventType: 'tool_call', node: 'tools', toolName: 'get_aws_credentials', toolArgs: { accountId: '590183986748' } }),
+            makeEvent({ eventType: 'tool_result', node: 'tools', toolName: 'get_aws_credentials', toolOutput: '{"success":true}' }),
+        ];
+        const md = buildRunReportMarkdown(makeRun(), events);
+        expect(md).toContain('get_aws_credentials');
+        expect(md).toContain('**Arguments:**');
+        expect(md).toContain('"accountId": "590183986748"');
+        expect(md).toContain('**Output:**');
+        expect(md).toContain('{"success":true}');
+        expect(md).toContain('```json');
+    });
+
+    it('escapes tool output containing triple backticks with a longer fence', () => {
+        const events = [
+            makeEvent({ eventType: 'tool_call', node: 'tools', toolName: 'read_file', toolArgs: { path: 'x.md' } }),
+            makeEvent({ eventType: 'tool_result', node: 'tools', toolName: 'read_file', toolOutput: 'text\n```js\ncode\n```\nmore' }),
+        ];
+        const md = buildRunReportMarkdown(makeRun(), events);
+        // The inner ``` must not terminate the fence — a 4-backtick fence wraps it.
+        expect(md).toContain('````');
+        expect(md).toContain('```js');
+    });
+
+    it('renders "Worked" groups EXPANDED with every tool call visible', () => {
+        // 3+ contiguous tool steps fold into a group in the UI; markdown renders
+        // the group header AND all nested steps (a document can't be clicked open).
+        const events = ['a', 'b', 'c'].flatMap(name => [
+            makeEvent({ eventType: 'tool_call', node: 'tools', toolName: `tool_${name}`, toolArgs: { name } }),
+            makeEvent({ eventType: 'tool_result', node: 'tools', toolName: `tool_${name}`, toolOutput: `out-${name}` }),
+        ]);
+        const md = buildRunReportMarkdown(makeRun(), events);
+        expect(md).toContain('Worked — 3 tool calls');
+        expect(md).toContain('tool_a');
+        expect(md).toContain('tool_b');
+        expect(md).toContain('tool_c');
+        expect(md).toContain('out-c');
+    });
+
+    it('renders planning, reflection, memory, and evaluation steps', () => {
+        const events = [
+            makeEvent({ eventType: 'memory_recall', node: 'memory_recall', content: 'Recalled 5 facts · 1 rule', metadata: { facts: [1, 2, 3, 4, 5], rules: [1], episodes: [] } as any }),
+            makeEvent({ eventType: 'evaluation', node: 'evaluator', content: 'Cost task, read-only', metadata: { mode: 'plan', skillName: 'cost-analyser' } as any }),
+            makeEvent({ eventType: 'planning', node: 'planner', content: 'Plan created:\n1. Get credentials\n2. Query costs' }),
+            makeEvent({ eventType: 'reflection', node: 'reflect', content: 'All steps complete.' }),
+        ];
+        const md = buildRunReportMarkdown(makeRun(), events);
+        expect(md).toContain('Recalled 5 facts');
+        expect(md).toContain('Evaluated request');
+        expect(md).toContain('1. Get credentials');
+        expect(md).toContain('All steps complete.');
+    });
+
+    it('marks a cancelled run in the timeline', () => {
+        const events = [makeEvent({ eventType: 'final', node: '__cancelled__', content: 'Run was cancelled by user.' })];
+        const md = buildRunReportMarkdown(makeRun({ status: 'cancelled' }), events);
+        expect(md).toContain('Run cancelled');
+        expect(md).toContain('CANCELLED');
+    });
+
+    it('handles a run with no events', () => {
+        const md = buildRunReportMarkdown(makeRun(), []);
+        expect(md).toContain('No events recorded.');
+    });
+});

--- a/apps/web-ui/tests/agent-ops/model-factory-reflector.test.ts
+++ b/apps/web-ui/tests/agent-ops/model-factory-reflector.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Reflector model budget — regression test for the reflector token starvation.
+ *
+ * Claude Sonnet 5 (Bedrock) emits a reasoning_content block before its text.
+ * The reflector was capped at min(maxTokens, 2048); the model spent the entire
+ * budget on reasoning, stopped at max_tokens with ZERO text, and the empty
+ * critique drove the fast-agent reflection loop in circles.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createAgentModels, DEFAULT_MAX_OUTPUT_TOKENS } from '../../lib/agent/model-factory';
+import type { ResolvedModelConfig } from '../../lib/agent/agent-shared';
+
+const bedrockConfig: ResolvedModelConfig = {
+    provider: 'bedrock',
+    modelId: 'global.anthropic.claude-sonnet-5',
+    region: 'ap-south-1',
+    accessKeyId: 'test-key',
+    secretAccessKey: 'test-secret',
+};
+
+describe('createAgentModels reflector budget', () => {
+    it('gives the Bedrock reflector the full default output budget (no 2048 clamp)', () => {
+        const { reflector } = createAgentModels(bedrockConfig);
+        expect((reflector as any).maxTokens).toBe(DEFAULT_MAX_OUTPUT_TOKENS);
+    });
+
+    it('gives the Anthropic reflector the full default output budget (no 2048 clamp)', () => {
+        const { reflector } = createAgentModels({
+            provider: 'anthropic',
+            modelId: 'claude-sonnet-5',
+            apiKey: 'test-key',
+        });
+        expect((reflector as any).maxTokens).toBe(DEFAULT_MAX_OUTPUT_TOKENS);
+    });
+});

--- a/libs/prisma/migrations/20260713070000_agent_ops_check_constraints_new_values/migration.sql
+++ b/libs/prisma/migrations/20260713070000_agent_ops_check_constraints_new_values/migration.sql
@@ -1,0 +1,22 @@
+-- Re-sync agent_ops CHECK constraints with the code's value sets.
+-- The 2026-03-28 migration froze these lists; the code has since added:
+--   eventType: memory_recall / memory_save / evaluation (run-timeline redesign)
+--              and notification (scheduled digest delivery marker)
+--   source:    telegram / discord / webhook (gateway channel adapters)
+-- Every INSERT with a new value fails 23514 and is swallowed by the repository's
+-- try/catch, so memory/evaluation/notification timeline events were silently
+-- dropped, and a telegram/discord/webhook-triggered run cannot be created.
+-- Keep in sync with AgentEventType and TriggerSource in
+-- apps/web-ui/lib/agent-ops/types.ts.
+
+ALTER TABLE "agent_ops_events" DROP CONSTRAINT "agent_ops_events_event_type_check";
+ALTER TABLE "agent_ops_events" ADD CONSTRAINT "agent_ops_events_event_type_check"
+    CHECK ("eventType" IN (
+        'planning', 'execution', 'tool_call', 'tool_result', 'reflection',
+        'revision', 'final', 'error',
+        'memory_recall', 'memory_save', 'evaluation', 'notification'
+    ));
+
+ALTER TABLE "agent_ops_runs" DROP CONSTRAINT "agent_ops_runs_source_check";
+ALTER TABLE "agent_ops_runs" ADD CONSTRAINT "agent_ops_runs_source_check"
+    CHECK ("source" IN ('slack', 'jira', 'discord', 'telegram', 'webhook', 'api', 'scheduled'));


### PR DESCRIPTION
## Summary
- `extractTextContent()` centralizes Bedrock content extraction (string or content-block array) and joins text deltas with `''` instead of `'\n'` — fixes narrative text rendering one-token-per-line in the run timeline UI and PDF export
- Reflect→revise stall detector (`computeReflectionStall`, `REFLECTION_STALL_LIMIT`): finalizes a run after 2 consecutive reflections report the same blocking issue instead of churning to `MAX_ITERATIONS`
- Rebuilt PDF export (`export-pdf.ts`) on jsPDF's vector text API, removing the html2canvas rasterization step that silently blanked large reports (Chrome caps canvas height at 65,535px with no error)
- New markdown export (`export-markdown.ts`) alongside PDF
- New migration re-syncing `agent_ops_events`/`agent_ops_runs` CHECK constraints with the `eventType`/`source` value sets the code has added since the constraints were frozen — `memory_recall`/`memory_save`/`evaluation`/`notification` event types and `telegram`/`discord`/`webhook` sources were being silently dropped/rejected (23514, swallowed by the repository's try/catch)
- Executor credentials fix: pass `tenantId` in `configurable` at both invoke sites so `execute_command` can resolve the tenant's STS credentials file
- New/updated tests: `clarification-resume.test.ts`, `export-markdown.test.ts`, `model-factory-reflector.test.ts`, expanded `agent-shared.test.ts` and `executor-event-coverage.test.ts`

## Test plan
- [x] `cd apps/web-ui && bun run test` — 891/949 passing; the 58 failures are pre-existing on `master-v1`/base commit `a57c36a3` (verified via `git stash` + re-run, identical failure set — unrelated mock-harness issues in account/schedule/rbac/inventory repo tests, not touched by this change)
- [ ] Apply the new migration (`db:migrate`) and manually verify a Telegram/Discord/webhook-triggered run persists its timeline events without 23514 drops
- [ ] Spot-check a long-running Agent Ops run's timeline + PDF/markdown export for correctly joined prose text

🤖 Generated with [Claude Code](https://claude.com/claude-code)