### PR TITLE
feat(memory): Markdown export for agent memories (report + portable frontmatter)

### DIFF
--- a/apps/web-ui/components/memory/memory-client-component.tsx
+++ b/apps/web-ui/components/memory/memory-client-component.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 import type { ColumnDef, PaginationState, SortingState } from "@tanstack/react-table";
-import { Brain, MoreHorizontal, Eye, Trash2, Search, X, Sparkles } from "lucide-react";
+import { Brain, MoreHorizontal, Eye, Trash2, Search, X, Sparkles, Download, FileDown, FileCode, FileArchive, ChevronDown, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { PageHeader } from "@/components/shared/page-header";
 import { Input } from "@/components/ui/input";
@@ -24,6 +24,13 @@ import {
     type MemoryRow,
     type MemorySortField,
 } from "@/lib/queries/agent-memories";
+import { fetchAllAgentMemories } from "@/lib/queries/agent-memories";
+import {
+    exportMemoryToMarkdown,
+    exportMemoryToFile,
+    exportAllMemoriesToMarkdown,
+    exportAllMemoriesToZip,
+} from "@/lib/memory-export";
 import { useDebounce } from "@/hooks/use-debounce";
 import { MemoryDetailDialog } from "./memory-detail-dialog";
 import { DeleteMemoryDialog } from "./delete-memory-dialog";
@@ -60,6 +67,7 @@ export function MemoryClientComponent() {
     const [detail, setDetail] = useState<MemoryRow | null>(null);
     const [deleteTarget, setDeleteTarget] = useState<MemoryRow | null>(null);
     const [promote, setPromote] = useState<{ draft: SkillDraft; sourceRunId: string | null } | null>(null);
+    const [exporting, setExporting] = useState(false);
 
     const sort = sorting[0];
     const { data, isLoading } = useAgentMemories({
@@ -109,6 +117,34 @@ export function MemoryClientComponent() {
                 });
             },
         });
+    };
+
+    const runExportAll = async (mode: "report" | "zip") => {
+        if (exporting) return;
+        setExporting(true);
+        try {
+            const { memories, total } = await fetchAllAgentMemories();
+            if (memories.length === 0) {
+                toast.error("Nothing to export", { description: "No memories found." });
+                return;
+            }
+            if (memories.length < total) {
+                toast.warning("Export truncated", {
+                    description: `Exported ${memories.length} of ${total} records (safety cap).`,
+                });
+            }
+            if (mode === "report") {
+                exportAllMemoriesToMarkdown(memories);
+                toast.success("Memories exported", { description: `${memories.length} record(s) downloaded` });
+            } else {
+                await exportAllMemoriesToZip(memories);
+                toast.success("Memories exported", { description: `${memories.length} file(s) zipped` });
+            }
+        } catch (e) {
+            toast.error("Export failed", { description: e instanceof Error ? e.message : "Try again" });
+        } finally {
+            setExporting(false);
+        }
     };
 
     const columns = useMemo<ColumnDef<MemoryRow>[]>(
@@ -215,6 +251,32 @@ export function MemoryClientComponent() {
                                         </DropdownMenuItem>
                                     ) : null}
                                     <DropdownMenuItem
+                                        onClick={() => {
+                                            try {
+                                                exportMemoryToMarkdown(m);
+                                                toast.success("Memory exported", { description: `${m.key}.md downloaded` });
+                                            } catch (e) {
+                                                toast.error("Export failed", { description: e instanceof Error ? e.message : "Try again" });
+                                            }
+                                        }}
+                                    >
+                                        <FileDown className="mr-2 h-4 w-4" />
+                                        Export markdown
+                                    </DropdownMenuItem>
+                                    <DropdownMenuItem
+                                        onClick={() => {
+                                            try {
+                                                exportMemoryToFile(m);
+                                                toast.success("Memory file exported", { description: `${m.key}.md downloaded` });
+                                            } catch (e) {
+                                                toast.error("Export failed", { description: e instanceof Error ? e.message : "Try again" });
+                                            }
+                                        }}
+                                    >
+                                        <FileCode className="mr-2 h-4 w-4" />
+                                        Export memory (.md)
+                                    </DropdownMenuItem>
+                                    <DropdownMenuItem
                                         onClick={() => setDeleteTarget(m)}
                                         className="text-destructive"
                                     >
@@ -286,6 +348,29 @@ export function MemoryClientComponent() {
                                 <X className="ml-2 h-4 w-4" />
                             </Button>
                         )}
