### PR TITLE
Agent Ops: Slack tenant-resolution fix + channel setup guides + skills export

### DIFF
--- a/apps/web-ui/Dockerfile
+++ b/apps/web-ui/Dockerfile
@@ -64,13 +64,22 @@ RUN npx prisma@5 generate --schema=./libs/prisma/schema.prisma
 # Build the application
 RUN npm run build
 
-# ── Stage 3: Production runner (Bun) ──
-FROM oven/bun:1-slim AS runner
+# ── Stage 4: Production runner (Node) ──
+#
+# Runner is Node, not Bun, for two hard reasons:
+#   1. stdio MCP servers launch as `npx -y <pkg>` and are Node packages with a
+#      `#!/usr/bin/env node` shebang — they need node + npm/npx on PATH.
+#   2. Bun does not implement `node:v8` (`isBuildingSnapshot`), which the
+#      MongoDB LangGraph checkpointer reaches on the deep-agent approve path.
+# Next's standalone server.js is a Node artifact and the builder stage above is
+# already node:20-slim, so this is the native runtime for it.
+FROM node:20-slim AS runner
 WORKDIR /app
 
 # Install system dependencies, AWS CLI, Python3 (for uvx/MCP servers)
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get install -y --no-install-recommends \
+    ca-certificates \
     curl \
     unzip \
     git \
@@ -82,7 +91,7 @@ RUN apt-get update && \
     python3 \
     python3-venv && \
     curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip" && \
-    unzip awscliv2.zip && \
+    unzip -q awscliv2.zip && \
     ./aws/install && \
     rm -rf aws awscliv2.zip && \
     rm -rf /var/lib/apt/lists/*
@@ -93,7 +102,12 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
     cp /root/.local/bin/uvx /usr/local/bin/uvx && \
     chmod +x /usr/local/bin/uv /usr/local/bin/uvx
 
-# Set environment variables
+# Set environment variables.
+# HOME + the cache dirs must be writable by the non-root `node` user: npx stages
+# packages under $HOME/.npm/_npx, uvx under $UV_CACHE_DIR, and `mcp-remote`
+# persists its OAuth tokens under $HOME/.mcp-auth. These keys are on the
+# buildStdioEnv() allowlist in lib/agent/mcp-manager.ts, so they reach the
+# spawned MCP subprocess.
 ENV PORT=3000 \
     HOSTNAME="0.0.0.0" \
     NODE_ENV=production \
@@ -101,7 +115,13 @@ ENV PORT=3000 \
     NEXT_PUBLIC_AWS_REGION=ap-south-1 \
     NEXT_PUBLIC_APP_TABLE_NAME=NucleusAppTable \
     NEXT_PUBLIC_AUDIT_TABLE_NAME=NucleusAuditTable \
-    NEXT_PUBLIC_AWS_USE_STS=true
+    NEXT_PUBLIC_AWS_USE_STS=true \
+    HOME=/home/node \
+    NPM_CONFIG_CACHE=/home/node/.npm \
+    NPM_CONFIG_UPDATE_NOTIFIER=false \
+    NPM_CONFIG_FUND=false \
+    XDG_CACHE_HOME=/home/node/.cache \
+    UV_CACHE_DIR=/home/node/.cache/uv
 
 # Download RDS CA bundle for TLS connections
 RUN curl -sSL https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem \
@@ -133,13 +153,24 @@ RUN ln -sf /tmp/cache ./.next/cache
 COPY apps/web-ui/docker-entrypoint.sh /app/docker-entrypoint.sh
 RUN chmod +x /app/docker-entrypoint.sh
 
-# Set proper permissions
-RUN chown -R bun:bun /app /tmp/cache
+# Set proper permissions (incl. the npx / uvx / mcp-remote writable cache dirs)
+RUN mkdir -p /home/node/.npm /home/node/.cache/uv /home/node/.mcp-auth && \
+    chown -R node:node /app /tmp/cache /home/node
 
 # Switch to non-root user
-USER bun
+USER node
+
+# Warm the npx cache for the MCP servers we ship support for, so the first agent
+# run does not pay a cold npm-registry fetch (and still works if egress stalls).
+# `npm exec --package=<pkg> -- true` populates $HOME/.npm/_npx under the same key
+# `npx -y <pkg>` uses, without launching the server's stdio loop. Best-effort:
+# a registry hiccup at build time must not fail the image.
+RUN npm exec --yes --package=@modelcontextprotocol/server-slack -- true > /dev/null 2>&1 || \
+      echo "WARN: could not pre-warm npx cache for @modelcontextprotocol/server-slack"; \
+    npm exec --yes --package=mcp-remote -- true > /dev/null 2>&1 || \
+      echo "WARN: could not pre-warm npx cache for mcp-remote"
 
 EXPOSE 3000
 
-# Entrypoint: retry DB connection, run Prisma migrations, then start Next.js via Bun
+# Entrypoint: retry DB connection, run Prisma migrations, then start Next.js via Node
 ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/apps/web-ui/app/api/agent-ops/[runId]/cancel/route.ts
