### PR TITLE
Channels: reset configuration + server-side run-history pagination

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,8 +129,8 @@ LANGFUSE_HOST=https://cloud.langfuse.com
 # LANGFUSE_PUBLIC_KEY=pk-lf-...
 # LANGFUSE_SECRET_KEY=sk-lf-...
 
-# Slack (agent-ops webhook)
-# SLACK_SIGNING_SECRET=your-slack-signing-secret
+# Slack signing secret and bot token are now stored per tenant via
+# Settings → Channels → Slack (tenant config key: agent-ops-slack).
 
 # Jira
 # JIRA_WEBHOOK_SECRET=your-jira-webhook-secret

--- a/apps/web-ui/app/api/agent-ops/scheduled-tasks/[taskId]/runs/route.ts
+++ b/apps/web-ui/app/api/agent-ops/scheduled-tasks/[taskId]/runs/route.ts
@@ -1,17 +1,40 @@
+/**
+ * GET /api/agent-ops/scheduled-tasks/[taskId]/runs
+ *
+ * Paginated run history for one scheduled task. The taskId filter is pushed into
+ * the query (trigger->>'taskId') rather than applied in JS over a tenant-wide
+ * page of runs — the latter silently drops this task's older runs as soon as
+ * other tasks' runs fill the fetch window, and makes `total` meaningless.
+ */
 import { NextResponse } from 'next/server';
 import { agentOpsService } from '@/lib/agent-ops/agent-ops-service';
 import { getSessionTenantId } from '@/lib/auth-session';