+                        <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                                <Button variant="outline" size="sm" disabled={exporting || total === 0} className="h-9">
+                                    {exporting ? (
+                                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                    ) : (
+                                        <Download className="mr-2 h-4 w-4" />
+                                    )}
+                                    Export all
+                                    <ChevronDown className="ml-1 h-4 w-4" />
+                                </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end">
+                                <DropdownMenuItem onClick={() => runExportAll("report")}>
+                                    <FileDown className="mr-2 h-4 w-4" />
+                                    Markdown (one file)
+                                </DropdownMenuItem>
+                                <DropdownMenuItem onClick={() => runExportAll("zip")}>
+                                    <FileArchive className="mr-2 h-4 w-4" />
+                                    Portable .md (zip)
+                                </DropdownMenuItem>
+                            </DropdownMenuContent>
+                        </DropdownMenu>
                     </div>
                 }
             />

--- a/apps/web-ui/lib/export-utils.ts
+++ b/apps/web-ui/lib/export-utils.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared helpers for Markdown/Blob export modules (skills, memory, and future
+ * exporters). Pure helpers (fence/anchor/fileSafe/yamlScalar) are unit-tested
+ * via their consumers; downloadBlob/downloadText are thin DOM wrappers.
+ */
+
+/**
+ * Wrap content in a code fence that cannot be terminated early: the fence is
+ * one backtick longer than the longest backtick run inside the content.
+ */
+export function fence(content: string, lang = "markdown"): string {
+    const longestRun = content.match(/`+/g)?.reduce((max, run) => Math.max(max, run.length), 0) ?? 0;
+    const marker = "`".repeat(Math.max(3, longestRun + 1));
+    return `${marker}${lang}\n${content}\n${marker}`;
+}
+
+/** GitHub-style heading anchor: lowercase, trim, spaces → hyphens, drop non-alnum. */
+export function anchor(text: string): string {
+    return text.toLowerCase().trim().replace(/[^\w\s-]/g, "").replace(/\s+/g, "-");
+}
+
+/** Trigger a client-side download of a Blob. */
+export function downloadBlob(blob: Blob, filename: string): void {
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+}
+
+/** Trigger a client-side download of `content` as `filename`. */
+export function downloadText(content: string, filename: string, mimeType = "text/markdown;charset=utf-8"): void {
+    downloadBlob(new Blob([content], { type: mimeType }), filename);
+}
+
+/** Lowercase, alnum+hyphen-only, trimmed; falls back to `fallback` (default "item") when empty. */
+export function fileSafe(text: string, fallback = "item"): string {
+    return text.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || fallback;
+}
+
+/**
+ * Emit a YAML scalar safe to embed in frontmatter. Single-line values use
+ * double-quoted form (backslash + double-quote escaped); multi-line values use
+ * a block scalar so newlines are preserved verbatim.
+ */
+export function yamlScalar(value: string): string {
+    const v = value ?? "";
+    if (v.includes("\n")) {
+        const indented = v.split("\n").map((l) => `  ${l}`).join("\n");
+        return `|-\n${indented}`;
+    }
+    return `"${v.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}

--- a/apps/web-ui/lib/memory-export.test.ts
+++ b/apps/web-ui/lib/memory-export.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for the Memory → Markdown export builders. Mirrors
+ * lib/skill-export.test.ts: only the pure builders are tested; the Blob/zip
+ * wrappers are thin DOM code identical to skill-export's.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildMemoryMarkdown } from './memory-export';
+import type { MemoryRow } from './queries/agent-memories';
+
+function makeMemory(overrides: Partial<MemoryRow> = {}): MemoryRow {
+    return {
+        id: 'cm1a2b3c',
+        userId: 'user-1',
+        namespace: 'infra:ec2',
+        category: 'infra',
+        key: 'prod-stop-schedule',
+        fact: 'Prod EC2 stops at 7pm.',
+        source: 'scheduler-discovery-2026-07',
+        confidence: 'high',
+        value: { fact: 'Prod EC2 stops at 7pm.', source: 'scheduler-discovery-2026-07', confidence: 'high' },
+        kind: 'SEMANTIC',
+        sourceThreadId: null,
+        createdAt: '2026-07-13T00:00:00.000Z',
+        updatedAt: '2026-07-13T00:00:00.000Z',
+        expiresAt: '2026-10-11T00:00:00.000Z',
+        supersededById: null,
+        supersededAt: null,
+        ...overrides,
+    };
+}
+
+describe('buildMemoryMarkdown', () => {
+    it('renders the key as H1 and a metadata table', () => {
+        const md = buildMemoryMarkdown(makeMemory());
+        expect(md).toContain('# prod-stop-schedule');
+        expect(md).toContain('| Kind | SEMANTIC |');
+        expect(md).toContain('| Namespace | infra:ec2 |');
+        expect(md).toContain('| Category | infra |');
+        expect(md).toContain('| Confidence | high |');
+        expect(md).toContain('| Source | scheduler-discovery-2026-07 |');
+        expect(md).toContain('| Created | 2026-07-13T00:00:00.000Z |');
+    });
+
+    it('uses an em-dash for null confidence and source', () => {
+        const md = buildMemoryMarkdown(makeMemory({ confidence: null, source: null }));
+        expect(md).toContain('| Confidence | — |');
+        expect(md).toContain('| Source | — |');
+    });
+
+    it('renders the superseded-by row', () => {
+        const md = buildMemoryMarkdown(makeMemory({ supersededById: 'cm999' }));
+        expect(md).toContain('| Superseded by | cm999 |');
+    });
+
+    it('renders SEMANTIC value body as Fact/Source/Confidence', () => {
+        const md = buildMemoryMarkdown(makeMemory({ kind: 'SEMANTIC' }));
+        expect(md).toContain('**Fact:** Prod EC2 stops at 7pm.');
+        expect(md).toContain('**Source:** scheduler-discovery-2026-07');
+        expect(md).toContain('**Confidence:** high');
+    });
+
+    it('renders EPISODIC value body as Context/Reasoning/Action/Outcome', () => {
+        const md = buildMemoryMarkdown(
+            makeMemory({
+                kind: 'EPISODIC',
+                confidence: null,
+                value: { context: 'High CPU', reasoning: 'Scale up', action: 'Bumped ASG max', outcome: 'CPU normalized' },
+            })
+        );
+        expect(md).toContain('**Context:** High CPU');
+        expect(md).toContain('**Reasoning:** Scale up');
+        expect(md).toContain('**Action:** Bumped ASG max');
+        expect(md).toContain('**Outcome:** CPU normalized');
+    });
+
+    it('renders PROCEDURAL value body as Instruction/Trigger/Evidence/Confidence', () => {
+        const md = buildMemoryMarkdown(
+            makeMemory({
+                kind: 'PROCEDURAL',
+                confidence: 'medium',
+                value: { instruction: 'Restart RDS', trigger: 'failover event', evidence: 'worked 3x', confidence: 'medium' },
+            })
+        );
+        expect(md).toContain('**Instruction:** Restart RDS');
+        expect(md).toContain('**Trigger:** failover event');
+        expect(md).toContain('**Evidence:** worked 3x');
+        expect(md).toContain('**Confidence:** medium');
+    });
+
+    it('renders an em-dash for missing value fields', () => {
+        const md = buildMemoryMarkdown(
+            makeMemory({ kind: 'EPISODIC', confidence: null, value: { context: 'only context' } })
+        );
+        expect(md).toContain('**Context:** only context');
+        expect(md).toContain('**Reasoning:** —');
+        expect(md).toContain('**Action:** —');
+        expect(md).toContain('**Outcome:** —');
+    });
+});

--- a/apps/web-ui/lib/memory-export.test.ts
+++ b/apps/web-ui/lib/memory-export.test.ts
@@ -4,7 +4,7 @@
  * wrappers are thin DOM code identical to skill-export's.
  */
 import { describe, it, expect } from 'vitest';
-import { buildMemoryMarkdown, buildAllMemoriesMarkdown } from './memory-export';
+import { buildMemoryMarkdown, buildAllMemoriesMarkdown, buildMemoryFile } from './memory-export';
 import type { MemoryRow } from './queries/agent-memories';
 
 function makeMemory(overrides: Partial<MemoryRow> = {}): MemoryRow {
@@ -151,5 +151,53 @@ describe('buildAllMemoriesMarkdown', () => {
         const md = buildAllMemoriesMarkdown([makeMemory({ kind: 'PROCEDURAL' })]);
         expect(md).not.toContain('### SEMANTIC');
         expect(md).toContain('### PROCEDURAL');
+    });
+});
+
+describe('buildMemoryFile (portable frontmatter)', () => {
+    it('emits YAML frontmatter delimited by --- fences', () => {
+        const md = buildMemoryFile(makeMemory());
+        expect(md.startsWith('---\n')).toBe(true);
+        expect(md).toMatch(/\n---\n/);
+    });
+
+    it('places kind, namespace, key, category, created_at, updated_at in frontmatter', () => {
+        const md = buildMemoryFile(makeMemory());
+        expect(md).toContain('kind: SEMANTIC');
+        expect(md).toContain('namespace: "infra:ec2"');
+        expect(md).toContain('key: "prod-stop-schedule"');
+        expect(md).toContain('category: infra');
+        expect(md).toContain('created_at: 2026-07-13T00:00:00.000Z');
+        expect(md).toContain('updated_at: 2026-07-13T00:00:00.000Z');
+    });
+
+    it('includes confidence when present', () => {
+        const md = buildMemoryFile(makeMemory({ confidence: 'high' }));
+        expect(md).toContain('confidence: high');
+    });
+
+    it('omits the confidence line when null', () => {
+        const md = buildMemoryFile(makeMemory({ confidence: null }));
+        expect(md).not.toMatch(/^confidence:/m);
+    });
+
+    it('puts the kind-aware body after the frontmatter', () => {
+        const md = buildMemoryFile(makeMemory({ kind: 'SEMANTIC' }));
+        const bodyStart = md.indexOf('\n---\n') + '\n---\n'.length;
+        const body = md.slice(bodyStart);
+        expect(body).toContain('**Fact:** Prod EC2 stops at 7pm.');
+        expect(body).toContain('**Source:** scheduler-discovery-2026-07');
+        expect(body).toContain('**Confidence:** high');
+    });
+
+    it('escapes double quotes and backslashes in namespace/key', () => {
+        const md = buildMemoryFile(makeMemory({ namespace: 'a"b', key: 'c\\d' }));
+        expect(md).toContain('namespace: "a\\"b"');
+        expect(md).toContain('key: "c\\\\d"');
+    });
+
+    it('uses a YAML block scalar for multi-line namespaces', () => {
+        const md = buildMemoryFile(makeMemory({ namespace: 'line one\nline two' }));
+        expect(md).toContain('namespace: |-\n  line one\n  line two');
     });
 });

--- a/apps/web-ui/lib/memory-export.test.ts
+++ b/apps/web-ui/lib/memory-export.test.ts
@@ -4,7 +4,7 @@
  * wrappers are thin DOM code identical to skill-export's.
  */
 import { describe, it, expect } from 'vitest';
-import { buildMemoryMarkdown } from './memory-export';
+import { buildMemoryMarkdown, buildAllMemoriesMarkdown } from './memory-export';
 import type { MemoryRow } from './queries/agent-memories';
 
 function makeMemory(overrides: Partial<MemoryRow> = {}): MemoryRow {
@@ -95,5 +95,61 @@ describe('buildMemoryMarkdown', () => {
         expect(md).toContain('**Reasoning:** —');
         expect(md).toContain('**Action:** —');
         expect(md).toContain('**Outcome:** —');
+    });
+});
+
+describe('buildAllMemoriesMarkdown', () => {
+    it('renders a header with the record count', () => {
+        const md = buildAllMemoriesMarkdown([makeMemory(), makeMemory({ id: 'b', key: 'second' })]);
+        expect(md).toContain('# Memory export');
+        expect(md).toContain('Exported 2 memory record(s).');
+    });
+
+    it('renders an empty-state message when there are no memories', () => {
+        const md = buildAllMemoriesMarkdown([]);
+        expect(md).toContain('Exported 0 memory record(s).');
+        expect(md).toContain('_No memories to export._');
+    });
+
+    it('groups the table of contents by kind in enum order', () => {
+        const md = buildAllMemoriesMarkdown([
+            makeMemory({ id: 'p', key: 'proc', kind: 'PROCEDURAL' }),
+            makeMemory({ id: 's', key: 'sem', kind: 'SEMANTIC' }),
+            makeMemory({ id: 'e', key: 'ep', kind: 'EPISODIC' }),
+        ]);
+        expect(md).toContain('### SEMANTIC');
+        expect(md).toContain('### EPISODIC');
+        expect(md).toContain('### PROCEDURAL');
+        expect(md.indexOf('### SEMANTIC')).toBeLessThan(md.indexOf('### EPISODIC'));
+        expect(md.indexOf('### EPISODIC')).toBeLessThan(md.indexOf('### PROCEDURAL'));
+    });
+
+    it('links TOC entries to key anchors', () => {
+        const md = buildAllMemoriesMarkdown([makeMemory({ key: 'prod-stop-schedule' })]);
+        expect(md).toContain('- [prod-stop-schedule](#prod-stop-schedule)');
+    });
+
+    it('sorts memories within a kind by createdAt descending', () => {
+        const md = buildAllMemoriesMarkdown([
+            makeMemory({ id: 'old', key: 'old', kind: 'SEMANTIC', createdAt: '2026-01-01T00:00:00.000Z' }),
+            makeMemory({ id: 'new', key: 'new', kind: 'SEMANTIC', createdAt: '2026-07-01T00:00:00.000Z' }),
+        ]);
+        expect(md.indexOf('# new')).toBeLessThan(md.indexOf('# old'));
+    });
+
+    it('separates each memory with a horizontal rule and includes bodies', () => {
+        const md = buildAllMemoriesMarkdown([
+            makeMemory({ id: 'a', key: 'alpha' }),
+            makeMemory({ id: 'b', key: 'beta' }),
+        ]);
+        expect(md).toContain('# alpha');
+        expect(md).toContain('# beta');
+        expect(md).toContain('\n---\n');
+    });
+
+    it('omits a kind group entirely when no memories of that kind exist', () => {
+        const md = buildAllMemoriesMarkdown([makeMemory({ kind: 'PROCEDURAL' })]);
+        expect(md).not.toContain('### SEMANTIC');
+        expect(md).toContain('### PROCEDURAL');
     });
 });

--- a/apps/web-ui/lib/memory-export.ts
+++ b/apps/web-ui/lib/memory-export.ts
@@ -140,3 +140,35 @@ export function buildMemoryFile(memory: MemoryRow): string {
     fm.push(`created_at: ${memory.createdAt}`, `updated_at: ${memory.updatedAt}`, "---", "");
     return `${fm.join("\n")}\n${renderValueBody(memory)}`;
 }
+
+/** Download a single memory as a human-readable `.md` report. Impure (DOM + Blob). */
+export function exportMemoryToMarkdown(memory: MemoryRow): void {
+    downloadText(buildMemoryMarkdown(memory), `${fileSafe(memory.key, memory.id)}.md`);
+}
+
+/** Download all memories as a single combined `.md` report. Impure (DOM + Blob). */
+export function exportAllMemoriesToMarkdown(memories: MemoryRow[]): void {
+    downloadText(buildAllMemoriesMarkdown(memories), `memory-export-${new Date().toISOString().slice(0, 10)}.md`);
+}
+
+/** Download a single memory as a portable frontmatter `.md` file. Impure (DOM + Blob). */
+export function exportMemoryToFile(memory: MemoryRow): void {
+    downloadText(buildMemoryFile(memory), `${fileSafe(memory.key, memory.id)}.md`);
+}
+
+/**
+ * Download all memories as a `.zip` of portable frontmatter files, one per memory
+ * at `memories/<KIND>/<id>.md`, grouped into per-kind folders so a consuming
+ * tool can ingest by kind. jszip is dynamically imported so it stays out of the
+ * main bundle. Impure (DOM + Blob + dynamic import).
+ */
+export async function exportAllMemoriesToZip(memories: MemoryRow[]): Promise<void> {
+    const JSZip = (await import("jszip")).default;
+    const zip = new JSZip();
+    const root = zip.folder("memories");
+    if (!root) throw new Error("Failed to create memories folder in zip");
+    const ordered = KIND_ORDER.flatMap((kind) => memories.filter((m) => m.kind === kind));
+    for (const m of ordered) root.file(`${m.kind}/${m.id}.md`, buildMemoryFile(m));
+    const blob = await zip.generateAsync({ type: "blob" });
+    downloadBlob(blob, `memories-export-${new Date().toISOString().slice(0, 10)}.zip`);
+}

--- a/apps/web-ui/lib/memory-export.ts
+++ b/apps/web-ui/lib/memory-export.ts
@@ -122,3 +122,21 @@ export function buildAllMemoriesMarkdown(memories: MemoryRow[]): string {
     }
     return `${header.join("\n")}\n${body.join("\n")}`;
 }
+
+/**
+ * Build a portable `.md` for a memory: YAML frontmatter (kind, namespace, key,
+ * category, confidence, created_at, updated_at) + the kind-aware `value` body.
+ * Re-importable by other AI tools that read Markdown + frontmatter. Pure.
+ */
+export function buildMemoryFile(memory: MemoryRow): string {
+    const fm: string[] = [
+        "---",
+        `kind: ${memory.kind}`,
+        `namespace: ${yamlScalar(memory.namespace)}`,
+        `key: ${yamlScalar(memory.key)}`,
+        `category: ${memory.category}`,
+    ];
+    if (memory.confidence) fm.push(`confidence: ${memory.confidence}`);
+    fm.push(`created_at: ${memory.createdAt}`, `updated_at: ${memory.updatedAt}`, "---", "");
+    return `${fm.join("\n")}\n${renderValueBody(memory)}`;
+}

--- a/apps/web-ui/lib/memory-export.ts
+++ b/apps/web-ui/lib/memory-export.ts
@@ -81,3 +81,44 @@ export function buildMemoryMarkdown(memory: MemoryRow): string {
     ];
     return lines.join("\n");
 }
+
+/** Build the combined human-readable Markdown report for all memories (TOC + each memory). Pure. */
+export function buildAllMemoriesMarkdown(memories: MemoryRow[]): string {
+    const header: string[] = [
+        "# Memory export",
+        "",
+        `Exported ${memories.length} memory record(s).`,
+        "",
+    ];
+    if (memories.length === 0) {
+        header.push("_No memories to export._", "");
+        return header.join("\n");
+    }
+    const byKind = new Map<MemoryKind, MemoryRow[]>();
+    for (const m of memories) {
+        const arr = byKind.get(m.kind) ?? [];
+        arr.push(m);
+        byKind.set(m.kind, arr);
+    }
+    for (const arr of byKind.values()) {
+        arr.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+    }
+    header.push("## Table of contents", "");
+    for (const kind of KIND_ORDER) {
+        const arr = byKind.get(kind);
+        if (!arr || arr.length === 0) continue;
+        header.push(`### ${kind}`, "");
+        for (const m of arr) header.push(`- [${m.key}](#${anchor(m.key)})`);
+        header.push("");
+    }
+    header.push("---", "");
+    const body: string[] = [];
+    for (const kind of KIND_ORDER) {
+        const arr = byKind.get(kind);
+        if (!arr || arr.length === 0) continue;
+        for (const m of arr) {
+            body.push(buildMemoryMarkdown(m), "---", "");
+        }
+    }
+    return `${header.join("\n")}\n${body.join("\n")}`;
+}

