### PR TITLE
feat(aiops): chat-layer triage + dynamic skill loading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -109,11 +109,12 @@ PROCEDURAL_MEMORY_ENABLED=true
 
 # Hermes autonomy + observability
 # MEMORY_LOG_VERBOSE: print full injected memoryContext blocks (summary lines are always on).
-# AUTO_SKILL_SELECTION_ENABLED: chat auto-picks a skill when none selected.
+# CHAT_TRIAGE_ENABLED: chat-layer router — conversational messages get a direct reply instead of the agent workflow; the same call auto-picks the skill. false = always run the workflow (legacy behavior).
+# (Auto skill selection/loading has no env flag — it is always available and toggled per-session via the "Auto skills" switch in the AIOps console.)
 # AUTO_SKILL_CREATION_ENABLED: matured procedural domains auto-become/refresh enabled system skills (read-only tier).
 # AUTO_SKILL_MATURITY_THRESHOLD: accessCount a rule needs before promoting.
 MEMORY_LOG_VERBOSE=true
-AUTO_SKILL_SELECTION_ENABLED=true
+CHAT_TRIAGE_ENABLED=true
 AUTO_SKILL_CREATION_ENABLED=true
 AUTO_SKILL_MATURITY_THRESHOLD=3
 # SKILL_SYNTHESIS_MIN_RULES: matured rules a domain needs before it earns a synthesized skill.

--- a/apps/web-ui/app/api/chat/direct-chat.ts
+++ b/apps/web-ui/app/api/chat/direct-chat.ts
@@ -1,0 +1,159 @@
+import { HumanMessage, AIMessage, SystemMessage, BaseMessage } from '@langchain/core/messages';
+import { NextResponse } from 'next/server';
+import { createUIMessageStreamResponse, UIMessageChunk } from 'ai';
+import { createAgentModels } from '@/lib/agent/model-factory';
+import { buildBaseIdentity } from '@/lib/agent/prompt-templates';
+import { contentToText, type ResolvedModelConfig } from '@/lib/agent/agent-shared';
+
+/**
+ * direct-chat.ts — the conversational fast path in front of the agent workflow.
+ *
+ * When triage classifies a message as 'direct' (greeting/thanks/capability
+ * question), this responder streams a single plain LLM reply: no graph, no
+ * memory recall, no planner, no tools, no plan rail. One small completion —
+ * true chatbot latency. The reply renders as a plain answer row in the UI
+ * (no phase parts), and both messages persist to chat history so the thread
+ * reloads correctly.
+ *
+ * Continuity note: this exchange bypasses the LangGraph checkpointer, so it
+ * enters graph state only when a later task turn starts a fresh graph thread
+ * (the client sends full history then). For the conversational content this
+ * path handles, that trade-off is intentional.
+ */
+
+interface ClientMessage {
+    role: string;
+    content: string;
+    parts?: Array<{ type: string; text: string }>;
+}
+
+const DIRECT_HISTORY_WINDOW = 12;
+
+function textOf(m: ClientMessage): string {
+    if (typeof m.content === 'string' && m.content) return m.content;
+    return m.parts?.filter(p => p.type === 'text').map(p => p.text).join('') ?? '';
+}
+
+function buildDirectMessages(messages: ClientMessage[]): BaseMessage[] {
+    return messages
+        .slice(-DIRECT_HISTORY_WINDOW)
+        .filter(m => (m.role === 'user' || m.role === 'assistant') && textOf(m).trim())
+        .map(m => (m.role === 'user'
+            ? new HumanMessage({ content: textOf(m) })
+            : new AIMessage({ content: textOf(m) })));
+}
+
+function buildDirectSystemPrompt(): SystemMessage {
+    return new SystemMessage(`${buildBaseIdentity()}
+
+## Conversational Reply Mode
+
+The user's message is conversational — a greeting, thanks, a question about your capabilities, or something answerable from the conversation itself. Reply naturally and briefly. No tools are available in this mode, and none are needed.
+
+- Be warm and direct; a greeting gets a short greeting back, not a paragraph.
+- If asked what you can do: you operate AWS across the tenant's connected accounts — inventory and health checks, incident triage, cost analysis and right-sizing, resource scheduling, log/metric investigation, and recurring scheduled tasks. Invite the user to describe a task in plain language.
+- If the message references earlier findings in this conversation, answer from that visible history only — never invent data, resource IDs, or metrics.
+- If the request actually needs live data or an action, say you're ready to run it as a task and ask them to confirm or elaborate — do not fabricate results.`);
+}
+
+export async function respondDirect(params: {
+    messages: ClientMessage[];
+    resolvedModel: ResolvedModelConfig;
+    threadId: string;
+    tenantId: string;
+    userId: string;
+    stream: boolean;
+    releaseLock: () => void;
+    signal?: AbortSignal;
+}): Promise<Response> {
+    const { messages, resolvedModel, threadId, tenantId, userId, stream, releaseLock, signal } = params;
+
+    const history = buildDirectMessages(messages);
+    const lastUser = [...messages].reverse().find(m => m.role === 'user');
+    const userText = lastUser ? textOf(lastUser) : '';
+    const sessionTitle = userText.slice(0, 60) || 'New Chat';
+    const lcInput = [buildDirectSystemPrompt(), ...history];
+    const { main: model } = createAgentModels(resolvedModel);
+
+    // Persist the exchange so thread reload shows it (the workflow path persists
+    // from graph state; here we bypass the graph, so persist explicitly).
+    async function persistExchange(assistantText: string) {
+        try {
+            const { getChatHistory } = await import('@/lib/agent/persistence');
+            const chatHistory = await getChatHistory();
+            await chatHistory.addMessages(
+                tenantId,
+                userId,
+                threadId,
+                [
+                    { role: 'human', content: userText },
+                    { role: 'ai', content: assistantText },
+                ],
+                sessionTitle,
+            );
+        } catch (e) {
+            console.warn('[DirectChat] Failed to persist chat history (non-fatal):', e);
+        }
+    }
+
+    if (!stream) {
+        try {
+            const resp = await model.invoke(lcInput, signal ? { signal } : undefined);
+            const text = contentToText(resp.content);
+            await persistExchange(text);
+            return NextResponse.json({ role: 'assistant', content: text });
+        } finally {
+            releaseLock();
+        }
+    }
+
+    const uiStream = new ReadableStream<UIMessageChunk>({
+        async start(controller) {
+            let closed = false;
+            const enqueue = (chunk: UIMessageChunk): boolean => {
+                if (closed) return false;
+                try {
+                    controller.enqueue(chunk);
+                    return true;
+                } catch {
+                    closed = true;
+                    return false;
+                }
+            };
+            const partId = `direct-${Date.now()}`;
+            let fullText = '';
+            try {
+                enqueue({ type: 'start' });
+                enqueue({ type: 'text-start', id: partId });
+                const iterator = await model.stream(lcInput, signal ? { signal } : undefined);
+                for await (const chunk of iterator) {
+                    const delta = contentToText(chunk.content);
+                    if (!delta) continue;
+                    fullText += delta;
+                    if (!enqueue({ type: 'text-delta', id: partId, delta })) break;
+                }
+                enqueue({ type: 'text-end', id: partId });
+                enqueue({ type: 'finish' });
+            } catch (err: any) {
+                const aborted = err?.name === 'AbortError' || /abort/i.test(String(err?.message ?? ''));
+                if (aborted) {
+                    console.log('[DirectChat] Client aborted — closing stream.');
+                } else {
+                    console.error('[DirectChat] Stream failed:', err);
+                    // Best-effort user-visible error before closing.
+                    enqueue({ type: 'text-delta', id: partId, delta: `\n⚠️ Reply failed: ${err?.message ?? 'unknown error'}` });
+                    enqueue({ type: 'text-end', id: partId });
+                    enqueue({ type: 'finish' });
+                }
+            } finally {
+                if (fullText.trim()) await persistExchange(fullText);
+                releaseLock();
+                if (!closed) {
+                    try { controller.close(); } catch { /* already closed */ }
+                }
+            }
+        },
+    });
+
+    return createUIMessageStreamResponse({ stream: uiStream });
+}