+
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 100;
 
 export async function GET(req: Request, { params }: { params: Promise<{ taskId: string }> }) {
     try {
         const { taskId } = await params;
         const tenantId = await getSessionTenantId();
         const url = new URL(req.url);
-        const limit = parseInt(url.searchParams.get('limit') || '25', 10);
 
-        const { runs } = await agentOpsService.listRuns({ tenantId, source: 'scheduled', limit });
-        const taskRuns = runs.filter(r => (r.trigger as any)?.taskId === taskId);
-        return NextResponse.json({ runs: taskRuns });
+        const parsedPage = parseInt(url.searchParams.get('page') || '1', 10);
+        const parsedLimit = parseInt(url.searchParams.get('limit') || String(DEFAULT_LIMIT), 10);
+        const page = Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 1;
+        const limit = Number.isFinite(parsedLimit) && parsedLimit > 0
+            ? Math.min(parsedLimit, MAX_LIMIT)
+            : DEFAULT_LIMIT;
+
+        const { runs, total } = await agentOpsService.listRuns({
+            tenantId,
+            source: 'scheduled',
+            taskId,
+            page,
+            limit,
+        });
+
+        return NextResponse.json({ runs, total, page, limit });
     } catch (err) {
         return NextResponse.json({ error: err instanceof Error ? err.message : 'Internal server error' }, { status: 500 });
     }

--- a/apps/web-ui/app/api/agent-ops/settings/discord/route.ts
+++ b/apps/web-ui/app/api/agent-ops/settings/discord/route.ts
@@ -2,6 +2,7 @@
  * AgentOps Discord Settings API Route
  *
  * GET /api/agent-ops/settings/discord — Returns Discord config (secrets masked)
+ * DELETE /api/agent-ops/settings/discord — Resets (deletes) the stored config
  * PUT /api/agent-ops/settings/discord — Validates and saves Discord config to PostgreSQL
  */
 
@@ -134,6 +135,49 @@ export async function PUT(req: Request) {
         console.error('[API /agent-ops/settings/discord] PUT error:', error);
         return NextResponse.json(
             { error: error.message || 'Failed to save Discord settings' },
+            { status: 500 }
+        );
+    }
+}
+
+/**
+ * DELETE — reset the Discord integration: removes the stored credentials so the
+ * channel returns to its unconfigured state. Destructive and irreversible from
+ * the UI (secrets are never echoed back), hence the explicit RBAC gate and a
+ * high-severity audit record.
+ */
+export async function DELETE() {
+    try {
+        const authError = await authorize('delete', 'Agent');
+        if (authError) return authError;
+
+        const tenantId = await getSessionTenantId();
+        await TenantConfigService.deleteConfig(CONFIG_KEY, tenantId);
+
+        console.log('[API /agent-ops/settings/discord] Reset Discord config for tenant:', tenantId);
+
+        const session = await getAuthSession();
+        AuditService.logUserAction({
+            eventType: 'agent.settings.discord_reset',
+            severity: 'high',
+            apiRoute: 'DELETE /api/agent-ops/settings/discord',
+            httpMethod: 'DELETE',
+            action: 'Reset Discord Settings',
+            resourceType: 'agent',
+            resourceId: 'discord-integration',
+            resourceName: 'Discord Integration',
+            user: session?.user?.email || 'unknown',
+            userType: 'user',
+            status: 'success',
+            details: 'Reset Discord integration settings — stored credentials deleted',
+            metadata: { tenantId },
+        }).catch(() => {});
+
+        return NextResponse.json({ success: true, configured: false, enabled: false });
+    } catch (error: any) {
+        console.error('[API /agent-ops/settings/discord] DELETE error:', error);
+        return NextResponse.json(
+            { error: error.message || 'Failed to reset Discord settings' },
             { status: 500 }
         );
     }

--- a/apps/web-ui/app/api/agent-ops/settings/jira/route.ts
+++ b/apps/web-ui/app/api/agent-ops/settings/jira/route.ts
@@ -2,6 +2,7 @@
  * AgentOps Jira Settings API Route
  *
  * GET /api/agent-ops/settings/jira — Returns Jira config (secrets masked)
+ * DELETE /api/agent-ops/settings/jira — Resets (deletes) the stored config
  * PUT /api/agent-ops/settings/jira — Validates and saves Jira config to PostgreSQL
  */
 
@@ -142,6 +143,49 @@ export async function PUT(req: Request) {
         console.error('[API /agent-ops/settings/jira] PUT error:', error);
         return NextResponse.json(
             { error: error.message || 'Failed to save Jira settings' },
+            { status: 500 }
+        );
+    }
+}
+
+/**
+ * DELETE — reset the Jira integration: removes the stored credentials so the
+ * channel returns to its unconfigured state. Destructive and irreversible from
+ * the UI (secrets are never echoed back), hence the explicit RBAC gate and a
+ * high-severity audit record.
+ */
+export async function DELETE() {
+    try {
+        const authError = await authorize('delete', 'Agent');
+        if (authError) return authError;
+
+        const tenantId = await getSessionTenantId();
+        await TenantConfigService.deleteConfig(CONFIG_KEY, tenantId);
+
+        console.log('[API /agent-ops/settings/jira] Reset Jira config for tenant:', tenantId);
+
+        const session = await getAuthSession();
+        AuditService.logUserAction({
+            eventType: 'agent.settings.jira_reset',
+            severity: 'high',
+            apiRoute: 'DELETE /api/agent-ops/settings/jira',
+            httpMethod: 'DELETE',
+            action: 'Reset Jira Settings',
+            resourceType: 'agent',
+            resourceId: 'jira-integration',
+            resourceName: 'Jira Integration',
+            user: session?.user?.email || 'unknown',
+            userType: 'user',
+            status: 'success',
+            details: 'Reset Jira integration settings — stored credentials deleted',
+            metadata: { tenantId },
+        }).catch(() => {});
+
+        return NextResponse.json({ success: true, configured: false, enabled: false });
+    } catch (error: any) {
+        console.error('[API /agent-ops/settings/jira] DELETE error:', error);
+        return NextResponse.json(
+            { error: error.message || 'Failed to reset Jira settings' },
             { status: 500 }
         );
     }

--- a/apps/web-ui/app/api/agent-ops/settings/slack/route.ts
+++ b/apps/web-ui/app/api/agent-ops/settings/slack/route.ts
@@ -2,6 +2,7 @@
  * AgentOps Slack Settings API Route
  *
  * GET /api/agent-ops/settings/slack — Returns Slack config (secrets masked)
+ * DELETE /api/agent-ops/settings/slack — Resets (deletes) the stored config
  * PUT /api/agent-ops/settings/slack — Validates and saves Slack config to PostgreSQL
  */
 
@@ -226,6 +227,55 @@ export async function PUT(req: Request) {
         console.error('[API /agent-ops/settings/slack] PUT error:', error);
         return NextResponse.json(
             { error: error.message || 'Failed to save Slack settings' },
+            { status: 500 }
+        );
+    }
+}
+
+/**
+ * DELETE — reset the Slack integration: removes the stored credentials so the
+ * channel returns to its unconfigured state. Destructive and irreversible from
+ * the UI (secrets are never echoed back), hence the explicit RBAC gate and a
+ * high-severity audit record.
+ *
+ * Also drops the tenant's SlackWorkspaceLink. A link left behind would keep
+ * mapping the workspace's team_id to a tenant that no longer holds a signing
+ * secret, so inbound slash commands would fail signature verification instead
+ * of being cleanly rejected as unlinked.
+ */
+export async function DELETE() {
+    try {
+        const authError = await authorize('delete', 'Agent');
+        if (authError) return authError;
+
+        const tenantId = await getSessionTenantId();
+        await TenantConfigService.deleteConfig(CONFIG_KEY, tenantId);
+        await getSlackWorkspaceLinkRepository().deleteLinkForTenant(tenantId);
+
+        console.log('[API /agent-ops/settings/slack] Reset Slack config for tenant:', tenantId);
+
+        const session = await getAuthSession();
+        AuditService.logUserAction({
+            eventType: 'agent.settings.slack_reset',
+            severity: 'high',
+            apiRoute: 'DELETE /api/agent-ops/settings/slack',
+            httpMethod: 'DELETE',
+            action: 'Reset Slack Settings',
+            resourceType: 'agent',
+            resourceId: 'slack-integration',
+            resourceName: 'Slack Integration',
+            user: session?.user?.email || 'unknown',
+            userType: 'user',
+            status: 'success',
+            details: 'Reset Slack integration settings — stored credentials deleted',
+            metadata: { tenantId },
+        }).catch(() => {});
+
+        return NextResponse.json({ success: true, configured: false, enabled: false });
+    } catch (error: any) {
+        console.error('[API /agent-ops/settings/slack] DELETE error:', error);
+        return NextResponse.json(
+            { error: error.message || 'Failed to reset Slack settings' },
             { status: 500 }
         );
     }

--- a/apps/web-ui/app/api/agent-ops/settings/telegram/route.ts
+++ b/apps/web-ui/app/api/agent-ops/settings/telegram/route.ts
@@ -2,6 +2,7 @@
  * AgentOps Telegram Settings API Route
  *
  * GET /api/agent-ops/settings/telegram — Returns Telegram config (secrets masked)
+ * DELETE /api/agent-ops/settings/telegram — Resets (deletes) the stored config
  * PUT /api/agent-ops/settings/telegram — Validates and saves Telegram config to PostgreSQL
  */
 
@@ -130,6 +131,49 @@ export async function PUT(req: Request) {
         console.error('[API /agent-ops/settings/telegram] PUT error:', error);
         return NextResponse.json(
             { error: error.message || 'Failed to save Telegram settings' },
+            { status: 500 }
+        );
+    }
+}
+
+/**
+ * DELETE — reset the Telegram integration: removes the stored credentials so the
+ * channel returns to its unconfigured state. Destructive and irreversible from
+ * the UI (secrets are never echoed back), hence the explicit RBAC gate and a
+ * high-severity audit record.
+ */
+export async function DELETE() {
+    try {
+        const authError = await authorize('delete', 'Agent');
+        if (authError) return authError;
+
+        const tenantId = await getSessionTenantId();
+        await TenantConfigService.deleteConfig(CONFIG_KEY, tenantId);
+
+        console.log('[API /agent-ops/settings/telegram] Reset Telegram config for tenant:', tenantId);
+
+        const session = await getAuthSession();
+        AuditService.logUserAction({
+            eventType: 'agent.settings.telegram_reset',
+            severity: 'high',
+            apiRoute: 'DELETE /api/agent-ops/settings/telegram',
+            httpMethod: 'DELETE',
+            action: 'Reset Telegram Settings',
+            resourceType: 'agent',
+            resourceId: 'telegram-integration',
+            resourceName: 'Telegram Integration',
+            user: session?.user?.email || 'unknown',
+            userType: 'user',
+            status: 'success',
+            details: 'Reset Telegram integration settings — stored credentials deleted',
+            metadata: { tenantId },
+        }).catch(() => {});
+
+        return NextResponse.json({ success: true, configured: false, enabled: false });
+    } catch (error: any) {
+        console.error('[API /agent-ops/settings/telegram] DELETE error:', error);
+        return NextResponse.json(
+            { error: error.message || 'Failed to reset Telegram settings' },
             { status: 500 }
         );
     }

--- a/apps/web-ui/app/api/agent-ops/settings/webhook/route.ts
+++ b/apps/web-ui/app/api/agent-ops/settings/webhook/route.ts
@@ -2,6 +2,7 @@
  * AgentOps Webhook Settings API Route
  *
  * GET /api/agent-ops/settings/webhook — Returns Webhook config (secrets masked)
+ * DELETE /api/agent-ops/settings/webhook — Resets (deletes) the stored config
  * PUT /api/agent-ops/settings/webhook — Validates and saves Webhook config to PostgreSQL
  */
 
@@ -126,6 +127,49 @@ export async function PUT(req: Request) {
         console.error('[API /agent-ops/settings/webhook] PUT error:', error);
         return NextResponse.json(
             { error: error.message || 'Failed to save Webhook settings' },
+            { status: 500 }
+        );
+    }
+}
+
+/**
+ * DELETE — reset the Webhook integration: removes the stored credentials so the
+ * channel returns to its unconfigured state. Destructive and irreversible from
+ * the UI (secrets are never echoed back), hence the explicit RBAC gate and a
+ * high-severity audit record.
+ */
+export async function DELETE() {
+    try {
+        const authError = await authorize('delete', 'Agent');
+        if (authError) return authError;
+
+        const tenantId = await getSessionTenantId();
+        await TenantConfigService.deleteConfig(CONFIG_KEY, tenantId);
+
+        console.log('[API /agent-ops/settings/webhook] Reset Webhook config for tenant:', tenantId);
+
+        const session = await getAuthSession();
+        AuditService.logUserAction({
+            eventType: 'agent.settings.webhook_reset',
+            severity: 'high',
+            apiRoute: 'DELETE /api/agent-ops/settings/webhook',
+            httpMethod: 'DELETE',
+            action: 'Reset Webhook Settings',
+            resourceType: 'agent',
+            resourceId: 'webhook-integration',
+            resourceName: 'Webhook Integration',
+            user: session?.user?.email || 'unknown',
+            userType: 'user',
+            status: 'success',
+            details: 'Reset Webhook integration settings — stored credentials deleted',
+            metadata: { tenantId },
+        }).catch(() => {});
+
+        return NextResponse.json({ success: true, configured: false, enabled: false });
+    } catch (error: any) {
+        console.error('[API /agent-ops/settings/webhook] DELETE error:', error);
+        return NextResponse.json(
+            { error: error.message || 'Failed to reset Webhook settings' },
             { status: 500 }
         );
     }

--- a/apps/web-ui/app/app/agent-ops/[runId]/page.tsx
+++ b/apps/web-ui/app/app/agent-ops/[runId]/page.tsx
@@ -9,7 +9,7 @@ import { Textarea } from "@/components/ui/textarea"
 import { MarkdownContent } from "@/components/ui/markdown-content"
 import { Spinner } from "@/components/ui/spinner"
 import {
-  ArrowLeft, CheckCircle2, Clock, Loader2, MessageSquare, ShieldCheck, ShieldX, XCircle,
+  ArrowLeft, CheckCircle2, ChevronDown, Clock, Loader2, MessageSquare, ShieldCheck, ShieldX, XCircle,
 } from "lucide-react"
 import { RunHeader } from "@/components/agent-ops/run-timeline/run-header"
 import { RunTimeline } from "@/components/agent-ops/run-timeline/timeline"
@@ -30,6 +30,7 @@ export default function RunDetailPage() {
 
   const [exporting, setExporting] = useState(false)
   const [clarificationText, setClarificationText] = useState("")
+  const [resultOpen, setResultOpen] = useState(true)
 
   // First fetch without polling; useRunStream drives live updates, and we fall
   // back to 2s polling only while the run is active and the stream is down.
@@ -108,27 +109,39 @@ export default function RunDetailPage() {
         onBack={() => router.push("/app/agent-ops")}
       />
 
-      {/* Result */}
+      {/* Result — collapsible; long summaries otherwise bury the timeline below. */}
       {run.result?.summary && (
         <Card>
           <CardHeader className="pb-2">
-            <CardTitle className="flex items-center gap-2 text-sm text-green-600">
-              <CheckCircle2 className="h-4 w-4" /> Result
-            </CardTitle>
+            <button
+              type="button"
+              onClick={() => setResultOpen(v => !v)}
+              aria-expanded={resultOpen}
+              className="flex w-full items-center gap-2 text-left"
+            >
+              <CardTitle className="flex flex-1 items-center gap-2 text-sm text-green-600">
+                <CheckCircle2 className="h-4 w-4" /> Result
+              </CardTitle>
+              <ChevronDown
+                className={`h-4 w-4 text-muted-foreground transition-transform ${resultOpen ? "" : "-rotate-90"}`}
+              />
+            </button>
           </CardHeader>
-          <CardContent>
-            <div className="rounded-md bg-muted p-4">
-              <MarkdownContent content={run.result.summary} />
-            </div>
-            {run.result.toolsUsed?.length > 0 && (
-              <div className="mt-3 flex flex-wrap gap-1.5">
-                <span className="mr-1 text-xs text-muted-foreground">Tools used:</span>
-                {run.result.toolsUsed.map(tool => (
-                  <Badge key={tool} variant="outline" className="text-xs">{tool}</Badge>
-                ))}
+          {resultOpen && (
+            <CardContent>
+              <div className="rounded-md bg-muted p-4">
+                <MarkdownContent content={run.result.summary} />
               </div>
-            )}
-          </CardContent>
+              {run.result.toolsUsed?.length > 0 && (
+                <div className="mt-3 flex flex-wrap gap-1.5">
+                  <span className="mr-1 text-xs text-muted-foreground">Tools used:</span>
+                  {run.result.toolsUsed.map(tool => (
+                    <Badge key={tool} variant="outline" className="text-xs">{tool}</Badge>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          )}
         </Card>
       )}
 

--- a/apps/web-ui/app/app/agent-ops/scheduled-tasks/[taskId]/page.tsx
+++ b/apps/web-ui/app/app/agent-ops/scheduled-tasks/[taskId]/page.tsx
@@ -10,9 +10,11 @@ import {
     CheckCircle2, XCircle, Loader2, Clock, AlertCircle,
     MessageSquare, Globe, StopCircle, ShieldCheck,
 } from "lucide-react"
-import type { ScheduledTask, AgentOpsRun, AgentOpsStatus } from "@/lib/agent-ops/types"
+import type { ScheduledTask, AgentOpsStatus } from "@/lib/agent-ops/types"
 import { ScheduledTaskDialog } from "@/components/agent-ops/scheduled-task-dialog"
+import { PaginationBar } from "@/components/ui/pagination-bar"
 import { formatDateTime } from "@/lib/date-utils"
+import { useScheduledTaskRuns } from "@/lib/queries/agent-ops-scheduled-tasks"
 import { useTenant } from '@/lib/tenant-context'
 
 const STATUS_CONFIG: Record<AgentOpsStatus, { label: string; variant: "default" | "secondary" | "destructive" | "outline"; icon: typeof Clock }> = {
@@ -33,26 +35,32 @@ export default function ScheduledTaskDetailPage() {
     const { timezone } = useTenant()
 
     const [task, setTask] = useState<ScheduledTask | null>(null)
-    const [runs, setRuns] = useState<AgentOpsRun[]>([])
     const [loading, setLoading] = useState(true)
     const [busy, setBusy] = useState(false)
     const [promptExpanded, setPromptExpanded] = useState(false)
+    const [page, setPage] = useState(1)
+    const [pageSize, setPageSize] = useState(25)
+
+    // Run history is paginated server-side (filtered on trigger->>'taskId'), so
+    // `total` counts this task's runs rather than whatever slice was fetched.
+    const runsQuery = useScheduledTaskRuns(taskId, { page, limit: pageSize })
+    const runs = runsQuery.data?.runs ?? []
+    const totalRuns = runsQuery.data?.total ?? 0
 
     const fetchData = useCallback(async () => {
         setLoading(true)
         try {
-            const [taskRes, runsRes] = await Promise.all([
-                fetch(`/api/agent-ops/scheduled-tasks/${taskId}?tenantId=${tenantId}`),
-                fetch(`/api/agent-ops/scheduled-tasks/${taskId}/runs?tenantId=${tenantId}&limit=50`),
-            ])
-            const [taskData, runsData] = await Promise.all([taskRes.json(), runsRes.json()])
+            const taskRes = await fetch(`/api/agent-ops/scheduled-tasks/${taskId}?tenantId=${tenantId}`)
+            const taskData = await taskRes.json()
             setTask(taskData.task || null)
-            setRuns(runsData.runs || [])
+            await runsQuery.refetch()
         } catch (err) {
             console.error("Failed to fetch:", err)
         } finally {
             setLoading(false)
         }
+        // runsQuery.refetch is stable across renders; excluded to keep fetchData stable
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [taskId, tenantId])
 
     useEffect(() => { fetchData() }, [fetchData])
@@ -232,7 +240,11 @@ export default function ScheduledTaskDetailPage() {
                     <CardTitle className="text-base">Run History</CardTitle>
                 </CardHeader>
                 <CardContent>
-                    {runs.length === 0 ? (
+                    {runsQuery.isLoading ? (
+                        <div className="flex items-center justify-center py-8 text-muted-foreground">
+                            <Loader2 className="h-5 w-5 animate-spin" />
+                        </div>
+                    ) : runs.length === 0 ? (
                         <div className="text-center py-8 text-muted-foreground">
                             <Clock className="h-8 w-8 mx-auto mb-2 opacity-30" />
                             <p className="text-sm">No runs yet</p>
@@ -262,6 +274,15 @@ export default function ScheduledTaskDetailPage() {
                                     </div>
                                 )
                             })}
+
+                            <PaginationBar
+                                currentPage={page}
+                                totalItems={totalRuns}
+                                pageSize={pageSize}
+                                onPageChange={setPage}
+                                onPageSizeChange={size => { setPageSize(size); setPage(1) }}
+                                itemLabel="runs"
+                            />
                         </div>
                     )}
                 </CardContent>

--- a/apps/web-ui/app/app/channels/page.tsx
+++ b/apps/web-ui/app/app/channels/page.tsx
@@ -172,7 +172,7 @@ export default function ChannelsPage() {
                                             <Link href={channel.href} className="flex-1">
                                                 <Button variant="outline" size="sm" className="w-full gap-2">
                                                     <Settings2 className="h-3.5 w-3.5" />
-                                                    {configured ? 'Reconfigure' : 'Configure'}
+                                                    Configure
                                                 </Button>
                                             </Link>
                                             {configured && (

--- a/apps/web-ui/components/channels/channel-reset-card.tsx
+++ b/apps/web-ui/components/channels/channel-reset-card.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+/**
+ * ChannelResetCard
+ *
+ * Shared "danger zone" footer for every channel settings form. Deletes the
+ * channel's stored configuration, returning it to the unconfigured state.
+ *
+ * Renders nothing when the channel is not configured — there is nothing to
+ * reset, and an empty setup page should stay clean.
+ */
+import { useState } from 'react';
+import { Loader2, RotateCcw } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { useResetChannelSettings } from '@/lib/queries/channel-settings';
+
+interface ChannelResetCardProps {
+    /** Channel slug as used in /api/agent-ops/settings/<channel> */
+    channel: string;
+    /** Display name, e.g. "Slack" */
+    name: string;
+    /** What the reset destroys, e.g. "signing secret, bot token and workspace link" */
+    clears: string;
+    /** Whether the channel currently has a stored configuration */
+    configured: boolean;
+    /**
+     * Clear the parent form's local state after a successful reset. The forms seed
+     * their fields from props at mount, so invalidating the query alone would leave
+     * the emptied channel still rendering as configured.
+     */
+    onReset: () => void;
+}
+
+export function ChannelResetCard({ channel, name, clears, configured, onReset }: ChannelResetCardProps) {
+    const [open, setOpen] = useState(false);
+    const resetMutation = useResetChannelSettings(channel);
+
+    if (!configured) return null;
+
+    const handleReset = async () => {
+        try {
+            await resetMutation.mutateAsync();
+            setOpen(false);
+            onReset();
+            toast.success(`${name} configuration reset`);
+        } catch (error: unknown) {
+            const message = error instanceof Error ? error.message : '';
+            toast.error(message || `Failed to reset ${name} configuration`);
+        }
+    };
+
+    return (
+        <>
+            <Card className="border-destructive/30">
+                <CardContent className="flex flex-col gap-4 py-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="space-y-1">
+                        <p className="text-sm font-medium">Reset configuration</p>
+                        <p className="text-sm text-muted-foreground">
+                            Removes the stored {clears} for {name}.
+                        </p>
+                    </div>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        className="gap-2 shrink-0 text-destructive hover:text-destructive"
+                        onClick={() => setOpen(true)}
+                    >
+                        <RotateCcw className="h-3.5 w-3.5" />
+                        Reset
+                    </Button>
+                </CardContent>
+            </Card>
+
+            <AlertDialog open={open} onOpenChange={setOpen}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Reset {name} configuration?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            This deletes the stored {clears}. You&apos;ll need to enter them again to
+                            use {name}. This cannot be undone.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel disabled={resetMutation.isPending}>Cancel</AlertDialogCancel>
+                        <AlertDialogAction
+                            onClick={(e) => {
+                                // Keep the dialog open while the request is in flight; it is
+                                // closed explicitly on success so a failure stays visible.
+                                e.preventDefault();
+                                handleReset();
+                            }}
+                            disabled={resetMutation.isPending}
+                            className="gap-2 bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                        >
+                            {resetMutation.isPending && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+                            Reset
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+        </>
+    );
+}

--- a/apps/web-ui/components/channels/discord-settings-form.tsx
+++ b/apps/web-ui/components/channels/discord-settings-form.tsx
@@ -11,6 +11,7 @@ import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
+import { ChannelResetCard } from '@/components/channels/channel-reset-card';
 
 interface DiscordSettingsState {
     applicationId: string;
@@ -336,6 +337,19 @@ function DiscordSettingsFormInner({
                     </ol>
                 </CardContent>
             </Card>
+
+            <ChannelResetCard
+                channel="discord"
+                name="Discord"
+                clears="application ID, public key and bot token"
+                configured={configured}
+                onReset={() => {
+                    setConfigured(false);
+                    setRevealed(false);
+                    setSaveStatus('idle');
+                    setForm({ applicationId: '', publicKey: '', botToken: '', enabled: true });
+                }}
+            />
         </div>
     );
 }

--- a/apps/web-ui/components/channels/jira-settings-form.tsx
+++ b/apps/web-ui/components/channels/jira-settings-form.tsx
@@ -13,6 +13,7 @@ import { Switch } from '@/components/ui/switch';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { SetupGuideLink } from '@/components/channels/setup-guide-link';
+import { ChannelResetCard } from '@/components/channels/channel-reset-card';
 
 interface JiraSettingsForm {
     webhookSecret: string;
@@ -543,6 +544,18 @@ function JiraSettingsFormInner({
                 </CardContent>
             </Card>
 
+            <ChannelResetCard
+                channel="jira"
+                name="Jira"
+                clears="webhook secret, API token and site details"
+                configured={configured}
+                onReset={() => {
+                    setConfigured(false);
+                    setRevealed(false);
+                    setSaveStatus('idle');
+                    setForm({ webhookSecret: '', baseUrl: '', userEmail: '', apiToken: '', botAccountId: '', enabled: true });
+                }}
+            />
         </div>
     );
 }

--- a/apps/web-ui/components/channels/slack-settings-form.tsx
+++ b/apps/web-ui/components/channels/slack-settings-form.tsx
@@ -13,6 +13,7 @@ import { Switch } from '@/components/ui/switch';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { SetupGuideLink } from '@/components/channels/setup-guide-link';
+import { ChannelResetCard } from '@/components/channels/channel-reset-card';
 
 interface SlackSettingsState {
     signingSecret: string;
@@ -421,6 +422,19 @@ function SlackSettingsFormInner({
                     </Button>
                 </CardContent>
             </Card>
+
+            <ChannelResetCard
+                channel="slack"
+                name="Slack"
+                clears="signing secret, bot token and workspace link"
+                configured={configured}
+                onReset={() => {
+                    setConfigured(false);
+                    setRevealed(false);
+                    setSaveStatus('idle');
+                    setForm({ signingSecret: '', botToken: '', teamId: '', enabled: true });
+                }}
+            />
         </div>
     );
 }

--- a/apps/web-ui/components/channels/telegram-settings-form.tsx
+++ b/apps/web-ui/components/channels/telegram-settings-form.tsx
@@ -13,6 +13,7 @@ import { Switch } from '@/components/ui/switch';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { SetupSteps } from '@/components/channels/setup-steps';
+import { ChannelResetCard } from '@/components/channels/channel-reset-card';
 
 interface TelegramSettingsState {
     botToken: string;
@@ -508,6 +509,19 @@ function TelegramSettingsFormInner({
                     />
                 </CardContent>
             </Card>
+
+            <ChannelResetCard
+                channel="telegram"
+                name="Telegram"
+                clears="bot token and secret token"
+                configured={configured}
+                onReset={() => {
+                    setConfigured(false);
+                    setRevealed(false);
+                    setSaveStatus('idle');
+                    setForm({ botToken: '', secretToken: '', enabled: true });
+                }}
+            />
         </div>
     );
 }

--- a/apps/web-ui/components/channels/webhook-settings-form.tsx
+++ b/apps/web-ui/components/channels/webhook-settings-form.tsx
@@ -11,6 +11,7 @@ import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
+import { ChannelResetCard } from '@/components/channels/channel-reset-card';
 
 interface WebhookSettingsState {
     webhookSecret: string;
@@ -315,6 +316,19 @@ Header: x-webhook-signature: <hex digest>`}</code>
                     </ol>
                 </CardContent>
             </Card>
+
+            <ChannelResetCard
+                channel="webhook"
+                name="Webhook"
+                clears="webhook secret"
+                configured={configured}
+                onReset={() => {
+                    setConfigured(false);
+                    setRevealed(false);
+                    setSaveStatus('idle');
+                    setForm({ webhookSecret: '', enabled: true });
+                }}
+            />
         </div>
     );
 }

--- a/apps/web-ui/env.ts
+++ b/apps/web-ui/env.ts
@@ -69,7 +69,6 @@ export const env = createEnv({
         DATA_DIR: z.string().optional(),
 
         // Integrations
-        SLACK_SIGNING_SECRET: z.string().optional(),
         JIRA_WEBHOOK_SECRET: z.string().optional(),
         JIRA_BASE_URL: z.string().optional(),
         JIRA_USER_EMAIL: z.string().optional(),

--- a/apps/web-ui/lib/agent-ops/types.ts
+++ b/apps/web-ui/lib/agent-ops/types.ts
@@ -234,6 +234,12 @@ export interface RunListQuery {
     tenantId?: string;
     source?: TriggerSource;
     status?: AgentOpsStatus;
+    /**
+     * Scheduled-task filter, matched against trigger->>'taskId'. Applied in SQL so
+     * a task's run history can be paginated and counted; filtering in JS after a
+     * tenant-wide fetch silently drops older runs once other tasks fill the window.
+     */
+    taskId?: string;
     page?: number;
     limit?: number;
     sortBy?: 'createdAt' | 'updatedAt' | 'status' | 'source' | 'taskDescription' | 'durationMs';

--- a/apps/web-ui/lib/db/repositories/agent-ops-run/postgres.test.ts
+++ b/apps/web-ui/lib/db/repositories/agent-ops-run/postgres.test.ts
@@ -147,6 +147,45 @@ describe('AgentOpsRunPostgresRepository', () => {
             expect(callArg.where.status).toBe('completed');
             expect(result.runs).toEqual([]);
         });
+
+        // Scheduled-task run history used to fetch a tenant-wide page of scheduled runs
+        // and filter by taskId in JS, which silently dropped a task's older runs once
+        // other tasks filled the window — and made `total` a tenant-wide count. The
+        // filter must reach SQL.
+        it('filters by taskId in the query (trigger JSON path), not in memory', async () => {
+            mockPrisma.agentOpsRun.findMany.mockResolvedValue([makeRunRow({ source: 'scheduled' })]);
+            mockPrisma.agentOpsRun.count.mockResolvedValue(7);
+
+            const repo = new AgentOpsRunPostgresRepository();
+            const result = await repo.listRuns({
+                tenantId: 't1',
+                source: 'scheduled',
+                taskId: 'task-42',
+                page: 2,
+                limit: 25,
+            });
+
+            const callArg = mockPrisma.agentOpsRun.findMany.mock.calls[0][0];
+            expect(callArg.where.trigger).toEqual({ path: ['taskId'], equals: 'task-42' });
+            expect(callArg.where.source).toBe('scheduled');
+            expect(callArg.skip).toBe(25);
+            expect(callArg.take).toBe(25);
+
+            // The same where-clause must drive the count, or the pagination bar lies.
+            const countArg = mockPrisma.agentOpsRun.count.mock.calls[0][0];
+            expect(countArg.where.trigger).toEqual({ path: ['taskId'], equals: 'task-42' });
+            expect(result.total).toBe(7);
+        });
+
+        it('omits the trigger filter when no taskId is given', async () => {
+            mockPrisma.agentOpsRun.findMany.mockResolvedValue([]);
+
+            const repo = new AgentOpsRunPostgresRepository();
+            await repo.listRuns({ tenantId: 't1', source: 'scheduled' });
+
+            const callArg = mockPrisma.agentOpsRun.findMany.mock.calls[0][0];
+            expect(callArg.where.trigger).toBeUndefined();
+        });
     });
 
     describe('findAwaitingApprovalRun', () => {

--- a/apps/web-ui/lib/db/repositories/agent-ops-run/postgres.ts
+++ b/apps/web-ui/lib/db/repositories/agent-ops-run/postgres.ts
@@ -174,6 +174,8 @@ export class AgentOpsRunPostgresRepository implements IAgentOpsRunRepository {
 
         if (query.source) where.source = query.source;
         if (query.status) where.status = query.status;
+        // JSON-path filter on the trigger payload — same shape listActiveRunsByTask uses.
+        if (query.taskId) where.trigger = { path: ['taskId'], equals: query.taskId };
 
         const orderBy = this.buildOrderBy(query.sortBy, query.sortDir);
 

--- a/apps/web-ui/lib/db/repositories/slack-workspace-link/interface.ts
+++ b/apps/web-ui/lib/db/repositories/slack-workspace-link/interface.ts
@@ -38,4 +38,13 @@ export interface ISlackWorkspaceLinkRepository {
      * Look up the current link for a tenant, if any.
      */
     getLinkForTenant(tenantId: string): Promise<SlackWorkspaceLinkRecord | null>;
+
+    /**
+     * Drop a tenant's workspace link. Called when the tenant resets its Slack
+     * configuration: a link left behind would keep routing inbound team_ids to a
+     * tenant that no longer holds a signing secret, so every slash command would
+     * fail signature verification instead of being cleanly rejected as unlinked.
+     * Returns the number of rows removed (0 when the tenant had no link).
+     */
+    deleteLinkForTenant(tenantId: string): Promise<number>;
 }

--- a/apps/web-ui/lib/db/repositories/slack-workspace-link/postgres.ts
+++ b/apps/web-ui/lib/db/repositories/slack-workspace-link/postgres.ts
@@ -68,4 +68,20 @@ export class SlackWorkspaceLinkPostgresRepository implements ISlackWorkspaceLink
             throw new Error(`Failed to get Slack workspace link: ${msg}`);
         }
     }
+
+    async deleteLinkForTenant(tenantId: string): Promise<number> {
+        try {
+            const { count } = await getPrismaClient().slackWorkspaceLink.deleteMany({
+                where: { tenantId },
+            });
+            if (count > 0) {
+                console.log(`[SlackWorkspaceLinkPostgresRepository] Unlinked Slack workspace for tenant "${tenantId}"`);
+            }
+            return count;
+        } catch (error: unknown) {
+            const msg = error instanceof Error ? error.message : String(error);
+            console.error('[SlackWorkspaceLinkPostgresRepository] Error deleting link for tenant:', error);
+            throw new Error(`Failed to unlink Slack workspace: ${msg}`);
+        }
+    }
 }

--- a/apps/web-ui/lib/gateway/adapters/slack-adapter.ts
+++ b/apps/web-ui/lib/gateway/adapters/slack-adapter.ts
@@ -8,7 +8,6 @@
 
 import * as crypto from 'crypto';
 import type { NextRequest } from 'next/server';
-import { env } from '@/env';
 import { TenantConfigService } from '@/lib/tenant-config-service';
 import { getSlackWorkspaceLinkRepository } from '@/lib/db/repository-factory';
 import { agentOpsService } from '@/lib/agent-ops/agent-ops-service';
@@ -91,7 +90,7 @@ export class SlackAdapter implements ChannelAdapter {
             } catch { /* ignore */ }
         }
 
-        // Load signing secret: resolve tenant from team_id, then tenant config, env var fallback
+        // Load signing secret: resolve tenant from team_id, then tenant config.
         let signingSecret = '';
         const tenantId = await resolveTenantId(req, teamId);
         if (tenantId) {
@@ -102,10 +101,7 @@ export class SlackAdapter implements ChannelAdapter {
             signingSecret = config?.signingSecret || '';
         }
         if (!signingSecret) {
-            signingSecret = env.SLACK_SIGNING_SECRET || '';
-        }
-        if (!signingSecret) {
-            console.error('[SlackAdapter] Signing secret not configured');
+            console.error('[SlackAdapter] Signing secret not configured for tenant');
             return false;
         }
 

--- a/apps/web-ui/lib/queries/agent-ops-scheduled-tasks.ts
+++ b/apps/web-ui/lib/queries/agent-ops-scheduled-tasks.ts
@@ -3,7 +3,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { queryKeys } from '@/lib/queries/query-keys';
-import type { ScheduledTask } from '@/lib/agent-ops/types';
+import type { AgentOpsRun, ScheduledTask } from '@/lib/agent-ops/types';
 import type { TaskListQuery, TaskListStats } from '@/lib/db/repositories/scheduled-task/interface';
 
 export interface TaskListFilters {
@@ -50,6 +50,36 @@ export function useScheduledTasks(filters: TaskListFilters = {}) {
                 total: data.total ?? 0,
                 stats: data.stats ?? { active: 0, paused: 0, totalRuns: 0 },
             };
+        },
+    });
+}
+
+export interface RunHistoryPage {
+    runs: AgentOpsRun[];
+    total: number;
+}
+
+/**
+ * Server-paginated run history for one scheduled task. `total` is the count of
+ * that task's runs (filtered in SQL), so the pagination bar reflects reality.
+ * keepPreviousData avoids the list flashing empty while a page is fetched.
+ */
+export function useScheduledTaskRuns(
+    taskId: string,
+    filters: { page?: number; limit?: number } = {}
+) {
+    const page = filters.page ?? 1;
+    const limit = filters.limit ?? 25;
+    return useQuery({
+        queryKey: queryKeys.agentOps.scheduledTasks.runs(taskId, { page, limit }),
+        enabled: Boolean(taskId),
+        placeholderData: (prev) => prev,
+        queryFn: async (): Promise<RunHistoryPage> => {
+            const params = new URLSearchParams({ page: String(page), limit: String(limit) });
+            const data = await fetchJson<{ runs?: AgentOpsRun[]; total?: number; error?: string }>(
+                `/api/agent-ops/scheduled-tasks/${taskId}/runs?${params}`
+            );
+            return { runs: data.runs ?? [], total: data.total ?? 0 };
         },
     });
 }

--- a/apps/web-ui/lib/queries/channel-settings.ts
+++ b/apps/web-ui/lib/queries/channel-settings.ts
@@ -59,6 +59,27 @@ export function useSaveChannelSettings(channel: string) {
 }
 
 /**
+ * Reset a channel: deletes its stored configuration so it returns to the
+ * unconfigured state. Destructive — the secrets are not recoverable from the UI
+ * afterwards — so call sites must confirm first (see ChannelResetCard).
+ */
+export function useResetChannelSettings(channel: string) {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async () => {
+            const res = await fetch(`/api/agent-ops/settings/${channel}`, { method: 'DELETE' });
+            const data = await res.json().catch(() => ({}));
+            if (!res.ok) throw new Error(data.error || 'Failed to reset channel');
+            return data;
+        },
+        onSuccess: () => {
+            qc.invalidateQueries({ queryKey: ['channel-settings', channel] });
+            qc.invalidateQueries({ queryKey: ['channels', 'status'] });
+        },
+    });
+}
+
+/**
  * Activate/deactivate a configured channel without touching its credentials.
  * Safe because every settings PUT merges the body over the stored config, so
  * an `{ enabled }`-only body keeps all existing secrets. Only call this for

--- a/apps/web-ui/lib/queries/query-keys.ts
+++ b/apps/web-ui/lib/queries/query-keys.ts
@@ -78,6 +78,8 @@ export const queryKeys = {
             all: ['agent-ops', 'scheduled-tasks'] as const,
             lists: () => [...queryKeys.agentOps.scheduledTasks.all, 'list'] as const,
             list: (filters?: unknown) => [...queryKeys.agentOps.scheduledTasks.lists(), filters ?? {}] as const,
+            runs: (taskId: string, filters?: unknown) =>
+                [...queryKeys.agentOps.scheduledTasks.all, 'runs', taskId, filters ?? {}] as const,
         },
     },
     agentMemories: {

--- a/apps/web-ui/tests/agent-ops/channel-reset.test.ts
+++ b/apps/web-ui/tests/agent-ops/channel-reset.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Unit tests for the channel settings DELETE (reset) handlers.
+ *
+ * Reset deletes a channel's stored credentials so it returns to the unconfigured
+ * state. Two things must hold:
+ *   1. It is RBAC-gated — the credentials are destroyed irreversibly.
+ *   2. Slack additionally drops the SlackWorkspaceLink. A link left behind keeps
+ *      mapping the workspace's team_id to a tenant with no signing secret, so
+ *      inbound slash commands fail signature verification (the exact production
+ *      failure mode this table exists to prevent) instead of being rejected as
+ *      unlinked.
+ *
+ * Covers slack (link-owning) + webhook (plain config-only) — the two shapes all
+ * five channel routes reduce to.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+    mockDeleteConfig,
+    mockGetConfig,
+    mockSaveConfig,
+    mockGetSessionTenantId,
+    mockGetAuthSession,
+    mockLogUserAction,
+    mockAuthorize,
+    mockGetLinkForTenant,
+    mockUpsertLink,
+    mockFindTenantIdByTeamId,
+    mockDeleteLinkForTenant,
+} = vi.hoisted(() => ({
+    mockDeleteConfig: vi.fn(),
+    mockGetConfig: vi.fn(),
+    mockSaveConfig: vi.fn(),
+    mockGetSessionTenantId: vi.fn(),
+    mockGetAuthSession: vi.fn(),
+    mockLogUserAction: vi.fn(),
+    mockAuthorize: vi.fn(),
+    mockGetLinkForTenant: vi.fn(),
+    mockUpsertLink: vi.fn(),
+    mockFindTenantIdByTeamId: vi.fn(),
+    mockDeleteLinkForTenant: vi.fn(),
+}));
+
+vi.mock('@/lib/tenant-config-service', () => ({
+    TenantConfigService: {
+        getConfig: mockGetConfig,
+        saveConfig: mockSaveConfig,
+        deleteConfig: mockDeleteConfig,
+    },
+}));
+
+vi.mock('@/lib/auth-session', () => ({
+    getSessionTenantId: mockGetSessionTenantId,
+    getAuthSession: mockGetAuthSession,
+}));
+
+vi.mock('@/lib/audit-service', () => ({
+    AuditService: { logUserAction: mockLogUserAction },
+}));
+
+vi.mock('@/lib/rbac/authorize', () => ({
+    authorize: mockAuthorize,
+}));
+
+vi.mock('@/lib/db/repository-factory', () => ({
+    getSlackWorkspaceLinkRepository: () => ({
+        getLinkForTenant: mockGetLinkForTenant,
+        upsertLink: mockUpsertLink,
+        findTenantIdByTeamId: mockFindTenantIdByTeamId,
+        deleteLinkForTenant: mockDeleteLinkForTenant,
+    }),
+}));
+
+// Import after mocks
+import { DELETE as slackDELETE } from '../../app/api/agent-ops/settings/slack/route';
+import { DELETE as webhookDELETE } from '../../app/api/agent-ops/settings/webhook/route';
+
+const TENANT = 'tenant-abc';
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionTenantId.mockResolvedValue(TENANT);
+    mockGetAuthSession.mockResolvedValue({ user: { email: 'admin@example.com' } });
+    mockAuthorize.mockResolvedValue(null); // authorized
+    mockDeleteConfig.mockResolvedValue(undefined);
+    mockDeleteLinkForTenant.mockResolvedValue(1);
+    mockLogUserAction.mockResolvedValue(undefined);
+});
+
+describe('DELETE /api/agent-ops/settings/slack', () => {
+    it('deletes the stored config and the workspace link', async () => {
+        const res = await slackDELETE();
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body).toMatchObject({ success: true, configured: false });
+        expect(mockDeleteConfig).toHaveBeenCalledWith('agent-ops-slack', TENANT);
+        expect(mockDeleteLinkForTenant).toHaveBeenCalledWith(TENANT);
+    });
+
+    it('is RBAC-gated — an unauthorized caller deletes nothing', async () => {
+        const forbidden = new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403 });
+        mockAuthorize.mockResolvedValue(forbidden);
+
+        const res = await slackDELETE();
+
+        expect(res.status).toBe(403);
+        expect(mockDeleteConfig).not.toHaveBeenCalled();
+        expect(mockDeleteLinkForTenant).not.toHaveBeenCalled();
+    });
+
+    it('audits the reset as a high-severity event', async () => {
+        await slackDELETE();
+
+        expect(mockLogUserAction).toHaveBeenCalledWith(
+            expect.objectContaining({
+                eventType: 'agent.settings.slack_reset',
+                severity: 'high',
+                httpMethod: 'DELETE',
+                user: 'admin@example.com',
+                metadata: { tenantId: TENANT },
+            })
+        );
+    });
+
+    it('surfaces a repository failure as a 500', async () => {
+        mockDeleteConfig.mockRejectedValue(new Error('db down'));
+
+        const res = await slackDELETE();
+        const body = await res.json();
+
+        expect(res.status).toBe(500);
+        expect(body.error).toContain('db down');
+    });
+});
+
+describe('DELETE /api/agent-ops/settings/webhook', () => {
+    it('deletes the stored config', async () => {
+        const res = await webhookDELETE();
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body).toMatchObject({ success: true, configured: false });
+        expect(mockDeleteConfig).toHaveBeenCalledWith('agent-ops-webhook', TENANT);
+    });
+
+    it('is RBAC-gated', async () => {
+        mockAuthorize.mockResolvedValue(new Response(null, { status: 403 }));
+
+        const res = await webhookDELETE();
+
+        expect(res.status).toBe(403);
+        expect(mockDeleteConfig).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web-ui/tests/agent-ops/scheduled-task-runs-route.test.ts
+++ b/apps/web-ui/tests/agent-ops/scheduled-task-runs-route.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Unit tests for GET /api/agent-ops/scheduled-tasks/[taskId]/runs.
+ *
+ * The route previously fetched a tenant-wide page of scheduled runs and filtered
+ * by taskId in JS. It must now push taskId + page/limit into the query so the run
+ * history is complete and `total` counts only this task's runs.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockListRuns, mockGetSessionTenantId } = vi.hoisted(() => ({
+    mockListRuns: vi.fn(),
+    mockGetSessionTenantId: vi.fn(),
+}));
+
+vi.mock('@/lib/agent-ops/agent-ops-service', () => ({
+    agentOpsService: { listRuns: mockListRuns },
+}));
+
+vi.mock('@/lib/auth-session', () => ({
+    getSessionTenantId: mockGetSessionTenantId,
+}));
+
+import { GET } from '../../app/api/agent-ops/scheduled-tasks/[taskId]/runs/route';
+
+const TENANT = 'tenant-abc';
+const params = (taskId: string) => ({ params: Promise.resolve({ taskId }) });
+const req = (qs = '') => new Request(`http://localhost/api/agent-ops/scheduled-tasks/task-42/runs${qs}`);
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionTenantId.mockResolvedValue(TENANT);
+    mockListRuns.mockResolvedValue({ runs: [{ runId: 'r1' }], total: 42, stats: {} });
+});
+
+describe('GET scheduled task runs', () => {
+    it('pushes taskId, source and pagination into the query', async () => {
+        const res = await GET(req('?page=3&limit=10'), params('task-42'));
+        const body = await res.json();
+
+        expect(mockListRuns).toHaveBeenCalledWith({
+            tenantId: TENANT,
+            source: 'scheduled',
+            taskId: 'task-42',
+            page: 3,
+            limit: 10,
+        });
+        expect(body).toMatchObject({ runs: [{ runId: 'r1' }], total: 42, page: 3, limit: 10 });
+    });
+
+    it('defaults to page 1 / limit 25', async () => {
+        await GET(req(), params('task-42'));
+
+        expect(mockListRuns).toHaveBeenCalledWith(
+            expect.objectContaining({ page: 1, limit: 25 })
+        );
+    });
+
+    it('clamps a hostile limit and rejects non-positive pages', async () => {
+        await GET(req('?page=0&limit=100000'), params('task-42'));
+
+        expect(mockListRuns).toHaveBeenCalledWith(
+            expect.objectContaining({ page: 1, limit: 100 })
+        );
+    });
+
+    it('falls back to defaults on unparseable pagination params', async () => {
+        await GET(req('?page=abc&limit=xyz'), params('task-42'));
+
+        expect(mockListRuns).toHaveBeenCalledWith(
+            expect.objectContaining({ page: 1, limit: 25 })
+        );
+    });
+
+    it('returns 500 when the service throws', async () => {
+        mockListRuns.mockRejectedValue(new Error('db down'));
+
+        const res = await GET(req(), params('task-42'));
+        const body = await res.json();
+
+        expect(res.status).toBe(500);
+        expect(body.error).toBe('db down');
+    });
+});

--- a/docs/superpowers/specs/2026-07-15-channel-reset-and-run-history-pagination-design.md
+++ b/docs/superpowers/specs/2026-07-15-channel-reset-and-run-history-pagination-design.md
@@ -1,0 +1,107 @@
+# Channel Reset + Scheduled-Task Run History Pagination — Design
+
+Date: 2026-07-15
+Status: Approved
+
+Two independent, small changes to the Agentic Ops UI.
+
+---
+
+## 1. Channel reset
+
+### Problem
+
+The Channels overview offers a `Reconfigure` action on every configured card, which
+duplicates `Configure` and implies a distinct flow that does not exist. There is no way
+to *clear* a channel's stored credentials from the UI at all — the only path back to an
+unconfigured state is a manual DB edit.
+
+### Design
+
+**Channels overview** (`app/app/channels/page.tsx`): the primary card button always
+reads `Configure`, regardless of state. `Deactivate`/`Activate` is unchanged.
+
+**API**: add a `DELETE` handler to each channel settings route
+(`/api/agent-ops/settings/{slack,jira,discord,telegram,webhook}`). Each handler:
+
+- `authorize('delete', 'Agent')` — gated properly. (The existing `PUT` handlers only
+  authorize on the secret-*reveal* path, not the write itself; `DELETE` does not copy
+  that gap.)
+- `TenantConfigService.deleteConfig(CONFIG_KEY, tenantId)`.
+- Audit-logs `agent.settings.<channel>_reset`, severity `high` — it destroys credentials.
+- **Slack only:** additionally deletes the tenant's `slack_workspace_links` row. Leaving
+  it would keep a `team_id → tenant` mapping pointing at a tenant with no signing secret,
+  which is exactly the broken state that made inbound slash commands fail with
+  `[SlackAdapter] Signing secret not configured`. Requires a new repository method,
+  `deleteLinkForTenant(tenantId)`.
+
+Channel status on the cards derives from each route's `configured` flag (i.e. "does the
+config row exist"), so deleting the config flips the card back to `Not configured` with
+no extra plumbing.
+
+**UI**: a shared `ChannelResetCard` (`components/channels/channel-reset-card.tsx`) placed
+at the bottom of all five settings forms. Props: `{ channel, name, clears }`. Renders a
+quiet danger-styled card — "Reset configuration", one line of description, a `Reset`
+button — wired to the existing `AlertDialog` primitive for a confirm step. It renders
+only when the channel is configured, so a fresh setup page stays clean.
+
+**Data layer**: `useResetChannelSettings(channel)` in `lib/queries/channel-settings.ts`,
+alongside the existing save/toggle hooks. On success it invalidates `['channels','status']`
+and the per-channel settings key, then fires a `sonner` toast.
+
+### Scope choices
+
+- Reset does not touch the `enabled` flag separately — the whole config row goes.
+- No reset on the MCP or Providers pages; both already have per-item delete.
+
+### Testing
+
+Unit tests for the five `DELETE` routes (config deleted, 403 without permission) and for
+Slack reset removing the workspace link.
+
+---
+
+## 2. Scheduled-task run history pagination
+
+### Problem
+
+`GET /api/agent-ops/scheduled-tasks/[taskId]/runs` fetches the last N scheduled runs for
+the **whole tenant** (`listRuns({ source: 'scheduled', limit })`) and then filters by
+`taskId` in JavaScript. The run history is therefore silently lossy: once other tasks'
+runs fill the window, this task's older runs disappear from the page. Pagination cannot
+be built on top of that, and the displayed count cannot be trusted.
+
+### Design
+
+**Repository / types**: add `taskId?: string` to `RunListQuery`. In
+`AgentOpsRunPostgresRepository.listRuns`, apply it to the where-clause as a JSON-path
+filter — `trigger: { path: ['taskId'], equals: taskId }` — the same pattern
+`listActiveRunsByTask` already uses against this schema. `listRuns` already does
+`skip`/`take`/`count` and returns `{ runs, total }`, so pagination follows for free.
+
+**Route**: read `page` and `limit` from the query string, pass
+`{ tenantId, source: 'scheduled', taskId, page, limit }` through, return `{ runs, total }`.
+The in-JS `.filter()` is removed.
+
+**Client**: `useScheduledTaskRuns(taskId, { page, limit })` in `lib/queries/`, keyed via
+the central `query-keys.ts` factory, mirroring `useScheduledTasks`. The detail page holds
+`page`/`pageSize` state and renders the shared `<PaginationBar>` primitive with
+`itemLabel="runs"` — the same bar the tasks list uses.
+
+Only the Run History section moves to TanStack Query; the rest of the detail page's raw
+`fetch` calls are left alone to keep the diff contained (the page predates the query-hook
+convention — worth a separate follow-up).
+
+### Known limitation (accepted)
+
+The JSON-path filter on `trigger->>'taskId'` is unindexed; `AgentOpsRun` indexes
+`tenantId` and `[tenantId, source]` among others. Combined with `tenantId` +
+`source = 'scheduled'` the scan is narrow enough at current run volumes. If scheduled-run
+volume grows, the fix is a GIN index on `trigger` or a promoted `taskId` column. Not done
+now (YAGNI).
+
+### Testing
+
+- Repository: `listRuns({ taskId })` returns only that task's runs, with a correct `total`
+  — the regression the current in-JS filter cannot pass.
+- Route: `page`/`limit` passthrough.


### PR DESCRIPTION
## Summary

Two independent UI/API changes to Agentic Ops, plus two small fixes that were sitting in the working tree.

### 1. Channel reset (`feat(channels)`)
The Channels cards offered **Reconfigure**, which duplicated **Configure** and implied a flow that did not exist — while there was no way to *clear* a channel's stored credentials from the UI at all. The only path back to an unconfigured state was a manual DB edit.

- Cards always read **Configure**; `Deactivate`/`Activate` unchanged.
- New `DELETE` on all five channel settings routes (slack/jira/discord/telegram/webhook), gated on `authorize('delete', 'Agent')` and audit-logged as a high-severity `agent.settings.<channel>_reset` — it destroys credentials irreversibly.
- **Slack's reset also drops the tenant's `SlackWorkspaceLink`.** A link left behind keeps mapping the workspace's `team_id` to a tenant with no signing secret, so inbound slash commands fail signature verification instead of being cleanly rejected as unlinked — the exact production failure this table exists to prevent.
- Shared `ChannelResetCard`: confirm dialog, clears the parent form's local state, and only renders once a channel is configured.

### 2. Server-side run-history pagination (`fix(agent-ops)`)
`GET /scheduled-tasks/[taskId]/runs` fetched the last N scheduled runs **for the whole tenant** and filtered by `taskId` in JavaScript. The run history was silently lossy — once other tasks' runs filled the window, this task's older runs vanished — and the count could not be trusted.

- `taskId` is now a first-class `RunListQuery` filter applied in SQL as a `trigger->>'taskId'` JSON-path match (the shape `listActiveRunsByTask` already uses). `listRuns` already does `skip`/`take`/`count`, so real pagination follows.
- Detail page uses a `useScheduledTaskRuns` TanStack Query hook and the shared `PaginationBar`, matching the tasks list.
- **Known limitation (accepted):** the JSON-path filter is unindexed. Narrowed by `tenantId` + `source` it is fine at current volumes; if scheduled-run volume grows, add a GIN index on `trigger` or promote `taskId` to a column.

### 3. Carried along
- `refactor(slack)`: drop the `SLACK_SIGNING_SECRET` env fallback — Slack creds are per-tenant, and the global fallback could only ever serve one workspace (it was never set in any deployed task definition).
- `fix(agent-ops)`: the run Result card is now collapsible; long summaries were burying the step timeline.

## Testing

- **13 new tests, all passing** — reset routes (deletes config, deletes the Slack link, 403 blocks both, audits, 500 on failure), runs route (filter/pagination passthrough, defaults, limit clamping, unparseable params), repository `taskId` filter incl. that the same where-clause drives the count.
- **No regressions:** full web-ui suite run against a clean `master-v1` worktree for a true baseline. Both fail identically (17 files / 58 tests — all pre-existing mock-harness failures in untouched modules). This branch takes the suite from 951 → 964 passing.
- `tsc`: 182 errors, exactly the pre-existing baseline, none in touched files. Lint clean on all new code.

Not yet exercised in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)