--- a/apps/web-ui/lib/memory-export.ts
+++ b/apps/web-ui/lib/memory-export.ts
@@ -1,0 +1,83 @@
+/**
+ * Memory → Markdown export.
+ *
+ * Mirrors lib/skill-export.ts: buildMemoryMarkdown()/buildAllMemoriesMarkdown()
+ * are the pure cores of the human-readable "report" export;
+ * buildMemoryFile() is the pure core of the portable frontmatter export (for
+ * reuse with other AI tools). export*ToMarkdown()/exportAllMemoriesToZip() wrap
+ * them in Blob/zip downloads. Embeddings are never in the MemoryRow DTO, so
+ * there is nothing to strip.
+ */
+
+import type { MemoryRow } from "@/lib/queries/agent-memories";
+import type { MemoryKind } from "@/lib/agent/memory/types";
+// `fence` is intentionally NOT imported: memory bodies are prose, never fenced.
+// The other helpers come online in later tasks (anchor in Task 3, yamlScalar in
+// Task 4, the download/fileSafe trio in Task 5). Unused-import warnings are
+// non-failing (noUnusedLocals=false; lint no-unused-vars is a warning), so
+// importing them all up front is safe and avoids repeated edits to this line.
+import { anchor, downloadBlob, downloadText, fileSafe, yamlScalar } from "@/lib/export-utils";
+
+const KIND_ORDER: MemoryKind[] = ["SEMANTIC", "EPISODIC", "PROCEDURAL"];
+
+/** Read a string field from the raw `value` JSON, or "—" if absent/empty. */
+function field(value: Record<string, unknown>, key: string): string {
+    const v = value?.[key];
+    return typeof v === "string" && v.length ? v : "—";
+}
+
+/**
+ * Render the kind-specific `value` fields as labeled Markdown prose. Shared by
+ * the report and portable builders so they never drift. Pure.
+ */
+function renderValueBody(memory: MemoryRow): string {
+    const v = memory.value ?? {};
+    switch (memory.kind) {
+        case "SEMANTIC":
+            return [
+                `**Fact:** ${field(v, "fact")}`,
+                `**Source:** ${field(v, "source")}`,
+                `**Confidence:** ${memory.confidence ?? "—"}`,
+                "",
+            ].join("\n");
+        case "EPISODIC":
+            return [
+                `**Context:** ${field(v, "context")}`,
+                `**Reasoning:** ${field(v, "reasoning")}`,
+                `**Action:** ${field(v, "action")}`,
+                `**Outcome:** ${field(v, "outcome")}`,
+                "",
+            ].join("\n");
+        case "PROCEDURAL":
+            return [
+                `**Instruction:** ${field(v, "instruction")}`,
+                `**Trigger:** ${field(v, "trigger")}`,
+                `**Evidence:** ${field(v, "evidence")}`,
+                `**Confidence:** ${memory.confidence ?? "—"}`,
+                "",
+            ].join("\n");
+        default:
+            return "";
+    }
+}
+
+/** Build the human-readable Markdown report for a single memory. Pure. */
+export function buildMemoryMarkdown(memory: MemoryRow): string {
+    const lines: string[] = [
+        `# ${memory.key}`,
+        "",
+        "| Field | Value |",
+        "| --- | --- |",
+        `| Kind | ${memory.kind} |`,
+        `| Namespace | ${memory.namespace} |`,
+        `| Category | ${memory.category} |`,
+        `| Confidence | ${memory.confidence ?? "—"} |`,
+        `| Source | ${memory.source ?? "—"} |`,
+        `| Created | ${memory.createdAt} |`,
+        `| Updated | ${memory.updatedAt} |`,
+        `| Superseded by | ${memory.supersededById ?? "—"} |`,
+        "",
+        renderValueBody(memory),
+    ];
+    return lines.join("\n");
+}