--- a/apps/web-ui/app/api/chat/route.ts
+++ b/apps/web-ui/app/api/chat/route.ts
@@ -5,7 +5,8 @@ import { createReflectionGraph, createFastGraph, createDeepGraph } from '@/lib/a
 import { resolveModelConfig, resolveDefaultModelConfig } from '@/lib/agent/model-resolver';
 import { isProviderConfigError } from '@/lib/agent/provider-errors';
 import { buildClientErrorText } from '@/lib/agent/stream-error';
-import { autoSelectSkill } from '@/lib/agent/auto-skill-select';
+import { triageChatMessage } from '@/lib/agent/triage';
+import { respondDirect } from './direct-chat';
 import { resolveKnowledgeBaseIds } from '@/lib/agent/auto-kb-select';
 import { acquireThreadLock, releaseThreadLock as releaseThreadLockDb } from '@/lib/agent/thread-lock';
 import { buildPlanPart, buildPhasePart, buildInterruptParts, buildMemoryPart, humanizeReflection, humanizePlanning, isWorkingMemoryPayload, stripWorkingMemoryPrelude } from './stream-parts';
@@ -78,6 +79,7 @@ export async function POST(req: Request) {
             accountId,      // Deprecated: single AWS account ID for backwards compatibility
             accountName,    // Deprecated: single AWS account name
             selectedSkill,  // Skill ID for dynamic skill loading
+            autoLoadSkills = true, // Console "Auto skills" toggle: auto-select + mid-run load_skill
             mcpServerIds,   // MCP server IDs to activate for this session
             knowledgeBaseIds, // Knowledge Base IDs manually selected in the console
             decisions       // Per-tool approval decisions (new resume contract)
@@ -172,14 +174,45 @@ export async function POST(req: Request) {
             throw e;
         }
 
-        // Hermes-style disclosure: when no skill is picked, one cheap reflector call
-        // matches the message against the skill catalog. Manual selection always wins.
+        // Chat-layer triage: ONE cheap classifier call decides direct-reply vs
+        // workflow AND doubles as the skill auto-selector (Hermes disclosure) —
+        // it replaced the standalone autoSelectSkill call, so the chat layer
+        // costs zero net new LLM calls. Manual skill selection always wins.
+        // Resume turns (HITL decisions / tool results) are workflow continuations
+        // and must never be re-triaged.
+        const isResumeTurn = Array.isArray(decisions) || messages[messages.length - 1]?.role === 'tool';
         let effectiveSkill: string | null = selectedSkill || null;
-        if (!effectiveSkill && mode !== 'deep') {
+        let triageRoute: 'direct' | 'task' = 'task';
+        if (!isResumeTurn && mode !== 'deep') {
             const lastMsg = messages[messages.length - 1];
             const lastUserText = typeof lastMsg?.content === 'string' ? lastMsg.content : JSON.stringify(lastMsg?.content ?? '');
-            const auto = await autoSelectSkill({ tenantId: resolvedTenantId, message: lastUserText, model: resolvedModel });
-            if (auto) effectiveSkill = auto.slug;
+            const triage = await triageChatMessage({
+                tenantId: resolvedTenantId,
+                message: lastUserText,
+                model: resolvedModel,
+                // Skip skill matching when a skill is pinned OR the console
+                // "Auto skills" toggle is off (routing still runs either way).
+                skillAlreadySelected: !!effectiveSkill || autoLoadSkills === false,
+            });
+            triageRoute = triage.route;
+            if (!effectiveSkill && triage.skillId) effectiveSkill = triage.skillId;
+        }
+
+        // Direct path: conversational message → single plain LLM reply. Skips
+        // KB selection, graph creation, memory recall, and the plan rail
+        // entirely. respondDirect owns lock release on every outcome.
+        if (triageRoute === 'direct') {
+            console.log('🚦 [API] Triage → direct reply (no workflow)');
+            return await respondDirect({
+                messages,
+                resolvedModel,
+                threadId,
+                tenantId: resolvedTenantId,
+                userId: resolvedUserId,
+                stream: stream !== false,
+                releaseLock,
+                signal: req.signal,
+            });
         }
 
         // KB progressive disclosure: manual selection always wins. When none is picked,
@@ -199,6 +232,7 @@ export async function POST(req: Request) {
             accountId: accountId,       // Backwards compatibility
             accountName: accountName,
             selectedSkill: effectiveSkill,  // user pick, or auto-selected (Hermes disclosure), or null
+            autoLoadSkills: autoLoadSkills !== false, // console toggle → skill catalog + load_skill tool
             mcpServerIds: mcpServerIds || [],       // Pass MCP server IDs for dynamic tool loading
             knowledgeBaseIds: effectiveKbIds,       // user pick, or auto-selected KB ids, or []
             userId: resolvedUserId,                 // For memory store scoping

--- a/apps/web-ui/components/agent/workspace/__tests__/composer.test.tsx
+++ b/apps/web-ui/components/agent/workspace/__tests__/composer.test.tsx
@@ -47,6 +47,8 @@ function baseProps(overrides: Partial<React.ComponentProps<typeof Composer>> = {
     onAutoApproveChange: vi.fn(),
     showTools: false,
     onShowToolsChange: vi.fn(),
+    autoLoadSkills: true,
+    onAutoLoadSkillsChange: vi.fn(),
     ...overrides,
   }
 }

--- a/apps/web-ui/components/agent/workspace/composer.tsx
+++ b/apps/web-ui/components/agent/workspace/composer.tsx
@@ -42,6 +42,8 @@ export interface ComposerProps {
   onAutoApproveChange: (value: boolean) => void;
   showTools: boolean;
   onShowToolsChange: (value: boolean) => void;
+  autoLoadSkills: boolean;
+  onAutoLoadSkillsChange: (value: boolean) => void;
   /** "Enhance prompt with AI" (Wand2) — rewrites the draft via /api/enhance-prompt. */
   onEnhance?: () => void;
   isEnhancing?: boolean;
@@ -63,6 +65,8 @@ export function Composer({
   onAutoApproveChange,
   showTools,
   onShowToolsChange,
+  autoLoadSkills,
+  onAutoLoadSkillsChange,
   onEnhance,
   isEnhancing = false,
 }: ComposerProps) {
@@ -216,6 +220,21 @@ export function Composer({
                   id="composer-show-tools"
                   checked={showTools}
                   onCheckedChange={onShowToolsChange}
+                  disabled={disabled}
+                />
+              </div>
+              <div className="flex items-center justify-between gap-2">
+                <Label
+                  htmlFor="composer-auto-skills"
+                  className="text-xs font-normal text-muted-foreground"
+                  title="The agent auto-selects a matching skill for the task and can load additional skills mid-run. Off: only a manually pinned skill is used."
+                >
+                  Auto skills
+                </Label>
+                <Switch
+                  id="composer-auto-skills"
+                  checked={autoLoadSkills}
+                  onCheckedChange={onAutoLoadSkillsChange}
                   disabled={disabled}
                 />
               </div>

--- a/apps/web-ui/components/agent/workspace/session-view.tsx
+++ b/apps/web-ui/components/agent/workspace/session-view.tsx
@@ -351,6 +351,8 @@ export function SessionView({ threadId, ownerUserId, active, onStatusChange, onT
                 onAutoApproveChange={pickers.setAutoApprove}
                 showTools={showWork}
                 onShowToolsChange={setShowWork}
+                autoLoadSkills={pickers.autoLoadSkills}
+                onAutoLoadSkillsChange={pickers.setAutoLoadSkills}
                 onEnhance={handleEnhancePrompt}
                 isEnhancing={isEnhancing}
               />

--- a/apps/web-ui/components/agent/workspace/use-session-pickers.ts
+++ b/apps/web-ui/components/agent/workspace/use-session-pickers.ts
@@ -42,6 +42,8 @@ export interface UseSessionPickersResult {
   setAgentMode: (mode: string) => void;
   autoApprove: boolean;
   setAutoApprove: (value: boolean) => void;
+  autoLoadSkills: boolean;
+  setAutoLoadSkills: (value: boolean) => void;
 }
 
 export function useSessionPickers({
@@ -79,6 +81,8 @@ export function useSessionPickers({
   // ── Composer settings ───────────────────────────────────────────────────────
   const [agentMode, setAgentMode] = useState("fast");
   const [autoApprove, setAutoApprove] = useState(true);
+  // "Auto skills": auto-select a skill for the task + allow mid-run load_skill.
+  const [autoLoadSkills, setAutoLoadSkills] = useState(true);
 
   // Preselect the default provider's chat model; preserve an explicit user pick
   // across refetches (chat-interface.tsx:636-640).
@@ -166,6 +170,7 @@ export function useSessionPickers({
   bodyStateRef.current = {
     threadId,
     autoApprove,
+    autoLoadSkills,
     model: selectedModel,
     mode: agentMode,
     accounts:
@@ -246,5 +251,7 @@ export function useSessionPickers({
     setAgentMode,
     autoApprove,
     setAutoApprove,
+    autoLoadSkills,
+    setAutoLoadSkills,
   };
 }

--- a/apps/web-ui/lib/agent/agent-shared.ts
+++ b/apps/web-ui/lib/agent/agent-shared.ts
@@ -816,6 +816,10 @@ export interface GraphConfig {
     userId?: string;  // For long-term memory store scoping
     knowledgeBaseIds?: string[] | null;
     maxIterations?: number;  // Agent Ops per-tenant graph iteration limit (executor loop + recursionLimit)
+    // Per-session "Auto skills" console toggle (default on). false hides the
+    // skill catalog from prompts and drops the load_skill tool — the agent can
+    // then only use a skill the user pinned manually.
+    autoLoadSkills?: boolean;
 }
 
 // --- MCP Integration ---

--- a/apps/web-ui/lib/agent/auto-skill-select.test.ts
+++ b/apps/web-ui/lib/agent/auto-skill-select.test.ts
@@ -8,7 +8,7 @@ vi.mock('./model-factory', () => ({ createAgentModels: vi.fn() }));
 
 import { getSkillSummaries, getSkillById } from '@/lib/skill-service';
 import { createAgentModels } from './model-factory';
-import { autoSelectSkill, autoSkillSelectionEnabled } from './auto-skill-select';
+import { autoSelectSkill } from './auto-skill-select';
 
 const reflectorReturning = (content: string) => ({ reflector: { invoke: vi.fn().mockResolvedValue({ content }) } });
 const base = { tenantId: 't1', message: 'analyse our EC2 costs', model: {} as any };
@@ -18,16 +18,6 @@ beforeEach(() => {
     vi.mocked(getSkillSummaries).mockResolvedValue('Available Skills:\n- cost-analyser: Cost Analyser - analyses spend');
     vi.mocked(getSkillById).mockResolvedValue({ id: 'cost-analyser', name: 'Cost Analyser', description: 'analyses spend', tier: 'read-only' } as any);
 });
-afterEach(() => { delete process.env.AUTO_SKILL_SELECTION_ENABLED; });
-
-describe('autoSkillSelectionEnabled', () => {
-    it('defaults true; false disables', () => {
-        expect(autoSkillSelectionEnabled()).toBe(true);
-        process.env.AUTO_SKILL_SELECTION_ENABLED = 'false';
-        expect(autoSkillSelectionEnabled()).toBe(false);
-    });
-});
-
 describe('autoSelectSkill', () => {
     it('matches a skill and returns slug + reasoning', async () => {
         vi.mocked(createAgentModels).mockReturnValue(reflectorReturning('{"skillId": "cost-analyser", "reasoning": "cost question"}') as any);
@@ -57,12 +47,6 @@ describe('autoSelectSkill', () => {
         vi.mocked(createAgentModels).mockReturnValue(models as any);
         expect(await autoSelectSkill(base)).toBeNull();
         expect(models.reflector.invoke).not.toHaveBeenCalled();
-    });
-
-    it('flag off → null without any calls', async () => {
-        process.env.AUTO_SKILL_SELECTION_ENABLED = 'false';
-        expect(await autoSelectSkill(base)).toBeNull();
-        expect(createAgentModels).not.toHaveBeenCalled();
     });
 
     it('LLM throwing → null, does not throw', async () => {

--- a/apps/web-ui/lib/agent/auto-skill-select.ts
+++ b/apps/web-ui/lib/agent/auto-skill-select.ts
@@ -11,17 +11,11 @@ import { contentToText, type ResolvedModelConfig } from './agent-shared';
 import { createAgentModels } from './model-factory';
 import { getSkillSummaries, getSkillById } from '@/lib/skill-service';
 
-export function autoSkillSelectionEnabled(): boolean {
-    const v = process.env.AUTO_SKILL_SELECTION_ENABLED?.toLowerCase();
-    return !(v === 'false' || v === '0');
-}
-
 export async function autoSelectSkill(params: {
     tenantId: string;
     message: string;
     model: ResolvedModelConfig;
 }): Promise<{ slug: string; reasoning: string } | null> {
-    if (!autoSkillSelectionEnabled()) return null;
     try {
         const catalog = await getSkillSummaries(params.tenantId);
         if (catalog.startsWith('No specialized skills')) return null;

--- a/apps/web-ui/lib/agent/fast-agent.ts
+++ b/apps/web-ui/lib/agent/fast-agent.ts
@@ -30,7 +30,6 @@ import {
 } from "./prompt-templates";
 import { createAgentModels, assembleTools } from "./model-factory";
 import { createMemoryRecallNode, createMemorySaveNode } from "./memory-nodes";
-import { autoSkillSelectionEnabled } from "./auto-skill-select";
 import { prepareContext, buildWorkingMemorySection } from "./memory/working-memory";
 import { createGuardNode } from "./guard";
 import { routeAfterGuard } from "./gate-routing";
@@ -48,9 +47,13 @@ export async function createFastGraph(config: GraphConfig) {
     if (selectedSkill) {
         console.log(skillContent ? `[FastAgent] Loaded skill: ${selectedSkill}` : `[FastAgent] No content for skill: ${selectedSkill}`);
     }
-    // Catalog rides the auto-selection feature flag (true kill-switch) and the
-    // zero-skill sentinel string must not leak into the prompt.
-    const skillCatalog = !selectedSkill && tenantId && autoSkillSelectionEnabled()
+    // Skill catalog for progressive disclosure — gated by the console "Auto
+    // skills" toggle (default on). The zero-skill sentinel string must not leak
+    // into the prompt. Fetched even when a skill is pinned: the load_skill tool
+    // lets the agent pull ADDITIONAL skills mid-run for phases outside the
+    // active skill's scope.
+    const autoLoadSkills = config.autoLoadSkills !== false;
+    const skillCatalog = tenantId && autoLoadSkills
         ? await getSkillSummaries(tenantId)
             .then(s => (s.startsWith('No specialized skills') ? null : s))
             .catch(() => null)
@@ -68,7 +71,7 @@ export async function createFastGraph(config: GraphConfig) {
 
     // --- Tool Assembly (fast-agent does not use S3 tools) ---
     // Memory tools excluded — memory_recall and memory_save graph nodes handle memory deterministically
-    const tools = await assembleTools({ includeS3Tools: false, includeMemoryTools: false, userId: config.userId, mcpServerIds, tenantId, accounts, knowledgeBaseIds: config.knowledgeBaseIds });
+    const tools = await assembleTools({ includeS3Tools: false, includeMemoryTools: false, includeSkillTool: autoLoadSkills, userId: config.userId, mcpServerIds, tenantId, accounts, knowledgeBaseIds: config.knowledgeBaseIds });
     const modelWithTools = model.bindTools!(tools);
     const toolNode = new ToolNode(tools);
 

--- a/apps/web-ui/lib/agent/model-factory.ts
+++ b/apps/web-ui/lib/agent/model-factory.ts
@@ -25,6 +25,7 @@ import {
 } from "./tools";
 import { createGetRightSizingRecommendationsTool } from "./right-sizing-tool";
 import { createSearchKnowledgeBaseTool } from "./kb-tool";
+import { createLoadSkillTool } from "./skill-tool";
 import { getActiveMCPTools, isOpenAICompatibleProvider, type AccountContext, type ResolvedModelConfig } from "./agent-shared";
 import { tool } from "@langchain/core/tools";
 import { z } from "zod";
@@ -182,6 +183,9 @@ export interface AssembleToolsOptions {
     includeS3Tools?: boolean;
     /** Include long-term memory tools (save_memory, search_memory). Enable when DynamoDBStore is active. */
     includeMemoryTools?: boolean;
+    /** Include the load_skill progressive-disclosure tool. Default: true. The
+     *  console "Auto skills" toggle sets this false to disable dynamic skill loading. */
+    includeSkillTool?: boolean;
     /** User ID for scoping memory operations. Required when includeMemoryTools is true. */
     userId?: string;
     /** MCP server IDs to dynamically load tools from. */
@@ -239,7 +243,7 @@ export function createMemoryTools(tenantId: string, userId: string) {
  * Logs MCP tool count when any are loaded.
  */
 export async function assembleTools(options: AssembleToolsOptions = {}) {
-    const { includeS3Tools = false, includeMemoryTools = false, userId, mcpServerIds, tenantId, accounts, knowledgeBaseIds } = options;
+    const { includeS3Tools = false, includeMemoryTools = false, includeSkillTool = true, userId, mcpServerIds, tenantId, accounts, knowledgeBaseIds } = options;
 
     const effectiveTenantId = tenantId || 'default';
     if (!tenantId) {
@@ -248,6 +252,9 @@ export async function assembleTools(options: AssembleToolsOptions = {}) {
 
     const memoryTools = (includeMemoryTools && tenantId && userId) ? createMemoryTools(tenantId, userId) : [];
     const kbTools = tenantId ? [createSearchKnowledgeBaseTool(tenantId, knowledgeBaseIds ?? undefined)] : [];
+    // Progressive skill disclosure: catalog lives in the system prompt, full
+    // content loads on demand via this tool (tenant-scoped, enabled-only).
+    const skillTools = includeSkillTool && tenantId ? [createLoadSkillTool(tenantId)] : [];
 
     const customTools = [
         executeCommandTool,
@@ -264,6 +271,7 @@ export async function assembleTools(options: AssembleToolsOptions = {}) {
         ...(includeS3Tools ? [writeFileToS3Tool, getFileFromS3Tool] : []),
         ...memoryTools,
         ...kbTools,
+        ...skillTools,
     ];
 
     const mcpTools = await getActiveMCPTools(mcpServerIds, tenantId, accounts);

--- a/apps/web-ui/lib/agent/planning-agent.ts
+++ b/apps/web-ui/lib/agent/planning-agent.ts
@@ -33,7 +33,6 @@ import {
 } from "./prompt-templates";
 import { createAgentModels, assembleTools, deriveInputTokenBudget } from "./model-factory";
 import { createMemoryRecallNode, createMemorySaveNode } from "./memory-nodes";
-import { autoSkillSelectionEnabled } from "./auto-skill-select";
 import { prepareContext, buildWorkingMemorySection, estimateTokens } from "./memory/working-memory";
 import { createGuardNode } from "./guard";
 import { routeAfterGuard } from "./gate-routing";
@@ -198,9 +197,13 @@ export async function createReflectionGraph(config: GraphConfig) {
         console.log(skillContent ? `[PlanningAgent] Loaded skill: ${selectedSkill}` : `[PlanningAgent] No content for skill: ${selectedSkill}`);
     }
 
-    // Catalog rides the auto-selection feature flag (true kill-switch) and the
-    // zero-skill sentinel string must not leak into the prompt.
-    const skillCatalog = !selectedSkill && tenantId && autoSkillSelectionEnabled()
+    // Skill catalog for progressive disclosure — gated by the console "Auto
+    // skills" toggle (default on). The zero-skill sentinel string must not leak
+    // into the prompt. Fetched even when a skill is pinned: the load_skill tool
+    // lets the agent pull ADDITIONAL skills mid-run for phases outside the
+    // active skill's scope.
+    const autoLoadSkills = config.autoLoadSkills !== false;
+    const skillCatalog = tenantId && autoLoadSkills
         ? await getSkillSummaries(tenantId)
             .then(s => (s.startsWith('No specialized skills') ? null : s))
             .catch(() => null)
@@ -220,7 +223,7 @@ export async function createReflectionGraph(config: GraphConfig) {
 
     // --- Tool Assembly ---
     // Memory tools excluded — memory_recall and memory_save graph nodes handle memory deterministically
-    const tools = await assembleTools({ includeS3Tools: true, includeMemoryTools: false, userId: config.userId, mcpServerIds, tenantId, accounts, knowledgeBaseIds: config.knowledgeBaseIds });
+    const tools = await assembleTools({ includeS3Tools: true, includeMemoryTools: false, includeSkillTool: autoLoadSkills, userId: config.userId, mcpServerIds, tenantId, accounts, knowledgeBaseIds: config.knowledgeBaseIds });
     const modelWithTools = model.bindTools!(tools);
     const toolNode = new ToolNode(tools);
 

--- a/apps/web-ui/lib/agent/prompt-templates.ts
+++ b/apps/web-ui/lib/agent/prompt-templates.ts
@@ -73,7 +73,7 @@ export function buildEffectiveSkillSection(
     skillCatalog?: string | null,
 ): string {
     if (selectedSkill && skillContent) {
-        return `\n\n=== ACTIVE SKILL: ${selectedSkill.toUpperCase()} ===\n${skillContent}\n\nYou MUST follow the above skill-specific instructions. They define your privileges, safety guidelines, and workflow for this conversation.\n=== END SKILL ===\n`;
+        return `\n\n=== ACTIVE SKILL: ${selectedSkill.toUpperCase()} ===\n${skillContent}\n\nYou MUST follow the above skill-specific instructions. They define your privileges, safety guidelines, and workflow for this conversation.\n=== END SKILL ===\n${skillCatalog ? `\n${skillCatalog}\nIf a phase of the task falls outside the "${selectedSkill}" skill's scope but matches one of the skills above, call the load_skill tool with that skill's id to load its instructions for that phase. The active skill's rules still govern everything within its own scope.\n` : ''}`;
     }
     if (selectedSkill && !skillContent) {
         console.warn(`[PromptTemplates] No content provided for skill: ${selectedSkill}`);
@@ -86,7 +86,7 @@ You are operating as a general-purpose DevOps engineer with full read and write 
 **Capabilities:** All AWS operations (describe, list, create, update, delete, start, stop, reboot, terminate across EC2, ECS, EKS, RDS, Lambda, S3, IAM, VPC, CloudWatch, SSM, and more), file and IaC operations (Terraform, Ansible, Dockerfiles, CI/CD configs), shell execution.
 
 **Safety:** Verify state before mutation. Use --dry-run or terraform plan where supported. For irreversible actions (terminate, delete, drop), confirm intent is unambiguous before proceeding.
-${skillCatalog ? `\n${skillCatalog}\nIf one of these skills clearly fits the task, follow its documented intent.\n` : ''}
+${skillCatalog ? `\n${skillCatalog}\nIf one of these skills covers the task (or a phase of it), call the load_skill tool with its id to load the full instructions BEFORE doing that work, then follow them. Load additional skills later in the run if a different phase needs them. Do not reload a skill already loaded in this conversation.\n` : ''}
 `;
 }
 

--- a/apps/web-ui/lib/agent/skill-tool.ts
+++ b/apps/web-ui/lib/agent/skill-tool.ts
@@ -1,0 +1,37 @@
+import { tool } from '@langchain/core/tools';
+import { z } from 'zod';
+import { getSkillContent, getSkillSummaries } from '@/lib/skill-service';
+
+/**
+ * skill-tool.ts — progressive disclosure of skills as a tool (Claude Code model).
+ *
+ * The system prompt carries only the skill catalog (name + description lines);
+ * the agent calls load_skill(skill_id) at the moment a task phase needs those
+ * instructions. Multiple skills can be loaded across one run, each on demand,
+ * with no upfront token cost for unused skills.
+ *
+ * Tenant-scoped and enabled-only: getSkillContent() returns null for disabled
+ * or unknown slugs, so a disabled skill (veto) can never be loaded mid-run.
+ */
+export function createLoadSkillTool(tenantId: string) {
+    return tool(
+        async ({ skill_id }: { skill_id: string }) => {
+            const slug = skill_id.trim();
+            const content = await getSkillContent(tenantId, slug);
+            if (!content) {
+                const catalog = await getSkillSummaries(tenantId).catch(() => 'No specialized skills available.');
+                return `Error: skill "${slug}" not found or not enabled for this tenant.\n\n${catalog}`;
+            }
+            console.log(`🧩 [LOAD_SKILL] Loaded skill "${slug}" into context`);
+            return `=== SKILL LOADED: ${slug.toUpperCase()} ===\n${content}\n=== END SKILL ===\n\nFollow these instructions — they define your privileges, safety constraints, and workflow — for all work within this skill's scope.`;
+        },
+        {
+            name: 'load_skill',
+            description:
+                'Load the full instructions of a specialized skill by its id. The available skills are listed in your system prompt under "Available Skills". Call this BEFORE starting work that a skill\'s description covers — the loaded instructions define privileges, safety rules, and workflow for that scope. You may load multiple skills over the course of one task as different phases require them. Do not call it for skills already loaded in this conversation.',
+            schema: z.object({
+                skill_id: z.string().describe('The skill id (slug) exactly as listed in the Available Skills catalog'),
+            }),
+        },
+    );
+}

--- a/apps/web-ui/lib/agent/triage.test.ts
+++ b/apps/web-ui/lib/agent/triage.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@/lib/skill-service', () => ({
+    getSkillSummaries: vi.fn(),
+    getSkillById: vi.fn(),
+}));
+vi.mock('./model-factory', () => ({ createAgentModels: vi.fn() }));
+vi.mock('./auto-skill-select', () => ({ autoSelectSkill: vi.fn() }));
+
+import { getSkillSummaries, getSkillById } from '@/lib/skill-service';
+import { createAgentModels } from './model-factory';
+import { autoSelectSkill } from './auto-skill-select';
+import { triageChatMessage, parseTriageResponse, chatTriageEnabled } from './triage';
+
+const CATALOG = 'Available Skills:\n- cost-analyser: Cost Analyser - analyses spend';
+const reflectorReturning = (content: string) => ({ reflector: { invoke: vi.fn().mockResolvedValue({ content }) } });
+const base = { tenantId: 't1', message: 'hi there', model: {} as any };
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getSkillSummaries).mockResolvedValue(CATALOG);
+    vi.mocked(getSkillById).mockResolvedValue({ id: 'cost-analyser', name: 'Cost Analyser', description: 'analyses spend', tier: 'read-only' } as any);
+});
+afterEach(() => { delete process.env.CHAT_TRIAGE_ENABLED; });
+
+describe('chatTriageEnabled', () => {
+    it('defaults true; false disables', () => {
+        expect(chatTriageEnabled()).toBe(true);
+        process.env.CHAT_TRIAGE_ENABLED = 'false';
+        expect(chatTriageEnabled()).toBe(false);
+    });
+});
+
+describe('parseTriageResponse', () => {
+    it('parses a direct route', () => {
+        expect(parseTriageResponse('{"route": "direct", "skillId": null, "reasoning": "greeting"}', CATALOG))
+            .toEqual({ route: 'direct', skillId: null, reasoning: 'greeting' });
+    });
+
+    it('parses a task route with a catalog-valid skill', () => {
+        expect(parseTriageResponse('{"route": "task", "skillId": "cost-analyser", "reasoning": "costs"}', CATALOG))
+            .toEqual({ route: 'task', skillId: 'cost-analyser', reasoning: 'costs' });
+    });
+
+    it('drops a skill slug not present in the catalog', () => {
+        const res = parseTriageResponse('{"route": "task", "skillId": "made-up", "reasoning": "x"}', CATALOG);
+        expect(res.skillId).toBeNull();
+        expect(res.route).toBe('task');
+    });
+
+    it('fails open to task on unparseable output', () => {
+        expect(parseTriageResponse('sure, sounds conversational!', CATALOG).route).toBe('task');
+    });
+
+    it('fails open to task on malformed JSON', () => {
+        expect(parseTriageResponse('{"route": "direct", oops', CATALOG).route).toBe('task');
+    });
+
+    it('treats an unknown route value as task', () => {
+        expect(parseTriageResponse('{"route": "chat", "skillId": null}', CATALOG).route).toBe('task');
+    });
+});
+
+describe('triageChatMessage', () => {
+    it('routes a greeting to direct with no skill', async () => {
+        vi.mocked(createAgentModels).mockReturnValue(reflectorReturning('{"route": "direct", "skillId": null, "reasoning": "greeting"}') as any);
+        const res = await triageChatMessage(base);
+        expect(res.route).toBe('direct');
+        expect(res.skillId).toBeNull();
+    });
+
+    it('routes a task and auto-selects the skill in the same call', async () => {
+        vi.mocked(createAgentModels).mockReturnValue(reflectorReturning('{"route": "task", "skillId": "cost-analyser", "reasoning": "costs"}') as any);
+        const res = await triageChatMessage({ ...base, message: 'analyse our EC2 costs' });
+        expect(res).toEqual({ route: 'task', skillId: 'cost-analyser', reasoning: 'costs' });
+    });
+
+    it('drops a slug that fails the tenant DB re-verification', async () => {
+        vi.mocked(getSkillById).mockResolvedValue(null);
+        vi.mocked(createAgentModels).mockReturnValue(reflectorReturning('{"route": "task", "skillId": "cost-analyser", "reasoning": "x"}') as any);
+        const res = await triageChatMessage(base);
+        expect(res.skillId).toBeNull();
+    });
+
+    it('skips skill matching when a skill is already selected', async () => {
+        const models = reflectorReturning('{"route": "task", "skillId": null, "reasoning": "task"}');
+        vi.mocked(createAgentModels).mockReturnValue(models as any);
+        const res = await triageChatMessage({ ...base, skillAlreadySelected: true });
+        expect(res.route).toBe('task');
+        expect(vi.mocked(getSkillSummaries)).not.toHaveBeenCalled();
+    });
+
+    it('fails open to task when the model call throws', async () => {
+        vi.mocked(createAgentModels).mockReturnValue({ reflector: { invoke: vi.fn().mockRejectedValue(new Error('throttled')) } } as any);
+        const res = await triageChatMessage(base);
+        expect(res).toEqual({ route: 'task', skillId: null, reasoning: 'fallback' });
+    });
+
+    it('kill-switch: falls back to legacy autoSelectSkill with route task', async () => {
+        process.env.CHAT_TRIAGE_ENABLED = 'false';
+        vi.mocked(autoSelectSkill).mockResolvedValue({ slug: 'cost-analyser', reasoning: 'legacy' });
+        const res = await triageChatMessage(base);
+        expect(res).toEqual({ route: 'task', skillId: 'cost-analyser', reasoning: 'legacy' });
+        expect(vi.mocked(createAgentModels)).not.toHaveBeenCalled();
+    });
+
+    it('kill-switch + preselected skill: pure task fallback, no LLM calls', async () => {
+        process.env.CHAT_TRIAGE_ENABLED = 'false';
+        const res = await triageChatMessage({ ...base, skillAlreadySelected: true });
+        expect(res.route).toBe('task');
+        expect(vi.mocked(autoSelectSkill)).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web-ui/lib/agent/triage.ts
+++ b/apps/web-ui/lib/agent/triage.ts
@@ -1,0 +1,115 @@
+/**
+ * triage.ts — chat-layer routing in front of the agent workflow.
+ *
+ * One cheap reflector-model call classifies the incoming message:
+ *   - 'direct': conversational (greeting/thanks/capability question/answerable
+ *     from the visible conversation) → the chat route replies with a single
+ *     plain LLM call — no memory recall, no planner, no plan rail, no tools.
+ *   - 'task':   everything else → the normal agent workflow.
+ *
+ * The same call doubles as the skill auto-selector (Hermes disclosure), so
+ * adding the chat layer costs ZERO net new LLM calls per message — it replaces
+ * the previous standalone autoSelectSkill call.
+ *
+ * Fail-open: any error, parse failure, or disabled flag routes to 'task'
+ * (a wasted planner pass is cheaper than a wrong "I can't do that" reply).
+ * Kill-switch: CHAT_TRIAGE_ENABLED=false reverts routing to always-'task'
+ * while keeping skill auto-selection (via the legacy autoSelectSkill path).
+ */
+
+import { SystemMessage, HumanMessage } from '@langchain/core/messages';
+import { contentToText, type ResolvedModelConfig } from './agent-shared';
+import { createAgentModels } from './model-factory';
+import { getSkillSummaries, getSkillById } from '@/lib/skill-service';
+import { autoSelectSkill } from './auto-skill-select';
+
+export function chatTriageEnabled(): boolean {
+    const v = process.env.CHAT_TRIAGE_ENABLED?.toLowerCase();
+    return !(v === 'false' || v === '0');
+}
+
+export interface TriageResult {
+    route: 'direct' | 'task';
+    skillId: string | null;
+    reasoning: string;
+}
+
+const TASK_FALLBACK: TriageResult = { route: 'task', skillId: null, reasoning: 'fallback' };
+
+/**
+ * Pure parser for the triage model's JSON reply. Exported for unit tests.
+ * Unknown/malformed input fails open to 'task'. skillId membership in the
+ * catalog is checked here; per-tenant existence is re-verified by the caller.
+ */
+export function parseTriageResponse(content: string, catalog: string | null): TriageResult {
+    const match = content.match(/\{[\s\S]*\}/);
+    if (!match) return TASK_FALLBACK;
+    try {
+        const parsed = JSON.parse(match[0]) as { route?: string; skillId?: string | null; reasoning?: string };
+        const route = parsed.route === 'direct' ? 'direct' : 'task';
+        let skillId: string | null = typeof parsed.skillId === 'string' && parsed.skillId ? parsed.skillId : null;
+        // The catalog lists ENABLED skills only — membership rejects disabled or
+        // hallucinated slugs (same guard as auto-skill-select).
+        if (skillId && (!catalog || !catalog.includes(`- ${skillId}:`))) skillId = null;
+        return { route, skillId, reasoning: parsed.reasoning ?? '' };
+    } catch {
+        return TASK_FALLBACK;
+    }
+}
+
+export async function triageChatMessage(params: {
+    tenantId: string;
+    message: string;
+    model: ResolvedModelConfig;
+    /** True when the user manually pinned a skill — skill matching is skipped. */
+    skillAlreadySelected?: boolean;
+}): Promise<TriageResult> {
+    // Kill-switch: preserve pre-triage behavior exactly (always workflow,
+    // legacy standalone skill auto-selection).
+    if (!chatTriageEnabled()) {
+        if (params.skillAlreadySelected) return TASK_FALLBACK;
+        const auto = await autoSelectSkill({ tenantId: params.tenantId, message: params.message, model: params.model });
+        return { route: 'task', skillId: auto?.slug ?? null, reasoning: auto?.reasoning ?? 'triage disabled' };
+    }
+
+    try {
+        const catalog = params.skillAlreadySelected
+            ? null
+            : await getSkillSummaries(params.tenantId)
+                .then(s => (s.startsWith('No specialized skills') ? null : s))
+                .catch(() => null);
+
+        const skillInstruction = catalog
+            ? `\n${catalog}\n\nFor "task" routes, also pick the single most relevant skill from the catalog above — or null when none clearly matches its description. For "direct" routes, skillId is always null.`
+            : `\nskillId is always null.`;
+
+        const sys = new SystemMessage(
+            `You route an incoming message for a DevOps/cloud-operations AI agent.\n\n` +
+            `Classify the message as:\n` +
+            `- "direct" ONLY when it is: a greeting, thanks, farewell, or small talk; a question about what the assistant can do; or fully answerable from the conversation itself with NO tools, NO AWS/data lookups, and NO actions.\n` +
+            `- "task" for EVERYTHING else — any request that mentions or implies infrastructure, resources, accounts, costs, incidents, logs, files, schedules, reports, or any action or investigation.\n` +
+            `When in doubt, choose "task".\n` +
+            skillInstruction +
+            `\n\nReturn ONLY a JSON object: {"route": "direct" | "task", "skillId": "<slug>" | null, "reasoning": "<one short line>"}`,
+        );
+
+        const { reflector } = createAgentModels(params.model);
+        const resp = await reflector.invoke([sys, new HumanMessage(params.message.slice(0, 4000))]);
+        const result = parseTriageResponse(contentToText(resp.content), catalog);
+
+        // Re-verify the slug against the tenant DB (mirrors auto-skill-select).
+        if (result.skillId) {
+            const skill = await getSkillById(params.tenantId, result.skillId).catch(() => null);
+            if (!skill) {
+                console.warn(`🚦 [TRIAGE] Model returned unknown skill '${result.skillId}' — ignoring`);
+                result.skillId = null;
+            }
+        }
+
+        console.log(`🚦 [TRIAGE] route=${result.route}${result.skillId ? ` skill=${result.skillId}` : ''} — ${result.reasoning || '(no reasoning)'}`);
+        return result;
+    } catch (err: any) {
+        console.warn(`🚦 [TRIAGE] Failed (non-fatal, routing to task): ${err?.message ?? err}`);
+        return TASK_FALLBACK;
+    }
+}


### PR DESCRIPTION
## Summary

Two Claude Code-style upgrades to the AIOps agent so it behaves like a chatbot for conversational messages and loads skills on demand rather than binding one static skill per run.

### 1. Chat-layer triage — direct reply vs workflow
Previously every message — even "hi" — paid for memory recall → planner → executor → final → memory save, with a plan rail rendered for a greeting.

- **`lib/agent/triage.ts`** — one cheap reflector call classifies the message as `direct` vs `task` **and** auto-selects the skill in the same call. It **replaced** the standalone `autoSelectSkill` call, so the chat layer costs **zero net new LLM calls** per message.
- **`app/api/chat/direct-chat.ts`** — `direct` messages (greeting / thanks / "what can you do?" / answerable-from-history) stream a single plain LLM reply with **no graph, memory recall, planner, plan rail, or tools** — true chatbot latency. Both messages persist to chat history so reload works.
- Fails open to `task` on any error; resume turns (HITL approvals / tool results) and `deep` mode are never triaged. Env kill-switch `CHAT_TRIAGE_ENABLED` restores legacy always-workflow behavior.

### 2. Dynamic skill loading — progressive disclosure
Changed from *"one skill, chosen upfront, static for the whole run"* to on-demand, multi-skill loading (Anthropic Agent Skills model).

- **`lib/agent/skill-tool.ts`** — new `load_skill(skill_id)` tool loads full skill content as a tool result at the moment a phase needs it. The catalog (name + description) stays in the system prompt; both agents fetch it **even when a skill is pinned**, so out-of-scope phases can pull additional skills. Tenant-scoped and **enabled-only** — disabled skills can never load, preserving the veto.

### 3. Auto-skills console toggle
- Removed the `AUTO_SKILL_SELECTION_ENABLED` env var (auto-skill selection/loading is now on by default) and replaced it with a per-session **"Auto skills"** switch in the composer settings popover, directly below **"Show work"**.
- Off = only a manually pinned skill is used (catalog + `load_skill` tool both suppressed). Threads through `GraphConfig.autoLoadSkills` → both agents + `assembleTools`.

## Testing
- **14 new triage unit tests** (`lib/agent/triage.test.ts`): routing, combined skill match, hallucinated-slug rejection, fail-open, kill-switch.
- Updated `auto-skill-select` and `composer` suites for the env-var removal and the new switch.
- Full suite: 440/441 pass (the one failure is a pre-existing, unrelated MCP config-merge test). No new TypeScript errors.

## Notes
- Direct-path exchanges bypass the LangGraph checkpointer; they enter graph state when a later `task` turn starts a fresh graph (client sends full history). Intentional trade-off for conversational content.
- The "Auto skills" switch is per-session state (resets to ON per new session), matching the existing "Auto-approve" switch behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011R9daK3pJRF34pCtsbJirB