### PR TITLE
fix(web-ui): provider default model in pickers, scheduled-task header layout, Connectors nav

### DIFF
--- a/apps/web-ui/app/api/settings/providers/route.ts
+++ b/apps/web-ui/app/api/settings/providers/route.ts
@@ -22,6 +22,8 @@ export async function GET(_request: NextRequest) {
         // hardcoded Bedrock baseline. Each model id is the composite
         // `{providerType}:{modelId}:{providerRecordId}` so model-resolver routes
         // it to the right transport (bedrock record / anthropic / openai-family).
+        // `isDefault` marks the default provider's selected chat model so every
+        // picker can preselect it instead of whatever happens to sort first.
         const configuredModels = providers
             .filter((p) => p.isEnabled)
             .flatMap((p) => {
@@ -33,6 +35,7 @@ export async function GET(_request: NextRequest) {
                     id: `${providerType}:${m.id}:${p.id}`,
                     label: `${m.label} (${p.name})`,
                     provider: providerType,
+                    isDefault: p.isDefault && p.chatModel === m.id,
                 }));
             });
 

--- a/apps/web-ui/app/app/agent-ops/scheduled-tasks/[taskId]/page.tsx
+++ b/apps/web-ui/app/app/agent-ops/scheduled-tasks/[taskId]/page.tsx
@@ -36,6 +36,7 @@ export default function ScheduledTaskDetailPage() {
     const [runs, setRuns] = useState<AgentOpsRun[]>([])
     const [loading, setLoading] = useState(true)
     const [busy, setBusy] = useState(false)
+    const [promptExpanded, setPromptExpanded] = useState(false)
 
     const fetchData = useCallback(async () => {
         setLoading(true)
@@ -117,20 +118,20 @@ export default function ScheduledTaskDetailPage() {
     return (
         <div className="space-y-6">
             {/* Header */}
-            <div className="flex items-center justify-between">
-                <div className="flex items-center gap-3">
-                    <Button variant="ghost" size="sm" onClick={() => router.push(`/app/agent-ops/scheduled-tasks?tenantId=${tenantId}`)}>
+            <div className="flex items-start justify-between gap-4">
+                <div className="flex items-start gap-3 min-w-0">
+                    <Button variant="ghost" size="sm" className="flex-shrink-0" onClick={() => router.push(`/app/agent-ops/scheduled-tasks?tenantId=${tenantId}`)}>
                         <ArrowLeft className="h-4 w-4 mr-1" /> Back
                     </Button>
-                    <div>
+                    <div className="min-w-0">
                         <h1 className="text-xl font-bold flex items-center gap-2">
-                            <CalendarClock className="h-5 w-5 text-blue-500" />
-                            {task.name}
+                            <CalendarClock className="h-5 w-5 flex-shrink-0 text-blue-500" />
+                            <span className="truncate">{task.name}</span>
                         </h1>
-                        <p className="text-muted-foreground text-sm mt-0.5">{task.description}</p>
+                        <p className="text-muted-foreground text-sm mt-0.5 line-clamp-2 break-words">{task.description}</p>
                     </div>
                 </div>
-                <div className="flex items-center gap-2">
+                <div className="flex flex-shrink-0 items-center gap-2">
                     <Button variant="outline" size="sm" onClick={fetchData} disabled={loading}>
                         <RefreshCw className={`h-4 w-4 mr-2 ${loading ? "animate-spin" : ""}`} /> Refresh
                     </Button>
@@ -152,6 +153,26 @@ export default function ScheduledTaskDetailPage() {
                     </Button>
                 </div>
             </div>
+
+            {/* Prompt */}
+            <Card>
+                <CardHeader className="pb-2">
+                    <CardTitle className="text-base">Prompt</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <p className={`text-sm text-muted-foreground whitespace-pre-wrap break-words ${promptExpanded ? "" : "line-clamp-6"}`}>
+                        {task.description}
+                    </p>
+                    <Button
+                        variant="link"
+                        size="sm"
+                        className="mt-1 h-auto p-0 text-xs"
+                        onClick={() => setPromptExpanded(v => !v)}
+                    >
+                        {promptExpanded ? "Show less" : "Show full prompt"}
+                    </Button>
+                </CardContent>
+            </Card>
 
             {/* Task Info */}
             <Card>

--- a/apps/web-ui/components/agent-ops/agent-ops-settings-form.tsx
+++ b/apps/web-ui/components/agent-ops/agent-ops-settings-form.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import { ArrowLeft, CheckCircle2, Cpu, Gauge, Loader2, Save } from 'lucide-react';
 import { toast } from 'sonner';
 import { useAgentOpsDefaults, useSaveAgentOpsDefaults } from '@/lib/queries/agent-ops-settings';
-import { useProviderModels } from '@/lib/queries/providers';
+import { useProviderModels, defaultModelId } from '@/lib/queries/providers';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -44,13 +44,15 @@ export function AgentOpsSettingsForm({
     const [saved, setSaved] = useState(false);
     const [error, setError] = useState('');
 
-    // Hydrate the form once the stored config arrives.
+    // Hydrate the form once the stored config arrives. With nothing stored yet,
+    // fall back to the LLM provider's default chat model rather than showing an
+    // empty picker — the same model the executor would resolve at runtime.
     useEffect(() => {
         if (data) {
-            setDefaultModel(data.defaultModel || '');
+            setDefaultModel((prev) => prev || data.defaultModel || defaultModelId(models ?? []));
             setMaxIterations(data.maxIterations || 150);
         }
-    }, [data]);
+    }, [data, models]);
 
     if (isLoading) {
         return (

--- a/apps/web-ui/components/agent/chat-interface.tsx
+++ b/apps/web-ui/components/agent/chat-interface.tsx
@@ -117,7 +117,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { ClientAccountService } from "@/lib/client-account-service";
 import { UIAccount } from "@/lib/types";
-import { useProviderModels } from "@/lib/queries/providers";
+import { useProviderModels, defaultModelId } from "@/lib/queries/providers";
 import { useKnowledgeBases } from "@/lib/queries/knowledge-base";
 import { FileUpload, FileAttachment } from "@/components/agent/file-upload";
 
@@ -541,13 +541,13 @@ export function ChatInterface({
   const [showTools, setShowTools] = useState(false);
   const [selectedModel, setSelectedModel] = useState("");
   // Models are sourced ONLY from tenant-configured providers (shared TanStack
-  // Query hook — no hardcoded Bedrock baseline). Auto-select the first available
-  // model so a configured tenant has a sensible default without picking one.
+  // Query hook — no hardcoded Bedrock baseline). Preselect the default provider's
+  // chat model; a user's explicit pick is preserved across refetches.
   const { data: availableModels = [] } = useProviderModels();
 
   useEffect(() => {
     setSelectedModel((prev) =>
-      prev && availableModels.some((m) => m.id === prev) ? prev : availableModels[0]?.id ?? "",
+      prev && availableModels.some((m) => m.id === prev) ? prev : defaultModelId(availableModels),
     );
   }, [availableModels]);
   const [modelDropdownOpen, setModelDropdownOpen] = useState(false);

--- a/apps/web-ui/components/deep-agent/deep-agent-chat.tsx
+++ b/apps/web-ui/components/deep-agent/deep-agent-chat.tsx
@@ -5,7 +5,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { cn } from '@/lib/utils';
 import { formatTime } from '@/lib/date-utils';
 import { useTenant } from '@/lib/tenant-context';
-import { useProviderModels } from '@/lib/queries/providers';
+import { useProviderModels, defaultModelId } from '@/lib/queries/providers';
 import { ThreadSidebar } from './thread-sidebar';
 import { TodoPanel } from './todo-panel';
 import { ApprovalDialog } from './approval-dialog';
@@ -92,7 +92,7 @@ export function DeepAgentChat() {
 
   useEffect(() => {
     setSelectedModel((prev) =>
-      prev && models.some((m) => m.id === prev) ? prev : models[0]?.id ?? '',
+      prev && models.some((m) => m.id === prev) ? prev : defaultModelId(models),
     );
   }, [models]);
   const [selectedMcpServers, setSelectedMcpServers] = useState<string[]>([]);

--- a/apps/web-ui/components/knowledge-base/kb-chat.tsx
+++ b/apps/web-ui/components/knowledge-base/kb-chat.tsx
@@ -14,7 +14,7 @@ import { KBChatSidebar } from "./kb-chat-sidebar";
 import { FileUpload, FileAttachment } from "@/components/agent/file-upload";
 import { useKnowledgeBases } from "@/lib/queries/knowledge-base";
 import { useKBChatMessages } from "@/lib/queries/kb-chat";
-import { useProviderModels } from "@/lib/queries/providers";
+import { useProviderModels, defaultModelId } from "@/lib/queries/providers";
 import { queryKeys } from "@/lib/queries/query-keys";
 
 const EXAMPLE_PROMPTS = [
@@ -61,10 +61,10 @@ export function KBChat({ initialKbId }: KBChatProps) {
   const { data: availableModels = [] } = useProviderModels();
   const { data: history, isFetching: isLoadingHistory } = useKBChatMessages(loadId);
 
-  // Default the model to the first available; keep current selection if still valid.
+  // Default to the provider's default chat model; keep current selection if still valid.
   useEffect(() => {
     setSelectedModel((prev) =>
-      prev && availableModels.some((m) => m.id === prev) ? prev : availableModels[0]?.id ?? "",
+      prev && availableModels.some((m) => m.id === prev) ? prev : defaultModelId(availableModels),
     );
   }, [availableModels]);
 

--- a/apps/web-ui/lib/nav-config.ts
+++ b/apps/web-ui/lib/nav-config.ts
@@ -62,8 +62,8 @@ export const navMenus: NavItem[] = [
     icon: Cable,
     items: [
       { title: "Channels", href: "/app/channels" },
-      { title: "Jira", href: "/app/agent-ops/jira-settings" },
       { title: "Slack", href: "/app/agent-ops/slack-settings" },
+      { title: "Telegram", href: "/app/channels/telegram-settings" },
     ],
   },
   {

--- a/apps/web-ui/lib/queries/providers.ts
+++ b/apps/web-ui/lib/queries/providers.ts
@@ -87,6 +87,17 @@ export interface ProviderModelOption {
     id: string;
     label: string;
     provider: string;
+    /** True for the default provider's selected chat model. At most one entry. */
+    isDefault?: boolean;
+}
+
+/**
+ * The model a picker should land on with no explicit user choice: the default
+ * provider's chat model, else the first configured model. Keeps every dropdown
+ * (AI Ops, Agent Ops, KB, deep agent) agreeing on the same initial selection.
+ */
+export function defaultModelId(models: ProviderModelOption[]): string {
+    return (models.find((m) => m.isDefault) ?? models[0])?.id ?? '';
 }
 
 export function useProviders() {


### PR DESCRIPTION
## Summary

Three small UI fixes across web-ui.

**1. Model dropdowns preselect the provider's default model**

Every picker sourced its list from `/api/settings/providers` and then defaulted to `models[0]` — whatever happened to sort first — so a tenant whose default provider model is, say, Claude 4.5 would still land on Claude 3 Sonnet. The API now flags the one option matching the default provider's configured `chatModel` with `isDefault`, and a shared `defaultModelId()` helper in `lib/queries/providers.ts` resolves it (falling back to the first model when no default provider is set).

Applied to all four consumers: AI Ops chat, Agent Ops settings, Knowledge Base chat, deep agent chat. An explicit pick still wins — each effect only reassigns when the current selection is empty or no longer valid.

**2. Scheduled-task detail header layout**

`task.description` doubles as the agent prompt, and it was rendered untruncated in the header flex row — a 2000-character prompt stretched the row and pushed the Refresh / Run Now / Pause / Delete buttons into the middle of the page. The description is now clamped to two lines, the button group is `flex-shrink-0`, and the full prompt lives in its own expandable **Prompt** card.

**3. Connectors nav**

Removed the Jira link; added Telegram. Now: Channels / Slack / Telegram. The Jira pages and the Jira notification type still exist — only the sidebar entry was removed.

## Test plan

- [ ] Set a default provider + chat model in Settings → Providers, then confirm AI Ops, Agent Ops settings, KB chat, and deep agent all open on that model
- [ ] Change the model in a dropdown and confirm the selection sticks
- [ ] Open a scheduled task with a long prompt and confirm the action buttons stay top-right
- [ ] Confirm the Connectors menu shows Channels / Slack / Telegram

Typecheck clean on all touched files (the pre-existing `chat-interface.tsx` `onFinish` AI SDK type error is unrelated and unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)