--- a/apps/web-ui/lib/queries/agent-memories.ts
+++ b/apps/web-ui/lib/queries/agent-memories.ts
@@ -101,3 +101,29 @@ export function useDeleteAgentMemory() {
         },
     });
 }
+
+/**
+ * Fetch every memory in the tenant for export-all, paging through
+ * GET /api/agent-memories until the known `total` is reached. Safety-capped at
+ * MAX_PAGES so an unexpected runaway cannot loop forever; callers compare
+ * `memories.length < total` to detect truncation and warn. Not a hook — call
+ * from an event handler, not render.
+ */
+export async function fetchAllAgentMemories(): Promise<{ memories: MemoryRow[]; total: number }> {
+    const LIMIT = 500;
+    const MAX_PAGES = 100;
+    const memories: MemoryRow[] = [];
+    let total = 0;
+    for (let page = 1; page <= MAX_PAGES; page++) {
+        const res = await fetch(`/api/agent-memories?limit=${LIMIT}&page=${page}&sort=createdAt&dir=asc`);
+        const json = await res.json();
+        if (!res.ok || !json.success) {
+            throw new Error(json.error || 'Failed to load memories');
+        }
+        const rows = json.data as MemoryRow[];
+        total = json.total ?? 0;
+        memories.push(...rows);
+        if (rows.length < LIMIT || memories.length >= total) break;
+    }
+    return { memories, total };
+}