+++ b/apps/web-ui/app/api/agent-ops/[runId]/cancel/route.ts
@@ -42,6 +42,7 @@ export async function POST(
         await agentOpsService.updateRunStatus(tenantId, runId, 'cancelled');
         await agentOpsService.recordEvent({
             runId,
+            tenantId,
             eventType: 'final',
             node: '__cancelled__',
             content: 'Run cancelled by user.',

--- a/apps/web-ui/app/api/agent-ops/[runId]/resume/route.ts
+++ b/apps/web-ui/app/api/agent-ops/[runId]/resume/route.ts
@@ -53,7 +53,11 @@ export async function POST(
         // Mark run as in_progress again before re-triggering
         await agentOpsService.updateRunStatus(tenantId, runId, 'in_progress');
 
-        // Re-execute with the enriched task description (new threadId = same LangGraph state reset)
+        // Re-execute with the enriched task description on the SAME thread — the
+        // checkpoint state (including the stale mode='end' evaluation) survives.
+        // evaluatorNode's isReusableEvaluation() guard handles this: a stale
+        // clarification evaluation is discarded and the enriched task (with the
+        // user's reply) is re-evaluated, so the run can't loop on the old question.
         const resumedRun = {
             ...run,
             taskDescription: enrichedTask,

--- a/apps/web-ui/app/api/agent-ops/settings/slack/route.ts
+++ b/apps/web-ui/app/api/agent-ops/settings/slack/route.ts
@@ -10,9 +10,42 @@ import { TenantConfigService } from '@/lib/tenant-config-service';
 import { getSessionTenantId, getAuthSession } from '@/lib/auth-session';
 import { AuditService } from '@/lib/audit-service';
 import { authorize } from '@/lib/rbac/authorize';
+import { getSlackWorkspaceLinkRepository } from '@/lib/db/repository-factory';
+import { SlackWorkspaceLinkConflictError } from '@/lib/db/repositories/slack-workspace-link/interface';
 import type { SlackIntegrationConfig } from '@/lib/agent-ops/types';
 
 const CONFIG_KEY = 'agent-ops-slack';
+
+/**
+ * Resolve the Slack team_id + bot_id for a bot token via Slack's auth.test API.
+ * Used at save time to (re)establish the SlackWorkspaceLink used for inbound
+ * request routing — a token that fails verification can't be linked.
+ */
+async function verifyBotToken(botToken: string): Promise<{ teamId: string; botUserId: string | null } | { error: string }> {
+    try {
+        const res = await fetch('https://slack.com/api/auth.test', {
+            method: 'POST',
+            headers: { Authorization: `Bearer ${botToken}` },
+            signal: AbortSignal.timeout(10_000),
+        });
+        const data = (await res.json().catch(() => ({}))) as {
+            ok?: boolean;
+            error?: string;
+            team_id?: string;
+            bot_id?: string;
+        };
+        if (!data.ok || !data.team_id) {
+            return { error: data.error || 'Slack rejected the Bot Token' };
+        }
+        return { teamId: data.team_id, botUserId: data.bot_id || null };
+    } catch (error: any) {
+        const message =
+            error?.name === 'TimeoutError' || error?.name === 'AbortError'
+                ? 'Slack API did not respond within 10 seconds'
+                : error.message || 'Connection to Slack failed';
+        return { error: message };
+    }
+}
 
 function maskSecret(value: string | undefined): string {
     if (!value) return '';
@@ -39,6 +72,7 @@ export async function GET(req: Request) {
         }
 
         const show = (value: string | undefined) => (reveal ? value ?? '' : maskSecret(value));
+        const link = await getSlackWorkspaceLinkRepository().getLinkForTenant(tenantId);
 
         if (reveal) {
             const session = await getAuthSession();
@@ -64,6 +98,7 @@ export async function GET(req: Request) {
             enabled: config.enabled,
             signingSecret: show(config.signingSecret),
             botToken: show(config.botToken),
+            teamId: link?.teamId ?? null,
         });
     } catch (error: any) {
         console.error('[API /agent-ops/settings/slack] GET error:', error);
@@ -77,7 +112,7 @@ export async function GET(req: Request) {
 export async function PUT(req: Request) {
     try {
         const tenantId = await getSessionTenantId();
-        const body = await req.json() as Partial<SlackIntegrationConfig>;
+        const body = await req.json() as Partial<SlackIntegrationConfig> & { teamId?: string };
 
         // "Leave blank to keep existing values": merge the incoming body over the
         // stored config so blank secret fields retain what's already saved rather
@@ -92,15 +127,75 @@ export async function PUT(req: Request) {
             );
         }
 
+        const botToken = body.botToken?.trim() || existing?.botToken || undefined;
+        const newBotTokenProvided = !!body.botToken?.trim();
+
+        // Bare `{ enabled }` toggle calls (useToggleChannelEnabled) never touch
+        // credentials, so they must keep working without requiring a team_id link —
+        // only enforce link resolution on an actual credentials save.
+        const isCredentialSave =
+            body.signingSecret !== undefined || body.botToken !== undefined || body.teamId !== undefined;
+
+        const linkRepo = getSlackWorkspaceLinkRepository();
+        const existingLink = await linkRepo.getLinkForTenant(tenantId);
+
+        // Resolve the Slack workspace this tenant is linked to. Inbound requests only
+        // carry team_id, never our tenantId, so this link is what makes signature
+        // verification and run routing resolvable at all — see SlackWorkspaceLink.
+        let teamId: string | undefined = existingLink?.teamId;
+        let botUserId: string | null | undefined = existingLink?.botUserId;
+
+        if (isCredentialSave) {
+            if (botToken) {
+                if (newBotTokenProvided || !existingLink) {
+                    const verified = await verifyBotToken(botToken);
+                    if ('error' in verified) {
+                        return NextResponse.json(
+                            { error: `Could not verify Bot Token against Slack: ${verified.error}` },
+                            { status: 400 }
+                        );
+                    }
+                    teamId = verified.teamId;
+                    botUserId = verified.botUserId;
+                }
+            } else {
+                teamId = body.teamId?.trim() || existingLink?.teamId;
+                if (!teamId) {
+                    return NextResponse.json(
+                        { error: 'Slack Workspace/Team ID is required when no Bot Token is set — find it in your Slack workspace URL (starts with "T")' },
+                        { status: 400 }
+                    );
+                }
+            }
+
+            if (!teamId) {
+                // Unreachable given the branches above, but keeps upsertLink's
+                // required `teamId: string` honest without an unsafe cast.
+                return NextResponse.json(
+                    { error: 'Could not resolve a Slack workspace to link' },
+                    { status: 500 }
+                );
+            }
+
+            try {
+                await linkRepo.upsertLink({ teamId, tenantId, botUserId });
+            } catch (error) {
+                if (error instanceof SlackWorkspaceLinkConflictError) {
+                    return NextResponse.json({ error: error.message }, { status: 409 });
+                }
+                throw error;
+            }
+        }
+
         const config: SlackIntegrationConfig = {
             signingSecret,
-            botToken: body.botToken?.trim() || existing?.botToken || undefined,
+            botToken,
             enabled: body.enabled ?? existing?.enabled ?? true,
         };
 
         await TenantConfigService.saveConfig(CONFIG_KEY, config, tenantId);
 
-        console.log('[API /agent-ops/settings/slack] Saved Slack config');
+        console.log('[API /agent-ops/settings/slack] Saved Slack config, linked team:', teamId);
 
         const session = await getAuthSession();
         AuditService.logUserAction({
@@ -125,6 +220,7 @@ export async function PUT(req: Request) {
             enabled: config.enabled,
             signingSecret: maskSecret(config.signingSecret),
             botToken: maskSecret(config.botToken),
+            teamId,
         });
     } catch (error: any) {
         console.error('[API /agent-ops/settings/slack] PUT error:', error);

--- a/apps/web-ui/app/api/skills/route.ts
+++ b/apps/web-ui/app/api/skills/route.ts
@@ -11,8 +11,8 @@ import { slugify } from '@/lib/skill-service';
 import { AuditService } from '@/lib/audit-service';
 import type { SkillRecord } from '@/lib/db/repositories/skill/interface';
 
-function toDTO(s: SkillRecord) {
-    return {
+function toDTO(s: SkillRecord, includeContent = false) {
+    const dto = {
         id: s.slug,
         name: s.name,
         description: s.description,
@@ -23,14 +23,17 @@ function toDTO(s: SkillRecord) {
         createdAt: s.createdAt,
         updatedAt: s.updatedAt,
     };
+    return includeContent ? { ...dto, content: s.content } : dto;
 }
 
 export async function GET(request: NextRequest) {
     try {
         const tenantId = await getSessionTenantId();
-        const includeDisabled = new URL(request.url).searchParams.has('all');
+        const params = new URL(request.url).searchParams;
+        const includeDisabled = params.has('all');
+        const withContent = params.has('withContent');
         const skills = await getSkillRepository().listByTenant(tenantId, { includeDisabled });
-        return NextResponse.json({ success: true, skills: skills.map(toDTO) });
+        return NextResponse.json({ success: true, skills: skills.map((s) => toDTO(s, withContent)) });
     } catch (error) {
         if (error instanceof Error && error.message.startsWith('Unauthenticated')) {
             return NextResponse.json({ success: false, error: 'Unauthenticated' }, { status: 401 });

--- a/apps/web-ui/app/app/agent-ops/[runId]/page.tsx
+++ b/apps/web-ui/app/app/agent-ops/[runId]/page.tsx
@@ -16,6 +16,7 @@ import { RunTimeline } from "@/components/agent-ops/run-timeline/timeline"
 import { useRunStream } from "@/components/agent-ops/run-timeline/use-run-stream"
 import { useAgentOpsRunDetail, useApproveRun, useCancelRun, useResumeRun } from "@/lib/queries/agent-ops"
 import { exportRunToPdf } from "@/lib/agent-ops/export-pdf"
+import { exportRunToMarkdown } from "@/lib/agent-ops/export-markdown"
 import { useTenant } from "@/lib/tenant-context"
 import { toast } from "sonner"
 
@@ -51,13 +52,22 @@ export default function RunDetailPage() {
     if (!run) return
     setExporting(true)
     try {
-      await exportRunToPdf(run, events)
+      await exportRunToPdf(run, events, timezone)
     } catch (err) {
       toast.error("PDF export failed", { description: (err as Error).message })
     } finally {
       setExporting(false)
     }
-  }, [run, events])
+  }, [run, events, timezone])
+
+  const handleExportMarkdown = useCallback(() => {
+    if (!run) return
+    try {
+      exportRunToMarkdown(run, events, timezone)
+    } catch (err) {
+      toast.error("Markdown export failed", { description: (err as Error).message })
+    }
+  }, [run, events, timezone])
 
   if (detail.isLoading) {
     return <div className="flex flex-1 items-center justify-center py-24"><Spinner /></div>
@@ -93,6 +103,7 @@ export default function RunDetailPage() {
         onCancel={() => cancelRun.mutate({ runId, body: { tenantId: run.tenantId } })}
         cancelling={cancelRun.isPending}
         onExportPdf={handleExportPdf}
+        onExportMarkdown={handleExportMarkdown}
         exporting={exporting}
         onBack={() => router.push("/app/agent-ops")}
       />

--- a/apps/web-ui/components/agent-ops/run-timeline/run-header.tsx
+++ b/apps/web-ui/components/agent-ops/run-timeline/run-header.tsx
@@ -1,11 +1,14 @@
 "use client";
 
 import {
-  ArrowLeft, CalendarClock, CheckCircle2, Cpu, Download, Globe, Loader2,
+  ArrowLeft, CalendarClock, CheckCircle2, ChevronDown, Cpu, Download, FileText, Globe, Loader2,
   MessageSquare, ShieldCheck, StopCircle, Timer, Wifi, XCircle, Zap,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 import type { AgentOpsRun, AgentOpsStatus } from "@/lib/agent-ops/types";
 
@@ -31,7 +34,7 @@ function fmtDuration(ms?: number): string {
 }
 
 export function RunHeader({
-  run, tokens, streaming, onCancel, cancelling, onExportPdf, exporting, onBack,
+  run, tokens, streaming, onCancel, cancelling, onExportPdf, onExportMarkdown, exporting, onBack,
 }: {
   run: AgentOpsRun;
   tokens: { input: number; output: number };
@@ -39,6 +42,7 @@ export function RunHeader({
   onCancel: () => void;
   cancelling: boolean;
   onExportPdf: () => void;
+  onExportMarkdown: () => void;
   exporting: boolean;
   onBack: () => void;
 }) {
@@ -64,10 +68,23 @@ export function RunHeader({
         )}
         <span className="ml-auto flex items-center gap-2">
           {run.status !== "queued" && run.status !== "in_progress" && (
-            <Button variant="outline" size="sm" onClick={onExportPdf} disabled={exporting}>
-              {exporting ? <Loader2 className="mr-1.5 size-3.5 animate-spin" /> : <Download className="mr-1.5 size-3.5" />}
-              PDF
-            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" size="sm" disabled={exporting}>
+                  {exporting ? <Loader2 className="mr-1.5 size-3.5 animate-spin" /> : <Download className="mr-1.5 size-3.5" />}
+                  Export
+                  <ChevronDown className="ml-1 size-3.5" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={onExportPdf}>
+                  <Download className="mr-2 size-3.5" /> PDF
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={onExportMarkdown}>
+                  <FileText className="mr-2 size-3.5" /> Markdown
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           )}
           {active && (
             <Button variant="destructive" size="sm" onClick={onCancel} disabled={cancelling}>

--- a/apps/web-ui/components/channels/jira-settings-form.tsx
+++ b/apps/web-ui/components/channels/jira-settings-form.tsx
@@ -12,7 +12,7 @@ import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
-import { SetupSteps } from '@/components/channels/setup-steps';
+import { SetupGuideLink } from '@/components/channels/setup-guide-link';
 
 interface JiraSettingsForm {
     webhookSecret: string;
@@ -235,6 +235,12 @@ function JiraSettingsFormInner({
                     </Badge>
                 )}
             </div>
+
+            {/* Setup Guide */}
+            <SetupGuideLink
+                href="/docs/jira-integration"
+                description="Part 1 wires Jira → Agent Ops (trigger runs). Part 2 wires Agent Ops → Jira (result comments)."
+            />
 
             {/* Webhook URL */}
             <Card>
@@ -537,154 +543,6 @@ function JiraSettingsFormInner({
                 </CardContent>
             </Card>
 
-            {/* Setup Guide */}
-            <Card>
-                <CardHeader>
-                    <CardTitle className="text-base">Step-by-step Setup Guide</CardTitle>
-                    <CardDescription>
-                        Part 1 wires Jira → Agent Ops (trigger runs). Part 2 wires Agent Ops → Jira (result comments).
-                    </CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-6">
-                    <div className="space-y-4">
-                        <p className="text-sm font-semibold text-foreground">Part 1 — Trigger runs from Jira (required)</p>
-                        <SetupSteps
-                            steps={[
-                                {
-                                    title: 'Generate and save the Webhook Secret',
-                                    detail: (
-                                        <>
-                                            Click <strong className="text-foreground">Generate</strong> next to the
-                                            Webhook Secret field above, copy the value somewhere safe, and click{' '}
-                                            <strong className="text-foreground">Save Settings</strong>.
-                                        </>
-                                    ),
-                                },
-                                {
-                                    title: 'Create a Jira Automation rule',
-                                    detail: (
-                                        <>
-                                            In Jira, open{' '}
-                                            <strong className="text-foreground">Project settings → Automation</strong>{' '}
-                                            (or <strong className="text-foreground">Settings → System → Automation</strong>{' '}
-                                            for a global rule) and click{' '}
-                                            <strong className="text-foreground">Create rule</strong>.
-                                        </>
-                                    ),
-                                },
-                                {
-                                    title: 'Choose a trigger',
-                                    detail: (
-                                        <>
-                                            For example <strong className="text-foreground">Issue created</strong>,{' '}
-                                            <strong className="text-foreground">Issue transitioned</strong>, or{' '}
-                                            <strong className="text-foreground">Manually triggered</strong>. Optionally add
-                                            a condition (e.g. label = <code className="bg-muted px-1 rounded">agent-ops</code>)
-                                            so only selected issues trigger runs.
-                                        </>
-                                    ),
-                                },
-                                {
-                                    title: 'Add a "Send web request" action',
-                                    detail: (
-                                        <ul className="list-disc list-inside space-y-1">
-                                            <li>
-                                                <strong className="text-foreground">Web request URL</strong>: the Webhook
-                                                Endpoint shown at the top of this page
-                                            </li>
-                                            <li>
-                                                <strong className="text-foreground">HTTP method</strong>:{' '}
-                                                <code className="bg-muted px-1 rounded">POST</code>
-                                            </li>
-                                            <li>
-                                                <strong className="text-foreground">Web request body</strong>: Custom data →
-                                                paste the <em>Automation template</em> from the Webhook Payload card
-                                            </li>
-                                            <li>
-                                                <strong className="text-foreground">Headers</strong>: add{' '}
-                                                <code className="bg-muted px-1 rounded">Authorization</code> ={' '}
-                                                <code className="bg-muted px-1 rounded">Bearer &lt;your-secret&gt;</code>{' '}
-                                                (the Webhook Secret from step 1)
-                                            </li>
-                                        </ul>
-                                    ),
-                                },
-                                {
-                                    title: 'Publish and test the rule',
-                                    detail: (
-                                        <>
-                                            Use the rule&apos;s <strong className="text-foreground">Validate</strong>{' '}
-                                            button or create a test issue — the run appears under{' '}
-                                            <strong className="text-foreground">Agent Ops → Runs</strong> with source{' '}
-                                            <code className="bg-muted px-1 rounded">jira</code>.
-                                        </>
-                                    ),
-                                },
-                            ]}
-                        />
-                    </div>
-                    <div className="space-y-4">
-                        <p className="text-sm font-semibold text-foreground">
-                            Part 2 — Post results back to issues (recommended)
-                        </p>
-                        <SetupSteps
-                            startAt={6}
-                            steps={[
-                                {
-                                    title: 'Pick the bot account',
-                                    detail: (
-                                        <>
-                                            Use a dedicated Atlassian service account (recommended) or your own — run
-                                            results are posted as comments by this user.
-                                        </>
-                                    ),
-                                },
-                                {
-                                    title: 'Create an API token',
-                                    detail: (
-                                        <>
-                                            Signed in as that account, open{' '}
-                                            <a
-                                                href="https://id.atlassian.com/manage-profile/security/api-tokens"
-                                                target="_blank"
-                                                rel="noopener noreferrer"
-                                                className="inline-flex items-center gap-1 text-blue-500 hover:underline"
-                                            >
-                                                Atlassian account → Security → API tokens
-                                                <ExternalLink className="h-3 w-3" />
-                                            </a>{' '}
-                                            and click <strong className="text-foreground">Create API token</strong>. Copy
-                                            it right away — it is shown only once.
-                                        </>
-                                    ),
-                                },
-                                {
-                                    title: 'Fill in Base URL, User Email, and API Token',
-                                    detail: (
-                                        <>
-                                            Base URL is your site, e.g.{' '}
-                                            <code className="bg-muted px-1 rounded">https://your-org.atlassian.net</code>;
-                                            User Email is the bot account&apos;s email; API Token is the value from the
-                                            previous step.
-                                        </>
-                                    ),
-                                },
-                                {
-                                    title: 'Test and save',
-                                    detail: (
-                                        <>
-                                            Click <strong className="text-foreground">Test Connection</strong> — on
-                                            success the <strong className="text-foreground">Bot Account ID</strong> is
-                                            auto-filled (it prevents the bot from reacting to its own comments). Then
-                                            click <strong className="text-foreground">Save Settings</strong>.
-                                        </>
-                                    ),
-                                },
-                            ]}
-                        />
-                    </div>
-                </CardContent>
-            </Card>
         </div>
     );
 }

--- a/apps/web-ui/components/channels/setup-guide-link.tsx
+++ b/apps/web-ui/components/channels/setup-guide-link.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link';
+import { ArrowUpRight, BookOpenText } from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+interface SetupGuideLinkProps {
+    href: string;
+    description: string;
+}
+
+/**
+ * Points channel settings pages at the full step-by-step guide rendered in
+ * the in-app docs site, instead of duplicating the steps inline here.
+ */
+export function SetupGuideLink({ href, description }: SetupGuideLinkProps) {
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle className="text-base">Step-by-step Setup Guide</CardTitle>
+                <CardDescription>{description}</CardDescription>
+            </CardHeader>
+            <CardContent>
+                <Link
+                    href={href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1.5 text-sm font-medium text-blue-500 hover:underline"
+                >
+                    <BookOpenText className="h-4 w-4" />
+                    Open the full setup guide
+                    <ArrowUpRight className="h-3.5 w-3.5" />
+                </Link>
+            </CardContent>
+        </Card>
+    );
+}

--- a/apps/web-ui/components/channels/slack-settings-form.tsx
+++ b/apps/web-ui/components/channels/slack-settings-form.tsx
@@ -12,11 +12,12 @@ import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
-import { SetupSteps } from '@/components/channels/setup-steps';
+import { SetupGuideLink } from '@/components/channels/setup-guide-link';
 
 interface SlackSettingsState {
     signingSecret: string;
     botToken: string;
+    teamId: string;
     enabled: boolean;
 }
 
@@ -39,6 +40,7 @@ export function SlackSettingsForm(props: SlackSettingsFormProps) {
             {...props}
             initialConfigured={data?.configured ?? false}
             initialEnabled={data?.enabled ?? true}
+            initialTeamId={(data?.teamId as string | null) ?? ''}
         />
     );
 }
@@ -48,7 +50,8 @@ function SlackSettingsFormInner({
     backLabel = 'Back to Agent Ops',
     initialConfigured,
     initialEnabled,
-}: SlackSettingsFormProps & { initialConfigured: boolean; initialEnabled: boolean }) {
+    initialTeamId,
+}: SlackSettingsFormProps & { initialConfigured: boolean; initialEnabled: boolean; initialTeamId: string }) {
     const router = useRouter();
     const saveMutation = useSaveChannelSettings('slack');
     const saving = saveMutation.isPending;
@@ -77,6 +80,7 @@ function SlackSettingsFormInner({
     const [form, setForm] = useState<SlackSettingsState>({
         signingSecret: '',
         botToken: '',
+        teamId: initialTeamId,
         enabled: initialEnabled,
     });
 
@@ -124,16 +128,22 @@ function SlackSettingsFormInner({
             setSaveStatus('error');
             return;
         }
+        if (!configured && !form.botToken.trim() && !form.teamId.trim()) {
+            setErrorMessage('Enter a Bot Token, or a Slack Workspace/Team ID if you\'re not using one');
+            setSaveStatus('error');
+            return;
+        }
         try {
             setErrorMessage('');
-            await saveMutation.mutateAsync({
+            const result = await saveMutation.mutateAsync({
                 signingSecret: form.signingSecret,
                 botToken: form.botToken || undefined,
+                teamId: form.teamId.trim() || undefined,
                 enabled: form.enabled,
             });
             setConfigured(true);
             setSaveStatus('saved');
-            setForm(prev => ({ ...prev, signingSecret: '', botToken: '' }));
+            setForm(prev => ({ ...prev, signingSecret: '', botToken: '', teamId: (result.teamId as string) || prev.teamId }));
             setRevealed(false);
             setShowSigningSecret(false);
             setShowBotToken(false);
@@ -201,6 +211,12 @@ function SlackSettingsFormInner({
                 )}
             </div>
 
+            {/* Setup Guide */}
+            <SetupGuideLink
+                href="/docs/slack-integration"
+                description="From zero to a working Slack integration in about five minutes."
+            />
+
             {/* Webhook URL */}
             <Card>
                 <CardHeader>
@@ -219,28 +235,6 @@ function SlackSettingsFormInner({
                     <p className="text-xs text-muted-foreground mt-2">
                         Method: <code className="bg-muted px-1 rounded">POST</code>
                     </p>
-                </CardContent>
-            </Card>
-
-            {/* App Manifest */}
-            <Card>
-                <CardHeader>
-                    <CardTitle className="text-base">App Manifest — quick create</CardTitle>
-                    <CardDescription>
-                        The fastest way to set up: create your Slack app <strong>from this manifest</strong> and the
-                        slash command, bot scopes, and interactivity endpoint are configured automatically.
-                    </CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-3">
-                    <pre className="bg-muted rounded-md p-4 text-xs overflow-x-auto max-h-64">{appManifest}</pre>
-                    <Button variant="outline" size="sm" onClick={() => copyToClipboard(appManifest, 'manifest')}>
-                        {copied === 'manifest' ? (
-                            <CheckCircle2 className="h-4 w-4 mr-2 text-green-500" />
-                        ) : (
-                            <Copy className="h-4 w-4 mr-2" />
-                        )}
-                        Copy app manifest
-                    </Button>
                 </CardContent>
             </Card>
 
@@ -324,6 +318,29 @@ function SlackSettingsFormInner({
                         </p>
                     </div>
 
+                    {/* Slack Workspace / Team ID — only needed when there's no Bot Token */}
+                    {!form.botToken.trim() && (
+                        <div className="space-y-2">
+                            <Label htmlFor="teamId">
+                                Slack Workspace/Team ID{' '}
+                                <span className="text-destructive">*</span>
+                            </Label>
+                            <Input
+                                id="teamId"
+                                placeholder="T0123ABCDEF"
+                                value={form.teamId}
+                                onChange={e => setForm(prev => ({ ...prev, teamId: e.target.value }))}
+                                className="font-mono"
+                            />
+                            <p className="text-xs text-muted-foreground">
+                                Used to route incoming slash commands to your organization. Found in your Slack
+                                workspace URL (<code className="bg-muted px-1 rounded">app.slack.com/client/T0123.../...</code>)
+                                or under <strong>Settings &amp; administration → About this workspace</strong>. Not
+                                needed if a Bot Token is set above — it&apos;s derived automatically.
+                            </p>
+                        </div>
+                    )}
+
                     {/* Enable toggle */}
                     <div className="flex items-center justify-between rounded-lg border p-4">
                         <div className="space-y-0.5">
@@ -383,98 +400,25 @@ function SlackSettingsFormInner({
                 </CardContent>
             </Card>
 
-            {/* Setup Guide */}
+            {/* App Manifest */}
             <Card>
                 <CardHeader>
-                    <CardTitle className="text-base">Step-by-step Setup Guide</CardTitle>
-                    <CardDescription>From zero to a working Slack integration in about five minutes.</CardDescription>
+                    <CardTitle className="text-base">App Manifest — quick create</CardTitle>
+                    <CardDescription>
+                        The fastest way to set up: create your Slack app <strong>from this manifest</strong> and the
+                        slash command, bot scopes, and interactivity endpoint are configured automatically.
+                    </CardDescription>
                 </CardHeader>
-                <CardContent>
-                    <SetupSteps
-                        steps={[
-                            {
-                                title: 'Create the Slack app',
-                                detail: (
-                                    <>
-                                        Go to{' '}
-                                        <a
-                                            href="https://api.slack.com/apps"
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                            className="text-blue-500 hover:underline"
-                                        >
-                                            api.slack.com/apps
-                                        </a>{' '}
-                                        → <strong className="text-foreground">Create New App</strong> →{' '}
-                                        <strong className="text-foreground">From a manifest</strong>. Pick your
-                                        workspace, choose JSON, and paste the App Manifest from the card above — this
-                                        auto-configures the slash command, bot scopes, and interactivity endpoint.
-                                    </>
-                                ),
-                            },
-                            {
-                                title: 'Copy the Signing Secret',
-                                detail: (
-                                    <>
-                                        In the app&apos;s settings, open{' '}
-                                        <strong className="text-foreground">Basic Information</strong>, scroll to{' '}
-                                        <strong className="text-foreground">App Credentials</strong>, click{' '}
-                                        <strong className="text-foreground">Show</strong> next to Signing Secret, and
-                                        paste it into the field above.
-                                    </>
-                                ),
-                            },
-                            {
-                                title: 'Install the app to your workspace',
-                                detail: (
-                                    <>
-                                        Open <strong className="text-foreground">Install App</strong> in the sidebar and
-                                        click <strong className="text-foreground">Install to Workspace</strong>, then
-                                        authorize the requested scopes (
-                                        <code className="bg-muted px-1 rounded">commands</code>,{' '}
-                                        <code className="bg-muted px-1 rounded">chat:write</code>,{' '}
-                                        <code className="bg-muted px-1 rounded">chat:write.public</code>).
-                                    </>
-                                ),
-                            },
-                            {
-                                title: 'Copy the Bot Token',
-                                detail: (
-                                    <>
-                                        After installation, go to{' '}
-                                        <strong className="text-foreground">OAuth &amp; Permissions</strong> and copy the{' '}
-                                        <strong className="text-foreground">Bot User OAuth Token</strong> (starts with{' '}
-                                        <code className="bg-muted px-1 rounded">xoxb-</code>) into the field above.
-                                    </>
-                                ),
-                            },
-                            {
-                                title: 'Invite the bot to your channel',
-                                detail: (
-                                    <>
-                                        In the Slack channel that should receive results or scheduled digests, run{' '}
-                                        <code className="bg-muted px-1 rounded">/invite @nucleus-cloud-ops</code>. To get
-                                        the <strong className="text-foreground">Channel ID</strong> (needed when
-                                        configuring a scheduled task&apos;s Slack notification): click the channel name
-                                        → scroll to the bottom of the About tab → copy the ID starting with{' '}
-                                        <code className="bg-muted px-1 rounded">C</code>.
-                                    </>
-                                ),
-                            },
-                            {
-                                title: 'Save, test, and run',
-                                detail: (
-                                    <>
-                                        Click <strong className="text-foreground">Save Settings</strong>, then{' '}
-                                        <strong className="text-foreground">Test Connection</strong> to verify the bot
-                                        token. Finally, try{' '}
-                                        <code className="bg-muted px-1 rounded">/cloud-ops check EC2 costs in prod</code>{' '}
-                                        in Slack.
-                                    </>
-                                ),
-                            },
-                        ]}
-                    />
+                <CardContent className="space-y-3">
+                    <pre className="bg-muted rounded-md p-4 text-xs overflow-x-auto max-h-64">{appManifest}</pre>
+                    <Button variant="outline" size="sm" onClick={() => copyToClipboard(appManifest, 'manifest')}>
+                        {copied === 'manifest' ? (
+                            <CheckCircle2 className="h-4 w-4 mr-2 text-green-500" />
+                        ) : (
+                            <Copy className="h-4 w-4 mr-2" />
+                        )}
+                        Copy app manifest
+                    </Button>
                 </CardContent>
             </Card>
         </div>

--- a/apps/web-ui/components/skills/skills-client.tsx
+++ b/apps/web-ui/components/skills/skills-client.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 import type { ColumnDef } from "@tanstack/react-table";
-import { Plus, Eye, Copy, Pencil, Trash2, Search, MoreHorizontal } from "lucide-react";
+import { Plus, Eye, Copy, Pencil, Trash2, Search, MoreHorizontal, Download, FileDown, FileCode, FileArchive, ChevronDown, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -15,6 +15,8 @@ import { useSkills, useDeleteSkill, useUpdateSkill } from "@/lib/queries/skills"
 import { SkillFormDialog } from "./skill-form-dialog";
 import { SkillDetailDialog } from "./skill-detail-dialog";
 import type { SkillDTO } from "@/lib/client-skill-service";
+import { ClientSkillService } from "@/lib/client-skill-service";
+import { exportSkillToMarkdown, exportAllSkillsToMarkdown, exportSkillToFile, exportAllSkillsToZip } from "@/lib/skill-export";
 
 function formatDate(value: string) {
   const d = new Date(value);
@@ -32,6 +34,7 @@ export function SkillsClient() {
   const [viewOpen, setViewOpen] = useState(false);
   const [viewing, setViewing] = useState<SkillDTO | null>(null);
   const [search, setSearch] = useState("");
+  const [exporting, setExporting] = useState(false);
 
   const openCreate = () => { setEditing(null); setCloning(null); setDialogOpen(true); };
   const openEdit = (s: SkillDTO) => { setEditing(s); setCloning(null); setDialogOpen(true); };
@@ -48,6 +51,61 @@ export function SkillsClient() {
       toast.success(next ? "Skill enabled" : "Skill disabled", { description: s.name });
     } catch (e) {
       toast.error("Update failed", { description: e instanceof Error ? e.message : "Try again" });
+    }
+  };
+  const onExportSkill = async (s: SkillDTO) => {
+    try {
+      // List DTOs omit content — fetch the full skill before exporting.
+      const full = await ClientSkillService.getSkill(s.id);
+      exportSkillToMarkdown(full);
+      toast.success("Skill exported", { description: `${s.name}.md downloaded` });
+    } catch (e) {
+      toast.error("Export failed", { description: e instanceof Error ? e.message : "Try again" });
+    }
+  };
+  const onExportSkillFile = async (s: SkillDTO) => {
+    try {
+      const full = await ClientSkillService.getSkill(s.id);
+      exportSkillToFile(full);
+      toast.success("SKILL.md exported", { description: `${s.id}.md downloaded` });
+    } catch (e) {
+      toast.error("Export failed", { description: e instanceof Error ? e.message : "Try again" });
+    }
+  };
+  const fetchAllWithContent = async (): Promise<SkillDTO[] | null> => {
+    const all = await ClientSkillService.listSkillsWithContent(true);
+    if (all.length === 0) {
+      toast.error("Nothing to export", { description: "No skills found." });
+      return null;
+    }
+    return all;
+  };
+  const onExportAll = async () => {
+    if (exporting) return;
+    setExporting(true);
+    try {
+      const all = await fetchAllWithContent();
+      if (!all) return;
+      exportAllSkillsToMarkdown(all);
+      toast.success("Skills exported", { description: `${all.length} skill(s) downloaded` });
+    } catch (e) {
+      toast.error("Export failed", { description: e instanceof Error ? e.message : "Try again" });
+    } finally {
+      setExporting(false);
+    }
+  };
+  const onExportAllZip = async () => {
+    if (exporting) return;
+    setExporting(true);
+    try {
+      const all = await fetchAllWithContent();
+      if (!all) return;
+      await exportAllSkillsToZip(all);
+      toast.success("Skills exported", { description: `${all.length} SKILL.md files zipped` });
+    } catch (e) {
+      toast.error("Export failed", { description: e instanceof Error ? e.message : "Try again" });
+    } finally {
+      setExporting(false);
     }
   };
 
@@ -124,6 +182,8 @@ export function SkillsClient() {
                 <DropdownMenuItem onClick={() => openView(s)}><Eye className="mr-2 h-4 w-4" /> View</DropdownMenuItem>
                 <DropdownMenuItem onClick={() => openEdit(s)}><Pencil className="mr-2 h-4 w-4" /> Edit</DropdownMenuItem>
                 <DropdownMenuItem onClick={() => openClone(s)}><Copy className="mr-2 h-4 w-4" /> Clone</DropdownMenuItem>
+                <DropdownMenuItem onClick={() => onExportSkill(s)}><FileDown className="mr-2 h-4 w-4" /> Export markdown</DropdownMenuItem>
+                <DropdownMenuItem onClick={() => onExportSkillFile(s)}><FileCode className="mr-2 h-4 w-4" /> Export SKILL.md</DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem onClick={() => onDelete(s)} className="text-destructive"><Trash2 className="mr-2 h-4 w-4" /> Delete</DropdownMenuItem>
               </DropdownMenuContent>
@@ -142,7 +202,22 @@ export function SkillsClient() {
           <h1 className="text-2xl font-semibold">Skills</h1>
           <p className="text-sm text-muted-foreground">Reusable agent skills for AI Ops and Agent Ops.</p>
         </div>
-        <Button onClick={openCreate}><Plus className="w-4 h-4 mr-1" /> Create skill</Button>
+        <div className="flex items-center gap-2">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" disabled={exporting || isLoading || rows.length === 0}>
+                {exporting ? <Loader2 className="w-4 h-4 mr-1 animate-spin" /> : <Download className="w-4 h-4 mr-1" />}
+                Export all
+                <ChevronDown className="w-4 h-4 ml-1" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={onExportAll}><FileDown className="mr-2 h-4 w-4" /> Markdown (one file)</DropdownMenuItem>
+              <DropdownMenuItem onClick={onExportAllZip}><FileArchive className="mr-2 h-4 w-4" /> SKILL.md files (zip)</DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <Button onClick={openCreate}><Plus className="w-4 h-4 mr-1" /> Create skill</Button>
+        </div>
       </div>
 
       <DataTable

--- a/apps/web-ui/content/docs/configuration.mdx
+++ b/apps/web-ui/content/docs/configuration.mdx
@@ -105,7 +105,7 @@ Ensure your execution role has:
 
 ### MCP Servers
 
-Add custom MCP servers under **Channels** → **MCP Servers** to extend the agent's capabilities. 16 MCP servers are supported out of the box.
+Add custom MCP servers under **Channels** → **MCP Servers** to extend the agent's capabilities. 16 MCP servers are supported out of the box. For connecting Atlassian's Jira/Confluence MCP server — including headless auth for Docker/ECS deployments — see the dedicated [Jira / Atlassian Integration](/docs/jira-integration) guide.
 
 ---
 
@@ -115,19 +115,14 @@ Add custom MCP servers under **Channels** → **MCP Servers** to extend the agen
 
 ### Slack Integration
 
-1. Go to **Channels** → **Slack** → **Configure**
-2. Create a Slack app and add the Bot Token
-3. Configure the webhook URL for notifications
-4. Test the connection
-
-Once configured, use Slack slash commands to trigger agent runs and receive results directly in your channels.
+See the dedicated [Slack Integration](/docs/slack-integration) guide for full setup steps —
+from creating the Slack app through inviting the bot and testing the connection.
 
 ### Jira Integration
 
-1. Go to **Channels** → **Jira** → **Configure**
-2. Enter your Jira base URL and API token
-3. Trigger agent runs from Jira Automation rules
-4. Receive results as issue comments
+See the dedicated [Jira / Atlassian Integration](/docs/jira-integration) guide — covers both the
+Jira Automation trigger channel and connecting Jira/Confluence as an MCP tool source (including
+headless auth for Docker/ECS deployments).
 
 ### MCP Servers
 

--- a/apps/web-ui/content/docs/index.mdx
+++ b/apps/web-ui/content/docs/index.mdx
@@ -24,6 +24,8 @@ The dashboard gives you a real-time view of your entire AWS footprint — total 
 | Inventory Discovery | Auto-discover all resources across all accounts — [tutorial](/docs/tutorials#tutorial-1-save-on-devstaging-environments) |
 | Knowledge Base | Vector-powered Q&A over your infrastructure docs — [tutorial](/docs/tutorials#tutorial-6-build-a-knowledge-base-from-your-docs) |
 | Channels | Slack, Jira, and MCP server integrations — [configure](/docs/configuration#channels--integrations) |
+| Slack | Trigger runs via slash commands, receive results and approvals in-channel — [guide](/docs/slack-integration) |
+| Jira / Atlassian | Trigger runs from Jira Automation or connect Jira/Confluence as an MCP tool — [guide](/docs/jira-integration) |
 | Audit Logs | Complete activity log with filtering and export — [tutorial](/docs/tutorials#tutorial-7-audit-who-changed-what) |
 
 ## Quick Links
@@ -31,5 +33,7 @@ The dashboard gives you a real-time view of your entire AWS footprint — total 
 - [Getting Started](/docs/getting-started) — Set up your first account in 5 minutes
 - [Installation](/docs/installation) — Deploy Nucleus Ops to your AWS environment
 - [Configuration](/docs/configuration) — Configure accounts, schedules, and the AI agent
+- [Slack Integration](/docs/slack-integration) — Slash commands, bot token, and channel setup
+- [Jira / Atlassian Integration](/docs/jira-integration) — Jira Automation trigger channel + MCP tool setup
 - [Tutorials](/docs/tutorials) — Step-by-step guides for common workflows
 - [FAQ](/docs/faq) — Frequently asked questions

--- a/apps/web-ui/content/docs/jira-integration.mdx
+++ b/apps/web-ui/content/docs/jira-integration.mdx
@@ -1,0 +1,118 @@
+---
+title: Jira / Atlassian Integration
+description: Trigger agent runs from Jira Automation and connect Jira/Confluence as an MCP tool source, including headless auth for containerized deployments.
+---
+
+Nucleus Ops connects to Jira in two independent ways — pick whichever (or both) fit your workflow:
+
+| | **Jira channel** | **Atlassian MCP tool** |
+|---|---|---|
+| Purpose | Trigger agent runs from Jira Automation, post results as issue comments | Give the AI Ops agent read/write access to Jira issues (and Confluence) as a tool |
+| Setup location | **Channels** → **Jira** | **Channels** → **MCP Servers** |
+| Auth | Webhook secret + API token | API token (headless) or browser OAuth |
+
+---
+
+## Jira Channel — Trigger Runs from Jira Automation
+
+**Goal:** Let a Jira Automation rule kick off an agent run (Part 1), and optionally have Nucleus
+Ops post the result back as a comment on the triggering issue (Part 2).
+
+![Channels](/screenshots/channels.png)
+
+Go to **Channels** → **Jira** to find the Webhook Endpoint, Credentials form, and an example
+Webhook Payload referenced in the steps below.
+
+### Part 1 — Trigger runs from Jira (required)
+
+1. **Generate and save the Webhook Secret** — click **Generate** next to the Webhook Secret
+   field, copy the value somewhere safe, and click **Save Settings**.
+2. **Create a Jira Automation rule** — in Jira, open **Project settings → Automation** (or
+   **Settings → System → Automation** for a global rule) and click **Create rule**.
+3. **Choose a trigger** — for example **Issue created**, **Issue transitioned**, or
+   **Manually triggered**. Optionally add a condition (e.g. label = `agent-ops`) so only
+   selected issues trigger runs.
+4. **Add a "Send web request" action**:
+   - **Web request URL**: the Webhook Endpoint shown on the Jira settings page
+   - **HTTP method**: `POST`
+   - **Web request body**: Custom data → paste the *Automation template* from the Webhook
+     Payload card (it uses Jira Automation smart values so the payload fills itself per issue)
+   - **Headers**: add `Authorization` = `Bearer <your-secret>` (the Webhook Secret from step 1)
+5. **Publish and test the rule** — use the rule's **Validate** button or create a test issue;
+   the run appears under **Agent Ops → Runs** with source `jira`.
+
+### Part 2 — Post results back to issues (recommended)
+
+6. **Pick the bot account** — use a dedicated Atlassian service account (recommended) or your
+   own; run results are posted as comments by this user.
+7. **Create an API token** — signed in as that account, open
+   [Atlassian account → Security → API tokens](https://id.atlassian.com/manage-profile/security/api-tokens)
+   and click **Create API token**. Copy it right away — it is shown only once.
+8. **Fill in Base URL, User Email, and API Token** on the Jira settings page — Base URL is your
+   site (e.g. `https://your-org.atlassian.net`), User Email is the bot account's email, API
+   Token is the value from the previous step.
+9. **Test and save** — click **Test Connection**; on success the **Bot Account ID** is
+   auto-filled (it prevents the bot from reacting to its own comments). Then click
+   **Save Settings**.
+
+**Example use case:** a "Restart staging DB" issue transitions to *In Progress* → Automation
+rule fires → Nucleus Ops runs the agent → result comment lands on the issue a few seconds later.
+
+---
+
+## Atlassian MCP Tool — Give the Agent Jira/Confluence Access
+
+**Goal:** Let the AI Ops agent search, read, and update Jira issues (or Confluence pages)
+directly during a run, via the official Atlassian Rovo MCP server.
+
+1. Go to **Channels** → **MCP Servers** → **Configure**.
+2. Add a new server pointing at `https://mcp.atlassian.com/v1/mcp` (see the two auth options
+   below).
+3. Once connected, Jira/Confluence tools become available to the AI Ops agent automatically —
+   no additional wiring needed.
+
+### Option A — Browser OAuth (interactive environments)
+
+If you're running Nucleus Ops somewhere with a browser available (local dev, a desktop client),
+the default flow works out of the box: add the server with just the URL, and `mcp-remote` will
+open a browser tab for you to approve access.
+
+### Option B — Headless auth (Docker / ECS / any non-interactive environment)
+
+The default OAuth flow opens a local callback server on port `3736` and waits for a browser to
+approve access. That has no way to succeed when Nucleus Ops runs the MCP client headlessly —
+inside a Docker container or an ECS task with no browser and no interactive user. The
+connection will hang or fail because nothing can ever complete the callback.
+
+The fix is to skip OAuth entirely and authenticate with an Atlassian **API token** over HTTP
+Basic Auth instead, passed straight to `mcp-remote` as a header:
+
+1. **Generate an API token** from your Atlassian account's security settings
+   (`id.atlassian.com` → **Manage profile** → **Security** → **API tokens**).
+2. **Base64-encode `email:api_token`**:
+   ```bash
+   echo -n "your.email@example.com:YOUR_API_TOKEN" | base64
+   ```
+3. **Add a new stdio MCP server** in **Channels** → **MCP Servers** with:
+   - **Command**: `npx`
+   - **Arguments** (one per line):
+     ```
+     -y
+     mcp-remote@latest
+     https://mcp.atlassian.com/v1/mcp
+     --header
+     Authorization: Basic <base64-string-from-step-2>
+     ```
+   - **Environment variables**: none needed — leave this empty. `mcp-remote` reads the
+     credential from the `--header` argument, not from an env var, so setting something like
+     `ATLASSIAN_API_TOKEN` here has no effect and can cause the client to fall back to the
+     OAuth flow instead.
+4. **Test connection** — with the Basic Auth header attached to the first request, the server
+   handshake completes immediately with no browser interaction required.
+
+<Callout type="warn">
+  The base64 string is a reversible encoding of your email and API token, not encryption —
+  treat it as a plaintext credential. Never commit it to a repo, paste it into a shared doc or
+  chat log, or store it outside the MCP server's own encrypted config. If a token is ever
+  exposed, revoke it from the Atlassian API token portal and issue a new one.
+</Callout>

--- a/apps/web-ui/content/docs/meta.json
+++ b/apps/web-ui/content/docs/meta.json
@@ -5,6 +5,8 @@
     "getting-started",
     "installation",
     "configuration",
+    "slack-integration",
+    "jira-integration",
     "tutorials",
     "faq"
   ]

--- a/apps/web-ui/content/docs/slack-integration.mdx
+++ b/apps/web-ui/content/docs/slack-integration.mdx
@@ -1,0 +1,46 @@
+---
+title: Slack Integration
+description: Trigger Agent Ops runs via Slack slash commands and receive results, scheduled digests, and approval requests back in your channels.
+---
+
+**Goal:** from zero to a working Slack integration in about five minutes.
+
+![Channels](/screenshots/channels.png)
+
+## 1. Create the Slack app
+
+Go to [api.slack.com/apps](https://api.slack.com/apps) → **Create New App** → **From a manifest**.
+Pick your workspace, choose JSON, and paste the App Manifest shown on the **Channels → Slack**
+settings page in Nucleus Ops — this auto-configures the slash command, bot scopes, and
+interactivity endpoint in one step, so you don't have to wire each of those up by hand.
+
+## 2. Copy the Signing Secret
+
+In the app's settings, open **Basic Information**, scroll to **App Credentials**, click **Show**
+next to Signing Secret, and paste it into the **Signing Secret** field on the Slack settings page.
+This is what lets Nucleus Ops verify that incoming requests really came from Slack.
+
+## 3. Install the app to your workspace
+
+Open **Install App** in the sidebar and click **Install to Workspace**, then authorize the
+requested scopes (`commands`, `chat:write`, `chat:write.public`).
+
+## 4. Copy the Bot Token
+
+After installation, go to **OAuth & Permissions** and copy the **Bot User OAuth Token** (starts
+with `xoxb-`) into the **Bot Token** field. Without it, only ephemeral replies to slash commands
+work — you need this token for Nucleus Ops to post run results, scheduled-task digests, and
+approval buttons back into Slack.
+
+## 5. Invite the bot to your channel
+
+In the Slack channel that should receive results or scheduled digests, run
+`/invite @nucleus-cloud-ops`. To get the **Channel ID** (needed when configuring a scheduled
+task's Slack notification): click the channel name → scroll to the bottom of the About tab →
+copy the ID starting with `C`.
+
+## 6. Save, test, and run
+
+Click **Save Settings**, then **Test Connection** to verify the bot token against Slack's
+`auth.test` API. Finally, try `/cloud-ops check EC2 costs in prod` in Slack — the run appears
+under **Agent Ops → Runs** with source `slack`, and results stream back to the channel.

--- a/apps/web-ui/content/docs/tutorials.mdx
+++ b/apps/web-ui/content/docs/tutorials.mdx
@@ -39,13 +39,7 @@ description: Step-by-step guides for common Nucleus Ops workflows.
 
 **Goal:** Let your team trigger cloud operations from Slack.
 
-![Channels](/screenshots/channels.png)
-
-1. Go to **Channels** → **Slack** → **Configure**
-2. Create a Slack app, add the Bot Token and webhook URL
-3. Test the connection
-4. In Slack, use slash commands to trigger agent runs
-5. Results are posted back to your configured channel
+See the dedicated [Slack Integration](/docs/slack-integration) guide for full setup steps.
 
 **Example Slack command:** `/nucleus is there any ec2 instance running in partner system non prod stx`
 
@@ -55,10 +49,9 @@ description: Step-by-step guides for common Nucleus Ops workflows.
 
 **Goal:** Trigger cloud operations from Jira Automation rules.
 
-1. Go to **Channels** → **Jira** → **Configure**
-2. Enter your Jira base URL and API token
-3. In Jira Automation, create a rule that calls the Nucleus Ops webhook
-4. Agent results are posted as issue comments
+See the dedicated [Jira / Atlassian Integration](/docs/jira-integration) guide for full setup
+steps — both the Jira Automation trigger channel and connecting Jira/Confluence as an MCP tool
+source for the agent.
 
 ---
 

--- a/apps/web-ui/docker-entrypoint.sh
+++ b/apps/web-ui/docker-entrypoint.sh
@@ -7,7 +7,7 @@ RETRY_DELAY=3
 echo "Waiting for database connectivity..."
 retries=0
 while [ $retries -lt $MAX_RETRIES ]; do
-    if bunx prisma@5 migrate deploy --schema=./libs/prisma/schema.prisma 2>&1; then
+    if npx --yes prisma@5 migrate deploy --schema=./libs/prisma/schema.prisma 2>&1; then
         echo "Prisma migrations applied successfully."
         break
     fi
@@ -24,4 +24,4 @@ while [ $retries -lt $MAX_RETRIES ]; do
 done
 
 echo "Starting Next.js server..."
-exec bun run server.js
+exec node server.js

--- a/apps/web-ui/lib/agent-ops/agent-executor.ts
+++ b/apps/web-ui/lib/agent-ops/agent-executor.ts
@@ -147,7 +147,17 @@ export async function executeAgentRun(run: AgentOpsRun, eventBus?: GatewayEventB
         } catch { /* non-fatal */ }
 
         const graphInput = { messages: [new HumanMessage(taskDescription)] };
-        const graphRunConfig = { configurable: { thread_id: threadId }, recursionLimit: maxIterations };
+        // tenant_id/user_id MUST be in configurable: execute_command reads
+        // config.configurable.tenant_id at invoke time to point
+        // AWS_SHARED_CREDENTIALS_FILE at the tenant creds file where
+        // get_aws_credentials wrote the STS profile. Without it the AWS CLI
+        // falls back to the empty ~/.aws/credentials and every command fails
+        // with "The config profile could not be found". (Matches the AIOps
+        // chat route in app/api/chat/route.ts.)
+        const graphRunConfig = {
+            configurable: { thread_id: threadId, tenant_id: tenantId, user_id: deriveUserId(run) },
+            recursionLimit: maxIterations,
+        };
 
         // ── Event tracking ────────────────────────────────────────────────────
         const toolsUsed = new Set<string>();
@@ -486,15 +496,27 @@ async function processLangGraphEvent(
             if (typeof rawContent === 'string') {
                 textContent = rawContent.trim();
             } else if (Array.isArray(rawContent)) {
-                // Bedrock returns [{type:'text', text:'...'}, {type:'tool_use', ...}]
+                // Bedrock streaming yields content as an array of un-coalesced
+                // text deltas ([{type:'text',text:'The'},{type:'text',text:' request'}...]).
+                // Each delta carries its own leading space, so join with '' —
+                // join('\n') shatters the text one delta per line in the UI + PDF.
+                // (Matches getStringContent() in fast-agent.ts.)
                 textContent = rawContent
                     .filter((c: any) => c.type === 'text' && c.text?.trim())
                     .map((c: any) => c.text)
-                    .join('\n')
+                    .join('')
                     .trim();
             }
 
-            if (textContent) {
+            // planner/evaluator/reflect each emit a clean STRUCTURED event at
+            // on_chain_end (Plan created / evaluation / parsed reflection). Their
+            // raw model text here is a duplicate twin — recording it too double-
+            // lists every planning/reflection step in the timeline. Skip it; the
+            // token usage above is still captured. (generate/agent → execution,
+            // revise → revision, final → final have no structured twin, so keep.)
+            const STRUCTURED_TWIN_NODES = new Set(['planner', 'evaluator', 'reflect']);
+
+            if (textContent && !STRUCTURED_TWIN_NODES.has(node)) {
                 if (node === 'final' || (node === 'generate' && !toolCalls.length)) {
                     result.finalContent = textContent;
                 }
@@ -604,7 +626,12 @@ export async function resumeApprovedRun(run: AgentOpsRun, eventBus?: GatewayEven
         // Match the initial-run recursionLimit (the tenant's configured graph
         // limit); otherwise a resumed run would fall back to LangGraph's default
         // of 25, tighter than what the initial run used.
-        const graphRunConfig = { configurable: { thread_id: threadId }, recursionLimit: maxIterations };
+        // tenant_id/user_id in configurable are required for execute_command to
+        // resolve AWS credentials on resume too — see the initial-run comment above.
+        const graphRunConfig = {
+            configurable: { thread_id: threadId, tenant_id: tenantId, user_id: deriveUserId(run) },
+            recursionLimit: maxIterations,
+        };
 
         // Inject approvalStatus='approved' so routing skips both gates on resume
         await (graph as any).updateState(graphRunConfig, {

--- a/apps/web-ui/lib/agent-ops/executor-graphs.ts
+++ b/apps/web-ui/lib/agent-ops/executor-graphs.ts
@@ -34,6 +34,9 @@ import {
     getActiveMCPTools,
     getMCPToolsDescription,
     getMCPManager,
+    computeReflectionStall,
+    extractTextContent,
+    critiqueVerdict,
 } from "@/lib/agent/agent-shared";
 import {
     buildBaseIdentity,
@@ -51,7 +54,7 @@ import { resolveKnowledgeBaseIds } from "@/lib/agent/auto-kb-select";
 
 // ── Agent Ops-specific imports ────────────────────────────────────────────────
 import { GraphConfig } from "@/lib/agent/agent-shared";
-import { ReflectionState, graphState, PlanStep, RequestEvaluation, ToolResultEntry } from "./executor-state";
+import { ReflectionState, graphState, PlanStep, RequestEvaluation, ToolResultEntry, isReusableEvaluation } from "./executor-state";
 import { filterMutativeToolCalls } from "./tool-classifier";
 import { env } from "@/env";
 
@@ -151,7 +154,12 @@ export async function createDynamicExecutorGraph(config: GraphConfig) {
     // NODE: EVALUATOR — determines mode, skill, account, and whether clarification needed
     // ============================================================================
     async function evaluatorNode(state: ReflectionState): Promise<Partial<ReflectionState>> {
-        if (state.evaluation) return {}; // Already evaluated (e.g. resumed from checkpoint)
+        // Reuse a checkpointed PLAN evaluation (approval resume). A stale 'end'
+        // (clarification) evaluation must be re-evaluated: on clarification resume
+        // the user's reply is in the last message, and skipping the LLM here made
+        // routeFromEvaluator replay the old mode='end' → clarify → the run
+        // re-asked the identical question forever.
+        if (isReusableEvaluation(state.evaluation)) return {};
 
         const lastMessage = state.messages[state.messages.length - 1];
         const taskDescription = typeof lastMessage.content === 'string'
@@ -199,7 +207,7 @@ Return only the JSON object.`);
         };
 
         try {
-            const content = response.content as string;
+            const content = extractTextContent(response.content);
             const match = content.match(/\{[\s\S]*\}/);
             if (match) {
                 const parsed = JSON.parse(match[0]);
@@ -296,7 +304,7 @@ Return ONLY a JSON array of step strings. Example:
 
         let planSteps: PlanStep[] = [];
         try {
-            const match = (response.content as string).match(/\[[\s\S]*\]/);
+            const match = extractTextContent(response.content).match(/\[[\s\S]*\]/);
             if (match) {
                 planSteps = JSON.parse(match[0]).map((step: string) => ({ step, status: 'pending' as const }));
             }
@@ -490,10 +498,18 @@ Otherwise list specific issues to fix. Do not generate the fixed answer.`);
         const response = await reflectorModel.invoke(inputs);
         llmAuditLog('REFLECTOR', inputs, response, start);
 
-        const content = typeof response.content === 'string' ? response.content : JSON.stringify(response.content);
+        const content = extractTextContent(response.content);
 
         if (isComplex) {
             let analysis = '', issues = 'None', isComplete = false, updatedPlan: PlanStep[] = [];
+            // Empty reflector text (reasoning consumed the output budget) parses to
+            // nothing and would loop forever with issues='None' resetting the stall
+            // counter. Report it as a CONSTANT issue so consecutive repeats trip
+            // computeReflectionStall and the run finalizes instead of churning.
+            if (!content.trim()) {
+                analysis = 'Reflector returned no text output.';
+                issues = 'EMPTY_REFLECTION: reflector produced no text';
+            }
             try {
                 const match = content.match(/\{[\s\S]*\}/);
                 if (match) {
@@ -505,17 +521,34 @@ Otherwise list specific issues to fix. Do not generate the fixed answer.`);
                 }
             } catch { isComplete = false; }
 
-            console.log(`[REFLECTOR] Complete: ${isComplete} | Issues: ${issues !== 'None' ? issues : 'None'}`);
+            // Stall detection: if the reflector keeps reporting the SAME blocking
+            // issue, the revise loop isn't making progress. Bail to final rather
+            // than churning to AGENT_OPS_MAX_ITERATIONS (the Jira run burned 1.4M
+            // tokens repeating a single tool-arg error before the user cancelled).
+            const prevIssues = state.errors?.[0];
+            const { stallCount, stalled } = computeReflectionStall(
+                issues === 'None' ? '' : issues,
+                prevIssues,
+                state.reflectionStallCount ?? 0,
+            );
+            const analysisOut = stalled
+                ? `${analysis}\n\n⚠️ Reflection stalled: the issue "${issues}" persisted across multiple reflections without resolution — finalizing with current findings instead of retrying further.`
+                : analysis;
+
+            console.log(`[REFLECTOR] Complete: ${isComplete} | Issues: ${issues !== 'None' ? issues : 'None'}${stalled ? ` | STALLED (count=${stallCount})` : ''}`);
 
             return {
-                messages: [new AIMessage({ content: `🔍 **Reflection:**\n${analysis}${issues !== 'None' ? `\n⚠️ Issues: ${issues}` : ''}` })],
-                reflection: analysis,
+                messages: [new AIMessage({ content: `🔍 **Reflection:**\n${analysisOut}${issues !== 'None' ? `\n⚠️ Issues: ${issues}` : ''}` })],
+                reflection: analysisOut,
                 errors: issues !== 'None' ? [issues] : [],
-                isComplete: isComplete || iterationCount >= AGENT_OPS_MAX_ITERATIONS,
+                isComplete: isComplete || iterationCount >= AGENT_OPS_MAX_ITERATIONS || stalled,
                 plan: updatedPlan.length > 0 ? updatedPlan : plan,
+                reflectionStallCount: stallCount,
             };
         } else {
-            if (content.includes('COMPLETE') || iterationCount >= AGENT_OPS_MAX_ITERATIONS) {
+            // critiqueVerdict also accepts on an EMPTY critique — looping on empty
+            // reflector feedback burns iterations with nothing to fix.
+            if (critiqueVerdict(content) === 'accept' || iterationCount >= AGENT_OPS_MAX_ITERATIONS) {
                 return { messages: [response], isComplete: true };
             }
             return {
@@ -602,7 +635,7 @@ Be specific — include resource IDs, account names, and numeric values where av
         const response = await model.invoke(inputs);
         llmAuditLog('FINAL', inputs, response, start);
 
-        const summaryContent = typeof response.content === 'string' ? response.content : JSON.stringify(response.content);
+        const summaryContent = extractTextContent(response.content);
         const finalMessage = `✅ **Task Complete**\n\n**Original Task:** ${taskDescription}\n**Iterations:** ${iterationCount}\n\n---\n\n${summaryContent}`;
 
         return { messages: [new AIMessage({ content: finalMessage })], isComplete: true };

--- a/apps/web-ui/lib/agent-ops/executor-state.ts
+++ b/apps/web-ui/lib/agent-ops/executor-state.ts
@@ -46,6 +46,7 @@ export interface ReflectionState {
     clarificationQuestion: string | null;
     approvalStatus: 'pending' | 'approved' | 'rejected' | null;
     pendingToolApprovals: string[];  // tool names awaiting approval at mutative_approval_gate
+    reflectionStallCount?: number;   // consecutive unproductive reflections (stall detector)
 }
 
 export const graphState: StateGraphArgs<ReflectionState>["channels"] = {
@@ -84,6 +85,12 @@ export const graphState: StateGraphArgs<ReflectionState>["channels"] = {
         reducer: (_x: boolean, y: boolean) => y,
         default: () => false,
     },
+    // Stall detector: without this channel LangGraph silently DROPS the value the
+    // reflect node returns, so the counter never accumulates and the bail never fires.
+    reflectionStallCount: {
+        reducer: (x: number | undefined, y: number | undefined) => y ?? x ?? 0,
+        default: () => 0,
+    },
     toolResults: {
         reducer: (x: ToolResultEntry[], y: ToolResultEntry[]) => x.concat(y),
         default: () => [],
@@ -113,3 +120,19 @@ export const graphState: StateGraphArgs<ReflectionState>["channels"] = {
         default: () => [],
     },
 };
+
+/**
+ * Whether a checkpointed evaluation can be REUSED on a graph re-invoke.
+ *
+ * The clarification resume re-runs the graph on the SAME thread, so the
+ * previous run's evaluation survives in the checkpoint (the channel reducer
+ * keeps it). A plan-mode evaluation is a real execution decision — reusing it
+ * is correct (that's what the approval resume relies on). But a mode='end'
+ * (clarification) decision must NEVER be reused: the user's reply is now in
+ * the conversation and the evaluator has to actually read it — otherwise the
+ * stale decision routes straight back to clarify and the run re-asks the same
+ * question forever, no matter what the user answers.
+ */
+export function isReusableEvaluation(evaluation: RequestEvaluation | null | undefined): boolean {
+    return !!evaluation && evaluation.mode !== 'end';
+}

--- a/apps/web-ui/lib/agent-ops/export-markdown.ts
+++ b/apps/web-ui/lib/agent-ops/export-markdown.ts
@@ -1,0 +1,213 @@
+/**
+ * Agent Ops run → Markdown report.
+ *
+ * Companion to export-pdf.ts: same data, same buildSteps() step model as the
+ * on-screen timeline, rendered as a self-contained .md document (the pattern
+ * users know from the AI Ops chat export in lib/chat-export.ts).
+ *
+ * buildRunReportMarkdown() is pure (unit-tested); exportRunToMarkdown() wraps
+ * it in a Blob download.
+ */
+
+import type { AgentOpsRun, AgentOpsEvent } from "./types"
+import { formatDateTime } from '@/lib/date-utils';
+import { buildSteps, type TimelineStep } from "@/components/agent-ops/run-timeline/build-steps";
+
+function formatTime(iso: string, timeZone?: string) {
+    return formatDateTime(iso, 'longDateTime', timeZone);
+}
+
+function formatDuration(ms?: number) {
+    if (!ms) return "—"
+    if (ms < 1000) return `${ms}ms`
+    if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`
+    return `${(ms / 60000).toFixed(1)}m`
+}
+
+/**
+ * Wrap content in a code fence that cannot be terminated early: the fence is
+ * one backtick longer than the longest backtick run inside the content.
+ */
+function fence(content: string, lang = ""): string {
+    const longestRun = content.match(/`+/g)?.reduce((max, run) => Math.max(max, run.length), 0) ?? 0
+    const marker = "`".repeat(Math.max(3, longestRun + 1))
+    return `${marker}${lang}\n${content}\n${marker}`
+}
+
+const STEP_ICONS: Record<string, string> = {
+    memory: "🧠",
+    evaluation: "🧭",
+    planning: "📋",
+    thinking: "💭",
+    tool: "🔧",
+    reflection: "🔍",
+    final: "✅",
+    error: "❌",
+}
+
+export function buildRunReportMarkdown(
+    run: AgentOpsRun,
+    events: AgentOpsEvent[],
+    timeZone?: string,
+): string {
+    const lines: string[] = []
+    const push = (...ls: string[]) => { lines.push(...ls) }
+
+    const tokens = events.reduce(
+        (acc, e) => {
+            acc.input += (e.metadata?.inputTokens as number) || 0
+            acc.output += (e.metadata?.outputTokens as number) || 0
+            return acc
+        },
+        { input: 0, output: 0 },
+    )
+    const tokenStr = tokens.input + tokens.output > 0
+        ? `${tokens.input.toLocaleString()} in / ${tokens.output.toLocaleString()} out`
+        : "—"
+
+    // ── Header + metadata ───────────────────────────────────────────────────
+    push(
+        `# Agent Ops Run Report`,
+        ``,
+        `\`${run.runId}\` · **${run.status.replace(/_/g, " ").toUpperCase()}**`,
+        ``,
+        `| Source | Mode | Duration | Tokens | Events | Started |${run.completedAt ? " Completed |" : ""}`,
+        `|---|---|---|---|---|---|${run.completedAt ? "---|" : ""}`,
+        `| ${run.source} | ${run.mode} | ${formatDuration(run.durationMs)} | ${tokenStr} | ${events.length} | ${formatTime(run.createdAt, timeZone)} |${run.completedAt ? ` ${formatTime(run.completedAt, timeZone)} |` : ""}`,
+        ``,
+    )
+
+    // ── Task ────────────────────────────────────────────────────────────────
+    push(`## Task Description`, ``, run.taskDescription, ``)
+    const taskMeta = [
+        run.selectedSkill ? `**Skill:** ${run.selectedSkill}` : "",
+        run.accountName ? `**Account:** ${run.accountName}${run.accountId ? ` (${run.accountId})` : ""}` : "",
+    ].filter(Boolean)
+    if (taskMeta.length) push(taskMeta.join(" · "), ``)
+
+    // ── Result / Error ──────────────────────────────────────────────────────
+    if (run.result?.summary) {
+        push(`## Result`, ``, run.result.summary, ``)
+        if (run.result.toolsUsed?.length) push(`**Tools used:** ${run.result.toolsUsed.join(", ")}`, ``)
+        if (run.result.iterations) push(`*${run.result.iterations} iteration(s)*`, ``)
+    }
+    if (run.error) {
+        push(`## Error`, ``, fence(run.error), ``)
+    }
+
+    // ── Execution Timeline ──────────────────────────────────────────────────
+    // Same step model as the UI timeline and the PDF. Groups render EXPANDED:
+    // a document can't be clicked open, so every grouped tool call is inlined.
+    push(`## Execution Timeline (${events.length} events)`, ``)
+
+    const steps = buildSteps(events, run.status)
+    if (steps.length === 0) push(`*No events recorded.*`, ``)
+
+    const t = (e: AgentOpsEvent) => formatTime(e.createdAt, timeZone)
+
+    function renderStep(step: TimelineStep, depth: number) {
+        // Group children render one heading level deeper (#### instead of ###).
+        const h = "#".repeat(Math.min(3 + depth, 6))
+
+        switch (step.kind) {
+            case "group": {
+                const toolCount = step.steps.filter(s => s.kind === "tool").length
+                const dur = step.durationMs > 0 ? ` · ${formatDuration(step.durationMs)}` : ""
+                push(`${h} ⚙️ Worked — ${toolCount} tool call${toolCount === 1 ? "" : "s"}${dur}`, ``)
+                for (const s of step.steps) renderStep(s, depth + 1)
+                break
+            }
+            case "tool": {
+                const anchor = step.call ?? step.result
+                const statusMark = step.status === "error" ? "✗" : step.status === "running" ? "…" : "✓"
+                const dur = step.durationMs !== undefined ? ` ${formatDuration(step.durationMs)}` : ""
+                push(`${h} ${STEP_ICONS.tool} Tool: \`${step.toolName}\` ${statusMark}${dur}${anchor ? ` — ${t(anchor)}` : ""}`, ``)
+                const args = step.call?.toolArgs
+                const output = step.result?.toolOutput ?? step.result?.content
+                if (args && Object.keys(args).length > 0) {
+                    push(`**Arguments:**`, ``, fence(JSON.stringify(args, null, 2), "json"), ``)
+                }
+                if (output) {
+                    push(`**Output:**`, ``, fence(output), ``)
+                }
+                if (!args && !output) push(`*No detail captured.*`, ``)
+                break
+            }
+            case "planning":
+                push(`${h} ${STEP_ICONS.planning} Planning — ${t(step.event)}`, ``)
+                if (step.event.content) push(step.event.content, ``)
+                break
+            case "reflection":
+                push(`${h} ${STEP_ICONS.reflection} ${step.event.eventType === "revision" ? "Revision" : "Reflection"} — ${t(step.event)}`, ``)
+                if (step.event.content) push(step.event.content, ``)
+                break
+            case "thinking":
+                if (!step.event.content) break
+                push(`${h} ${STEP_ICONS.thinking} Thinking — ${t(step.event)}`, ``)
+                push(step.event.content, ``)
+                break
+            case "evaluation": {
+                const m = (step.event.metadata ?? {}) as Record<string, unknown>
+                const kbs = (m.knowledgeBaseIds as unknown[] | undefined) ?? []
+                const badges = [
+                    m.mode ? `${m.mode} mode` : "",
+                    (m.skillName || m.skillId) ? `skill: ${m.skillName ?? m.skillId}` : "",
+                    kbs.length ? `KB ×${kbs.length}` : "",
+                    m.requiresApproval ? "approval required" : "",
+                ].filter(Boolean).join(" · ")
+                push(`${h} ${STEP_ICONS.evaluation} Evaluated request — ${t(step.event)}`, ``)
+                if (badges) push(`*${badges}*`, ``)
+                if (step.event.content) push(step.event.content, ``)
+                break
+            }
+            case "memory": {
+                const m = (step.event.metadata ?? {}) as Record<string, unknown>
+                const title = step.event.content || (step.phase === "recall" ? "Memory recall" : "Memory save")
+                push(`${h} ${STEP_ICONS.memory} ${title} — ${t(step.event)}`, ``)
+                if (step.phase === "recall") {
+                    const parts = [
+                        (m.facts as unknown[])?.length ? `${(m.facts as unknown[]).length} fact(s)` : "",
+                        (m.rules as unknown[])?.length ? `${(m.rules as unknown[]).length} rule(s)` : "",
+                        (m.episodes as unknown[])?.length ? `${(m.episodes as unknown[]).length} episode(s)` : "",
+                    ].filter(Boolean).join(" · ")
+                    if (parts) push(`*${parts}*`, ``)
+                } else if (m.savedFacts !== undefined) {
+                    push(`*${m.savedFacts ?? 0} fact(s), ${m.savedRules ?? 0} rule(s) saved · episode: ${m.episodeCaptured ? "yes" : "no"}*`, ``)
+                }
+                break
+            }
+            case "final":
+                push(`${h} ${STEP_ICONS.final} ${step.event.node === "__cancelled__" ? "Run cancelled" : "Final summary"} — ${t(step.event)}`, ``)
+                if (step.event.content) push(step.event.content, ``)
+                break
+            case "error":
+                push(`${h} ${STEP_ICONS.error} Error — ${t(step.event)}`, ``)
+                if (step.event.content) push(fence(step.event.content), ``)
+                break
+        }
+    }
+
+    for (const step of steps) renderStep(step, 0)
+
+    push(`---`, ``, `*Generated ${formatDateTime(new Date(), 'longDateTime', timeZone)} · Nucleus Cloud Ops*`)
+
+    return lines.join("\n")
+}
+
+/** Build the report and trigger a browser download (same pattern as chat-export.ts). */
+export function exportRunToMarkdown(
+    run: AgentOpsRun,
+    events: AgentOpsEvent[],
+    timeZone?: string,
+): void {
+    const markdown = buildRunReportMarkdown(run, events, timeZone)
+    const blob = new Blob([markdown], { type: "text/markdown;charset=utf-8" })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement("a")
+    link.href = url
+    link.download = `agent-ops-run-${run.runId.slice(0, 8)}-${new Date().toISOString().slice(0, 10)}.md`
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+    URL.revokeObjectURL(url)
+}

--- a/apps/web-ui/lib/agent-ops/export-pdf.ts
+++ b/apps/web-ui/lib/agent-ops/export-pdf.ts
@@ -1,5 +1,6 @@
 import type { AgentOpsRun, AgentOpsEvent } from "./types"
 import { formatDateTime } from '@/lib/date-utils';
+import { buildSteps, type TimelineStep } from "@/components/agent-ops/run-timeline/build-steps";
 
 const EVENT_META: Record<string, { label: string; bg: string; color: string }> = {
     planning: { label: "Planning", bg: "#dbeafe", color: "#1d4ed8" },
@@ -173,9 +174,20 @@ export function buildRunReportHtml(run: AgentOpsRun, events: AgentOpsEvent[], ti
     }
     const statusStyle = statusColors[run.status] ?? "background:#f3f4f6;color:#374151;"
 
+    // The <title> becomes the browser's default "Save as PDF" filename.
+    const docTitle = `agent-ops-run-${run.runId.slice(0, 8)}`
+
     return `<!DOCTYPE html>
 <html>
-<head><meta charset="utf-8"/><title>Agent Ops Run Report</title></head>
+<head>
+  <meta charset="utf-8"/>
+  <title>${esc(docTitle)}</title>
+  <style>
+    @page { size: A4; margin: 8mm; }
+    /* Force badge/section background colors to print (they carry meaning). */
+    html, body { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  </style>
+</head>
 <body style="${S.body}">
 
   <!-- Header -->
@@ -240,57 +252,346 @@ export function buildRunReportHtml(run: AgentOpsRun, events: AgentOpsEvent[], ti
 </html>`
 }
 
-export async function exportRunToPdf(run: AgentOpsRun, events: AgentOpsEvent[]): Promise<void> {
-    const html2pdf = (await import("html2pdf.js")).default
+// hex "#rrggbb" → [r,g,b] for jsPDF's setFillColor/setTextColor.
+function hexToRgb(hex: string): [number, number, number] {
+    const m = /^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex)
+    if (!m) return [55, 65, 81]
+    return [parseInt(m[1], 16), parseInt(m[2], 16), parseInt(m[3], 16)]
+}
 
-    const html = buildRunReportHtml(run, events)
-    const filename = `agent-ops-run-${run.runId.slice(0, 8)}-${new Date().toISOString().slice(0, 10)}.pdf`
+/**
+ * Export a run to PDF using jsPDF's vector text API — NOT html2canvas.
+ *
+ * Two earlier approaches failed:
+ *  1. html2pdf/html2canvas rasterized the whole report into ONE canvas. Chrome
+ *     silently caps canvas height at 65,535 px (transparent, no error), so long
+ *     runs produced a blank PDF.
+ *  2. Native window.print() has no canvas limit but opens the OS print dialog,
+ *     which is dead-in-the-water on machines with no printer configured (macOS
+ *     shows "No Printer Selected" and hides Save-as-PDF in a small menu).
+ *
+ * jsPDF text rendering has neither problem: no raster canvas (no size limit),
+ * selectable text, tiny files, jsPDF.save() triggers a normal browser download
+ * with a real filename on every OS. We paginate manually via a y-cursor.
+ */
+export async function exportRunToPdf(
+    run: AgentOpsRun,
+    events: AgentOpsEvent[],
+    timeZone?: string
+): Promise<void> {
+    const { jsPDF } = await import("jspdf")
+    const doc = new jsPDF({ unit: "mm", format: "a4", orientation: "portrait" })
 
-    // html2pdf.js clones the source node (via snapdom's deepCloneBasic, which
-    // copies inline styles verbatim with cloneNode) and places the clone inside
-    // its own `height:auto` capture container, then runs html2canvas on that
-    // *container*. If the source node's inline style makes it out-of-flow
-    // (position: fixed/absolute, or off-screen coordinates), the clone is also
-    // out-of-flow and contributes zero height to the capture container — so
-    // html2canvas renders a 0-height canvas and jsPDF emits an empty PDF
-    // (verified: 1468x0 canvas → 3 KB blank PDF).
-    //
-    // Fix: keep the off-screen positioning on a WRAPPER that is never cloned,
-    // and leave the holder itself as an in-flow block carrying only the body's
-    // base styles (S.body). html2pdf clones the holder (not the wrapper), so
-    // the clone flows normally inside the capture container and the container
-    // gets the content's height (verified: 733x1161 → 1468x2324 canvas,
-    // ~1M non-white pixels → 370 KB PDF). All report styling is inline, so the
-    // clone needs no external stylesheets.
-    const wrapper = document.createElement("div")
-    wrapper.style.cssText = "position:fixed;top:0;left:-99999px;z-index:-9999;pointer-events:none;"
-    const holder = document.createElement("div")
-    holder.style.cssText = S.body
-    holder.innerHTML = new DOMParser().parseFromString(html, "text/html").body.innerHTML
-    wrapper.appendChild(holder)
-    document.body.appendChild(wrapper)
+    const M = 12                 // page margin (mm)
+    const PW = 210, PH = 297     // A4 (mm)
+    const CW = PW - M * 2        // content width (mm)
+    const PT = 0.352778          // 1 pt in mm
+    let y = M
 
-    // Let layout settle before capture.
-    await new Promise(r => setTimeout(r, 50))
+    const clean = (s: unknown) => String(s ?? "").replace(/\r/g, "").replace(/\t/g, "    ")
+    const ensure = (h: number) => { if (y + h > PH - M) { doc.addPage(); y = M } }
 
-    try {
-        await html2pdf()
-            .set({
-                margin: [8, 8, 8, 8],
-                filename,
-                image: { type: "jpeg", quality: 0.98 },
-                html2canvas: {
-                    scale: 2,
-                    useCORS: true,
-                    logging: false,
-                    windowWidth: 794,
-                    scrollY: 0,
-                },
-                jsPDF: { unit: "mm", format: "a4", orientation: "portrait" },
-            })
-            .from(holder)
-            .save()
-    } finally {
-        document.body.removeChild(wrapper)
+    // Wrapped paragraph. Returns nothing; advances y (paginating as needed).
+    function para(
+        text: string,
+        opts: { size?: number; color?: [number, number, number]; font?: string; style?: string; indent?: number; gap?: number } = {}
+    ) {
+        const { size = 9, color = [55, 65, 81], font = "helvetica", style = "normal", indent = 0, gap = 1.35 } = opts
+        doc.setFont(font, style)
+        doc.setFontSize(size)
+        doc.setTextColor(color[0], color[1], color[2])
+        const lh = size * PT * gap
+        const lines: string[] = doc.splitTextToSize(clean(text), CW - indent)
+        for (const ln of lines) {
+            ensure(lh)
+            doc.text(ln, M + indent, y + size * PT)  // baseline offset
+            y += lh
+        }
     }
+
+    // Small filled label chip. Draws at (x, y-top); returns its width (mm).
+    function chip(label: string, x: number, bgHex: string, fgHex: string): number {
+        const size = 7.5
+        doc.setFont("helvetica", "bold")
+        doc.setFontSize(size)
+        const w = doc.getTextWidth(label) + 3
+        const h = 4.2
+        const [br, bg, bb] = hexToRgb(bgHex)
+        const [fr, fg, fb] = hexToRgb(fgHex)
+        doc.setFillColor(br, bg, bb)
+        doc.roundedRect(x, y, w, h, 0.8, 0.8, "F")
+        doc.setTextColor(fr, fg, fb)
+        doc.text(label, x + 1.5, y + h - 1.3)
+        return w
+    }
+
+    function rule() {
+        ensure(3)
+        doc.setDrawColor(229, 231, 235)
+        doc.setLineWidth(0.2)
+        doc.line(M, y, PW - M, y)
+        y += 3
+    }
+
+    // ── Header ────────────────────────────────────────────────────────────
+    para("Agent Ops Run Report", { size: 18, style: "bold", color: [17, 24, 39], gap: 1.1 })
+    para(run.runId, { size: 9, font: "courier", color: [107, 114, 128] })
+    y += 1
+    const statusMeta: Record<string, [string, string]> = {
+        completed: ["#dcfce7", "#166534"], failed: ["#fee2e2", "#dc2626"],
+        in_progress: ["#dbeafe", "#1d4ed8"], cancelled: ["#f3f4f6", "#6b7280"],
+    }
+    const [sbg, sfg] = statusMeta[run.status] ?? ["#f3f4f6", "#374151"]
+    chip(run.status.replace(/_/g, " ").toUpperCase(), M, sbg, sfg)
+    y += 7
+
+    // ── Meta ──────────────────────────────────────────────────────────────
+    const tokenTotals = events.reduce(
+        (a, e) => {
+            if (e.metadata) {
+                a.input += (e.metadata.inputTokens as number) || 0
+                a.output += (e.metadata.outputTokens as number) || 0
+            }
+            return a
+        },
+        { input: 0, output: 0 }
+    )
+    const tokenStr = tokenTotals.input + tokenTotals.output > 0
+        ? `${tokenTotals.input.toLocaleString()} in / ${tokenTotals.output.toLocaleString()} out`
+        : "—"
+    const metaPairs: [string, string][] = [
+        ["Source", clean(run.source)],
+        ["Mode", clean(run.mode)],
+        ["Duration", formatDuration(run.durationMs)],
+        ["Tokens", tokenStr],
+        ["Events", String(events.length)],
+        ["Started", formatTime(run.createdAt, timeZone)],
+    ]
+    if (run.completedAt) metaPairs.push(["Completed", formatTime(run.completedAt, timeZone)])
+    for (const [k, v] of metaPairs) {
+        ensure(5)
+        doc.setFont("helvetica", "bold"); doc.setFontSize(9); doc.setTextColor(107, 114, 128)
+        doc.text(`${k}:`, M, y + 3)
+        doc.setFont("helvetica", "normal"); doc.setTextColor(17, 24, 39)
+        doc.text(clean(v), M + 26, y + 3)
+        y += 5
+    }
+    y += 3
+
+    // ── Task ──────────────────────────────────────────────────────────────
+    para("Task Description", { size: 12, style: "bold", color: [55, 65, 81] })
+    rule()
+    para(run.taskDescription, { size: 10, color: [17, 24, 39] })
+    if (run.selectedSkill) para(`Skill: ${run.selectedSkill}`, { size: 8, color: [107, 114, 128] })
+    if (run.accountName) para(`Account: ${run.accountName} (${run.accountId ?? ""})`, { size: 8, color: [107, 114, 128] })
+    y += 3
+
+    // ── Result / Error ──────────────────────────────────────────────────────
+    if (run.result?.summary) {
+        para("Result", { size: 12, style: "bold", color: [22, 101, 52] })
+        rule()
+        para(run.result.summary, { size: 9, color: [17, 24, 39] })
+        if (run.result.toolsUsed?.length) para(`Tools used: ${run.result.toolsUsed.join(", ")}`, { size: 8, color: [107, 114, 128] })
+        if (run.result.iterations) para(`${run.result.iterations} iteration(s)`, { size: 8, color: [107, 114, 128] })
+        y += 3
+    }
+    if (run.error) {
+        para("Error", { size: 12, style: "bold", color: [220, 38, 38] })
+        rule()
+        para(run.error, { size: 9, font: "courier", color: [220, 38, 38] })
+        y += 3
+    }
+
+    // ── Execution Timeline ──────────────────────────────────────────────────
+    // Reuse the SAME step model the web UI builds (run-timeline/build-steps.ts)
+    // so the PDF and the on-screen timeline never drift: tool_call + tool_result
+    // are paired into one Tool step (name, arguments, output, status, duration),
+    // and steps carry the same kinds/labels/colors as the UI. The ONE deliberate
+    // difference: the UI folds long work runs into collapsible "Worked — N tool
+    // calls" groups, but a PDF can't be clicked open, so groups are rendered
+    // EXPANDED here and every tool call shows its arguments + output inline.
+    para(`Execution Timeline (${events.length} events)`, { size: 12, style: "bold", color: [55, 65, 81] })
+    rule()
+
+    const steps = buildSteps(events, run.status)
+    if (steps.length === 0) {
+        para("No events recorded.", { size: 9, color: [156, 163, 175] })
+    }
+
+    const fmtDur = (ms?: number) =>
+        ms === undefined ? "" : ms < 1000 ? `${ms}ms` : ms < 60000 ? `${(ms / 1000).toFixed(1)}s` : `${(ms / 60000).toFixed(1)}m`
+    const firstLine = (t?: string, n = 110) => {
+        if (!t) return ""
+        const l = clean(t).split("\n").find((s) => s.trim()) ?? ""
+        return l.length > n ? `${l.slice(0, n)}…` : l
+    }
+
+    type Chip = { label: string; bg: string; fg: string }
+    const KIND: Record<string, Chip> = {
+        memory:     { label: "Memory",     bg: "#ede9fe", fg: "#6d28d9" },
+        evaluation: { label: "Evaluated",  bg: "#fef3c7", fg: "#b45309" },
+        planning:   { label: "Planning",   bg: "#dbeafe", fg: "#1d4ed8" },
+        thinking:   { label: "Thinking",   bg: "#f3f4f6", fg: "#6b7280" },
+        tool:       { label: "Tool",       bg: "#e0f2fe", fg: "#0369a1" },
+        reflection: { label: "Reflection", bg: "#f3e8ff", fg: "#7e22ce" },
+        final:      { label: "Final",      bg: "#dcfce7", fg: "#166534" },
+        error:      { label: "Error",      bg: "#fee2e2", fg: "#dc2626" },
+    }
+
+    // Header row for a step: chip + optional title (+ status) + right-aligned time.
+    function stepHead(
+        chipLabel: string,
+        c: Chip,
+        indent: number,
+        opts: { title?: string; titleMono?: boolean; status?: string; statusColor?: [number, number, number]; time?: string } = {}
+    ) {
+        ensure(6)
+        const x0 = M + indent
+        const cw = chip(chipLabel, x0, c.bg, c.fg)
+        let cx = x0 + cw + 2
+        const timeStr = opts.time ?? ""
+        let timeW = 0
+        if (timeStr) {
+            doc.setFont("helvetica", "normal"); doc.setFontSize(7.5)
+            timeW = doc.getTextWidth(timeStr)
+        }
+        const rightEdge = PW - M - (timeW ? timeW + 2 : 0)
+        if (opts.title) {
+            doc.setFont(opts.titleMono ? "courier" : "helvetica", opts.titleMono ? "normal" : "bold")
+            doc.setFontSize(9); doc.setTextColor(17, 24, 39)
+            const t = (doc.splitTextToSize(clean(opts.title), Math.max(20, rightEdge - cx - 2))[0] as string) ?? ""
+            doc.text(t, cx, y + 3)
+            cx += doc.getTextWidth(t) + 3
+        }
+        if (opts.status) {
+            doc.setFont("helvetica", "normal"); doc.setFontSize(8)
+            const sc = opts.statusColor ?? [107, 114, 128]
+            doc.setTextColor(sc[0], sc[1], sc[2])
+            doc.text(opts.status, cx, y + 3)
+        }
+        if (timeStr) {
+            doc.setFont("helvetica", "normal"); doc.setFontSize(7.5); doc.setTextColor(156, 163, 175)
+            doc.text(timeStr, PW - M - timeW, y + 3)
+        }
+        y += 6
+    }
+
+    function renderStep(step: TimelineStep, indent: number) {
+        const bodyIndent = indent + 4
+        const t = (e: AgentOpsEvent) => formatTime(e.createdAt, timeZone)
+
+        switch (step.kind) {
+            case "group": {
+                const toolCount = step.steps.filter((s) => s.kind === "tool").length
+                ensure(6)
+                doc.setFont("helvetica", "bold"); doc.setFontSize(8.5); doc.setTextColor(107, 114, 128)
+                const dur = step.durationMs > 0 ? `  ·  ${fmtDur(step.durationMs)}` : ""
+                doc.text(`Worked — ${toolCount} tool call${toolCount === 1 ? "" : "s"}${dur}`, M + indent, y + 3)
+                y += 6
+                for (const s of step.steps) renderStep(s, indent + 4)
+                y += 1
+                break
+            }
+            case "tool": {
+                const anchor = step.call ?? step.result
+                const statusLabel = step.status === "error" ? "failed" : step.status === "running" ? "running" : ""
+                const statusColor: [number, number, number] = step.status === "error" ? [220, 38, 38] : [107, 114, 128]
+                stepHead(KIND.tool.label, KIND.tool, indent, {
+                    title: step.toolName,
+                    titleMono: true,
+                    status: [statusLabel, step.durationMs !== undefined ? fmtDur(step.durationMs) : ""].filter(Boolean).join("  "),
+                    statusColor,
+                    time: anchor ? t(anchor) : undefined,
+                })
+                const args = step.call?.toolArgs
+                const output = step.result?.toolOutput ?? step.result?.content
+                if (args && Object.keys(args).length > 0) {
+                    para("ARGUMENTS", { size: 7, style: "bold", color: [107, 114, 128], indent: bodyIndent })
+                    para(JSON.stringify(args, null, 2), { size: 7.5, font: "courier", color: [55, 65, 81], indent: bodyIndent, gap: 1.25 })
+                }
+                if (output) {
+                    para("OUTPUT", { size: 7, style: "bold", color: [107, 114, 128], indent: bodyIndent })
+                    para(output, { size: 7.5, font: "courier", color: step.status === "error" ? [220, 38, 38] : [55, 65, 81], indent: bodyIndent, gap: 1.25 })
+                }
+                if (!args && !output) para("No detail captured.", { size: 8, color: [156, 163, 175], indent: bodyIndent })
+                y += 1.5
+                break
+            }
+            case "planning":
+                stepHead(KIND.planning.label, KIND.planning, indent, { title: firstLine(step.event.content) || "Planning", time: t(step.event) })
+                if (step.event.content) para(step.event.content, { size: 8.5, color: [55, 65, 81], indent: bodyIndent })
+                y += 1.5
+                break
+            case "reflection":
+                stepHead(step.event.eventType === "revision" ? "Revision" : "Reflection", KIND.reflection, indent, { time: t(step.event) })
+                if (step.event.content) para(step.event.content, { size: 8.5, color: [55, 65, 81], indent: bodyIndent })
+                y += 1.5
+                break
+            case "thinking":
+                if (!step.event.content) break
+                stepHead(KIND.thinking.label, KIND.thinking, indent, { time: t(step.event) })
+                para(step.event.content, { size: 8.5, color: [107, 114, 128], style: "italic", indent: bodyIndent })
+                y += 1.5
+                break
+            case "evaluation": {
+                const m = (step.event.metadata ?? {}) as Record<string, unknown>
+                const kbs = (m.knowledgeBaseIds as unknown[] | undefined) ?? []
+                const badges = [
+                    m.mode ? `${m.mode} mode` : "",
+                    (m.skillName || m.skillId) ? `skill: ${m.skillName ?? m.skillId}` : "",
+                    kbs.length ? `KB ×${kbs.length}` : "",
+                    m.requiresApproval ? "approval" : "",
+                ].filter(Boolean).join("    ·    ")
+                stepHead(KIND.evaluation.label, KIND.evaluation, indent, { title: "Evaluated request", time: t(step.event) })
+                if (badges) para(badges, { size: 7.5, color: [107, 114, 128], indent: bodyIndent })
+                if (step.event.content) para(step.event.content, { size: 8.5, color: [55, 65, 81], indent: bodyIndent })
+                y += 1.5
+                break
+            }
+            case "memory": {
+                const m = (step.event.metadata ?? {}) as Record<string, unknown>
+                stepHead(KIND.memory.label, KIND.memory, indent, {
+                    title: step.event.content || (step.phase === "recall" ? "Memory recall" : "Memory save"),
+                    time: t(step.event),
+                })
+                if (step.phase === "recall") {
+                    const parts = [
+                        (m.facts as unknown[])?.length ? `${(m.facts as unknown[]).length} fact(s)` : "",
+                        (m.rules as unknown[])?.length ? `${(m.rules as unknown[]).length} rule(s)` : "",
+                        (m.episodes as unknown[])?.length ? `${(m.episodes as unknown[]).length} episode(s)` : "",
+                    ].filter(Boolean).join("    ·    ")
+                    if (parts) para(parts, { size: 7.5, color: [107, 114, 128], indent: bodyIndent })
+                } else if (m.savedFacts !== undefined) {
+                    para(`${m.savedFacts ?? 0} fact(s), ${m.savedRules ?? 0} rule(s) saved · episode: ${m.episodeCaptured ? "yes" : "no"}`,
+                        { size: 7.5, color: [107, 114, 128], indent: bodyIndent })
+                }
+                y += 1.5
+                break
+            }
+            case "final":
+                stepHead(KIND.final.label, KIND.final, indent, { title: step.event.node === "__cancelled__" ? "Run cancelled" : "Final summary", time: t(step.event) })
+                if (step.event.content) para(step.event.content, { size: 9, color: [17, 24, 39], indent: bodyIndent })
+                y += 1.5
+                break
+            case "error":
+                stepHead(KIND.error.label, KIND.error, indent, { title: firstLine(step.event.content) || "Error", time: t(step.event) })
+                if (step.event.content) para(step.event.content, { size: 8, font: "courier", color: [220, 38, 38], indent: bodyIndent })
+                y += 1.5
+                break
+        }
+    }
+
+    for (const step of steps) renderStep(step, 0)
+
+    // ── Footer on every page ────────────────────────────────────────────────
+    const pages = doc.getNumberOfPages()
+    for (let p = 1; p <= pages; p++) {
+        doc.setPage(p)
+        doc.setFont("helvetica", "normal"); doc.setFontSize(7.5); doc.setTextColor(156, 163, 175)
+        const footer = `Nucleus Cloud Ops  ·  Page ${p} of ${pages}`
+        doc.text(footer, PW / 2 - doc.getTextWidth(footer) / 2, PH - 6)
+    }
+
+    const filename = `agent-ops-run-${run.runId.slice(0, 8)}-${new Date().toISOString().slice(0, 10)}.pdf`
+    doc.save(filename)
 }

--- a/apps/web-ui/lib/agent/agent-shared.ts
+++ b/apps/web-ui/lib/agent/agent-shared.ts
@@ -81,6 +81,7 @@ export interface ReflectionState {
     memoryStats: MemoryStats | null;
     runningSummary: string; // Phase 1: rolling summary of compacted turns
     scratchpad: Scratchpad; // Phase 1: structured working-memory scratchpad
+    reflectionStallCount?: number; // consecutive reflections with the same blocking issue (stall detector)
 }
 
 // --- Schema for StateGraph ---
@@ -150,10 +151,109 @@ export const graphState: StateGraphArgs<ReflectionState>["channels"] = {
         reducer: (x: Scratchpad, y: Scratchpad) => y || x,
         default: () => ({ openGoals: [], keyFindings: [], resourceIds: [], pendingSteps: [] }),
     },
+    reflectionStallCount: {
+        reducer: (x: number | undefined, y: number | undefined) => y ?? x ?? 0,
+        default: () => 0,
+    },
 };
+
+/**
+ * Extract the plain text of an LLM response, whatever shape it arrives in.
+ *
+ * Bedrock returns `AIMessage.content` as EITHER a string OR an array of content
+ * blocks ([{type:'text',text:'…'}, {type:'tool_use',…}]) — and under streaming
+ * the text blocks are un-coalesced per-delta. Casting that array `as string`
+ * (which several nodes used to do) is a lie TypeScript cannot catch: at runtime
+ * `content.match(...)` / `content.toLowerCase()` throw TypeError, and
+ * `String(content)` yields "[object Object],[object Object]".
+ *
+ * That crash silently broke plan parsing and, worse, made the reflector return
+ * isComplete=false forever — spinning the reflect→revise loop until
+ * MAX_ITERATIONS. ALWAYS route LLM content through this helper.
+ *
+ * Text deltas carry their own leading spaces, so blocks join with '' (never '\n',
+ * which shatters the prose one delta per line).
+ */
+export function extractTextContent(content: unknown): string {
+    if (content == null) return '';
+    if (typeof content === 'string') return content;
+    if (Array.isArray(content)) {
+        return content
+            .map((block: any) => {
+                if (typeof block === 'string') return block;
+                if (block?.type === 'text' && typeof block.text === 'string') return block.text;
+                return '';
+            })
+            .join('');
+    }
+    return typeof content === 'object' ? JSON.stringify(content) : String(content);
+}
+
+/**
+ * Decide what to do with a reflector critique.
+ *
+ * 'accept' when the critique says COMPLETE — or when it is EMPTY. An empty
+ * critique happens for real: Claude Sonnet 5 on Bedrock emits a
+ * reasoning_content block first, and if the reflector's output budget runs out
+ * mid-reasoning (stopReason max_tokens) there is no text at all. Feeding an
+ * empty "[REFLECTION FEEDBACK]" back to the agent just burns iterations — the
+ * agent has nothing to fix, so accept the answer instead.
+ */
+export function critiqueVerdict(critique: string): 'accept' | 'revise' {
+    const trimmed = critique.trim();
+    if (!trimmed) return 'accept';
+    if (trimmed.includes('COMPLETE')) return 'accept';
+    return 'revise';
+}
+
+/**
+ * Format the run's tool results as ground-truth evidence for the reflector.
+ *
+ * Takes ALL results (already capped at 10 by the toolResults reducer), not just
+ * the current iteration's: reflection usually runs an iteration or two AFTER
+ * the tool calls (on the no-tools text turn), and a per-iteration filter hands
+ * the reflector an empty log — which it reads as "no tools were run" and then
+ * falsely accuses the agent of fabricating data it genuinely fetched.
+ */
+export function buildToolExecutionLog(
+    toolResults: ToolResultEntry[] | undefined,
+): string {
+    if (!toolResults?.length) return '';
+    const entries = toolResults
+        .map(tr => `- [iteration ${tr.iterationIndex}] ${tr.toolName}: ${tr.isError ? 'ERROR' : 'OK'}\n  Output: ${tr.output}`)
+        .join('\n');
+    return `\n<TOOL_EXECUTION_LOG>\nThe following tools were executed during this run:\n${entries}\n</TOOL_EXECUTION_LOG>\n`;
+}
 
 // --- Constants ---
 export const MAX_ITERATIONS = 30;
+
+// Reflect→revise stall detection. If the reflector reports the SAME blocking
+// issue in this many consecutive reflections, the revise step isn't making
+// progress — finalize with current findings instead of churning to
+// MAX_ITERATIONS (which wastes tokens and leaves the run looking "hung").
+export const REFLECTION_STALL_LIMIT = 2;
+
+/**
+ * Decide whether the reflect→revise loop has stalled. A stall is the SAME
+ * non-empty blocking issue repeating across consecutive reflections: the
+ * revise attempts aren't resolving it. Any change in the issue (or an issue
+ * clearing to 'None'/'') resets the counter.
+ *
+ * Heuristic by design — it matches on the reflector's verbatim issues string,
+ * so a model that rephrases the same blocker each round won't trip it; the
+ * MAX_ITERATIONS cap remains the hard backstop for those cases.
+ */
+export function computeReflectionStall(
+    currentIssues: string,
+    prevIssues: string | undefined,
+    prevStallCount: number,
+): { stallCount: number; stalled: boolean } {
+    const hasIssue = !!currentIssues && currentIssues !== 'None';
+    const repeated = hasIssue && !!prevIssues && prevIssues === currentIssues;
+    const stallCount = repeated ? prevStallCount + 1 : 0;
+    return { stallCount, stalled: stallCount >= REFLECTION_STALL_LIMIT };
+}
 
 // ---------------------------------------------------------------------------
 // LLM Audit Logger

--- a/apps/web-ui/lib/agent/fast-agent.ts
+++ b/apps/web-ui/lib/agent/fast-agent.ts
@@ -13,6 +13,9 @@ import {
     tagMessagePhase,
     getCheckpointer,
     getStore,
+    extractTextContent,
+    critiqueVerdict,
+    buildToolExecutionLog,
 } from "./agent-shared";
 
 // Maximum number of reflection cycles before accepting the answer as-is.
@@ -177,15 +180,12 @@ Review the full conversation history before responding:
         const { messages, toolResults } = state;
         const lastMessage = messages[messages.length - 1];
 
-        // Build tool execution summary from the CURRENT iteration only (not stale prior iterations)
-        const currentIterationResults = toolResults?.filter(tr => tr.iterationIndex === state.iterationCount) ?? [];
-        let toolExecutionLog = '';
-        if (currentIterationResults.length > 0) {
-            const entries = currentIterationResults.map(tr =>
-                `- ${tr.toolName}: ${tr.isError ? 'ERROR' : 'OK'}\n  Output: ${tr.output}`
-            ).join('\n');
-            toolExecutionLog = `\n<TOOL_EXECUTION_LOG>\nThe following tools were executed:\n${entries}\n</TOOL_EXECUTION_LOG>\n`;
-        }
+        // Ground-truth evidence for the reflector: ALL of the run's tool results
+        // (reducer-capped at 10). Reflection typically runs an iteration or two
+        // AFTER the tool calls, so a current-iteration-only filter handed the
+        // reflector an empty log and it falsely accused the agent of fabricating
+        // data it had genuinely fetched.
+        const toolExecutionLog = buildToolExecutionLog(toolResults);
 
         // If only tool calls, skip reflection (need an answer to reflect on)
         if ((lastMessage as AIMessage).tool_calls && ((lastMessage as AIMessage).tool_calls?.length ?? 0) > 0) {
@@ -261,7 +261,7 @@ Please provide your critique.`
             console.warn(`⚠️ [FAST REFLECTOR] Skipping reflection due to model error: ${err?.message ?? err}`);
             return { isComplete: true };
         }
-        const content = typeof response.content === 'string' ? response.content : JSON.stringify(response.content);
+        const content = extractTextContent(response.content);
 
         if (!content) {
             console.log(`⚠️ [FAST REFLECTOR] Empty content received!`);
@@ -272,7 +272,11 @@ Please provide your critique.`
 
         console.log(`   Critique: ${truncateOutput(content, 200)}`);
 
-        if (content.includes("COMPLETE")) {
+        if (critiqueVerdict(content) === 'accept') {
+            // COMPLETE — or an EMPTY critique (reflector spent its whole budget on a
+            // reasoning block, stopReason max_tokens): looping on empty feedback gives
+            // the agent nothing to fix, so accept the answer.
+            if (!content.trim()) console.warn(`⚠️ [FAST REFLECTOR] Empty critique — accepting answer instead of looping.`);
             // Do NOT add the reflector's message to state — the agent's answer is already there.
             // Adding "COMPLETE" would overwrite the last message and leak to the UI.
             return { isComplete: true };
@@ -288,14 +292,9 @@ Please provide your critique.`
         };
     }
 
-    // Helper to safely extract string content
-    function getStringContent(content: string | any[]): string {
-        if (typeof content === 'string') return content;
-        if (Array.isArray(content)) {
-            return content.map(c => c.text || JSON.stringify(c)).join('');
-        }
-        return JSON.stringify(content);
-    }
+    // Kept as a thin alias — the canonical implementation is extractTextContent()
+    // in agent-shared.ts, which every graph now shares.
+    const getStringContent = extractTextContent;
 
     // ---------------------------------------------------------------------------
     // FINALIZE NODE

--- a/apps/web-ui/lib/agent/mcp-manager.ts
+++ b/apps/web-ui/lib/agent/mcp-manager.ts
@@ -13,16 +13,35 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
-import { execFileSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
 import { MCPServerConfig, DEFAULT_MCP_SERVERS } from './mcp-config';
 
 /**
  * Check if a command binary is available on the system PATH.
+ *
+ * Resolved by walking PATH directly rather than shelling out to `which`: if
+ * `which` itself is missing from a slim base image, the spawn throws and every
+ * stdio MCP server is reported as unavailable — a total, silent outage.
  */
-function isCommandAvailable(command: string): boolean {
+export function isCommandAvailable(command: string, searchPath: string = process.env.PATH || ''): boolean {
+    if (!command) return false;
+
+    // An explicit path (absolute or relative) is not a PATH lookup.
+    if (command.includes('/')) {
+        return isExecutable(path.resolve(command));
+    }
+
+    return searchPath
+        .split(path.delimiter)
+        .filter(Boolean)
+        .some(dir => isExecutable(path.join(dir, command)));
+}
+
+function isExecutable(candidate: string): boolean {
     try {
-        execFileSync('which', [command], { stdio: 'ignore' });
-        return true;
+        fs.accessSync(candidate, fs.constants.X_OK);
+        return fs.statSync(candidate).isFile();
     } catch {
         return false;
     }

--- a/apps/web-ui/lib/agent/memory-nodes.ts
+++ b/apps/web-ui/lib/agent/memory-nodes.ts
@@ -8,7 +8,7 @@
 
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
-import { truncateOutput } from "./agent-shared";
+import { truncateOutput, extractTextContent } from "./agent-shared";
 import { saveMemory } from "./persistence";
 import { getMemoryService } from "./memory/memory-service";
 import { memoryLogVerbose } from "./memory/log";
@@ -90,9 +90,7 @@ ${memorySummary}
 Return only the relevant memories.`
                     });
                     const response = await reflectorModel.invoke([filterPrompt, filterInput]);
-                    const content = typeof response.content === "string"
-                        ? response.content
-                        : JSON.stringify(response.content);
+                    const content = extractTextContent(response.content);
                     factsSection = (content.trim() === "NONE") ? "" : content.trim();
                     console.log(`🧠 [RECALL:facts] LLM filter ${factsSection ? `kept:\n${factsSection}` : 'kept none (NONE)'}`);
                 } catch (err: any) {
@@ -248,9 +246,7 @@ Extract memories to save.`
 
         try {
             const response = await reflectorModel.invoke([extractPrompt, extractInput]);
-            const content = typeof response.content === "string"
-                ? response.content
-                : JSON.stringify(response.content);
+            const content = extractTextContent(response.content);
 
             const jsonMatch = content.match(/\[[\s\S]*\]/);
             if (!jsonMatch) {

--- a/apps/web-ui/lib/agent/model-factory.ts
+++ b/apps/web-ui/lib/agent/model-factory.ts
@@ -130,7 +130,11 @@ export function createAgentModels(config: ResolvedModelConfig): AgentModels {
             }),
             reflector: new ChatAnthropic({
                 ...anthropicConfig,
-                maxTokens: Math.min(defaultMaxTokens, 2048),
+                // Full budget, not min(…, 2048): Claude Sonnet 5 emits a reasoning
+                // block before its text, and a 2048 cap let reasoning consume the
+                // whole budget (stopReason max_tokens) — the reflector returned
+                // ZERO text and the reflection loop spun on empty critiques.
+                maxTokens: defaultMaxTokens,
                 streaming: false,
             }),
         };
@@ -164,7 +168,8 @@ export function createAgentModels(config: ResolvedModelConfig): AgentModels {
         }),
         reflector: new ChatBedrockConverse({
             ...bedrockConfig,
-            maxTokens: Math.min(defaultMaxTokens, 2048),
+            // Full budget, not min(…, 2048) — see the ChatAnthropic reflector note.
+            maxTokens: defaultMaxTokens,
             streaming: false,
         }),
     };

--- a/apps/web-ui/lib/agent/planning-agent.ts
+++ b/apps/web-ui/lib/agent/planning-agent.ts
@@ -15,6 +15,8 @@ import {
     llmAuditLog,
     getCheckpointer,
     getStore,
+    extractTextContent,
+    REFLECTION_STALL_LIMIT,
 } from "./agent-shared";
 import {
     buildBaseIdentity,
@@ -155,7 +157,7 @@ Only return the JSON array, nothing else.`);
 
         let planSteps: PlanStep[] = [];
         try {
-            const content = response.content as string;
+            const content = extractTextContent(response.content);
             const jsonMatch = content.match(/\[[\s\S]*\]/);
             if (jsonMatch) {
                 const parsed = JSON.parse(jsonMatch[0]);
@@ -434,9 +436,14 @@ ${plan.map((s, i) => `${i + 1}. [${s.status}] ${s.step}`).join('\n')}`
         let isComplete = false;
         let updatedPlan: PlanStep[] = [];
 
+        let parseFailed = false;
         try {
-            const content = response.content as string;
+            const content = extractTextContent(response.content);
             console.log(`[Reflector] Raw content: ${truncateOutput(content, 200)}`);
+            // Empty reflector text (reasoning consumed the whole output budget,
+            // stopReason max_tokens) — route through the parse-failure path so the
+            // consecutive-failure fail-safe below can force completion.
+            if (!content.trim()) throw new Error('reflector returned no text output');
 
             // Extract outermost JSON object using balanced-brace scan to avoid
             // greedy regex capturing embedded JSON strings in large tool outputs.
@@ -479,8 +486,22 @@ ${plan.map((s, i) => `${i + 1}. [${s.status}] ${s.step}`).join('\n')}`
             }
         } catch (e) {
             console.error("[Reflector] Parsing failed:", e);
+            parseFailed = true;
             analysis = "Reflection parsing failed. Continuing with next iteration.";
             isComplete = false;
+        }
+
+        // Fail-safe (defense in depth): a reflector we cannot parse must NEVER be
+        // able to spin the reflect→revise loop. Before this guard, a parse failure
+        // left isComplete=false every round, so the loop churned all the way to
+        // MAX_ITERATIONS burning an LLM call per lap. After REFLECTION_STALL_LIMIT
+        // consecutive unparseable reflections, finalize with what we already have.
+        const priorFailures = state.reflectionStallCount ?? 0;
+        const parseFailures = parseFailed ? priorFailures + 1 : 0;
+        if (parseFailed && parseFailures >= REFLECTION_STALL_LIMIT) {
+            isComplete = true;
+            analysis = `Reflection output could not be parsed ${parseFailures} times in a row — finalizing with the results gathered so far rather than retrying further.`;
+            console.warn(`⚠️ [REFLECTOR] ${parseFailures} consecutive parse failures — forcing completion.`);
         }
 
         console.log(`\n🧐 [REFLECTOR] Analysis Complete:`);
@@ -508,7 +529,8 @@ ${suggestions !== "None" ? `💡 **Suggestions:** ${suggestions}` : ""}
             reflection: analysis,
             errors: issues !== "None" ? [issues] : [],
             isComplete,
-            nextAction: isComplete ? "complete" : "revise"
+            nextAction: isComplete ? "complete" : "revise",
+            reflectionStallCount: parseFailures,
         };
 
         if (updatedPlan.length > 0) {
@@ -636,9 +658,7 @@ Write for an engineer audience. Be specific — include resource IDs, account na
         try {
             const summaryResponse = await model.invoke(_auditInputs_fin);
             llmAuditLog('FINAL', _auditInputs_fin, summaryResponse, _auditStart_fin);
-            summaryContent = typeof summaryResponse.content === 'string'
-                ? summaryResponse.content
-                : JSON.stringify(summaryResponse.content);
+            summaryContent = extractTextContent(summaryResponse.content);
         } catch (err: any) {
             // A finalize failure must never crash the run — assemble a best-effort summary
             // from the tool results and review notes already captured in state.

--- a/apps/web-ui/lib/agent/text-to-sql/nodes/generate-sql.ts
+++ b/apps/web-ui/lib/agent/text-to-sql/nodes/generate-sql.ts
@@ -1,4 +1,5 @@
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
+import { extractTextContent } from '@/lib/agent/agent-shared';
 import { buildSQLGenerationPrompt } from '../prompts';
 import { type TextToSQLState, requireModelConfig } from '../state';
 import { createAgentModels } from '@/lib/agent/model-factory';
@@ -33,9 +34,7 @@ export async function generateSQLNode(state: TextToSQLState): Promise<Partial<Te
     ]);
 
     // Extract SQL — strip markdown fences if present
-    let sql = typeof response.content === 'string'
-        ? response.content
-        : JSON.stringify(response.content);
+    let sql = extractTextContent(response.content);
     sql = sql.replace(/```sql\n?/gi, '').replace(/```\n?/g, '').trim();
 
     console.log(`[TextToSQL] Generated SQL (iteration ${state.iteration + 1}): ${sql}`);

--- a/apps/web-ui/lib/agent/text-to-sql/nodes/reflect.ts
+++ b/apps/web-ui/lib/agent/text-to-sql/nodes/reflect.ts
@@ -1,4 +1,5 @@
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
+import { extractTextContent } from '@/lib/agent/agent-shared';
 import { buildReflectionPrompt } from '../prompts';
 import { type TextToSQLState, requireModelConfig } from '../state';
 import { createAgentModels } from '@/lib/agent/model-factory';
@@ -33,9 +34,7 @@ export async function reflectNode(state: TextToSQLState): Promise<Partial<TextTo
         new HumanMessage(prompt),
     ]);
 
-    const content = typeof response.content === 'string'
-        ? response.content
-        : JSON.stringify(response.content);
+    const content = extractTextContent(response.content);
 
     // Parse JSON response
     let satisfied = true;

--- a/apps/web-ui/lib/agent/text-to-sql/nodes/synthesize.ts
+++ b/apps/web-ui/lib/agent/text-to-sql/nodes/synthesize.ts
@@ -1,4 +1,5 @@
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
+import { extractTextContent } from '@/lib/agent/agent-shared';
 import { buildSynthesisPrompt } from '../prompts';
 import { type TextToSQLState, requireModelConfig } from '../state';
 import { createAgentModels } from '@/lib/agent/model-factory';
@@ -28,9 +29,7 @@ export async function synthesizeNode(state: TextToSQLState): Promise<Partial<Tex
             new HumanMessage(prompt),
         ]);
 
-        const finalAnswer = typeof response.content === 'string'
-            ? response.content
-            : JSON.stringify(response.content);
+        const finalAnswer = extractTextContent(response.content);
 
         console.log(`[TextToSQL] Synthesized answer: ${finalAnswer.length} chars`);
         return { finalAnswer };

--- a/apps/web-ui/lib/client-skill-service.ts
+++ b/apps/web-ui/lib/client-skill-service.ts
@@ -19,6 +19,15 @@ export const ClientSkillService = {
         const body = await jsonOrThrow(res);
         return body.skills as SkillDTO[];
     },
+    /** List skills with their full `content` (used for markdown export). */
+    async listSkillsWithContent(all = true): Promise<SkillDTO[]> {
+        const params = new URLSearchParams();
+        if (all) params.set('all', '1');
+        params.set('withContent', '1');
+        const res = await fetch(`/api/skills?${params.toString()}`);
+        const body = await jsonOrThrow(res);
+        return body.skills as SkillDTO[];
+    },
     async getSkill(id: string): Promise<SkillDTO> {
         return (await jsonOrThrow(await fetch(`/api/skills/${id}`))).data;
     },

--- a/apps/web-ui/lib/db/repositories/slack-workspace-link/interface.ts
+++ b/apps/web-ui/lib/db/repositories/slack-workspace-link/interface.ts
@@ -1,0 +1,41 @@
+/**
+ * ISlackWorkspaceLinkRepository
+ *
+ * Reverse index from a Slack workspace (team_id) to the tenant that
+ * registered it. Inbound Slack payloads only carry team_id, never our
+ * internal tenantId, so signature verification needs this lookup before it
+ * can find the right signing secret in TenantConfig.
+ */
+export interface SlackWorkspaceLinkRecord {
+    teamId: string;
+    tenantId: string;
+    botUserId: string | null;
+}
+
+/** Thrown when a Slack team_id is already linked to a different tenant. */
+export class SlackWorkspaceLinkConflictError extends Error {
+    constructor(public readonly teamId: string) {
+        super(`Slack workspace "${teamId}" is already linked to a different tenant`);
+        this.name = 'SlackWorkspaceLinkConflictError';
+    }
+}
+
+export interface ISlackWorkspaceLinkRepository {
+    /**
+     * Resolve the tenantId that owns a Slack workspace. Returns null if no
+     * tenant has linked this team_id yet.
+     */
+    findTenantIdByTeamId(teamId: string): Promise<string | null>;
+
+    /**
+     * Link a Slack workspace to a tenant (upsert on teamId). Throws if the
+     * teamId is already linked to a *different* tenant — a workspace can only
+     * ever belong to one tenant.
+     */
+    upsertLink(params: { teamId: string; tenantId: string; botUserId?: string | null }): Promise<void>;
+
+    /**
+     * Look up the current link for a tenant, if any.
+     */
+    getLinkForTenant(tenantId: string): Promise<SlackWorkspaceLinkRecord | null>;
+}

--- a/apps/web-ui/lib/db/repositories/slack-workspace-link/postgres.test.ts
+++ b/apps/web-ui/lib/db/repositories/slack-workspace-link/postgres.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { getPrismaClient } from '@/lib/db/pg-config';
+import { SlackWorkspaceLinkPostgresRepository } from './postgres';
+import { SlackWorkspaceLinkConflictError } from './interface';
+
+// These tests require a local Postgres (docker compose up -d postgres) + migrations applied.
+const repo = new SlackWorkspaceLinkPostgresRepository();
+const prisma = getPrismaClient();
+
+const TENANT_A = 'swl-test-tenant-a';
+const TENANT_B = 'swl-test-tenant-b';
+
+async function cleanup() {
+    await prisma.slackWorkspaceLink.deleteMany({ where: { tenantId: { in: [TENANT_A, TENANT_B] } } });
+}
+
+beforeAll(async () => {
+    await cleanup();
+    await prisma.tenant.createMany({
+        data: [
+            { id: TENANT_A, name: 'SWL Test Tenant A', slug: 'swl-test-tenant-a' },
+            { id: TENANT_B, name: 'SWL Test Tenant B', slug: 'swl-test-tenant-b' },
+        ],
+        skipDuplicates: true,
+    });
+});
+
+afterAll(async () => {
+    await cleanup();
+    await prisma.tenant.deleteMany({ where: { id: { in: [TENANT_A, TENANT_B] } } });
+});
+
+beforeEach(cleanup);
+
+describe('SlackWorkspaceLinkPostgresRepository', () => {
+    it('resolves the tenant that linked a given team_id', async () => {
+        await repo.upsertLink({ teamId: 'T-A', tenantId: TENANT_A, botUserId: 'B-A' });
+        expect(await repo.findTenantIdByTeamId('T-A')).toBe(TENANT_A);
+    });
+
+    it('returns null for an unlinked team_id', async () => {
+        expect(await repo.findTenantIdByTeamId('T-UNKNOWN')).toBeNull();
+    });
+
+    it('upsertLink is idempotent for the same tenant', async () => {
+        await repo.upsertLink({ teamId: 'T-A', tenantId: TENANT_A, botUserId: 'B-OLD' });
+        await repo.upsertLink({ teamId: 'T-A', tenantId: TENANT_A, botUserId: 'B-NEW' });
+        expect(await repo.findTenantIdByTeamId('T-A')).toBe(TENANT_A);
+        expect((await repo.getLinkForTenant(TENANT_A))?.botUserId).toBe('B-NEW');
+    });
+
+    it('refuses to relink a team_id already owned by a different tenant', async () => {
+        await repo.upsertLink({ teamId: 'T-SHARED', tenantId: TENANT_A });
+        await expect(
+            repo.upsertLink({ teamId: 'T-SHARED', tenantId: TENANT_B }),
+        ).rejects.toThrow(SlackWorkspaceLinkConflictError);
+        // Original link is untouched
+        expect(await repo.findTenantIdByTeamId('T-SHARED')).toBe(TENANT_A);
+    });
+
+    it('getLinkForTenant returns null when the tenant has no link', async () => {
+        expect(await repo.getLinkForTenant(TENANT_B)).toBeNull();
+    });
+});

--- a/apps/web-ui/lib/db/repositories/slack-workspace-link/postgres.ts
+++ b/apps/web-ui/lib/db/repositories/slack-workspace-link/postgres.ts
@@ -1,0 +1,71 @@
+/**
+ * SlackWorkspaceLinkPostgresRepository
+ *
+ * PostgreSQL implementation of ISlackWorkspaceLinkRepository using Prisma ORM.
+ * Reads/writes the `slack_workspace_links` table (defined in libs/prisma/schema.prisma).
+ *
+ * findTenantIdByTeamId is intentionally NOT tenant-scoped — resolving which
+ * tenant owns an inbound Slack team_id is the whole point of this table, so
+ * it uses the unscoped Prisma client rather than getTenantClient().
+ */
+import { getPrismaClient } from '@/lib/db/pg-config';
+import {
+    SlackWorkspaceLinkConflictError,
+    type ISlackWorkspaceLinkRepository,
+    type SlackWorkspaceLinkRecord,
+} from './interface';
+
+export class SlackWorkspaceLinkPostgresRepository implements ISlackWorkspaceLinkRepository {
+    async findTenantIdByTeamId(teamId: string): Promise<string | null> {
+        try {
+            const record = await getPrismaClient().slackWorkspaceLink.findUnique({
+                where: { teamId },
+                select: { tenantId: true },
+            });
+            return record?.tenantId ?? null;
+        } catch (error: unknown) {
+            const msg = error instanceof Error ? error.message : String(error);
+            console.error('[SlackWorkspaceLinkPostgresRepository] Error resolving teamId:', error);
+            throw new Error(`Failed to resolve Slack team_id: ${msg}`);
+        }
+    }
+
+    async upsertLink(params: { teamId: string; tenantId: string; botUserId?: string | null }): Promise<void> {
+        const { teamId, tenantId, botUserId = null } = params;
+        try {
+            const existing = await getPrismaClient().slackWorkspaceLink.findUnique({
+                where: { teamId },
+                select: { tenantId: true },
+            });
+            if (existing && existing.tenantId !== tenantId) {
+                throw new SlackWorkspaceLinkConflictError(teamId);
+            }
+
+            await getPrismaClient().slackWorkspaceLink.upsert({
+                where: { teamId },
+                update: { botUserId },
+                create: { teamId, tenantId, botUserId },
+            });
+            console.log(`[SlackWorkspaceLinkPostgresRepository] Linked team "${teamId}" to tenant "${tenantId}"`);
+        } catch (error: unknown) {
+            if (error instanceof SlackWorkspaceLinkConflictError) throw error;
+            const msg = error instanceof Error ? error.message : String(error);
+            console.error('[SlackWorkspaceLinkPostgresRepository] Error upserting link:', error);
+            throw new Error(`Failed to link Slack workspace: ${msg}`);
+        }
+    }
+
+    async getLinkForTenant(tenantId: string): Promise<SlackWorkspaceLinkRecord | null> {
+        try {
+            const record = await getPrismaClient().slackWorkspaceLink.findFirst({
+                where: { tenantId },
+            });
+            if (!record) return null;
+            return { teamId: record.teamId, tenantId: record.tenantId, botUserId: record.botUserId };
+        } catch (error: unknown) {
+            const msg = error instanceof Error ? error.message : String(error);
+            console.error('[SlackWorkspaceLinkPostgresRepository] Error getting link for tenant:', error);
+            throw new Error(`Failed to get Slack workspace link: ${msg}`);
+        }
+    }
+}

--- a/apps/web-ui/lib/db/repository-factory.ts
+++ b/apps/web-ui/lib/db/repository-factory.ts
@@ -27,6 +27,7 @@ import type { IRightSizingRepository } from './repositories/right-sizing/interfa
 import type { IPricingCatalogRepository } from './repositories/pricing/interface';
 import type { IAgentMemoryRepository } from './repositories/agent-memory/interface';
 import type { ISkillRepository } from './repositories/skill/interface';
+import type { ISlackWorkspaceLinkRepository } from './repositories/slack-workspace-link/interface';
 
 export function getTenantConfigRepository(): ITenantConfigRepository {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -128,6 +129,12 @@ export function getSkillRepository(): ISkillRepository {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { SkillPostgresRepository } = require('./repositories/skill/postgres');
     return new SkillPostgresRepository();
+}
+
+export function getSlackWorkspaceLinkRepository(): ISlackWorkspaceLinkRepository {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { SlackWorkspaceLinkPostgresRepository } = require('./repositories/slack-workspace-link/postgres');
+    return new SlackWorkspaceLinkPostgresRepository();
 }
 
 /**

--- a/apps/web-ui/lib/gateway/adapters/slack-adapter.ts
+++ b/apps/web-ui/lib/gateway/adapters/slack-adapter.ts
@@ -10,6 +10,7 @@ import * as crypto from 'crypto';
 import type { NextRequest } from 'next/server';
 import { env } from '@/env';
 import { TenantConfigService } from '@/lib/tenant-config-service';
+import { getSlackWorkspaceLinkRepository } from '@/lib/db/repository-factory';
 import { agentOpsService } from '@/lib/agent-ops/agent-ops-service';
 import { buildDashboardRespondUrl, buildDashboardRunUrl } from '@/lib/gateway/utils/dashboard-url';
 import type {
@@ -45,6 +46,21 @@ async function readBody(req: NextRequest): Promise<string> {
     return text;
 }
 
+/**
+ * Cache the team_id → tenantId resolution across validateRequest → parseInbound
+ * so both use the same (correct) internal tenantId without a duplicate lookup.
+ * Value is `null` when resolution was attempted but no link exists.
+ */
+const tenantIdCache = new WeakMap<NextRequest, string | null>();
+
+async function resolveTenantId(req: NextRequest, teamId: string): Promise<string | null> {
+    if (!teamId) return null;
+    if (tenantIdCache.has(req)) return tenantIdCache.get(req) ?? null;
+    const tenantId = await getSlackWorkspaceLinkRepository().findTenantIdByTeamId(teamId).catch(() => null);
+    tenantIdCache.set(req, tenantId);
+    return tenantId;
+}
+
 export class SlackAdapter implements ChannelAdapter {
     readonly channelType: ChannelType = 'slack';
     readonly deliveryMode: DeliveryMode = 'callback';
@@ -63,18 +79,21 @@ export class SlackAdapter implements ChannelAdapter {
 
         if (!timestamp || !signature) return false;
 
-        // Try to resolve tenantId from the body (team_id in slash commands or interaction payloads)
+        // Resolve the Slack team_id from the body (slash commands or interaction payloads).
+        // team_id is Slack's workspace identifier — NOT our internal tenantId — so it must
+        // be translated via SlackWorkspaceLink before it can be used to look up config.
         const params = new URLSearchParams(body);
-        let tenantId = params.get('team_id') || '';
-        if (!tenantId && params.has('payload')) {
+        let teamId = params.get('team_id') || '';
+        if (!teamId && params.has('payload')) {
             try {
                 const payload = JSON.parse(params.get('payload')!);
-                tenantId = payload.team?.id || '';
+                teamId = payload.team?.id || '';
             } catch { /* ignore */ }
         }
 
-        // Load signing secret: tenant config first, env var fallback
+        // Load signing secret: resolve tenant from team_id, then tenant config, env var fallback
         let signingSecret = '';
+        const tenantId = await resolveTenantId(req, teamId);
         if (tenantId) {
             const config = await TenantConfigService.getConfig<SlackIntegrationConfig>(
                 'agent-ops-slack',
@@ -124,7 +143,7 @@ export class SlackAdapter implements ChannelAdapter {
         }
 
         // ── Slash command ────────────────────────────────────────────
-        return this.parseSlashCommand(params);
+        return this.parseSlashCommand(params, req);
     }
 
     async sendAck(_req: NextRequest, runId: string): Promise<Response> {
@@ -353,7 +372,7 @@ export class SlackAdapter implements ChannelAdapter {
         ).catch(() => null);
     }
 
-    private async parseSlashCommand(params: URLSearchParams): Promise<GatewayMessage> {
+    private async parseSlashCommand(params: URLSearchParams, req: NextRequest): Promise<GatewayMessage> {
         const text = params.get('text') || '';
         const userId = params.get('user_id') || '';
         const channelId = params.get('channel_id') || '';
@@ -362,6 +381,16 @@ export class SlackAdapter implements ChannelAdapter {
         const threadTs = params.get('thread_ts') || undefined;
         const userName = params.get('user_name') || undefined;
         const channelName = params.get('channel_name') || undefined;
+
+        // team_id is Slack's workspace identifier, not our internal tenantId — resolve it
+        // via the same SlackWorkspaceLink lookup validateRequest already did (cached on req).
+        // Falls back to the raw team_id only if no link exists (e.g. env-var-only setups),
+        // matching prior (already-broken) behavior rather than silently dropping the run.
+        const resolvedTenantId = await resolveTenantId(req, teamId);
+        if (!resolvedTenantId) {
+            console.warn('[SlackAdapter] No tenant linked for Slack team_id, falling back to raw team_id:', teamId);
+        }
+        const tenantId = resolvedTenantId || teamId;
 
         // If this is a threaded reply, check for an awaiting_input run
         let replyContext: ReplyContext | undefined;
@@ -382,7 +411,7 @@ export class SlackAdapter implements ChannelAdapter {
 
         return {
             channelType: 'slack',
-            tenantId: teamId,
+            tenantId,
             taskDescription: text,
             userId,
             replyContext,

--- a/apps/web-ui/lib/skill-export.test.ts
+++ b/apps/web-ui/lib/skill-export.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Unit tests for the Skill → Markdown export builder.
+ *
+ * buildSkillMarkdown()/buildAllSkillsMarkdown() are the pure cores of the
+ * "Export markdown" (per-skill) and "Export all" (toolbar) downloads. Mirrors
+ * tests/agent-ops/export-markdown.test.ts.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildSkillMarkdown, buildAllSkillsMarkdown, buildSkillFile } from './skill-export';
+import type { SkillDTO } from './client-skill-service';
+
+function makeSkill(overrides: Partial<SkillDTO> = {}): SkillDTO {
+    return {
+        id: 'stop-ec2-at-night',
+        name: 'Stop EC2 at night',
+        description: 'Stop non-prod EC2 instances overnight to save cost.',
+        tier: 'mutation',
+        source: 'user',
+        isEnabled: true,
+        createdBy: 'user-1',
+        createdAt: '2026-07-13T00:00:00.000Z',
+        updatedAt: '2026-07-13T00:00:00.000Z',
+        content: '## Steps\n\n1. List instances\n2. Stop them',
+        ...overrides,
+    };
+}
+
+describe('buildSkillMarkdown', () => {
+    it('renders the skill name as the H1 and description as a blockquote', () => {
+        const md = buildSkillMarkdown(makeSkill());
+        expect(md).toContain('# Stop EC2 at night');
+        expect(md).toContain('> Stop non-prod EC2 instances overnight to save cost.');
+    });
+
+    it('renders the metadata table with slug, tier, source and status', () => {
+        const md = buildSkillMarkdown(makeSkill());
+        expect(md).toContain('| Slug | `stop-ec2-at-night` |');
+        expect(md).toContain('| Tier | mutation |');
+        expect(md).toContain('| Source | user |');
+        expect(md).toContain('| Status | Enabled |');
+    });
+
+    it('marks disabled skills as Disabled in the status row', () => {
+        const md = buildSkillMarkdown(makeSkill({ isEnabled: false }));
+        expect(md).toContain('| Status | Disabled |');
+    });
+
+    it('falls back to an em-dash when createdBy is null', () => {
+        const md = buildSkillMarkdown(makeSkill({ createdBy: null }));
+        expect(md).toContain('| Created by | — |');
+    });
+
+    it('wraps content in a fenced code block', () => {
+        const md = buildSkillMarkdown(makeSkill({ content: 'do the thing' }));
+        expect(md).toContain('## Content');
+        expect(md).toContain('```markdown\ndo the thing\n```');
+    });
+
+    it('lengthens the fence when content itself contains backtick runs', () => {
+        const content = 'Here is a code block:\n```js\nconsole.log("hi")\n```';
+        const md = buildSkillMarkdown(makeSkill({ content }));
+        // The fence must be 4 backticks (one longer than the 3-run inside content).
+        expect(md).toContain('````markdown\n' + content + '\n````');
+        // ...and must NOT contain a bare 3-backtick fence that would close early.
+        expect(md).not.toContain('````\n```\n');
+    });
+});
+
+describe('buildAllSkillsMarkdown', () => {
+    it('renders a header with the skill count', () => {
+        const md = buildAllSkillsMarkdown([makeSkill(), makeSkill({ id: 'a', name: 'Alpha skill' })]);
+        expect(md).toContain('# Skills export');
+        expect(md).toContain('Exported 2 skill(s).');
+    });
+
+    it('renders an empty-state message when there are no skills', () => {
+        const md = buildAllSkillsMarkdown([]);
+        expect(md).toContain('Exported 0 skill(s).');
+        expect(md).toContain('_No skills to export._');
+    });
+
+    it('renders a table of contents linking to each skill by name anchor', () => {
+        const md = buildAllSkillsMarkdown([
+            makeSkill({ id: 'alpha', name: 'Alpha skill' }),
+            makeSkill({ id: 'beta', name: 'Beta skill' }),
+        ]);
+        expect(md).toContain('## Table of contents');
+        expect(md).toContain('- [Alpha skill](#alpha-skill)');
+        expect(md).toContain('- [Beta skill](#beta-skill)');
+    });
+
+    it('sorts skills by name and separates them with horizontal rules', () => {
+        const md = buildAllSkillsMarkdown([
+            makeSkill({ id: 'zeta', name: 'Zeta skill' }),
+            makeSkill({ id: 'alpha', name: 'Alpha skill' }),
+        ]);
+        const alphaIdx = md.indexOf('# Alpha skill');
+        const zetaIdx = md.indexOf('# Zeta skill');
+        expect(alphaIdx).toBeGreaterThan(-1);
+        expect(zetaIdx).toBeGreaterThan(-1);
+        expect(alphaIdx).toBeLessThan(zetaIdx);
+        expect(md).toContain('\n---\n');
+    });
+
+    it('includes the full body of every skill', () => {
+        const md = buildAllSkillsMarkdown([
+            makeSkill({ id: 'a', name: 'A', content: 'AAA' }),
+            makeSkill({ id: 'b', name: 'B', content: 'BBB' }),
+        ]);
+        expect(md).toContain('# A');
+        expect(md).toContain('AAA');
+        expect(md).toContain('# B');
+        expect(md).toContain('BBB');
+    });
+});
+
+describe('buildSkillFile (portable SKILL.md)', () => {
+    it('emits YAML frontmatter delimited by --- fences', () => {
+        const md = buildSkillFile(makeSkill());
+        expect(md.startsWith('---\n')).toBe(true);
+        expect(md).toMatch(/\n---\n/);
+    });
+
+    it('places name, description, tier and enabled in the frontmatter', () => {
+        const md = buildSkillFile(makeSkill());
+        expect(md).toContain('name: "Stop EC2 at night"');
+        expect(md).toContain('description: "Stop non-prod EC2 instances overnight to save cost."');
+        expect(md).toContain('tier: "mutation"');
+        expect(md).toContain('enabled: true');
+    });
+
+    it('writes enabled: false for disabled skills', () => {
+        const md = buildSkillFile(makeSkill({ isEnabled: false }));
+        expect(md).toContain('enabled: false');
+    });
+
+    it('puts the skill content as the body after the frontmatter', () => {
+        const md = buildSkillFile(makeSkill({ content: '## Steps\n1. Do the thing' }));
+        const bodyStart = md.indexOf('\n---\n') + '\n---\n'.length;
+        const body = md.slice(bodyStart);
+        expect(body.trim()).toBe('## Steps\n1. Do the thing');
+    });
+
+    it('escapes double quotes and backslashes in frontmatter values', () => {
+        const md = buildSkillFile(makeSkill({ name: 'A "quoted" skill', description: 'path\\to thing' }));
+        expect(md).toContain('name: "A \\"quoted\\" skill"');
+        expect(md).toContain('description: "path\\\\to thing"');
+    });
+
+    it('uses a YAML block scalar for multi-line descriptions', () => {
+        const md = buildSkillFile(makeSkill({ description: 'line one\nline two' }));
+        expect(md).toContain('description: |-\n  line one\n  line two');
+    });
+});

--- a/apps/web-ui/lib/skill-export.ts
+++ b/apps/web-ui/lib/skill-export.ts
@@ -1,0 +1,163 @@
+/**
+ * Skill → Markdown export.
+ *
+ * Mirrors the pure-core + Blob-download split used by lib/agent-ops/export-markdown.ts
+ * and lib/chat-export.ts: buildSkillMarkdown()/buildAllSkillsMarkdown() are pure
+ * (unit-tested); exportSkillToMarkdown()/exportAllSkillsToMarkdown() wrap them in a
+ * Blob download. Skill `content` is fenced so triple-backtick runs inside it cannot
+ * terminate the fence early.
+ */
+
+import type { SkillDTO } from "@/lib/client-skill-service";
+
+/**
+ * Wrap content in a code fence that cannot be terminated early: the fence is
+ * one backtick longer than the longest backtick run inside the content.
+ */
+function fence(content: string, lang = "markdown"): string {
+    const longestRun = content.match(/`+/g)?.reduce((max, run) => Math.max(max, run.length), 0) ?? 0;
+    const marker = "`".repeat(Math.max(3, longestRun + 1));
+    return `${marker}${lang}\n${content}\n${marker}`;
+}
+
+/** GitHub-style heading anchor: lowercase, trim, spaces → hyphens, drop non-alnum. */
+function anchor(text: string): string {
+    return text.toLowerCase().trim().replace(/[^\w\s-]/g, "").replace(/\s+/g, "-");
+}
+
+/** Build the Markdown document for a single skill. Pure. */
+export function buildSkillMarkdown(skill: SkillDTO): string {
+    const content = skill.content ?? "";
+    const lines: string[] = [
+        `# ${skill.name}`,
+        "",
+        `> ${skill.description}`,
+        "",
+        "| Field | Value |",
+        "| --- | --- |",
+        `| Slug | \`${skill.id}\` |`,
+        `| Tier | ${skill.tier} |`,
+        `| Source | ${skill.source} |`,
+        `| Status | ${skill.isEnabled ? "Enabled" : "Disabled"} |`,
+        `| Created | ${skill.createdAt} |`,
+        `| Updated | ${skill.updatedAt} |`,
+        `| Created by | ${skill.createdBy ?? "—"} |`,
+        "",
+        "## Content",
+        "",
+        fence(content),
+        "",
+    ];
+    return lines.join("\n");
+}
+
+/** Build the Markdown document for a collection of skills (table of contents + each skill). Pure. */
+export function buildAllSkillsMarkdown(skills: SkillDTO[]): string {
+    const sorted = [...skills].sort((a, b) => a.name.localeCompare(b.name));
+    const header: string[] = [
+        "# Skills export",
+        "",
+        `Exported ${sorted.length} skill(s).`,
+        "",
+    ];
+    if (sorted.length === 0) {
+        header.push("_No skills to export._", "");
+        return header.join("\n");
+    }
+    header.push("## Table of contents", "");
+    for (const s of sorted) {
+        header.push(`- [${s.name}](#${anchor(s.name)})`);
+    }
+    header.push("", "---", "");
+    const body = sorted.map((s) => `${buildSkillMarkdown(s)}\n---\n`);
+    return `${header.join("\n")}\n${body.join("\n")}`;
+}
+
+/** Trigger a client-side download of a Blob. */
+function downloadBlob(blob: Blob, filename: string): void {
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+}
+
+/** Trigger a client-side download of `content` as `filename`. */
+function downloadText(content: string, filename: string, mimeType = "text/markdown;charset=utf-8"): void {
+    downloadBlob(new Blob([content], { type: mimeType }), filename);
+}
+
+function fileSafe(text: string): string {
+    return text.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "skill";
+}
+
+/**
+ * Emit a YAML scalar that is safe to embed in frontmatter. Single-line values use
+ * double-quoted form (backslash + double-quote escaped); multi-line values use a
+ * block scalar so newlines are preserved verbatim.
+ */
+function yamlScalar(value: string): string {
+    const v = value ?? "";
+    if (v.includes("\n")) {
+        const indented = v.split("\n").map((l) => `  ${l}`).join("\n");
+        return `|-\n${indented}`;
+    }
+    return `"${v.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * Build a portable SKILL.md document for a skill: YAML frontmatter (name,
+ * description, tier, enabled) followed by the skill `content` as the body.
+ * This is the Anthropic Agent Skills convention — re-importable by other AI tools
+ * that consume SKILL.md files. Pure.
+ */
+export function buildSkillFile(skill: SkillDTO): string {
+    const frontmatter = [
+        "---",
+        `name: ${yamlScalar(skill.name)}`,
+        `description: ${yamlScalar(skill.description)}`,
+        `tier: ${yamlScalar(skill.tier)}`,
+        `enabled: ${skill.isEnabled ? "true" : "false"}`,
+        "---",
+        "",
+    ].join("\n");
+    return `${frontmatter}\n${skill.content ?? ""}\n`;
+}
+
+/** Download a single skill as a portable SKILL.md-formatted `.md` file. Impure (DOM + Blob). */
+export function exportSkillToFile(skill: SkillDTO): void {
+    downloadText(buildSkillFile(skill), `${skill.id || fileSafe(skill.name)}.md`);
+}
+
+/** Download a single skill as a `.md` file (human-readable report). Impure (DOM + Blob). */
+export function exportSkillToMarkdown(skill: SkillDTO): void {
+    const markdown = buildSkillMarkdown(skill);
+    downloadText(markdown, `skill-${fileSafe(skill.name)}.md`);
+}
+
+/** Download all skills as a single `.md` file (human-readable report). Impure (DOM + Blob). */
+export function exportAllSkillsToMarkdown(skills: SkillDTO[]): void {
+    const markdown = buildAllSkillsMarkdown(skills);
+    downloadText(markdown, `skills-export-${new Date().toISOString().slice(0, 10)}.md`);
+}
+
+/**
+ * Download all skills as a `.zip` of portable SKILL.md files, one per skill at
+ * `skills/<slug>/SKILL.md` (the Claude Code skill layout). jszip is dynamically
+ * imported so it stays out of the main bundle for users who never export. Impure
+ * (DOM + Blob + dynamic import).
+ */
+export async function exportAllSkillsToZip(skills: SkillDTO[]): Promise<void> {
+    const JSZip = (await import("jszip")).default;
+    const zip = new JSZip();
+    const root = zip.folder("skills");
+    if (!root) throw new Error("Failed to create skills folder in zip");
+    for (const s of [...skills].sort((a, b) => a.name.localeCompare(b.name))) {
+        root.file(`${s.id}/SKILL.md`, buildSkillFile(s));
+    }
+    const blob = await zip.generateAsync({ type: "blob" });
+    downloadBlob(blob, `skills-export-${new Date().toISOString().slice(0, 10)}.zip`);
+}

--- a/apps/web-ui/tests/agent-ops/agent-shared.test.ts
+++ b/apps/web-ui/tests/agent-ops/agent-shared.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { AIMessage, HumanMessage, ToolMessage, BaseMessage } from '@langchain/core/messages';
-import { sanitizeMessagesForBedrock, getRecentMessages, graphState, tagMessagePhase } from '../../lib/agent/agent-shared';
+import { sanitizeMessagesForBedrock, getRecentMessages, graphState, tagMessagePhase, computeReflectionStall, REFLECTION_STALL_LIMIT, extractTextContent, critiqueVerdict, buildToolExecutionLog } from '../../lib/agent/agent-shared';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -247,5 +247,133 @@ describe('executionOutput graphState reducer', () => {
     it('initialises to empty string', () => {
         const defaultFn = graphState.executionOutput?.default as () => string;
         expect(defaultFn()).toBe('');
+    });
+});
+
+describe('extractTextContent', () => {
+    it('returns a plain string unchanged', () => {
+        expect(extractTextContent('hello world')).toBe('hello world');
+    });
+
+    it('joins Bedrock text-delta blocks into the original prose (not "[object Object]")', () => {
+        // The runtime bug: `response.content as string` on this array yielded
+        // "[object Object],[object Object]" and blew up .match()/.toLowerCase().
+        const blocks = [
+            { type: 'text', text: '{"analysis":' },
+            { type: 'text', text: ' "looks good",' },
+            { type: 'text', text: ' "isComplete": true}' },
+        ];
+        const out = extractTextContent(blocks);
+        expect(out).toBe('{"analysis": "looks good", "isComplete": true}');
+        expect(out).not.toContain('[object Object]');
+        expect(() => JSON.parse(out)).not.toThrow();
+    });
+
+    it('keeps only text blocks, dropping tool_use blocks', () => {
+        const blocks = [
+            { type: 'text', text: 'thinking' },
+            { type: 'tool_use', id: 't1', name: 'foo', input: {} },
+        ];
+        expect(extractTextContent(blocks)).toBe('thinking');
+    });
+
+    it('returns a usable string (never throws) for empty / null content', () => {
+        expect(extractTextContent([])).toBe('');
+        expect(extractTextContent(null)).toBe('');
+        expect(extractTextContent(undefined)).toBe('');
+    });
+
+    it('produces output that supports the string ops the reflector calls', () => {
+        const blocks = [{ type: 'text', text: 'Task Complete' }];
+        const out = extractTextContent(blocks);
+        // These are exactly the calls that threw at planning-agent.ts:476 / :159
+        expect(out.toLowerCase()).toContain('task complete');
+        expect(out.indexOf('{')).toBe(-1);
+        expect(() => out.match(/\[[\s\S]*\]/)).not.toThrow();
+    });
+});
+
+describe('critiqueVerdict', () => {
+    it('accepts when the critique contains COMPLETE', () => {
+        expect(critiqueVerdict('COMPLETE')).toBe('accept');
+        expect(critiqueVerdict('The answer is good. COMPLETE')).toBe('accept');
+    });
+
+    it('accepts when the critique is empty — an empty critique must never drive a revision loop', () => {
+        // Live failure: reflector burned its whole output budget on a
+        // reasoning_content block (stopReason max_tokens) → no text → the agent
+        // received "[REFLECTION FEEDBACK]" with an empty issue list and looped.
+        expect(critiqueVerdict('')).toBe('accept');
+        expect(critiqueVerdict('   \n  ')).toBe('accept');
+    });
+
+    it('revises when the critique lists real issues', () => {
+        expect(critiqueVerdict('- Missing --output json on the CLI call')).toBe('revise');
+    });
+});
+
+describe('buildToolExecutionLog', () => {
+    it('includes tool results from ALL iterations, not just the current one', () => {
+        // Live failure: tools ran in iterations 1-2, reflection happened at
+        // iteration 3 → the per-iteration filter produced an empty log and the
+        // reflector falsely accused the agent of fabricating tool data.
+        const results = [
+            { toolName: 'searchJiraIssuesUsingJql', output: '{"issues":[...]}', isError: false, iterationIndex: 1 },
+            { toolName: 'getJiraIssue', output: '{"key":"DEVCHNMGM-817"}', isError: false, iterationIndex: 2 },
+        ];
+        const log = buildToolExecutionLog(results);
+        expect(log).toContain('searchJiraIssuesUsingJql');
+        expect(log).toContain('getJiraIssue');
+        expect(log).toContain('<TOOL_EXECUTION_LOG>');
+    });
+
+    it('returns empty string when no tools were executed', () => {
+        expect(buildToolExecutionLog([])).toBe('');
+        expect(buildToolExecutionLog(undefined)).toBe('');
+    });
+
+    it('marks errored tool calls', () => {
+        const log = buildToolExecutionLog([
+            { toolName: 'execute_command', output: 'Command failed', isError: true, iterationIndex: 1 },
+        ]);
+        expect(log).toContain('ERROR');
+    });
+});
+
+describe('computeReflectionStall', () => {
+    it('does not stall on the first reflection with an issue', () => {
+        const r = computeReflectionStall('AWS CLI missing --output json', undefined, 0);
+        expect(r.stallCount).toBe(0);
+        expect(r.stalled).toBe(false);
+    });
+
+    it('resets the count when the issue changes between reflections', () => {
+        const r = computeReflectionStall('new different issue', 'old issue', 1);
+        expect(r.stallCount).toBe(0);
+        expect(r.stalled).toBe(false);
+    });
+
+    it('resets the count when the current reflection reports no issues', () => {
+        const r = computeReflectionStall('None', 'some issue', 1);
+        expect(r.stallCount).toBe(0);
+        expect(r.stalled).toBe(false);
+    });
+
+    it('increments the count when the same blocking issue repeats', () => {
+        const r = computeReflectionStall('same issue', 'same issue', 0);
+        expect(r.stallCount).toBe(1);
+        expect(r.stalled).toBe(false);
+    });
+
+    it('flags stalled once the same issue persists to the limit', () => {
+        const r = computeReflectionStall('same issue', 'same issue', REFLECTION_STALL_LIMIT - 1);
+        expect(r.stallCount).toBe(REFLECTION_STALL_LIMIT);
+        expect(r.stalled).toBe(true);
+    });
+
+    it('treats empty-string issues as no issue (no false stall)', () => {
+        const r = computeReflectionStall('', '', 1);
+        expect(r.stallCount).toBe(0);
+        expect(r.stalled).toBe(false);
     });
 });

--- a/apps/web-ui/tests/agent-ops/channel-settings-merge.test.ts
+++ b/apps/web-ui/tests/agent-ops/channel-settings-merge.test.ts
@@ -20,6 +20,9 @@ const {
     mockGetAuthSession,
     mockLogUserAction,
     mockAuthorize,
+    mockGetLinkForTenant,
+    mockUpsertLink,
+    mockFindTenantIdByTeamId,
 } = vi.hoisted(() => ({
     mockGetConfig: vi.fn(),
     mockSaveConfig: vi.fn(),
@@ -27,6 +30,9 @@ const {
     mockGetAuthSession: vi.fn(),
     mockLogUserAction: vi.fn(),
     mockAuthorize: vi.fn(),
+    mockGetLinkForTenant: vi.fn(),
+    mockUpsertLink: vi.fn(),
+    mockFindTenantIdByTeamId: vi.fn(),
 }));
 
 vi.mock('@/lib/tenant-config-service', () => ({
@@ -44,6 +50,16 @@ vi.mock('@/lib/audit-service', () => ({
 
 vi.mock('@/lib/rbac/authorize', () => ({
     authorize: mockAuthorize,
+}));
+
+// Slack's team_id → tenantId link — irrelevant to Jira, but the shared slack
+// route imports it, so it must be mocked regardless of which channel a test targets.
+vi.mock('@/lib/db/repository-factory', () => ({
+    getSlackWorkspaceLinkRepository: () => ({
+        getLinkForTenant: mockGetLinkForTenant,
+        upsertLink: mockUpsertLink,
+        findTenantIdByTeamId: mockFindTenantIdByTeamId,
+    }),
 }));
 
 // Import after mocks
@@ -69,6 +85,11 @@ beforeEach(() => {
     mockLogUserAction.mockResolvedValue(undefined);
     mockSaveConfig.mockResolvedValue(undefined);
     mockAuthorize.mockResolvedValue(null); // authorized by default
+    // Default: tenant is already linked to a Slack workspace, so merge-on-blank
+    // saves don't need to re-verify a bot token against the real Slack API.
+    mockGetLinkForTenant.mockResolvedValue({ teamId: 'T-EXIST', tenantId: 'tenant-1', botUserId: 'B-EXIST' });
+    mockUpsertLink.mockResolvedValue(undefined);
+    mockFindTenantIdByTeamId.mockResolvedValue('tenant-1');
 });
 
 describe('Slack settings PUT — merge on blank', () => {

--- a/apps/web-ui/tests/agent-ops/clarification-resume.test.ts
+++ b/apps/web-ui/tests/agent-ops/clarification-resume.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Regression test for the clarification-resume loop.
+ *
+ * Live failure: a run asked a clarification (evaluation.mode='end'), the user
+ * answered, and the resume re-invoked the graph on the SAME thread. The
+ * evaluator's "already evaluated" guard saw the checkpointed evaluation and
+ * returned instantly — never calling the LLM, never reading the user's reply —
+ * and routeFromEvaluator routed to clarify again off the stale mode='end'.
+ * The run re-asked the identical question forever, whatever the user answered.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isReusableEvaluation } from '../../lib/agent-ops/executor-state';
+import type { RequestEvaluation } from '../../lib/agent-ops/executor-state';
+
+function evaluation(overrides: Partial<RequestEvaluation>): RequestEvaluation {
+    return {
+        mode: 'plan', skillId: null, accountId: null, requiresApproval: false,
+        reasoning: '', clarificationQuestion: null, missingInfo: null,
+        skillName: null, knowledgeBaseIds: [],
+        ...overrides,
+    } as RequestEvaluation;
+}
+
+describe('isReusableEvaluation', () => {
+    it('is false when there is no evaluation yet — evaluator must run', () => {
+        expect(isReusableEvaluation(null)).toBe(false);
+        expect(isReusableEvaluation(undefined as unknown as null)).toBe(false);
+    });
+
+    it('is true for an executable plan decision — approval resume reuses it', () => {
+        expect(isReusableEvaluation(evaluation({ mode: 'plan', requiresApproval: true }))).toBe(true);
+    });
+
+    it("is FALSE for a stale clarification decision (mode='end') — the user's reply must be re-evaluated", () => {
+        expect(isReusableEvaluation(evaluation({
+            mode: 'end',
+            clarificationQuestion: 'Could you clarify the purpose of this message?',
+        }))).toBe(false);
+    });
+});

--- a/apps/web-ui/tests/agent-ops/executor-event-coverage.test.ts
+++ b/apps/web-ui/tests/agent-ops/executor-event-coverage.test.ts
@@ -135,4 +135,43 @@ describe('executor event coverage', () => {
         const chatter = mockRecordEvent.mock.calls.find(c => c[0].node === 'memory_recall' && c[0].eventType !== 'memory_recall');
         expect(chatter).toBeUndefined();
     });
+
+    it('joins streamed text-delta content blocks without inserting newlines', async () => {
+        // Bedrock streaming yields on_chat_model_end content as an array of
+        // un-coalesced deltas; each delta already carries its own leading space.
+        // Joining with '\n' shatters the text one delta per line — join with ''.
+        mockCreateDynamicExecutorGraph.mockResolvedValue(makeGraph([
+            {
+                event: 'on_chat_model_end', metadata: { langgraph_node: 'generate' },
+                data: {
+                    output: {
+                        content: [
+                            { type: 'text', text: 'The' },
+                            { type: 'text', text: ' request' },
+                            { type: 'text', text: ' involves' },
+                        ],
+                    },
+                },
+            },
+        ]));
+        await executeAgentRun(makeRun());
+        const call = mockRecordEvent.mock.calls.find(c => c[0].node === 'generate' && c[0].content);
+        expect(call).toBeDefined();
+        expect(call![0].content).toBe('The request involves');
+        expect(call![0].content).not.toContain('\n');
+    });
+
+    it('does NOT record raw model text for nodes that emit a structured twin', async () => {
+        // planner/evaluator/reflect each record a clean structured event at
+        // on_chain_end; their raw on_chat_model_end text is a duplicate.
+        mockCreateDynamicExecutorGraph.mockResolvedValue(makeGraph([
+            {
+                event: 'on_chat_model_end', metadata: { langgraph_node: 'reflect' },
+                data: { output: { content: 'raw reflector JSON blob' } },
+            },
+        ]));
+        await executeAgentRun(makeRun());
+        const twin = mockRecordEvent.mock.calls.find(c => c[0].node === 'reflect');
+        expect(twin).toBeUndefined();
+    });
 });

--- a/apps/web-ui/tests/agent-ops/export-markdown.test.ts
+++ b/apps/web-ui/tests/agent-ops/export-markdown.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Unit tests for the Agent Ops run → Markdown report builder.
+ *
+ * buildRunReportMarkdown() is the pure core of the "Download Markdown" export.
+ * It reuses the SAME buildSteps() model as the UI timeline and the PDF export,
+ * so the three renderings never drift.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildRunReportMarkdown } from '../../lib/agent-ops/export-markdown';
+import type { AgentOpsRun, AgentOpsEvent } from '../../lib/agent-ops/types';
+
+let seq = 0;
+function makeEvent(overrides: Partial<AgentOpsEvent>): AgentOpsEvent {
+    seq += 1;
+    return {
+        id: `ev-${seq}`,
+        tenantId: 't1',
+        runId: 'run-1',
+        eventType: 'execution',
+        node: 'generate',
+        content: '',
+        createdAt: new Date(1700000000000 + seq * 1000).toISOString(),
+        ...overrides,
+    } as AgentOpsEvent;
+}
+
+function makeRun(overrides: Partial<AgentOpsRun> = {}): AgentOpsRun {
+    return {
+        id: 'row-1',
+        tenantId: 't1',
+        runId: '5fbe4722-dd12-4fae-8c17-f4b2922bcb8a',
+        source: 'api',
+        status: 'completed',
+        taskDescription: 'Check the cost anomaly and report in slack',
+        mode: 'plan',
+        autoApprove: false,
+        threadId: 'th-1',
+        createdAt: new Date(1700000000000).toISOString(),
+        ...overrides,
+    } as AgentOpsRun;
+}
+
+describe('buildRunReportMarkdown', () => {
+    it('renders header, status, and metadata', () => {
+        const md = buildRunReportMarkdown(makeRun(), []);
+        expect(md).toContain('# Agent Ops Run Report');
+        expect(md).toContain('5fbe4722-dd12-4fae-8c17-f4b2922bcb8a');
+        expect(md).toContain('COMPLETED');
+        expect(md).toContain('| Source |');
+        expect(md).toContain('| api |');
+    });
+
+    it('renders the task description with skill and account', () => {
+        const md = buildRunReportMarkdown(
+            makeRun({ selectedSkill: 'cost-analyser', accountName: 'STX-MTSL', accountId: '590183986748' }),
+            [],
+        );
+        expect(md).toContain('## Task Description');
+        expect(md).toContain('Check the cost anomaly and report in slack');
+        expect(md).toContain('cost-analyser');
+        expect(md).toContain('STX-MTSL');
+    });
+
+    it('renders result summary and tools used', () => {
+        const md = buildRunReportMarkdown(
+            makeRun({ result: { summary: 'July trending 39% above June', toolsUsed: ['execute_command', 'get_aws_credentials'], iterations: 4 } as any }),
+            [],
+        );
+        expect(md).toContain('## Result');
+        expect(md).toContain('July trending 39% above June');
+        expect(md).toContain('execute_command');
+    });
+
+    it('renders the error section for failed runs', () => {
+        const md = buildRunReportMarkdown(makeRun({ status: 'failed', error: 'ValidationException: boom' }), []);
+        expect(md).toContain('## Error');
+        expect(md).toContain('ValidationException: boom');
+        expect(md).toContain('FAILED');
+    });
+
+    it('renders a paired tool step with fenced arguments and output', () => {
+        const events = [
+            makeEvent({ eventType: 'tool_call', node: 'tools', toolName: 'get_aws_credentials', toolArgs: { accountId: '590183986748' } }),
+            makeEvent({ eventType: 'tool_result', node: 'tools', toolName: 'get_aws_credentials', toolOutput: '{"success":true}' }),
+        ];
+        const md = buildRunReportMarkdown(makeRun(), events);
+        expect(md).toContain('get_aws_credentials');
+        expect(md).toContain('**Arguments:**');
+        expect(md).toContain('"accountId": "590183986748"');
+        expect(md).toContain('**Output:**');
+        expect(md).toContain('{"success":true}');
+        expect(md).toContain('```json');
+    });
+
+    it('escapes tool output containing triple backticks with a longer fence', () => {
+        const events = [
+            makeEvent({ eventType: 'tool_call', node: 'tools', toolName: 'read_file', toolArgs: { path: 'x.md' } }),
+            makeEvent({ eventType: 'tool_result', node: 'tools', toolName: 'read_file', toolOutput: 'text\n```js\ncode\n```\nmore' }),
+        ];
+        const md = buildRunReportMarkdown(makeRun(), events);
+        // The inner ``` must not terminate the fence — a 4-backtick fence wraps it.
+        expect(md).toContain('````');
+        expect(md).toContain('```js');
+    });
+
+    it('renders "Worked" groups EXPANDED with every tool call visible', () => {
+        // 3+ contiguous tool steps fold into a group in the UI; markdown renders
+        // the group header AND all nested steps (a document can't be clicked open).
+        const events = ['a', 'b', 'c'].flatMap(name => [
+            makeEvent({ eventType: 'tool_call', node: 'tools', toolName: `tool_${name}`, toolArgs: { name } }),
+            makeEvent({ eventType: 'tool_result', node: 'tools', toolName: `tool_${name}`, toolOutput: `out-${name}` }),
+        ]);
+        const md = buildRunReportMarkdown(makeRun(), events);
+        expect(md).toContain('Worked — 3 tool calls');
+        expect(md).toContain('tool_a');
+        expect(md).toContain('tool_b');
+        expect(md).toContain('tool_c');
+        expect(md).toContain('out-c');
+    });
+
+    it('renders planning, reflection, memory, and evaluation steps', () => {
+        const events = [
+            makeEvent({ eventType: 'memory_recall', node: 'memory_recall', content: 'Recalled 5 facts · 1 rule', metadata: { facts: [1, 2, 3, 4, 5], rules: [1], episodes: [] } as any }),
+            makeEvent({ eventType: 'evaluation', node: 'evaluator', content: 'Cost task, read-only', metadata: { mode: 'plan', skillName: 'cost-analyser' } as any }),
+            makeEvent({ eventType: 'planning', node: 'planner', content: 'Plan created:\n1. Get credentials\n2. Query costs' }),
+            makeEvent({ eventType: 'reflection', node: 'reflect', content: 'All steps complete.' }),
+        ];
+        const md = buildRunReportMarkdown(makeRun(), events);
+        expect(md).toContain('Recalled 5 facts');
+        expect(md).toContain('Evaluated request');
+        expect(md).toContain('1. Get credentials');
+        expect(md).toContain('All steps complete.');
+    });
+
+    it('marks a cancelled run in the timeline', () => {
+        const events = [makeEvent({ eventType: 'final', node: '__cancelled__', content: 'Run was cancelled by user.' })];
+        const md = buildRunReportMarkdown(makeRun({ status: 'cancelled' }), events);
+        expect(md).toContain('Run cancelled');
+        expect(md).toContain('CANCELLED');
+    });
+
+    it('handles a run with no events', () => {
+        const md = buildRunReportMarkdown(makeRun(), []);
+        expect(md).toContain('No events recorded.');
+    });
+});

--- a/apps/web-ui/tests/agent-ops/model-factory-reflector.test.ts
+++ b/apps/web-ui/tests/agent-ops/model-factory-reflector.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Reflector model budget — regression test for the reflector token starvation.
+ *
+ * Claude Sonnet 5 (Bedrock) emits a reasoning_content block before its text.
+ * The reflector was capped at min(maxTokens, 2048); the model spent the entire
+ * budget on reasoning, stopped at max_tokens with ZERO text, and the empty
+ * critique drove the fast-agent reflection loop in circles.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createAgentModels, DEFAULT_MAX_OUTPUT_TOKENS } from '../../lib/agent/model-factory';
+import type { ResolvedModelConfig } from '../../lib/agent/agent-shared';
+
+const bedrockConfig: ResolvedModelConfig = {
+    provider: 'bedrock',
+    modelId: 'global.anthropic.claude-sonnet-5',
+    region: 'ap-south-1',
+    accessKeyId: 'test-key',
+    secretAccessKey: 'test-secret',
+};
+
+describe('createAgentModels reflector budget', () => {
+    it('gives the Bedrock reflector the full default output budget (no 2048 clamp)', () => {
+        const { reflector } = createAgentModels(bedrockConfig);
+        expect((reflector as any).maxTokens).toBe(DEFAULT_MAX_OUTPUT_TOKENS);
+    });
+
+    it('gives the Anthropic reflector the full default output budget (no 2048 clamp)', () => {
+        const { reflector } = createAgentModels({
+            provider: 'anthropic',
+            modelId: 'claude-sonnet-5',
+            apiKey: 'test-key',
+        });
+        expect((reflector as any).maxTokens).toBe(DEFAULT_MAX_OUTPUT_TOKENS);
+    });
+});

--- a/apps/web-ui/tests/agent/dockerfile-runtime.test.ts
+++ b/apps/web-ui/tests/agent/dockerfile-runtime.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Guards the web-ui production runtime contract.
+ *
+ * The runner stage MUST be Node, not Bun. Two production outages came from the
+ * runner being `oven/bun:1-slim`:
+ *
+ *   1. stdio MCP servers launch via `npx -y <pkg>` and are Node packages with a
+ *      `#!/usr/bin/env node` shebang. The Bun image ships no node/npm/npx, so
+ *      every stdio MCP server died at pre-flight with "Command \"npx\" not found
+ *      on PATH" — Slack + Atlassian tools vanished from the agent's tool belt.
+ *   2. Bun does not implement `node:v8` (`isBuildingSnapshot is not yet
+ *      implemented in Bun`), which the MongoDB LangGraph checkpointer reaches on
+ *      /api/deep-agent/approve — an unhandledRejection that killed the route.
+ *
+ * A revert to Bun would silently reintroduce both, so it fails here instead.
+ * (Bun in the *dependency install* and *build* stages is fine and expected.)
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const webUiRoot = path.resolve(__dirname, '../..');
+const dockerfile = fs.readFileSync(path.join(webUiRoot, 'Dockerfile'), 'utf8');
+const entrypoint = fs.readFileSync(path.join(webUiRoot, 'docker-entrypoint.sh'), 'utf8');
+
+/** The `FROM … AS runner` line — the base image the container actually runs on. */
+const runnerFrom = dockerfile
+    .split('\n')
+    .find(line => /^\s*FROM\s.+\sAS\s+runner\s*$/i.test(line))
+    ?.trim();
+
+describe('web-ui Dockerfile — production runner', () => {
+    it('declares a runner stage', () => {
+        expect(runnerFrom).toBeDefined();
+    });
+
+    it('runs on a Node base image, never Bun', () => {
+        expect(runnerFrom).toMatch(/FROM\s+node:/i);
+        expect(runnerFrom).not.toMatch(/bun/i);
+    });
+
+    it('runs as the non-root `node` user with a writable HOME for npx/uvx caches', () => {
+        expect(dockerfile).toMatch(/^\s*USER\s+node\s*$/m);
+        expect(dockerfile).toMatch(/HOME=\/home\/node/);
+        expect(dockerfile).toMatch(/NPM_CONFIG_CACHE=/);
+        expect(dockerfile).toMatch(/UV_CACHE_DIR=/);
+        expect(dockerfile).toMatch(/chown -R node:node[^\n]*\/home\/node/);
+    });
+
+    it('still installs uv/uvx for Python-based MCP servers', () => {
+        expect(dockerfile).toMatch(/uvx/);
+    });
+});
+
+describe('web-ui docker-entrypoint.sh', () => {
+    it('starts the Next.js standalone server with node, not bun', () => {
+        expect(entrypoint).toMatch(/exec\s+node\s+server\.js/);
+        expect(entrypoint).not.toMatch(/\bbun\b/);
+    });
+
+    it('runs prisma migrate deploy without bunx', () => {
+        expect(entrypoint).toMatch(/npx[^\n]*prisma@5 migrate deploy/);
+        expect(entrypoint).not.toMatch(/bunx/);
+    });
+});

--- a/apps/web-ui/tests/agent/mcp-command-resolution.test.ts
+++ b/apps/web-ui/tests/agent/mcp-command-resolution.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Regression tests for stdio MCP command resolution.
+ *
+ * Production failure: the web-ui runner image was `oven/bun:1-slim`, which ships
+ * no node/npm/npx. Every stdio MCP server (`npx -y @modelcontextprotocol/server-slack`,
+ * `npx -y mcp-remote …`) failed its pre-flight check with
+ *   `Command "npx" not found on PATH`
+ * so Slack + Atlassian tools were simply absent from the agent's tool belt.
+ *
+ * The image fix (runner → node:20-slim) is enforced by dockerfile-runtime.test.ts.
+ * These tests cover the lookup itself, which previously shelled out to `which`:
+ * if `which` is missing from a slim base image, execFileSync throws and EVERY
+ * command is reported unavailable — a silent, total MCP outage. The PATH walk
+ * has no such dependency.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { isCommandAvailable } from '../../lib/agent/mcp-manager';
+
+let binDir: string;
+let emptyDir: string;
+
+beforeAll(() => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-path-'));
+    binDir = path.join(root, 'bin');
+    emptyDir = path.join(root, 'empty');
+    fs.mkdirSync(binDir);
+    fs.mkdirSync(emptyDir);
+
+    // An executable stand-in for `npx`.
+    fs.writeFileSync(path.join(binDir, 'npx'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+    // Present but NOT executable — must not count as available.
+    fs.writeFileSync(path.join(binDir, 'not-exec'), 'nope\n', { mode: 0o644 });
+    // A directory named like a command — must not count as available.
+    fs.mkdirSync(path.join(binDir, 'a-directory'));
+});
+
+afterAll(() => {
+    fs.rmSync(path.dirname(binDir), { recursive: true, force: true });
+});
+
+
+
+describe('isCommandAvailable', () => {
+    it('finds an executable on PATH', () => {
+        expect(isCommandAvailable('npx', binDir)).toBe(true);
+    });
+
+    it('finds an executable in any PATH entry, not just the first', () => {
+        const p = [emptyDir, binDir].join(path.delimiter);
+        expect(isCommandAvailable('npx', p)).toBe(true);
+    });
+
+    it('reports a command absent from PATH as unavailable — the production npx failure', () => {
+        expect(isCommandAvailable('npx', emptyDir)).toBe(false);
+    });
+
+    it('does not depend on `which` being installed (empty PATH still resolves cleanly)', () => {
+        expect(() => isCommandAvailable('npx', '')).not.toThrow();
+        expect(isCommandAvailable('npx', '')).toBe(false);
+    });
+
+    it('rejects a non-executable file', () => {
+        expect(isCommandAvailable('not-exec', binDir)).toBe(false);
+    });
+
+    it('rejects a directory that shares a command name', () => {
+        expect(isCommandAvailable('a-directory', binDir)).toBe(false);
+    });
+
+    it('resolves an explicit path without consulting PATH', () => {
+        const abs = path.join(binDir, 'npx');
+        expect(isCommandAvailable(abs, emptyDir)).toBe(true);
+        expect(isCommandAvailable(path.join(emptyDir, 'npx'), binDir)).toBe(false);
+    });
+
+    it('treats an empty command as unavailable', () => {
+        expect(isCommandAvailable('', binDir)).toBe(false);
+    });
+});

--- a/apps/web-ui/tests/gateway/adapters/slack-adapter.test.ts
+++ b/apps/web-ui/tests/gateway/adapters/slack-adapter.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as crypto from 'crypto';
 import { SlackAdapter } from '@/lib/gateway/adapters/slack-adapter';
 import { TenantConfigService } from '@/lib/tenant-config-service';
+import { getSlackWorkspaceLinkRepository } from '@/lib/db/repository-factory';
 import type { ScheduledTask, AgentOpsRun } from '@/lib/agent-ops/types';
 
 vi.mock('@/lib/tenant-config-service', () => ({
@@ -20,11 +22,26 @@ vi.mock('@/lib/agent-ops/agent-ops-service', () => ({
     },
 }));
 
+// team_id (Slack's workspace id) must be translated to our internal tenantId
+// via SlackWorkspaceLink — it is never usable as a tenantId directly.
+vi.mock('@/lib/db/repository-factory', () => ({
+    getSlackWorkspaceLinkRepository: vi.fn().mockReturnValue({
+        findTenantIdByTeamId: vi.fn().mockResolvedValue('tenant-1'),
+        upsertLink: vi.fn().mockResolvedValue(undefined),
+        getLinkForTenant: vi.fn().mockResolvedValue(null),
+    }),
+}));
+
 describe('SlackAdapter', () => {
     let adapter: SlackAdapter;
 
     beforeEach(() => {
         adapter = new SlackAdapter();
+        vi.mocked(getSlackWorkspaceLinkRepository).mockReturnValue({
+            findTenantIdByTeamId: vi.fn().mockResolvedValue('tenant-1'),
+            upsertLink: vi.fn().mockResolvedValue(undefined),
+            getLinkForTenant: vi.fn().mockResolvedValue(null),
+        } as any);
     });
 
     it('has correct channel metadata', () => {
@@ -50,7 +67,47 @@ describe('SlackAdapter', () => {
         expect(result).toBe(false);
     });
 
-    it('parseInbound extracts slash command fields', async () => {
+    it('rejects requests when team_id has no linked tenant, even with a correct signature', async () => {
+        vi.mocked(getSlackWorkspaceLinkRepository).mockReturnValue({
+            findTenantIdByTeamId: vi.fn().mockResolvedValue(null),
+            upsertLink: vi.fn().mockResolvedValue(undefined),
+            getLinkForTenant: vi.fn().mockResolvedValue(null),
+        } as any);
+        const body = 'text=hello&team_id=T-UNLINKED';
+        const timestamp = Math.floor(Date.now() / 1000).toString();
+        const req = new Request('http://localhost/api/v1/gateway/slack', {
+            method: 'POST',
+            headers: {
+                'x-slack-request-timestamp': timestamp,
+                'x-slack-signature': 'v0=irrelevant-secret-is-empty',
+            },
+            body,
+        });
+        const result = await adapter.validateRequest(req as any);
+        expect(result).toBe(false);
+    });
+
+    it('resolves the signing secret via SlackWorkspaceLink and accepts a valid signature', async () => {
+        const body = 'text=hello&team_id=T789';
+        const timestamp = Math.floor(Date.now() / 1000).toString();
+        const signature = `v0=${crypto
+            .createHmac('sha256', 'test-secret')
+            .update(`v0:${timestamp}:${body}`)
+            .digest('hex')}`;
+        const req = new Request('http://localhost/api/v1/gateway/slack', {
+            method: 'POST',
+            headers: {
+                'x-slack-request-timestamp': timestamp,
+                'x-slack-signature': signature,
+            },
+            body,
+        });
+        const result = await adapter.validateRequest(req as any);
+        expect(result).toBe(true);
+        expect(TenantConfigService.getConfig).toHaveBeenCalledWith('agent-ops-slack', 'tenant-1');
+    });
+
+    it('parseInbound resolves the internal tenantId from team_id via SlackWorkspaceLink', async () => {
         const body = 'text=check+lambdas&user_id=U123&channel_id=C456&response_url=https%3A%2F%2Fhooks.slack.com%2Ftest&team_id=T789&user_name=kartik&channel_name=general';
         const req = new Request('http://localhost/api/v1/gateway/slack', {
             method: 'POST',
@@ -60,11 +117,29 @@ describe('SlackAdapter', () => {
         const msg = await adapter.parseInbound(req as any);
         expect(msg.channelType).toBe('slack');
         expect(msg.taskDescription).toBe('check lambdas');
-        expect(msg.tenantId).toBe('T789');
+        // NOT 'T789' — that's Slack's team_id, not our tenantId
+        expect(msg.tenantId).toBe('tenant-1');
         expect(msg.channelMeta).toMatchObject({
             userId: 'U123',
             channelId: 'C456',
+            teamId: 'T789',
         });
+    });
+
+    it('parseInbound falls back to the raw team_id when no SlackWorkspaceLink exists', async () => {
+        vi.mocked(getSlackWorkspaceLinkRepository).mockReturnValue({
+            findTenantIdByTeamId: vi.fn().mockResolvedValue(null),
+            upsertLink: vi.fn().mockResolvedValue(undefined),
+            getLinkForTenant: vi.fn().mockResolvedValue(null),
+        } as any);
+        const body = 'text=hello&user_id=U123&channel_id=C456&team_id=T999';
+        const req = new Request('http://localhost/api/v1/gateway/slack', {
+            method: 'POST',
+            headers: { 'content-type': 'application/x-www-form-urlencoded' },
+            body,
+        });
+        const msg = await adapter.parseInbound(req as any);
+        expect(msg.tenantId).toBe('T999');
     });
 
     it('parseInbound detects interaction payload as ReplyContext', async () => {

--- a/docs/agent-ops/README.md
+++ b/docs/agent-ops/README.md
@@ -213,6 +213,11 @@ It checks `hilCapabilities` first and falls back to a dashboard URL when the cha
 ### Discord / Jira
 Same pattern — set the platform's interaction/webhook URL to `/api/v1/gateway/{discord|jira}` and paste credentials into the matching settings page.
 
+Note: this is the **Jira gateway channel** (triggers runs from Jira Automation, posts results as issue
+comments — webhook + API token, see the `Jira` row above). It's separate from adding **Atlassian/Jira
+as an MCP tool source** (giving the agent read/write access to Jira issues via the Atlassian Rovo MCP
+server) — for headless auth to that server, see `apps/web-ui/content/docs/jira-integration.mdx`.
+
 ---
 
 ## Adding a brand-new channel (e.g. MS Teams, WhatsApp)

--- a/docs/superpowers/plans/2026-07-14-memory-export.md
+++ b/docs/superpowers/plans/2026-07-14-memory-export.md
@@ -1,0 +1,958 @@
+# Memory Export Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Markdown export (report + portable frontmatter modes, per-memory and export-all) to the agent memory module, mirroring the skills export.
+
+**Architecture:** New `lib/memory-export.ts` with pure builders + thin Blob/zip wrappers (same split as `lib/skill-export.ts`). Shared helpers (`fence`, `anchor`, `downloadBlob`, `downloadText`, `fileSafe`, `yamlScalar`) extracted to `lib/export-utils.ts` and consumed by both export modules. No API or schema change — memory list DTOs already carry the full `value`; export-all paginates the existing `GET /api/agent-memories`.
+
+**Tech Stack:** Next.js 15 App Router, React 19, TanStack Query, Vitest, `jszip` (already a dep, dynamically imported), `sonner` toasts, shadcn `DropdownMenu`.
+
+## Global Constraints
+
+- Run all commands from `apps/web-ui/` unless noted.
+- Vitest single-run: `bunx vitest run <file>` (NOT watch).
+- TypeScript strict; tsc baseline is **182 errors** (pre-existing, none in changed files) — do not increase it.
+- Lint: `bun run lint` — changed source files must introduce zero new errors.
+- Memory `kind` is the `MemoryKind` enum in declaration order: `SEMANTIC`, `EPISODIC`, `PROCEDURAL`.
+- `MemoryRow.value` is `Record<string, unknown>`; render fields by `kind` (see `lib/agent/memory/types.ts`).
+- Embeddings are never in the DTO — nothing to strip.
+- RBAC `authorize('read','Memory')` already gates `GET /api/agent-memories`; no new permission.
+- Export-all scope = whole tenant, no filters (per brainstorm decision).
+- Frontmatter is lean: `kind`, `namespace`, `key`, `category`, `confidence` (omitted when null), `created_at`, `updated_at`. No `tenantId`/`userId`.
+- No raw JSON embedded (user chose "Markdown + frontmatter", not sidecar JSON).
+
+---
+
+## File Structure
+
+| File | Responsibility | Create/Modify |
+|---|---|---|
+| `apps/web-ui/lib/export-utils.ts` | Shared export helpers: `fence`, `anchor`, `downloadBlob`, `downloadText`, `fileSafe`, `yamlScalar` | Create |
+| `apps/web-ui/lib/skill-export.ts` | Import the six helpers from `export-utils` instead of defining them | Modify |
+| `apps/web-ui/lib/memory-export.ts` | Pure builders (`buildMemoryMarkdown`, `buildAllMemoriesMarkdown`, `buildMemoryFile`, `renderValueBody`) + impure wrappers (`exportMemoryToMarkdown`, `exportAllMemoriesToMarkdown`, `exportMemoryToFile`, `exportAllMemoriesToZip`) | Create |
+| `apps/web-ui/lib/memory-export.test.ts` | Vitest unit tests for the pure builders | Create |
+| `apps/web-ui/lib/queries/agent-memories.ts` | Add exported `fetchAllAgentMemories()` (paginated, safety-capped) | Modify |
+| `apps/web-ui/components/memory/memory-client-component.tsx` | Per-row export items + "Export all ▾" toolbar dropdown + handlers/state | Modify |
+
+---
+
+### Task 1: Extract shared helpers to `lib/export-utils.ts`
+
+**Files:**
+- Create: `apps/web-ui/lib/export-utils.ts`
+- Modify: `apps/web-ui/lib/skill-export.ts` (remove the six helper definitions, import them instead)
+- Test: `apps/web-ui/lib/skill-export.test.ts` (existing — must still pass unchanged)
+
+**Interfaces:**
+- Produces (exported from `export-utils.ts`): `fence(content: string, lang?: string): string`, `anchor(text: string): string`, `downloadBlob(blob: Blob, filename: string): void`, `downloadText(content: string, filename: string, mimeType?: string): void`, `fileSafe(text: string, fallback?: string): string`, `yamlScalar(value: string): string`.
+
+- [ ] **Step 1: Create `apps/web-ui/lib/export-utils.ts`**
+
+```typescript
+/**
+ * Shared helpers for Markdown/Blob export modules (skills, memory, and future
+ * exporters). Pure helpers (fence/anchor/fileSafe/yamlScalar) are unit-tested
+ * via their consumers; downloadBlob/downloadText are thin DOM wrappers.
+ */
+
+/**
+ * Wrap content in a code fence that cannot be terminated early: the fence is
+ * one backtick longer than the longest backtick run inside the content.
+ */
+export function fence(content: string, lang = "markdown"): string {
+    const longestRun = content.match(/`+/g)?.reduce((max, run) => Math.max(max, run.length), 0) ?? 0;
+    const marker = "`".repeat(Math.max(3, longestRun + 1));
+    return `${marker}${lang}\n${content}\n${marker}`;
+}
+
+/** GitHub-style heading anchor: lowercase, trim, spaces → hyphens, drop non-alnum. */
+export function anchor(text: string): string {
+    return text.toLowerCase().trim().replace(/[^\w\s-]/g, "").replace(/\s+/g, "-");
+}
+
+/** Trigger a client-side download of a Blob. */
+export function downloadBlob(blob: Blob, filename: string): void {
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+}
+
+/** Trigger a client-side download of `content` as `filename`. */
+export function downloadText(content: string, filename: string, mimeType = "text/markdown;charset=utf-8"): void {
+    downloadBlob(new Blob([content], { type: mimeType }), filename);
+}
+
+/** Lowercase, alnum+hyphen-only, trimmed; falls back to `fallback` (default "item") when empty. */
+export function fileSafe(text: string, fallback = "item"): string {
+    return text.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || fallback;
+}
+
+/**
+ * Emit a YAML scalar safe to embed in frontmatter. Single-line values use
+ * double-quoted form (backslash + double-quote escaped); multi-line values use
+ * a block scalar so newlines are preserved verbatim.
+ */
+export function yamlScalar(value: string): string {
+    const v = value ?? "";
+    if (v.includes("\n")) {
+        const indented = v.split("\n").map((l) => `  ${l}`).join("\n");
+        return `|-\n${indented}`;
+    }
+    return `"${v.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+```
+
+- [ ] **Step 2: Refactor `apps/web-ui/lib/skill-export.ts` to import the helpers**
+
+Replace the six local helper definitions (the `fence` function at lines 13–21, `anchor` at 23–26, `downloadBlob` at 76–86, `downloadText` at 88–91, `fileSafe` at 93–95, `yamlScalar` at 97–109) with a single import. Keep everything else (the `build*`/`export*` functions) byte-identical.
+
+Change the top of the file so the import block reads:
+
+```typescript
+import type { SkillDTO } from "@/lib/client-skill-service";
+import { fence, anchor, downloadBlob, downloadText, fileSafe, yamlScalar } from "@/lib/export-utils";
+```
+
+Delete the now-duplicated `function fence(...)`, `function anchor(...)`, `function downloadBlob(...)`, `function downloadText(...)`, `function fileSafe(...)`, and `function yamlScalar(...)` definitions from `skill-export.ts`. The `buildSkillMarkdown`, `buildAllSkillsMarkdown`, `buildSkillFile`, and the four `export*` functions remain unchanged and continue to call these names (now imported).
+
+Note: `fileSafe`'s empty-input fallback changes from `"skill"` to `"item"`. This is unreachable in practice (skills require a non-empty `name`), and no existing test exercises an empty name, so `skill-export.test.ts` stays green.
+
+- [ ] **Step 3: Run the existing skill-export tests to confirm no regression**
+
+Run: `cd apps/web-ui && bunx vitest run lib/skill-export.test.ts`
+Expected: `Test Files 1 passed (1)` / `Tests 17 passed (17)`.
+
+- [ ] **Step 4: Typecheck + lint the two files**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep -E "export-utils|skill-export"`
+Expected: no output (zero errors in these files).
+
+Run: `cd apps/web-ui && bun run lint 2>&1 | grep -E "export-utils|skill-export\.ts"`
+Expected: no output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web-ui/lib/export-utils.ts apps/web-ui/lib/skill-export.ts
+git commit -m "refactor(export): extract shared markdown/blob helpers to lib/export-utils.ts
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `renderValueBody` + `buildMemoryMarkdown` (report, single)
+
+**Files:**
+- Create: `apps/web-ui/lib/memory-export.ts`
+- Test: `apps/web-ui/lib/memory-export.test.ts`
+
+**Interfaces:**
+- Consumes: `MemoryRow` from `@/lib/queries/agent-memories`; `MemoryKind` from `@/lib/agent/memory/types`; `fence` not needed yet (body is prose); no helpers needed for this task.
+- Produces: `buildMemoryMarkdown(memory: MemoryRow): string` (pure) and the module-private `renderValueBody(memory: MemoryRow): string` (pure).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/web-ui/lib/memory-export.test.ts`:
+
+```typescript
+/**
+ * Unit tests for the Memory → Markdown export builders. Mirrors
+ * lib/skill-export.test.ts: only the pure builders are tested; the Blob/zip
+ * wrappers are thin DOM code identical to skill-export's.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildMemoryMarkdown } from './memory-export';
+import type { MemoryRow } from './queries/agent-memories';
+
+function makeMemory(overrides: Partial<MemoryRow> = {}): MemoryRow {
+    return {
+        id: 'cm1a2b3c',
+        userId: 'user-1',
+        namespace: 'infra:ec2',
+        category: 'infra',
+        key: 'prod-stop-schedule',
+        fact: 'Prod EC2 stops at 7pm.',
+        source: 'scheduler-discovery-2026-07',
+        confidence: 'high',
+        value: { fact: 'Prod EC2 stops at 7pm.', source: 'scheduler-discovery-2026-07', confidence: 'high' },
+        kind: 'SEMANTIC',
+        sourceThreadId: null,
+        createdAt: '2026-07-13T00:00:00.000Z',
+        updatedAt: '2026-07-13T00:00:00.000Z',
+        expiresAt: '2026-10-11T00:00:00.000Z',
+        supersededById: null,
+        supersededAt: null,
+        ...overrides,
+    };
+}
+
+describe('buildMemoryMarkdown', () => {
+    it('renders the key as H1 and a metadata table', () => {
+        const md = buildMemoryMarkdown(makeMemory());
+        expect(md).toContain('# prod-stop-schedule');
+        expect(md).toContain('| Kind | SEMANTIC |');
+        expect(md).toContain('| Namespace | infra:ec2 |');
+        expect(md).toContain('| Category | infra |');
+        expect(md).toContain('| Confidence | high |');
+        expect(md).toContain('| Source | scheduler-discovery-2026-07 |');
+        expect(md).toContain('| Created | 2026-07-13T00:00:00.000Z |');
+    });
+
+    it('uses an em-dash for null confidence and source', () => {
+        const md = buildMemoryMarkdown(makeMemory({ confidence: null, source: null }));
+        expect(md).toContain('| Confidence | — |');
+        expect(md).toContain('| Source | — |');
+    });
+
+    it('renders the superseded-by row', () => {
+        const md = buildMemoryMarkdown(makeMemory({ supersededById: 'cm999' }));
+        expect(md).toContain('| Superseded by | cm999 |');
+    });
+
+    it('renders SEMANTIC value body as Fact/Source/Confidence', () => {
+        const md = buildMemoryMarkdown(makeMemory({ kind: 'SEMANTIC' }));
+        expect(md).toContain('**Fact:** Prod EC2 stops at 7pm.');
+        expect(md).toContain('**Source:** scheduler-discovery-2026-07');
+        expect(md).toContain('**Confidence:** high');
+    });
+
+    it('renders EPISODIC value body as Context/Reasoning/Action/Outcome', () => {
+        const md = buildMemoryMarkdown(
+            makeMemory({
+                kind: 'EPISODIC',
+                confidence: null,
+                value: { context: 'High CPU', reasoning: 'Scale up', action: 'Bumped ASG max', outcome: 'CPU normalized' },
+            })
+        );
+        expect(md).toContain('**Context:** High CPU');
+        expect(md).toContain('**Reasoning:** Scale up');
+        expect(md).toContain('**Action:** Bumped ASG max');
+        expect(md).toContain('**Outcome:** CPU normalized');
+    });
+
+    it('renders PROCEDURAL value body as Instruction/Trigger/Evidence/Confidence', () => {
+        const md = buildMemoryMarkdown(
+            makeMemory({
+                kind: 'PROCEDURAL',
+                confidence: 'medium',
+                value: { instruction: 'Restart RDS', trigger: 'failover event', evidence: 'worked 3x', confidence: 'medium' },
+            })
+        );
+        expect(md).toContain('**Instruction:** Restart RDS');
+        expect(md).toContain('**Trigger:** failover event');
+        expect(md).toContain('**Evidence:** worked 3x');
+        expect(md).toContain('**Confidence:** medium');
+    });
+
+    it('renders an em-dash for missing value fields', () => {
+        const md = buildMemoryMarkdown(
+            makeMemory({ kind: 'EPISODIC', confidence: null, value: { context: 'only context' } })
+        );
+        expect(md).toContain('**Context:** only context');
+        expect(md).toContain('**Reasoning:** —');
+        expect(md).toContain('**Action:** —');
+        expect(md).toContain('**Outcome:** —');
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/web-ui && bunx vitest run lib/memory-export.test.ts`
+Expected: FAIL — "Failed to resolve import './memory-export'" (module not created yet).
+
+- [ ] **Step 3: Create `apps/web-ui/lib/memory-export.ts` with the builders**
+
+```typescript
+/**
+ * Memory → Markdown export.
+ *
+ * Mirrors lib/skill-export.ts: buildMemoryMarkdown()/buildAllMemoriesMarkdown()
+ * are the pure cores of the human-readable "report" export;
+ * buildMemoryFile() is the pure core of the portable frontmatter export (for
+ * reuse with other AI tools). export*ToMarkdown()/exportAllMemoriesToZip() wrap
+ * them in Blob/zip downloads. Embeddings are never in the MemoryRow DTO, so
+ * there is nothing to strip.
+ */
+
+import type { MemoryRow } from "@/lib/queries/agent-memories";
+import type { MemoryKind } from "@/lib/agent/memory/types";
+// `fence` is intentionally NOT imported: memory bodies are prose, never fenced.
+// The other helpers come online in later tasks (anchor in Task 3, yamlScalar in
+// Task 4, the download/fileSafe trio in Task 5). Unused-import warnings are
+// non-failing (noUnusedLocals=false; lint no-unused-vars is a warning), so
+// importing them all up front is safe and avoids repeated edits to this line.
+import { anchor, downloadBlob, downloadText, fileSafe, yamlScalar } from "@/lib/export-utils";
+
+const KIND_ORDER: MemoryKind[] = ["SEMANTIC", "EPISODIC", "PROCEDURAL"];
+
+/** Read a string field from the raw `value` JSON, or "—" if absent/empty. */
+function field(value: Record<string, unknown>, key: string): string {
+    const v = value?.[key];
+    return typeof v === "string" && v.length ? v : "—";
+}
+
+/**
+ * Render the kind-specific `value` fields as labeled Markdown prose. Shared by
+ * the report and portable builders so they never drift. Pure.
+ */
+function renderValueBody(memory: MemoryRow): string {
+    const v = memory.value ?? {};
+    switch (memory.kind) {
+        case "SEMANTIC":
+            return [
+                `**Fact:** ${field(v, "fact")}`,
+                `**Source:** ${field(v, "source")}`,
+                `**Confidence:** ${memory.confidence ?? "—"}`,
+                "",
+            ].join("\n");
+        case "EPISODIC":
+            return [
+                `**Context:** ${field(v, "context")}`,
+                `**Reasoning:** ${field(v, "reasoning")}`,
+                `**Action:** ${field(v, "action")}`,
+                `**Outcome:** ${field(v, "outcome")}`,
+                "",
+            ].join("\n");
+        case "PROCEDURAL":
+            return [
+                `**Instruction:** ${field(v, "instruction")}`,
+                `**Trigger:** ${field(v, "trigger")}`,
+                `**Evidence:** ${field(v, "evidence")}`,
+                `**Confidence:** ${memory.confidence ?? "—"}`,
+                "",
+            ].join("\n");
+        default:
+            return "";
+    }
+}
+
+/** Build the human-readable Markdown report for a single memory. Pure. */
+export function buildMemoryMarkdown(memory: MemoryRow): string {
+    const lines: string[] = [
+        `# ${memory.key}`,
+        "",
+        "| Field | Value |",
+        "| --- | --- |",
+        `| Kind | ${memory.kind} |`,
+        `| Namespace | ${memory.namespace} |`,
+        `| Category | ${memory.category} |`,
+        `| Confidence | ${memory.confidence ?? "—"} |`,
+        `| Source | ${memory.source ?? "—"} |`,
+        `| Created | ${memory.createdAt} |`,
+        `| Updated | ${memory.updatedAt} |`,
+        `| Superseded by | ${memory.supersededById ?? "—"} |`,
+        "",
+        renderValueBody(memory),
+    ];
+    return lines.join("\n");
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/web-ui && bunx vitest run lib/memory-export.test.ts`
+Expected: PASS — `Tests 8 passed (8)`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web-ui/lib/memory-export.ts apps/web-ui/lib/memory-export.test.ts
+git commit -m "feat(memory): add buildMemoryMarkdown report builder + kind-aware body
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `buildAllMemoriesMarkdown` (report, all)
+
+**Files:**
+- Modify: `apps/web-ui/lib/memory-export.ts` (add `buildAllMemoriesMarkdown`)
+- Test: `apps/web-ui/lib/memory-export.test.ts` (append tests)
+
+**Interfaces:**
+- Consumes: `buildMemoryMarkdown` from Task 2; `anchor` from `export-utils`; `KIND_ORDER` defined in Task 2.
+- Produces: `buildAllMemoriesMarkdown(memories: MemoryRow[]): string` (pure).
+
+- [ ] **Step 1: Append the failing tests**
+
+Add to `apps/web-ui/lib/memory-export.test.ts` (update the `import` line to also import `buildAllMemoriesMarkdown`):
+
+```typescript
+import { buildMemoryMarkdown, buildAllMemoriesMarkdown } from './memory-export';
+```
+
+Append this `describe` block at the end of the file:
+
+```typescript
+describe('buildAllMemoriesMarkdown', () => {
+    it('renders a header with the record count', () => {
+        const md = buildAllMemoriesMarkdown([makeMemory(), makeMemory({ id: 'b', key: 'second' })]);
+        expect(md).toContain('# Memory export');
+        expect(md).toContain('Exported 2 memory record(s).');
+    });
+
+    it('renders an empty-state message when there are no memories', () => {
+        const md = buildAllMemoriesMarkdown([]);
+        expect(md).toContain('Exported 0 memory record(s).');
+        expect(md).toContain('_No memories to export._');
+    });
+
+    it('groups the table of contents by kind in enum order', () => {
+        const md = buildAllMemoriesMarkdown([
+            makeMemory({ id: 'p', key: 'proc', kind: 'PROCEDURAL' }),
+            makeMemory({ id: 's', key: 'sem', kind: 'SEMANTIC' }),
+            makeMemory({ id: 'e', key: 'ep', kind: 'EPISODIC' }),
+        ]);
+        expect(md).toContain('### SEMANTIC');
+        expect(md).toContain('### EPISODIC');
+        expect(md).toContain('### PROCEDURAL');
+        expect(md.indexOf('### SEMANTIC')).toBeLessThan(md.indexOf('### EPISODIC'));
+        expect(md.indexOf('### EPISODIC')).toBeLessThan(md.indexOf('### PROCEDURAL'));
+    });
+
+    it('links TOC entries to key anchors', () => {
+        const md = buildAllMemoriesMarkdown([makeMemory({ key: 'prod-stop-schedule' })]);
+        expect(md).toContain('- [prod-stop-schedule](#prod-stop-schedule)');
+    });
+
+    it('sorts memories within a kind by createdAt descending', () => {
+        const md = buildAllMemoriesMarkdown([
+            makeMemory({ id: 'old', key: 'old', kind: 'SEMANTIC', createdAt: '2026-01-01T00:00:00.000Z' }),
+            makeMemory({ id: 'new', key: 'new', kind: 'SEMANTIC', createdAt: '2026-07-01T00:00:00.000Z' }),
+        ]);
+        expect(md.indexOf('# new')).toBeLessThan(md.indexOf('# old'));
+    });
+
+    it('separates each memory with a horizontal rule and includes bodies', () => {
+        const md = buildAllMemoriesMarkdown([
+            makeMemory({ id: 'a', key: 'alpha' }),
+            makeMemory({ id: 'b', key: 'beta' }),
+        ]);
+        expect(md).toContain('# alpha');
+        expect(md).toContain('# beta');
+        expect(md).toContain('\n---\n');
+    });
+
+    it('omits a kind group entirely when no memories of that kind exist', () => {
+        const md = buildAllMemoriesMarkdown([makeMemory({ kind: 'PROCEDURAL' })]);
+        expect(md).not.toContain('### SEMANTIC');
+        expect(md).toContain('### PROCEDURAL');
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/web-ui && bunx vitest run lib/memory-export.test.ts`
+Expected: FAIL — `buildAllMemoriesMarkdown is not exported from ./memory-export` (or resolve error).
+
+- [ ] **Step 3: Implement `buildAllMemoriesMarkdown` in `apps/web-ui/lib/memory-export.ts`**
+
+Append after `buildMemoryMarkdown`:
+
+```typescript
+/** Build the combined human-readable Markdown report for all memories (TOC + each memory). Pure. */
+export function buildAllMemoriesMarkdown(memories: MemoryRow[]): string {
+    const header: string[] = [
+        "# Memory export",
+        "",
+        `Exported ${memories.length} memory record(s).`,
+        "",
+    ];
+    if (memories.length === 0) {
+        header.push("_No memories to export._", "");
+        return header.join("\n");
+    }
+    const byKind = new Map<MemoryKind, MemoryRow[]>();
+    for (const m of memories) {
+        const arr = byKind.get(m.kind) ?? [];
+        arr.push(m);
+        byKind.set(m.kind, arr);
+    }
+    for (const arr of byKind.values()) {
+        arr.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+    }
+    header.push("## Table of contents", "");
+    for (const kind of KIND_ORDER) {
+        const arr = byKind.get(kind);
+        if (!arr || arr.length === 0) continue;
+        header.push(`### ${kind}`, "");
+        for (const m of arr) header.push(`- [${m.key}](#${anchor(m.key)})`);
+        header.push("");
+    }
+    header.push("---", "");
+    const body: string[] = [];
+    for (const kind of KIND_ORDER) {
+        const arr = byKind.get(kind);
+        if (!arr || arr.length === 0) continue;
+        for (const m of arr) {
+            body.push(buildMemoryMarkdown(m), "---", "");
+        }
+    }
+    return `${header.join("\n")}\n${body.join("\n")}`;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/web-ui && bunx vitest run lib/memory-export.test.ts`
+Expected: PASS — `Tests 15 passed (15)` (8 from Task 2 + 7 here).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web-ui/lib/memory-export.ts apps/web-ui/lib/memory-export.test.ts
+git commit -m "feat(memory): add buildAllMemoriesMarkdown combined report builder
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: `buildMemoryFile` (portable, single)
+
+**Files:**
+- Modify: `apps/web-ui/lib/memory-export.ts` (add `buildMemoryFile`)
+- Test: `apps/web-ui/lib/memory-export.test.ts` (append tests)
+
+**Interfaces:**
+- Consumes: `renderValueBody` (module-private, Task 2); `yamlScalar` from `export-utils`.
+- Produces: `buildMemoryFile(memory: MemoryRow): string` (pure) — YAML frontmatter + kind-aware body.
+
+- [ ] **Step 1: Append the failing tests**
+
+Update the import line in `apps/web-ui/lib/memory-export.test.ts`:
+
+```typescript
+import { buildMemoryMarkdown, buildAllMemoriesMarkdown, buildMemoryFile } from './memory-export';
+```
+
+Append:
+
+```typescript
+describe('buildMemoryFile (portable frontmatter)', () => {
+    it('emits YAML frontmatter delimited by --- fences', () => {
+        const md = buildMemoryFile(makeMemory());
+        expect(md.startsWith('---\n')).toBe(true);
+        expect(md).toMatch(/\n---\n/);
+    });
+
+    it('places kind, namespace, key, category, created_at, updated_at in frontmatter', () => {
+        const md = buildMemoryFile(makeMemory());
+        expect(md).toContain('kind: SEMANTIC');
+        expect(md).toContain('namespace: "infra:ec2"');
+        expect(md).toContain('key: "prod-stop-schedule"');
+        expect(md).toContain('category: infra');
+        expect(md).toContain('created_at: 2026-07-13T00:00:00.000Z');
+        expect(md).toContain('updated_at: 2026-07-13T00:00:00.000Z');
+    });
+
+    it('includes confidence when present', () => {
+        const md = buildMemoryFile(makeMemory({ confidence: 'high' }));
+        expect(md).toContain('confidence: high');
+    });
+
+    it('omits the confidence line when null', () => {
+        const md = buildMemoryFile(makeMemory({ confidence: null }));
+        expect(md).not.toMatch(/^confidence:/m);
+    });
+
+    it('puts the kind-aware body after the frontmatter', () => {
+        const md = buildMemoryFile(makeMemory({ kind: 'SEMANTIC' }));
+        const bodyStart = md.indexOf('\n---\n') + '\n---\n'.length;
+        const body = md.slice(bodyStart);
+        expect(body).toContain('**Fact:** Prod EC2 stops at 7pm.');
+        expect(body).toContain('**Source:** scheduler-discovery-2026-07');
+        expect(body).toContain('**Confidence:** high');
+    });
+
+    it('escapes double quotes and backslashes in namespace/key', () => {
+        const md = buildMemoryFile(makeMemory({ namespace: 'a"b', key: 'c\\d' }));
+        expect(md).toContain('namespace: "a\\"b"');
+        expect(md).toContain('key: "c\\\\d"');
+    });
+
+    it('uses a YAML block scalar for multi-line namespaces', () => {
+        const md = buildMemoryFile(makeMemory({ namespace: 'line one\nline two' }));
+        expect(md).toContain('namespace: |-\n  line one\n  line two');
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/web-ui && bunx vitest run lib/memory-export.test.ts`
+Expected: FAIL — `buildMemoryFile is not exported`.
+
+- [ ] **Step 3: Implement `buildMemoryFile` in `apps/web-ui/lib/memory-export.ts`**
+
+Append:
+
+```typescript
+/**
+ * Build a portable `.md` for a memory: YAML frontmatter (kind, namespace, key,
+ * category, confidence, created_at, updated_at) + the kind-aware `value` body.
+ * Re-importable by other AI tools that read Markdown + frontmatter. Pure.
+ */
+export function buildMemoryFile(memory: MemoryRow): string {
+    const fm: string[] = [
+        "---",
+        `kind: ${memory.kind}`,
+        `namespace: ${yamlScalar(memory.namespace)}`,
+        `key: ${yamlScalar(memory.key)}`,
+        `category: ${memory.category}`,
+    ];
+    if (memory.confidence) fm.push(`confidence: ${memory.confidence}`);
+    fm.push(`created_at: ${memory.createdAt}`, `updated_at: ${memory.updatedAt}`, "---", "");
+    return `${fm.join("\n")}\n${renderValueBody(memory)}`;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/web-ui && bunx vitest run lib/memory-export.test.ts`
+Expected: PASS — `Tests 22 passed (22)` (15 + 7).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web-ui/lib/memory-export.ts apps/web-ui/lib/memory-export.test.ts
+git commit -m "feat(memory): add buildMemoryFile portable frontmatter builder
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Impure wrappers (Blob + zip downloads)
+
+**Files:**
+- Modify: `apps/web-ui/lib/memory-export.ts` (add the four `export*` functions)
+
+**Interfaces:**
+- Consumes: `buildMemoryMarkdown`, `buildAllMemoriesMarkdown`, `buildMemoryFile` (Tasks 2–4); `downloadText`, `downloadBlob`, `fileSafe` from `export-utils`; dynamic `import("jszip")`.
+- Produces: `exportMemoryToMarkdown(memory: MemoryRow): void`, `exportAllMemoriesToMarkdown(memories: MemoryRow[]): void`, `exportMemoryToFile(memory: MemoryRow): void`, `exportAllMemoriesToZip(memories: MemoryRow[]): Promise<void>`.
+
+These are thin DOM/Blob wrappers (no unit tests — identical pattern to `skill-export.ts`).
+
+- [ ] **Step 1: Append the four wrappers to `apps/web-ui/lib/memory-export.ts`**
+
+```typescript
+/** Download a single memory as a human-readable `.md` report. Impure (DOM + Blob). */
+export function exportMemoryToMarkdown(memory: MemoryRow): void {
+    downloadText(buildMemoryMarkdown(memory), `${fileSafe(memory.key, memory.id)}.md`);
+}
+
+/** Download all memories as a single combined `.md` report. Impure (DOM + Blob). */
+export function exportAllMemoriesToMarkdown(memories: MemoryRow[]): void {
+    downloadText(buildAllMemoriesMarkdown(memories), `memory-export-${new Date().toISOString().slice(0, 10)}.md`);
+}
+
+/** Download a single memory as a portable frontmatter `.md` file. Impure (DOM + Blob). */
+export function exportMemoryToFile(memory: MemoryRow): void {
+    downloadText(buildMemoryFile(memory), `${fileSafe(memory.key, memory.id)}.md`);
+}
+
+/**
+ * Download all memories as a `.zip` of portable frontmatter files, one per memory
+ * at `memories/<KIND>/<id>.md`, grouped into per-kind folders so a consuming
+ * tool can ingest by kind. jszip is dynamically imported so it stays out of the
+ * main bundle. Impure (DOM + Blob + dynamic import).
+ */
+export async function exportAllMemoriesToZip(memories: MemoryRow[]): Promise<void> {
+    const JSZip = (await import("jszip")).default;
+    const zip = new JSZip();
+    const root = zip.folder("memories");
+    if (!root) throw new Error("Failed to create memories folder in zip");
+    const ordered = KIND_ORDER.flatMap((kind) => memories.filter((m) => m.kind === kind));
+    for (const m of ordered) root.file(`${m.kind}/${m.id}.md`, buildMemoryFile(m));
+    const blob = await zip.generateAsync({ type: "blob" });
+    downloadBlob(blob, `memories-export-${new Date().toISOString().slice(0, 10)}.zip`);
+}
+```
+
+- [ ] **Step 2: Typecheck + lint the wrappers**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep -E "memory-export"`
+Expected: no output.
+
+Run: `cd apps/web-ui && bun run lint 2>&1 | grep -E "memory-export\.ts"`
+Expected: no output (unused-import warnings from earlier tasks are non-falling; by end of Task 5 all of `anchor/yamlScalar/downloadBlob/downloadText/fileSafe` are used).
+
+- [ ] **Step 3: Re-run the pure-builder tests (must stay green)**
+
+Run: `cd apps/web-ui && bunx vitest run lib/memory-export.test.ts`
+Expected: `Tests 22 passed (22)`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web-ui/lib/memory-export.ts
+git commit -m "feat(memory): add Blob + zip export wrappers (report + portable)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: `fetchAllAgentMemories` (paginated, safety-capped)
+
+**Files:**
+- Modify: `apps/web-ui/lib/queries/agent-memories.ts` (add exported function)
+
+**Interfaces:**
+- Consumes: `MemoryRow` (defined in this file); `GET /api/agent-memories?limit=&page=&sort=createdAt&dir=asc` (RBAC `authorize('read','Memory')` already enforced).
+- Produces: `fetchAllAgentMemories(): Promise<{ memories: MemoryRow[]; total: number }>` — exported, non-hook.
+
+- [ ] **Step 1: Add the function to `apps/web-ui/lib/queries/agent-memories.ts`**
+
+Append at the end of the file (after `useDeleteAgentMemory`):
+
+```typescript
+/**
+ * Fetch every memory in the tenant for export-all, paging through
+ * GET /api/agent-memories until the known `total` is reached. Safety-capped at
+ * MAX_PAGES so an unexpected runaway cannot loop forever; callers compare
+ * `memories.length < total` to detect truncation and warn. Not a hook — call
+ * from an event handler, not render.
+ */
+export async function fetchAllAgentMemories(): Promise<{ memories: MemoryRow[]; total: number }> {
+    const LIMIT = 500;
+    const MAX_PAGES = 100;
+    const memories: MemoryRow[] = [];
+    let total = 0;
+    for (let page = 1; page <= MAX_PAGES; page++) {
+        const res = await fetch(`/api/agent-memories?limit=${LIMIT}&page=${page}&sort=createdAt&dir=asc`);
+        const json = await res.json();
+        if (!res.ok || !json.success) {
+            throw new Error(json.error || 'Failed to load memories');
+        }
+        const rows = json.data as MemoryRow[];
+        total = json.total ?? 0;
+        memories.push(...rows);
+        if (rows.length < LIMIT || memories.length >= total) break;
+    }
+    return { memories, total };
+}
+```
+
+- [ ] **Step 2: Typecheck + lint**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep -E "agent-memories"`
+Expected: no output.
+
+Run: `cd apps/web-ui && bun run lint 2>&1 | grep -E "queries/agent-memories"`
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web-ui/lib/queries/agent-memories.ts
+git commit -m "feat(memory): add fetchAllAgentMemories paginated tenant-wide fetch for export
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Wire the UI — per-row export + "Export all" dropdown
+
+**Files:**
+- Modify: `apps/web-ui/components/memory/memory-client-component.tsx`
+
+**Interfaces:**
+- Consumes: `exportMemoryToMarkdown`, `exportMemoryToFile`, `exportAllMemoriesToMarkdown`, `exportAllMemoriesToZip` from `@/lib/memory-export`; `fetchAllAgentMemories` from `@/lib/queries/agent-memories`; lucide icons `Download`, `FileDown`, `FileCode`, `FileArchive`, `ChevronDown`, `Loader2`.
+
+- [ ] **Step 1: Update imports**
+
+In `apps/web-ui/components/memory/memory-client-component.tsx`:
+
+Change the lucide import (line 5) to add the new icons:
+
+```typescript
+import { Brain, MoreHorizontal, Eye, Trash2, Search, X, Sparkles, Download, FileDown, FileCode, FileArchive, ChevronDown, Loader2 } from "lucide-react";
+```
+
+Add imports after the existing `@/lib/queries/agent-memories` import block (after line 26):
+
+```typescript
+import { fetchAllAgentMemories } from "@/lib/queries/agent-memories";
+import {
+    exportMemoryToMarkdown,
+    exportMemoryToFile,
+    exportAllMemoriesToMarkdown,
+    exportAllMemoriesToZip,
+} from "@/lib/memory-export";
+```
+
+- [ ] **Step 2: Add `exporting` state + the export-all handler**
+
+Inside `MemoryClientComponent()`, after the `promote` state (line 62), add:
+
+```typescript
+    const [exporting, setExporting] = useState(false);
+```
+
+After the `handleDelete` function (after line 112), add:
+
+```typescript
+    const runExportAll = async (mode: "report" | "zip") => {
+        if (exporting) return;
+        setExporting(true);
+        try {
+            const { memories, total } = await fetchAllAgentMemories();
+            if (memories.length === 0) {
+                toast.error("Nothing to export", { description: "No memories found." });
+                return;
+            }
+            if (memories.length < total) {
+                toast.warning("Export truncated", {
+                    description: `Exported ${memories.length} of ${total} records (safety cap).`,
+                });
+            }
+            if (mode === "report") {
+                exportAllMemoriesToMarkdown(memories);
+                toast.success("Memories exported", { description: `${memories.length} record(s) downloaded` });
+            } else {
+                await exportAllMemoriesToZip(memories);
+                toast.success("Memories exported", { description: `${memories.length} file(s) zipped` });
+            }
+        } catch (e) {
+            toast.error("Export failed", { description: e instanceof Error ? e.message : "Try again" });
+        } finally {
+            setExporting(false);
+        }
+    };
+```
+
+- [ ] **Step 3: Add the per-row export menu items**
+
+In the actions column's `DropdownMenuContent` (between the `PROCEDURAL` promote block ending at line 216 `) : null}` and the Delete `DropdownMenuItem` at line 217), insert two items. The block should read:
+
+```tsx
+                                    {m.kind === "PROCEDURAL" ? (
+                                        <DropdownMenuItem
+                                            onClick={() => {
+                                                const draft = buildSkillDraftFromMemory(m);
+                                                if (draft) {
+                                                    setPromote({ draft, sourceRunId: m.sourceThreadId ?? null });
+                                                } else {
+                                                    toast.error("This memory is missing rule fields and can't be promoted");
+                                                }
+                                            }}
+                                        >
+                                            <Sparkles className="mr-2 h-4 w-4" />
+                                            Promote to skill
+                                        </DropdownMenuItem>
+                                    ) : null}
+                                    <DropdownMenuItem
+                                        onClick={() => {
+                                            try {
+                                                exportMemoryToMarkdown(m);
+                                                toast.success("Memory exported", { description: `${m.key}.md downloaded` });
+                                            } catch (e) {
+                                                toast.error("Export failed", { description: e instanceof Error ? e.message : "Try again" });
+                                            }
+                                        }}
+                                    >
+                                        <FileDown className="mr-2 h-4 w-4" />
+                                        Export markdown
+                                    </DropdownMenuItem>
+                                    <DropdownMenuItem
+                                        onClick={() => {
+                                            try {
+                                                exportMemoryToFile(m);
+                                                toast.success("Memory file exported", { description: `${m.key}.md downloaded` });
+                                            } catch (e) {
+                                                toast.error("Export failed", { description: e instanceof Error ? e.message : "Try again" });
+                                            }
+                                        }}
+                                    >
+                                        <FileCode className="mr-2 h-4 w-4" />
+                                        Export memory (.md)
+                                    </DropdownMenuItem>
+                                    <DropdownMenuItem
+                                        onClick={() => setDeleteTarget(m)}
+                                        className="text-destructive"
+                                    >
+                                        <Trash2 className="mr-2 h-4 w-4" />
+                                        Delete
+                                    </DropdownMenuItem>
+```
+
+(These per-row handlers are inlined so they only close over stable imports `exportMemoryToMarkdown`/`exportMemoryToFile`/`toast` and the row `m` — they add no new dependencies to the `columns` `useMemo`, whose deps stay `[]`.)
+
+- [ ] **Step 4: Add the "Export all ▾" dropdown to the toolbar `header`**
+
+In the `header` prop's flex container (the `<div className="flex flex-wrap items-center gap-2">` starting at line 262), add the dropdown after the `hasFilters && (...)` Reset block (after line 288, before the closing `</div>` at line 289):
+
+```tsx
+                        <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                                <Button variant="outline" size="sm" disabled={exporting || total === 0} className="h-9">
+                                    {exporting ? (
+                                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                    ) : (
+                                        <Download className="mr-2 h-4 w-4" />
+                                    )}
+                                    Export all
+                                    <ChevronDown className="ml-1 h-4 w-4" />
+                                </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end">
+                                <DropdownMenuItem onClick={() => runExportAll("report")}>
+                                    <FileDown className="mr-2 h-4 w-4" />
+                                    Markdown (one file)
+                                </DropdownMenuItem>
+                                <DropdownMenuItem onClick={() => runExportAll("zip")}>
+                                    <FileArchive className="mr-2 h-4 w-4" />
+                                    Portable .md (zip)
+                                </DropdownMenuItem>
+                            </DropdownMenuContent>
+                        </DropdownMenu>
+```
+
+- [ ] **Step 5: Typecheck + lint the component**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep -E "memory-client-component"`
+Expected: no output.
+
+Run: `cd apps/web-ui && bun run lint 2>&1 | grep -E "memory-client-component"`
+Expected: no output.
+
+- [ ] **Step 6: Run the full memory-export test suite once more (sanity)**
+
+Run: `cd apps/web-ui && bunx vitest run lib/memory-export.test.ts lib/skill-export.test.ts`
+Expected: both files pass (22 + 17 = 39 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web-ui/components/memory/memory-client-component.tsx
+git commit -m "feat(memory): add per-memory + export-all Markdown/zip export to memory grid
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Final verification (after Task 7)
+
+- [ ] `cd apps/web-ui && bunx vitest run lib/memory-export.test.ts lib/skill-export.test.ts` → all pass.
+- [ ] `cd apps/web-ui && bunx tsc --noEmit -p tsconfig.json 2>&1 | grep -cE "error TS"` → 182 (unchanged baseline).
+- [ ] `cd apps/web-ui && bun run lint 2>&1 | grep -E "memory-export|export-utils|skill-export\.ts|memory-client-component|queries/agent-memories"` → no output.
+
+## Out of scope
+
+- Server-side export endpoint (Approach C) — not needed until large-tenant volume is real.
+- JSON / sidecar JSON portable format — deliberately not shipped.
+- Re-import / restore — outbound reuse only.

--- a/docs/superpowers/specs/2026-07-14-memory-export-design.md
+++ b/docs/superpowers/specs/2026-07-14-memory-export-design.md
@@ -1,0 +1,159 @@
+# Memory Export — Design
+
+**Date:** 2026-07-14
+**Branch:** `agent-ops`
+**Status:** Approved (brainstorm)
+**Depends on:** existing memory module (`/app/memory`, `/api/agent-memories`, `lib/agent/memory/*`) and the just-shipped skills export (`lib/skill-export.ts`).
+
+## Goal
+
+Add Markdown export to the agent memory module — both per-memory (from the grid's row actions) and export-all (from the toolbar) — in two formats:
+
+1. **Report Markdown** — a human/LLM-readable document (single memory, or a combined doc for all).
+2. **Portable Markdown + YAML frontmatter** — one `.md` per memory following a defined convention so memories can be **reused with other AI tools**. Export-all bundles these as a zip.
+
+This mirrors the skills export's dual-mode pattern (`skill-export.ts`).
+
+## Background & constraints
+
+- Memory UI is a TanStack `DataTable` grid at `/app/memory` (`components/memory/memory-client-component.tsx`) with a per-row actions dropdown (View details / Promote to skill / Delete) and a toolbar `header` (search + category faceted filter + Reset).
+- `AgentMemory` is **kind-discriminated** (`MemoryKind`: `SEMANTIC` | `EPISODIC` | `PROCEDURAL`); the `value: Json` shape depends on `kind`:
+  - `SemanticValue { fact, source, confidence }`
+  - `EpisodicValue { context, reasoning, action, outcome }`
+  - `ProceduralValue { instruction, trigger, evidence, confidence? }`
+- The memory **list DTO already includes the full `value`** (`AgentMemoryRecord` / `MemoryRow`). Unlike skills, **no `withContent`-style round-trip is needed**; per-memory export uses row data already in hand.
+- **Embeddings are never in the DTO** — the `embedding` column is `Unsupported("vector(1024)")` in Prisma and structurally excluded from the client type and repository mapper. There is nothing to strip from exports.
+- RBAC subject is `'Memory'` (module `'AIOps'`); `authorize('read', 'Memory')` already gates `GET /api/agent-memories`. Export is a read; **no new permission**.
+- Decisions confirmed during brainstorm:
+  - **Purpose:** reuse memories with other AI tools → portable format required.
+  - **Portable format:** Markdown + YAML frontmatter (no industry standard exists; we define the convention).
+  - **Export-all scope:** whole tenant, ignoring search/category/pagination.
+
+## Architecture
+
+New file **`apps/web-ui/lib/memory-export.ts`**, following the established pure-core + thin-Blob-wrapper split (same convention as `lib/skill-export.ts`, `lib/agent-ops/export-markdown.ts`, `lib/chat-export.ts`).
+
+### Shared helpers — extract to `apps/web-ui/lib/export-utils.ts`
+
+Move these six helpers out of `skill-export.ts` into a shared `lib/export-utils.ts`, and make `skill-export.ts` a thin importer:
+`fence()`, `anchor()`, `downloadBlob()`, `downloadText()`, `fileSafe()`, `yamlScalar()`.
+
+This avoids duplicating the helpers a second time in `memory-export.ts` and keeps both export modules consistent. The change to `skill-export.ts` is minimal (import instead of define) and directly serves this work.
+
+### Pure builders (unit-tested)
+
+- `renderValueBody(memory: MemoryRow): string` — switches on `kind` and renders the `value` fields as labeled Markdown sections. **Shared by both the report and portable builders so they never drift.**
+- `buildMemoryMarkdown(memory: MemoryRow): string` — single memory as a readable report doc.
+- `buildAllMemoriesMarkdown(memories: MemoryRow[]): string` — combined report with a TOC grouped by kind.
+- `buildMemoryFile(memory: MemoryRow): string` — single portable `.md` (YAML frontmatter + kind-aware body).
+
+### Impure wrappers (DOM/Blob)
+
+- `exportMemoryToMarkdown(memory: MemoryRow): void` — single `.md` report download.
+- `exportAllMemoriesToMarkdown(memories: MemoryRow[]): void` — combined report download.
+- `exportMemoryToFile(memory: MemoryRow): void` — single portable `.md` download.
+- `exportAllMemoriesToZip(memories: MemoryRow[]): Promise<void>` — dynamic-imports `jszip` (already a dependency), builds `memories/<KIND>/<id>.md`, downloads `.zip`.
+
+## Markdown formats
+
+### Kind-aware body (shared `renderValueBody`)
+
+Each `value` shape becomes labeled prose. Unknown/missing fields render as `—`. Fields are kept as prose (not fenced) so an LLM reading the file sees natural text.
+
+- **SEMANTIC** → `**Fact:**` / `**Source:**` / `**Confidence:**`
+- **EPISODIC** → `**Context:**` / `**Reasoning:**` / `**Action:**` / `**Outcome:**`
+- **PROCEDURAL** → `**Instruction:**` / `**Trigger:**` / `**Evidence:**` / `**Confidence:**`
+
+Per the "Markdown + frontmatter" choice, **no raw JSON is embedded** in either format — each file is clean prose + frontmatter.
+
+### Report mode
+
+**Single memory:** H1 = `key`; metadata table (kind, namespace, category, confidence, source, created, updated, superseded-by); then the kind-aware body.
+
+**Export-all:** combined doc — `# Memory export` header with count, a table of contents grouped by kind (`### SEMANTIC` / `### EPISODIC` / `### PROCEDURAL`, in `MemoryKind` enum declaration order) with anchor links to each `key`, then each memory separated by `---`. Sorted by kind (enum order), then `createdAt` desc within each kind. Empty state: `_No memories to export._`.
+
+### Portable mode
+
+**Single memory:** one `.md`:
+
+```markdown
+---
+kind: SEMANTIC
+namespace: "infra:ec2"
+key: "prod-instances-stop-schedule"
+category: infra
+confidence: high
+created_at: 2026-07-13T00:00:00.000Z
+updated_at: 2026-07-13T00:00:00.000Z
+---
+
+**Fact:** Prod EC2 instances follow a 7pm stop / 7am start schedule.
+**Source:** scheduler-discovery-2026-07
+**Confidence:** high
+```
+
+Frontmatter is intentionally lean: `kind`, `namespace`, `key`, `category`, `confidence`, `created_at`, `updated_at`. `tenantId`/`userId` are omitted (internal IDs meaningless to another tool). The `confidence` line is **omitted when null** (rather than written as `null`). `yamlScalar()` handles double-quote/backslash escaping and multi-line block scalars (`|-`).
+
+The single-memory download filename is `<fileSafe(key)>.md` (falling back to `<id>.md` if `key` sanitizes to empty), so a downloaded file is human-readable.
+
+**Export-all:** `memories-export-<date>.zip` with one file per memory at `memories/<KIND>/<id>.md` (e.g. `memories/SEMANTIC/cm1a2b3c.md`), grouped into per-kind folders so a consuming tool can ingest by kind. (The zip uses the stable `<id>` — not `key` — as the filename to guarantee uniqueness, since `key` is only unique within `tenantId + namespace + key`.)
+
+## Data flow
+
+Per-memory export: **no fetch** — the `MemoryRow` already in hand carries `value`.
+
+Export-all (whole tenant, no filters): a new exported non-hook function `fetchAllAgentMemories(): Promise<MemoryRow[]>` in `lib/queries/agent-memories.ts` loops pages (`limit=500`, incrementing `page`) until accumulated length ≥ `total` (the API returns `{ data, total }`), with a safety cap of 100 pages (50k records) that emits a truncation warning toast if ever hit.
+
+```
+Export-all click → fetchAllAgentMemories()
+                 → GET /api/agent-memories?limit=500&page=1..N  (RBAC authorize('read','Memory') already enforced)
+                 → buildAllMemoriesMarkdown / exportAllMemoriesToZip
+                 → Blob / zip download
+```
+
+No API or schema change. No new permission.
+
+## UI wiring — `components/memory/memory-client-component.tsx`
+
+- **Per-row actions dropdown** (after *View details* / *Promote to skill*, before *Delete*):
+  - **"Export markdown"** (`FileDown` icon) → `onExportMemory` → `exportMemoryToMarkdown(row)`.
+  - **"Export memory (.md)"** (`FileCode` icon) → `onExportMemoryFile` → `exportMemoryToFile(row)`.
+  - Both use row data already in hand; no extra request.
+- **DataTable `header`** (after the *Reset* button):
+  - An **"Export all ▾"** `DropdownMenu` with a `variant="outline"` trigger (`Download` + `ChevronDown`; `Loader2` spinner while `exporting`). Disabled when `total === 0`.
+  - Items: **"Markdown (one file)"** (`FileDown`) → `onExportAll`; **"Portable .md (zip)"** (`FileArchive`) → `onExportAllZip`.
+- `exporting` state flag; four handlers, each with `toast` success/error, mirroring `skills-client.tsx`.
+
+## Error handling
+
+- Per-memory: `try/catch` → `toast.error("Export failed", …)` (failures are DOM/Blob-only; no fetch).
+- Export-all: `exporting` re-entry guard; empty result → `toast.error("Nothing to export", …)`; fetch/zip failure → `toast.error`; safety-cap truncation → `toast.warning("Export truncated", …)`.
+- `jszip` dynamic-import failure → caught by the same `try/catch`.
+
+## Testing — `apps/web-ui/lib/memory-export.test.ts`
+
+Pure-builder unit tests mirroring `lib/skill-export.test.ts`:
+
+- `buildMemoryMarkdown`: metadata table fields; kind-aware body for each of the 3 kinds; missing-field → `—`; supersession row.
+- `buildAllMemoriesMarkdown`: header + count; TOC grouped by kind; sort order (kind, then `createdAt` desc); empty state; `---` separators.
+- `buildMemoryFile`: `---` frontmatter delimiters; all frontmatter fields present; kind-aware body; `yamlScalar` quote/backslash escaping; multi-line block scalar.
+- `fence` behavior (imported from `export-utils`) for any fenced content.
+
+No E2E/integration tests — the Blob/zip wrappers are thin and identical to the proven skill-export wrappers; the pure builders carry all the logic and are fully unit-testable.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `apps/web-ui/lib/export-utils.ts` | **New** — shared `fence/anchor/downloadBlob/downloadText/fileSafe/yamlScalar`. |
+| `apps/web-ui/lib/skill-export.ts` | Import the six helpers from `export-utils` instead of defining them. |
+| `apps/web-ui/lib/memory-export.ts` | **New** — pure builders + impure wrappers (report + portable). |
+| `apps/web-ui/lib/memory-export.test.ts` | **New** — unit tests for the pure builders. |
+| `apps/web-ui/lib/queries/agent-memories.ts` | Add exported `fetchAllAgentMemories()` (paginated, safety-capped). |
+| `apps/web-ui/components/memory/memory-client-component.tsx` | Per-row export items + "Export all ▾" toolbar dropdown + handlers/state. |
+
+## Out of scope / future
+
+- **Server-side export endpoint** (Approach C from brainstorm): if a tenant's memory volume ever makes client-side export slow, add `GET /api/agent-memories/export` that streams a zip server-side. Not needed now.
+- **JSON / sidecar JSON** portable format: deliberately not shipped (user chose Markdown + frontmatter). Can be added later if a concrete target tool needs structured ingestion.
+- **Re-import / restore**: not part of this work (purpose is outbound reuse, not backup-restore).

--- a/libs/prisma/migrations/20260713070000_agent_ops_check_constraints_new_values/migration.sql
+++ b/libs/prisma/migrations/20260713070000_agent_ops_check_constraints_new_values/migration.sql
@@ -1,0 +1,22 @@
+-- Re-sync agent_ops CHECK constraints with the code's value sets.
+-- The 2026-03-28 migration froze these lists; the code has since added:
+--   eventType: memory_recall / memory_save / evaluation (run-timeline redesign)
+--              and notification (scheduled digest delivery marker)
+--   source:    telegram / discord / webhook (gateway channel adapters)
+-- Every INSERT with a new value fails 23514 and is swallowed by the repository's
+-- try/catch, so memory/evaluation/notification timeline events were silently
+-- dropped, and a telegram/discord/webhook-triggered run cannot be created.
+-- Keep in sync with AgentEventType and TriggerSource in
+-- apps/web-ui/lib/agent-ops/types.ts.
+
+ALTER TABLE "agent_ops_events" DROP CONSTRAINT "agent_ops_events_event_type_check";
+ALTER TABLE "agent_ops_events" ADD CONSTRAINT "agent_ops_events_event_type_check"
+    CHECK ("eventType" IN (
+        'planning', 'execution', 'tool_call', 'tool_result', 'reflection',
+        'revision', 'final', 'error',
+        'memory_recall', 'memory_save', 'evaluation', 'notification'
+    ));
+
+ALTER TABLE "agent_ops_runs" DROP CONSTRAINT "agent_ops_runs_source_check";
+ALTER TABLE "agent_ops_runs" ADD CONSTRAINT "agent_ops_runs_source_check"
+    CHECK ("source" IN ('slack', 'jira', 'discord', 'telegram', 'webhook', 'api', 'scheduled'));

--- a/libs/prisma/migrations/20260714150000_add_slack_workspace_link/migration.sql
+++ b/libs/prisma/migrations/20260714150000_add_slack_workspace_link/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "slack_workspace_links" (
+    "id" TEXT NOT NULL,
+    "teamId" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "botUserId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "slack_workspace_links_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "slack_workspace_links_teamId_key" ON "slack_workspace_links"("teamId");
+
+-- CreateIndex
+CREATE INDEX "slack_workspace_links_tenantId_idx" ON "slack_workspace_links"("tenantId");
+
+-- AddForeignKey
+ALTER TABLE "slack_workspace_links" ADD CONSTRAINT "slack_workspace_links_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "tenants"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/libs/prisma/schema.prisma
+++ b/libs/prisma/schema.prisma
@@ -31,6 +31,7 @@ model Tenant {
 
   configs TenantConfig[]
   providerModels ProviderModel[]
+  slackWorkspaceLinks SlackWorkspaceLink[]
 
   @@index([status])
   @@map("tenants")
@@ -51,6 +52,26 @@ model TenantConfig {
   @@unique([tenantId, configKey])
   @@index([tenantId])
   @@map("tenant_configs")
+}
+
+// SlackWorkspaceLink — reverse index from a Slack workspace (team_id) to the
+// tenant that registered it. Inbound slash-command/interaction payloads carry
+// only the Slack team_id, never our internal tenantId, so signature
+// verification needs this lookup before it can find the right signing secret
+// in TenantConfig. teamId is globally unique: one Slack workspace maps to
+// exactly one tenant.
+model SlackWorkspaceLink {
+  id        String   @id @default(cuid())
+  teamId    String   @unique
+  tenantId  String
+  botUserId String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  tenant Tenant @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+
+  @@index([tenantId])
+  @@map("slack_workspace_links")
 }
 
 // ProviderModel — tenant-scoped self-hosted LLM provider configurations


### PR DESCRIPTION
## Summary

- **fix(agent-ops): resolve Slack team_id to tenant via SlackWorkspaceLink** — Slack slash commands were failing ("app did not respond") because request-signature verification looked up the signing secret using Slack's raw `team_id` as our internal tenantId, so it never matched. A deeper instance of the same bug meant every slash-command run was created under that bogus tenantId too. Adds a `SlackWorkspaceLink` table (indexed, unique on `team_id`) as the correct reverse index, auto-populated via Slack's `auth.test` when a Bot Token is saved, or a manually entered Workspace/Team ID when it isn't. Verified end-to-end against a real database and live server: reproduced the original 401, then confirmed 200 + correct tenantId once linked.
- **feat(agent-ops): channel setup guides + Slack/Jira settings UX cleanup** — adds step-by-step setup docs for Slack/Jira integrations, linked from a reusable `SetupGuideLink` card on each settings form; trims duplicated inline copy out of the Jira form now that the docs page covers it.
- **feat(web-ui): markdown export for skills** — per-skill export in the skills grid plus a bulk export-all option, using a portable `SKILL.md` format.
- Also includes prior commits already on this branch (Node runtime fix for stdio MCP/deep-agent approve, memory-export design spec + implementation plan, reflector/stall-detection/markdown-export fixes).

## Test plan

- [x] `bun run test` (web-ui) — new/updated Slack tests pass (repository, adapter, settings-route merge-on-blank); pre-existing unrelated baseline failures (accounts/schedules/RBAC/inventory mocks, a stale `slack-trigger.test.ts` testing a removed route implementation) untouched
- [x] `tsc --noEmit` — 182 errors, matching the existing baseline exactly, zero new errors
- [x] `next lint` — clean on all touched files
- [x] Live end-to-end verification: seeded a real tenant + signing secret with no `SlackWorkspaceLink`, sent a validly HMAC-signed request to a live dev server → reproduced the original 401; linked the workspace, resent the identical request → 200, and confirmed the created `agent_ops_runs` row has the correct internal tenantId (not the Slack team_id)
- [ ] Manual UI check of the new "Slack Workspace/Team ID" field in the settings form (not verified in-browser — no seeded dev login credentials in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)