### PR TITLE
chore(cicd): downsize deploy CodeBuild compute to LARGE

### DIFF
--- a/infra/cicd/index.ts
+++ b/infra/cicd/index.ts
@@ -448,7 +448,7 @@ const deployProject = new aws.codebuild.Project("nucleus-deploy", {
     artifacts: { type: "CODEPIPELINE" },
     environment: {
         type: "LINUX_CONTAINER",
-        computeType: "BUILD_GENERAL1_2XLARGE",
+        computeType: "BUILD_GENERAL1_LARGE",
         image: "aws/codebuild/standard:7.0",
         privilegedMode: true,
     },


### PR DESCRIPTION
## Summary

Downsizes the `nucleus-cloud-ops-deploy` CodeBuild project compute from `BUILD_GENERAL1_2XLARGE` (72 vCPUs, 144 GiB / g1.2xlarge) to `BUILD_GENERAL1_LARGE` (8 vCPUs, ~15 GiB / g1.large).

```diff
-        computeType: "BUILD_GENERAL1_2XLARGE",
+        computeType: "BUILD_GENERAL1_LARGE",
```

The Pulumi-up deploy job does not need 2XLARGE capacity; LARGE is sufficient and materially cheaper per build-minute.

## Why

Directly remediates the recurring CodeBuild cost anomalies from `g1.2xlarge` overuse in STX-CLOUD-PLATFORM (970547372609, ap-south-1):

- **DEVCHNMGM-819** — $72.74 spike (+774%)
- **DEVCHNMGM-832** — $84.13 spike (+703%)

Both tickets requested right-sizing this project down to `g1.large`.

## Deploy note

The CodeBuild project is Pulumi-managed, so this takes effect only after a deploy of the `infra/cicd` stack:

```bash
cd infra/cicd && AWS_PROFILE=PLATFORM-ADMIN pulumi preview --stack prod
cd infra/cicd && AWS_PROFILE=PLATFORM-ADMIN pulumi up --stack prod --yes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)