--- a/apps/web-ui/lib/skill-export.ts
+++ b/apps/web-ui/lib/skill-export.ts
@@ -80,13 +80,13 @@ export function buildSkillFile(skill: SkillDTO): string {
 
 /** Download a single skill as a portable SKILL.md-formatted `.md` file. Impure (DOM + Blob). */
 export function exportSkillToFile(skill: SkillDTO): void {
-    downloadText(buildSkillFile(skill), `${skill.id || fileSafe(skill.name)}.md`);
+    downloadText(buildSkillFile(skill), `${skill.id || fileSafe(skill.name, "skill")}.md`);
 }
 
 /** Download a single skill as a `.md` file (human-readable report). Impure (DOM + Blob). */
 export function exportSkillToMarkdown(skill: SkillDTO): void {
     const markdown = buildSkillMarkdown(skill);
-    downloadText(markdown, `skill-${fileSafe(skill.name)}.md`);
+    downloadText(markdown, `skill-${fileSafe(skill.name, "skill")}.md`);
 }
 
 /** Download all skills as a single `.md` file (human-readable report). Impure (DOM + Blob). */

--- a/apps/web-ui/lib/skill-export.ts
+++ b/apps/web-ui/lib/skill-export.ts
@@ -9,21 +9,7 @@
  */
 
 import type { SkillDTO } from "@/lib/client-skill-service";
-
-/**
- * Wrap content in a code fence that cannot be terminated early: the fence is
- * one backtick longer than the longest backtick run inside the content.
- */
-function fence(content: string, lang = "markdown"): string {
-    const longestRun = content.match(/`+/g)?.reduce((max, run) => Math.max(max, run.length), 0) ?? 0;
-    const marker = "`".repeat(Math.max(3, longestRun + 1));
-    return `${marker}${lang}\n${content}\n${marker}`;
-}
-
-/** GitHub-style heading anchor: lowercase, trim, spaces → hyphens, drop non-alnum. */
-function anchor(text: string): string {
-    return text.toLowerCase().trim().replace(/[^\w\s-]/g, "").replace(/\s+/g, "-");
-}
+import { fence, anchor, downloadBlob, downloadText, fileSafe, yamlScalar } from "@/lib/export-utils";
 
 /** Build the Markdown document for a single skill. Pure. */
 export function buildSkillMarkdown(skill: SkillDTO): string {
@@ -71,41 +57,6 @@ export function buildAllSkillsMarkdown(skills: SkillDTO[]): string {
     header.push("", "---", "");
     const body = sorted.map((s) => `${buildSkillMarkdown(s)}\n---\n`);
     return `${header.join("\n")}\n${body.join("\n")}`;
-}
-
-/** Trigger a client-side download of a Blob. */
-function downloadBlob(blob: Blob, filename: string): void {
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement("a");
-    link.href = url;
-    link.download = filename;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
-}
-
-/** Trigger a client-side download of `content` as `filename`. */
-function downloadText(content: string, filename: string, mimeType = "text/markdown;charset=utf-8"): void {
-    downloadBlob(new Blob([content], { type: mimeType }), filename);
-}
-
-function fileSafe(text: string): string {
-    return text.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "skill";
-}
-
-/**
- * Emit a YAML scalar that is safe to embed in frontmatter. Single-line values use
- * double-quoted form (backslash + double-quote escaped); multi-line values use a
- * block scalar so newlines are preserved verbatim.
- */
-function yamlScalar(value: string): string {
-    const v = value ?? "";
-    if (v.includes("\n")) {
-        const indented = v.split("\n").map((l) => `  ${l}`).join("\n");
-        return `|-\n${indented}`;
-    }
-    return `"${v.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds Markdown export to the agent memory module, mirroring the just-shipped skills export — both per-memory (row actions) and export-all (toolbar), in two formats:

1. **Report Markdown** — human/LLM-readable document (single memory, or a combined doc for all with a kind-grouped TOC).
2. **Portable Markdown + YAML frontmatter** — one `.md` per memory following a defined convention so memories can be **reused with other AI tools**. Export-all bundles these as a zip at `memories/<KIND>/<id>.md`.

## What's in the PR

| File | Change |
|---|---|
| `lib/export-utils.ts` | **New** — shared helpers extracted from skill-export: `fence`, `anchor`, `downloadBlob`, `downloadText`, `fileSafe`, `yamlScalar`. |
| `lib/skill-export.ts` | Refactored to import the six helpers from `export-utils` (byte-identical behavior; `fileSafe` fallback preserved explicitly). |
| `lib/memory-export.ts` | **New** — pure builders (`buildMemoryMarkdown`, `buildAllMemoriesMarkdown`, `buildMemoryFile`, kind-aware `renderValueBody`) + thin Blob/zip wrappers. |
| `lib/memory-export.test.ts` | **New** — 21 unit tests for the pure builders. |
| `lib/queries/agent-memories.ts` | Added exported non-hook `fetchAllAgentMemories()` (paginated, safety-capped at 100 pages). |
| `components/memory/memory-client-component.tsx` | Per-row "Export markdown" / "Export memory (.md)" items + "Export all ▾" toolbar dropdown (report / zip) + `exporting` state. |

## Design notes

- `renderValueBody` is **shared** by the report and portable builders so the two formats can never drift.
- Frontmatter is intentionally lean: `kind`, `namespace`, `key`, `category`, `confidence` (omitted when null), `created_at`, `updated_at`. **No `tenantId`/`userId`** (internal IDs meaningless to another tool). No raw JSON embedded — clean prose + frontmatter.
- Zip uses the stable DB `<id>` (not `key`) as the filename — `key` is only unique within `tenant + namespace`, so `<id>` guarantees uniqueness and avoids path traversal.
- Export-all fetches the **whole tenant** (no search/category/pagination filters) via `fetchAllAgentMemories`; `GET /api/agent-memories` is already RBAC-gated (`authorize('read','Memory')`) and tenant-scoped server-side. Truncation (safety cap hit) warns the user.
- `columns` `useMemo` deps stay `[]` — per-row export handlers are inline closures over stable imports.
- jszip is dynamically imported so it stays out of the main bundle.

## Verification

- `vitest run lib/memory-export.test.ts lib/skill-export.test.ts` → **38 passed** (21 memory-export + 17 skill-export).
- `tsc --noEmit` baseline unchanged (182 pre-existing errors; zero in touched files).
- `lint` clean for all touched files.
- Every task was TDD (RED → GREEN) and individually spec-reviewed; a final whole-branch review on Opus returned **Ready to merge** (no Critical/Important). The one Minor it found — Task 1's helper-extraction silently changed skill-export's `fileSafe` fallback — is fixed in the last commit.

Design spec: \`docs/superpowers/specs/2026-07-14-memory-export-design.md\` (already on master-v1 via #83).

🤖 Generated with [Claude Code](https://claude.com/claude-code)