### PR TITLE
AI Ops chat: multi-turn/resume crash fix, history reasoning rendering, higher input/output limits

### DIFF
--- a/apps/web-ui/app/api/threads/[threadId]/history/route.ts
+++ b/apps/web-ui/app/api/threads/[threadId]/history/route.ts
@@ -4,6 +4,7 @@ import { getChatHistory } from '@/lib/agent/persistence';
 import { getSessionTenantId, getSessionUserId } from '@/lib/auth-session';
 import { AIMessage, HumanMessage, ToolMessage, BaseMessage } from '@langchain/core/messages';
 import { normalizeLegacyContent } from '@/lib/agent-chat/legacy-normalizer';
+import { reconstructAiContentParts } from '@/lib/agent-chat/ai-content-parts';
 import { humanizePlanning, stripWorkingMemoryPrelude } from '@/app/api/chat/stream-parts';
 
 interface HistoryMessage {
@@ -114,12 +115,19 @@ function convertPlainMessage(msg: { role: string; content: string; metadata?: Re
     }
     if (role === 'ai') {
         const toolCalls = metadata?.tool_calls as Array<{ id?: string; name: string; args: Record<string, unknown> }> | undefined;
-        const parts: HistoryMessage['parts'] = content ? [...(buildPhaseParts(content) ?? [])] : [];
+        // Content-block arrays (extended-thinking) are reconstructed block-by-block; everything else keeps the marker path.
+        const reconstructed = reconstructAiContentParts(msg.content);
+        const parts: HistoryMessage['parts'] = reconstructed !== null
+            ? [...reconstructed]
+            : (content ? [...(buildPhaseParts(content) ?? [])] : []);
+        const displayContent = reconstructed !== null
+            ? reconstructed.filter((p) => p.type === 'text').map((p) => p.text).join('')
+            : content;
         for (const tc of toolCalls ?? []) {
             parts.push({ type: 'tool-invocation', toolCallId: tc.id ?? `tool-${index}-${tc.name}`, toolName: tc.name, args: tc.args, state: 'call' });
         }
         if (parts.length === 0) return null;
-        return { id: `history-${index}`, role: 'assistant', content, parts };
+        return { id: `history-${index}`, role: 'assistant', content: displayContent, parts };
     }
     if (role === 'tool') {
         const toolCallId = metadata?.tool_call_id as string | undefined;
@@ -138,12 +146,18 @@ function convertMessage(msg: BaseMessage, index: number): HistoryMessage | null 
     }
     if (msgType === 'ai') {
         const aiMsg = msg as AIMessage;
-        const parts: HistoryMessage['parts'] = content ? [...(buildPhaseParts(content) ?? [])] : [];
+        const reconstructed = reconstructAiContentParts(aiMsg.content);
+        const parts: HistoryMessage['parts'] = reconstructed !== null
+            ? [...reconstructed]
+            : (content ? [...(buildPhaseParts(content) ?? [])] : []);
+        const displayContent = reconstructed !== null
+            ? reconstructed.filter((p) => p.type === 'text').map((p) => p.text).join('')
+            : (content || '');
         for (const tc of aiMsg.tool_calls ?? []) {
             parts.push({ type: 'tool-invocation', toolCallId: tc.id ?? `tool-${index}-${tc.name}`, toolName: tc.name, args: tc.args as Record<string, unknown>, state: 'call' });
         }
         if (parts.length === 0) return null;
-        return { id: `history-${index}`, role: 'assistant', content: content || '', parts };
+        return { id: `history-${index}`, role: 'assistant', content: displayContent, parts };
     }
     if (msgType === 'tool') {
         const toolMsg = msg as ToolMessage;

--- a/apps/web-ui/components/agent/workspace/composer.tsx
+++ b/apps/web-ui/components/agent/workspace/composer.tsx
@@ -14,8 +14,8 @@ import { AccountChip, KbSection, ModelChip, SkillChip, ToolsSection, type Compos
 
 export type { ComposerContext } from "./composer-pickers";
 
-const MAX_CHARS = 2000;
-const CHAR_WARNING_THRESHOLD = 1800;
+const MAX_CHARS = 6000;
+const CHAR_WARNING_THRESHOLD = 5400;
 const TEXTAREA_MAX_HEIGHT_PX = 192; // matches max-h-48
 
 // Must stay in sync with the modes /api/chat accepts (fast | plan | deep) —

--- a/apps/web-ui/lib/agent-chat/__tests__/ai-content-parts.test.ts
+++ b/apps/web-ui/lib/agent-chat/__tests__/ai-content-parts.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { reconstructAiContentParts } from '../ai-content-parts';
+import { buildTranscript } from '../events';
+
+const noOpts = {
+    isStreaming: false,
+    toolVisibility: new Map<string, string>(),
+    decisions: new Map<string, { approved: boolean; answer?: string }>(),
+};
+
+describe('reconstructAiContentParts', () => {
+    it('returns null for a plain (non-array) string so the caller keeps the marker path', () => {
+        expect(reconstructAiContentParts('PLANNING_PHASE_START\nplan text')).toBeNull();
+        expect(reconstructAiContentParts('just an answer')).toBeNull();
+    });
+
+    it('returns [] for an array of only empty-text reasoning blocks', () => {
+        const raw = JSON.stringify([{ type: 'reasoning', reasoning: '', signature: 'sig' }]);
+        expect(reconstructAiContentParts(raw)).toEqual([]);
+    });
+
+    it('reconstructs a reasoning block that has text into a single reasoning part', () => {
+        const raw = JSON.stringify([{ type: 'reasoning', reasoning: 'Let me think about X.' }]);
+        expect(reconstructAiContentParts(raw)).toEqual([{ type: 'reasoning', text: 'Let me think about X.' }]);
+    });
+
+    it('reconstructs a mixed [reasoning, text] array preserving order', () => {
+        const raw = JSON.stringify([
+            { type: 'thinking', thinking: 'thinking hard' },
+            { type: 'text', text: 'the answer' },
+        ]);
+        expect(reconstructAiContentParts(raw)).toEqual([
+            { type: 'reasoning', text: 'thinking hard' },
+            { type: 'text', text: 'the answer' },
+        ]);
+    });
+
+    it('extracts the raw Bedrock reasoningContent shape', () => {
+        const raw = JSON.stringify([{ reasoningContent: { reasoningText: { text: 'deep thought' } } }]);
+        expect(reconstructAiContentParts(raw)).toEqual([{ type: 'reasoning', text: 'deep thought' }]);
+    });
+
+    it('drops a reasoningContent block whose text is null', () => {
+        const raw = JSON.stringify([{ reasoningContent: { reasoningText: { text: null } } }]);
+        expect(reconstructAiContentParts(raw)).toEqual([]);
+    });
+
+    it('skips tool_use blocks (tool calls come from metadata)', () => {
+        const raw = JSON.stringify([
+            { type: 'reasoning', reasoning: '' },
+            { type: 'tool_use', id: 't1', name: 'do_it', input: {} },
+        ]);
+        expect(reconstructAiContentParts(raw)).toEqual([]);
+    });
+
+    it('skips empty/whitespace text blocks', () => {
+        const raw = JSON.stringify([{ type: 'text', text: '   ' }, { type: 'text', text: 'real' }]);
+        expect(reconstructAiContentParts(raw)).toEqual([{ type: 'text', text: 'real' }]);
+    });
+
+    it('accepts an already-parsed array (checkpoint-fallback path)', () => {
+        expect(reconstructAiContentParts([{ type: 'text', text: 'hi' }])).toEqual([{ type: 'text', text: 'hi' }]);
+    });
+});
+
+describe('render parity with live (via buildTranscript)', () => {
+    it('a reasoning part with text yields a thinking event, like live', () => {
+        const parts = reconstructAiContentParts(JSON.stringify([{ type: 'reasoning', reasoning: 'hmm' }]))!;
+        const events = buildTranscript({ id: 'm1', role: 'assistant', parts } as any, noOpts);
+        expect(events).toEqual([expect.objectContaining({ kind: 'thinking', text: 'hmm' })]);
+    });
+
+    it('the reducer renders nothing for an empty reasoning part (documents live behavior)', () => {
+        const events = buildTranscript({ id: 'm1', role: 'assistant', parts: [{ type: 'reasoning', text: '' }] } as any, noOpts);
+        expect(events).toEqual([]);
+    });
+});

--- a/apps/web-ui/lib/agent-chat/ai-content-parts.ts
+++ b/apps/web-ui/lib/agent-chat/ai-content-parts.ts
@@ -1,0 +1,53 @@
+// Reconstructs UI parts from a persisted content-block array (Anthropic/Bedrock shapes); without this, history renders raw JSON.
+type AiContentPart = { type: 'reasoning' | 'text'; text: string };
+
+function normalizeToBlockArray(raw: unknown): unknown[] | null {
+    if (Array.isArray(raw)) return raw;
+    if (typeof raw === 'string') {
+        if (!raw.trimStart().startsWith('[')) return null;
+        try {
+            const parsed = JSON.parse(raw);
+            return Array.isArray(parsed) ? parsed : null;
+        } catch {
+            return null;
+        }
+    }
+    return null;
+}
+
+function isReasoningBlock(b: Record<string, unknown>): boolean {
+    if ('reasoningContent' in b || 'reasoning_content' in b) return true;
+    const t = b.type;
+    return t === 'reasoning' || t === 'thinking' || t === 'reasoning_content'
+        || t === 'redacted_reasoning' || t === 'redacted_thinking';
+}
+
+function extractReasoningText(b: Record<string, unknown>): string {
+    if (typeof b.reasoning === 'string') return b.reasoning;
+    if (typeof b.thinking === 'string') return b.thinking;
+    const rc = b.reasoningContent as { reasoningText?: { text?: unknown } } | undefined;
+    if (rc?.reasoningText && typeof rc.reasoningText.text === 'string') return rc.reasoningText.text;
+    return '';
+}
+
+// null = not a content-block array (caller keeps the string/marker path); otherwise reconstructed parts (possibly empty).
+export function reconstructAiContentParts(rawContent: unknown): AiContentPart[] | null {
+    const blocks = normalizeToBlockArray(rawContent);
+    if (blocks === null) return null;
+
+    const parts: AiContentPart[] = [];
+    for (const block of blocks) {
+        if (!block || typeof block !== 'object') continue;
+        const b = block as Record<string, unknown>;
+        if (b.type === 'text' && typeof b.text === 'string') {
+            if (b.text.trim().length > 0) parts.push({ type: 'text', text: b.text });
+            continue;
+        }
+        if (isReasoningBlock(b)) {
+            const text = extractReasoningText(b);
+            if (text.trim().length > 0) parts.push({ type: 'reasoning', text });
+        }
+        // tool_use / image / unknown → skipped (tool calls come from metadata.tool_calls)
+    }
+    return parts;
+}

--- a/apps/web-ui/lib/agent/agent-shared.ts
+++ b/apps/web-ui/lib/agent/agent-shared.ts
@@ -674,6 +674,28 @@ function stripReasoningBlocks(msg: BaseMessage): BaseMessage {
     });
 }
 
+// Empty AI content (post-strip) with no tool calls — rewritten, not dropped, so Bedrock role alternation is preserved.
+function isEmptyAiMessageContent(ai: AIMessage): boolean {
+    if (Array.isArray(ai.tool_calls) && ai.tool_calls.length > 0) return false;
+
+    const content = ai.content;
+    if (content == null) return true;
+    if (typeof content === 'string') return content.trim() === '';
+    if (!Array.isArray(content)) return false; // unknown non-array content — treat as present
+    if (content.length === 0) return true;
+
+    // Non-empty array: empty only if EVERY block is an empty/whitespace text block.
+    return (content as unknown[]).every((block) => {
+        if (block && typeof block === 'object') {
+            const b = block as Record<string, unknown>;
+            if (b.type === 'text') {
+                return typeof b.text !== 'string' || b.text.trim() === '';
+            }
+        }
+        return false; // tool_use, image, or any other block => real content
+    });
+}
+
 export function sanitizeMessagesForBedrock(messages: BaseMessage[]): BaseMessage[] {
     // Bedrock requires every toolResult to IMMEDIATELY follow the assistant
     // toolUse that owns it — "answered somewhere in the array" is not enough.
@@ -710,7 +732,22 @@ export function sanitizeMessagesForBedrock(messages: BaseMessage[]): BaseMessage
 
         // Strip reasoning/thinking blocks from AI messages — they come back with a
         // null reasoningText after a checkpoint round-trip and Bedrock rejects them.
-        const cleaned = stripReasoningBlocks(msg);
+        let cleaned = stripReasoningBlocks(msg);
+
+        // Rewrite (never drop) an emptied reasoning-only message: empty content crashes Bedrock, and dropping breaks role alternation.
+        if (cleaned._getType() === 'ai' && isEmptyAiMessageContent(cleaned as AIMessage)) {
+            const ai = cleaned as AIMessage;
+            cleaned = new AIMessage({
+                content: '(reasoning omitted)',
+                tool_calls: ai.tool_calls,
+                additional_kwargs: ai.additional_kwargs,
+                response_metadata: ai.response_metadata,
+                id: ai.id,
+                name: ai.name,
+                usage_metadata: ai.usage_metadata,
+            });
+        }
+
         result.push(cleaned);
 
         if (msg._getType() !== 'ai') continue;

--- a/apps/web-ui/lib/agent/model-factory.ts
+++ b/apps/web-ui/lib/agent/model-factory.ts
@@ -40,10 +40,10 @@ export interface AgentModels {
     reflector: BaseChatModel;
 }
 
-/** Conservative default output-token cap when a provider record doesn't specify one.
- *  4096 is safe across small/local models and matches the Anthropic/Bedrock defaults —
- *  the previous 40000 OpenAI-path default overflowed 8k–32k context windows. */
-export const DEFAULT_MAX_OUTPUT_TOKENS = 4096;
+/** Default output-token cap when a provider record doesn't specify one. 8192 suits the
+ *  Anthropic/Bedrock Claude models used by AI Ops; a small/local model with a lower hard
+ *  output limit should set maxTokens on its ProviderModel record to override this. */
+export const DEFAULT_MAX_OUTPUT_TOKENS = 8192;
 
 /** Provider-level context-window estimates (tokens). The ProviderModel schema has no
  *  per-model context-window field, so we approximate at the provider family level — no

--- a/apps/web-ui/lib/agent/sanitize-bedrock.test.ts
+++ b/apps/web-ui/lib/agent/sanitize-bedrock.test.ts
@@ -44,4 +44,90 @@ describe('sanitizeMessagesForBedrock — reasoning content', () => {
         const out = sanitizeMessagesForBedrock(input);
         expect(out[1]).toBe(ai);
     });
+
+    it('rewrites a reasoning-only AI message (empty after strip, no tool_calls) to a non-empty placeholder', () => {
+        const reasoningOnly = new AIMessage({
+            content: [
+                { reasoningContent: { reasoningText: { text: null, signature: 'sig' } } } as any,
+            ],
+        });
+        const out = sanitizeMessagesForBedrock([
+            new HumanMessage('first question'),
+            reasoningOnly,
+            new HumanMessage('Proceed.'),
+        ]);
+
+        // No AI message may leave sanitize with empty content.
+        const emptyAi = out.find((m) => {
+            if (m._getType() !== 'ai') return false;
+            const c = m.content;
+            if (typeof c === 'string') return c.trim() === '';
+            return Array.isArray(c) && c.length === 0;
+        });
+        expect(emptyAi).toBeUndefined();
+
+        // The rewritten message is present, in place, with the placeholder text.
+        expect(out).toHaveLength(3);
+        expect(out[1]._getType()).toBe('ai');
+        expect(out[1].content).toBe('(reasoning omitted)');
+    });
+
+    it('preserves message count and role order (no consecutive same-role pair)', () => {
+        const input = [
+            new HumanMessage('q1'),
+            new AIMessage({ content: [{ reasoningContent: { reasoningText: { text: null } } } as any] }),
+            new HumanMessage('Proceed.'),
+            new AIMessage({ content: 'the real answer' }),
+            new HumanMessage('q2'),
+        ];
+        const out = sanitizeMessagesForBedrock(input);
+
+        expect(out.map((m) => m._getType())).toEqual(['human', 'ai', 'human', 'ai', 'human']);
+        for (let i = 1; i < out.length; i++) {
+            expect(out[i]._getType()).not.toBe(out[i - 1]._getType());
+        }
+    });
+
+    it('does NOT rewrite an AI message that is empty-after-strip but has tool_calls', () => {
+        const toolTurn = new AIMessage({
+            content: [
+                { reasoningContent: { reasoningText: { text: null } } } as any,
+                { type: 'tool_use', id: 't1', name: 'do_it', input: {} } as any,
+            ],
+            tool_calls: [{ id: 't1', name: 'do_it', args: {}, type: 'tool_call' }],
+        });
+        const out = sanitizeMessagesForBedrock([
+            toolTurn,
+            new ToolMessage({ content: 'ok', tool_call_id: 't1' }),
+        ]);
+
+        const ai = out[0] as AIMessage;
+        expect(ai._getType()).toBe('ai');
+        expect(ai.content).not.toBe('(reasoning omitted)');           // untouched, not rewritten
+        expect(Array.isArray(ai.content)).toBe(true);
+        expect((ai.content as any[]).some((b) => b.type === 'tool_use')).toBe(true);
+        expect(ai.tool_calls?.[0]?.id).toBe('t1');
+        // tool result still re-emitted immediately after its owning AI message
+        expect(out[1]._getType()).toBe('tool');
+        expect((out[1] as any).tool_call_id).toBe('t1');
+    });
+
+    it('leaves an AI message untouched when it has a tool_use content block but no normalized tool_calls', () => {
+        const toolBlockOnly = new AIMessage({
+            content: [
+                { reasoningContent: { reasoningText: { text: null } } } as any,
+                { type: 'tool_use', id: 't9', name: 'do_it', input: {} } as any,
+            ],
+            // no tool_calls — the checkpoint-round-trip divergence the file warns about
+        });
+        const out = sanitizeMessagesForBedrock([
+            toolBlockOnly,
+            new ToolMessage({ content: 'ok', tool_call_id: 't9' }),
+        ]);
+        const ai = out[0] as AIMessage;
+        expect(ai.content).not.toBe('(reasoning omitted)');
+        expect(Array.isArray(ai.content)).toBe(true);
+        expect((ai.content as any[]).some((b) => b.type === 'tool_use')).toBe(true);
+        expect(out[1]._getType()).toBe('tool');
+    });
 });

--- a/docs/superpowers/plans/2026-07-21-aiops-history-reasoning-render.md
+++ b/docs/superpowers/plans/2026-07-21-aiops-history-reasoning-render.md
@@ -1,0 +1,335 @@
+# AI Ops History Reasoning-Block Rendering — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** In a reopened AI Ops history session, render reasoning that was persisted as an array of content blocks the same way the live stream does (empty reasoning → nothing; reasoning-with-text → a "Thought for Ns" block), instead of showing raw `[{"type":"reasoning",...}]` JSON.
+
+**Architecture:** A new pure module `lib/agent-chat/ai-content-parts.ts` reconstructs typed UI parts from an AI message's content-block array (reasoning → `reasoning` part, dropping empty ones; text → `text` part; tool_use skipped). The history route (`app/api/threads/[threadId]/history/route.ts`) calls it first in the AI branch of `convertPlainMessage` and `convertMessage`, falling back to the existing string/marker path when it returns `null`. Read-path only — storage, the write path, and the live stream are untouched, so it fixes existing and future sessions with no migration.
+
+**Tech Stack:** TypeScript, LangChain `@langchain/core/messages` (`AIMessage`), Next.js App Router route handler, Vitest (web-ui), Bun.
+
+## Global Constraints
+
+- Language/style: `app/api/threads/[threadId]/history/route.ts` and `lib/agent-chat/*` use **4-space indentation**. Match it.
+- Comments: default to none; a single concise line only where the WHY is non-obvious (user + repo convention). No multi-line comment blocks.
+- Surgical: only create `lib/agent-chat/ai-content-parts.ts` + its test, and modify `app/api/threads/[threadId]/history/route.ts`. No refactoring of adjacent code, no change to the write path (`app/api/chat/route.ts`) or storage.
+- Do NOT export non-handler functions from `route.ts` (Next.js route files accept only HTTP-method/config exports) — the reusable logic lives in the lib module.
+- "Match live exactly": empty-text reasoning renders as nothing; only non-empty reasoning becomes a `reasoning` part. This mirrors the reducer at `lib/agent-chat/events.ts:159-161`.
+- The reconstruction is gated to the **AI role only**; the human multimodal path (`extractDisplayText`) and the tool path stay unchanged.
+- Tests run from `apps/web-ui`: full suite `bun run test`; a single file `bunx vitest run <path>`.
+- Do NOT commit unless the human explicitly asks. The commit step at the end runs only on explicit go-ahead.
+
+---
+
+### Task 1: `reconstructAiContentParts` helper (pure module + tests)
+
+**Files:**
+- Create: `apps/web-ui/lib/agent-chat/ai-content-parts.ts`
+- Test: `apps/web-ui/lib/agent-chat/__tests__/ai-content-parts.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from other tasks. Imports `buildTranscript` from `../events` in the test only (to prove render parity).
+- Produces: `export function reconstructAiContentParts(rawContent: unknown): Array<{ type: 'reasoning' | 'text'; text: string }> | null`. Returns `null` when `rawContent` is not a content-block array (caller keeps its existing string path); returns a parts array (possibly empty) when it is. Task 2 consumes this.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `apps/web-ui/lib/agent-chat/__tests__/ai-content-parts.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { reconstructAiContentParts } from '../ai-content-parts';
+import { buildTranscript } from '../events';
+
+const noOpts = {
+    isStreaming: false,
+    toolVisibility: new Map<string, string>(),
+    decisions: new Map<string, { approved: boolean; answer?: string }>(),
+};
+
+describe('reconstructAiContentParts', () => {
+    it('returns null for a plain (non-array) string so the caller keeps the marker path', () => {
+        expect(reconstructAiContentParts('PLANNING_PHASE_START\nplan text')).toBeNull();
+        expect(reconstructAiContentParts('just an answer')).toBeNull();
+    });
+
+    it('returns [] for an array of only empty-text reasoning blocks', () => {
+        const raw = JSON.stringify([{ type: 'reasoning', reasoning: '', signature: 'sig' }]);
+        expect(reconstructAiContentParts(raw)).toEqual([]);
+    });
+
+    it('reconstructs a reasoning block that has text into a single reasoning part', () => {
+        const raw = JSON.stringify([{ type: 'reasoning', reasoning: 'Let me think about X.' }]);
+        expect(reconstructAiContentParts(raw)).toEqual([{ type: 'reasoning', text: 'Let me think about X.' }]);
+    });
+
+    it('reconstructs a mixed [reasoning, text] array preserving order', () => {
+        const raw = JSON.stringify([
+            { type: 'thinking', thinking: 'thinking hard' },
+            { type: 'text', text: 'the answer' },
+        ]);
+        expect(reconstructAiContentParts(raw)).toEqual([
+            { type: 'reasoning', text: 'thinking hard' },
+            { type: 'text', text: 'the answer' },
+        ]);
+    });
+
+    it('extracts the raw Bedrock reasoningContent shape', () => {
+        const raw = JSON.stringify([{ reasoningContent: { reasoningText: { text: 'deep thought' } } }]);
+        expect(reconstructAiContentParts(raw)).toEqual([{ type: 'reasoning', text: 'deep thought' }]);
+    });
+
+    it('drops a reasoningContent block whose text is null', () => {
+        const raw = JSON.stringify([{ reasoningContent: { reasoningText: { text: null } } }]);
+        expect(reconstructAiContentParts(raw)).toEqual([]);
+    });
+
+    it('skips tool_use blocks (tool calls come from metadata)', () => {
+        const raw = JSON.stringify([
+            { type: 'reasoning', reasoning: '' },
+            { type: 'tool_use', id: 't1', name: 'do_it', input: {} },
+        ]);
+        expect(reconstructAiContentParts(raw)).toEqual([]);
+    });
+
+    it('skips empty/whitespace text blocks', () => {
+        const raw = JSON.stringify([{ type: 'text', text: '   ' }, { type: 'text', text: 'real' }]);
+        expect(reconstructAiContentParts(raw)).toEqual([{ type: 'text', text: 'real' }]);
+    });
+
+    it('accepts an already-parsed array (checkpoint-fallback path)', () => {
+        expect(reconstructAiContentParts([{ type: 'text', text: 'hi' }])).toEqual([{ type: 'text', text: 'hi' }]);
+    });
+});
+
+describe('render parity with live (via buildTranscript)', () => {
+    it('a reasoning part with text yields a thinking event, like live', () => {
+        const parts = reconstructAiContentParts(JSON.stringify([{ type: 'reasoning', reasoning: 'hmm' }]))!;
+        const events = buildTranscript({ id: 'm1', role: 'assistant', parts } as any, noOpts);
+        expect(events).toEqual([expect.objectContaining({ kind: 'thinking', text: 'hmm' })]);
+    });
+
+    it('the reducer renders nothing for an empty reasoning part (documents live behavior)', () => {
+        const events = buildTranscript({ id: 'm1', role: 'assistant', parts: [{ type: 'reasoning', text: '' }] } as any, noOpts);
+        expect(events).toEqual([]);
+    });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent-chat/__tests__/ai-content-parts.test.ts`
+Expected: FAIL — `reconstructAiContentParts` cannot be imported (module does not exist yet).
+
+- [ ] **Step 3: Create the helper module**
+
+Create `apps/web-ui/lib/agent-chat/ai-content-parts.ts`:
+
+```ts
+// Reconstructs typed UI parts from an AI message whose persisted content is an
+// array of content blocks (Anthropic extended-thinking / Bedrock shapes). Without
+// this, the history read path renders such arrays as raw JSON.
+type AiContentPart = { type: 'reasoning' | 'text'; text: string };
+
+function normalizeToBlockArray(raw: unknown): unknown[] | null {
+    if (Array.isArray(raw)) return raw;
+    if (typeof raw === 'string') {
+        if (!raw.trimStart().startsWith('[')) return null;
+        try {
+            const parsed = JSON.parse(raw);
+            return Array.isArray(parsed) ? parsed : null;
+        } catch {
+            return null;
+        }
+    }
+    return null;
+}
+
+function isReasoningBlock(b: Record<string, unknown>): boolean {
+    if ('reasoningContent' in b || 'reasoning_content' in b) return true;
+    const t = b.type;
+    return t === 'reasoning' || t === 'thinking' || t === 'reasoning_content'
+        || t === 'redacted_reasoning' || t === 'redacted_thinking';
+}
+
+function extractReasoningText(b: Record<string, unknown>): string {
+    if (typeof b.reasoning === 'string') return b.reasoning;
+    if (typeof b.thinking === 'string') return b.thinking;
+    const rc = b.reasoningContent as { reasoningText?: { text?: unknown } } | undefined;
+    if (rc?.reasoningText && typeof rc.reasoningText.text === 'string') return rc.reasoningText.text;
+    return '';
+}
+
+// Returns null when rawContent is not a content-block array (caller keeps the
+// string/marker path); otherwise the reconstructed parts (possibly empty).
+export function reconstructAiContentParts(rawContent: unknown): AiContentPart[] | null {
+    const blocks = normalizeToBlockArray(rawContent);
+    if (blocks === null) return null;
+
+    const parts: AiContentPart[] = [];
+    for (const block of blocks) {
+        if (!block || typeof block !== 'object') continue;
+        const b = block as Record<string, unknown>;
+        if (b.type === 'text' && typeof b.text === 'string') {
+            if (b.text.trim().length > 0) parts.push({ type: 'text', text: b.text });
+            continue;
+        }
+        if (isReasoningBlock(b)) {
+            const text = extractReasoningText(b);
+            if (text.trim().length > 0) parts.push({ type: 'reasoning', text });
+        }
+        // tool_use / image / unknown → skipped (tool calls come from metadata.tool_calls)
+    }
+    return parts;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent-chat/__tests__/ai-content-parts.test.ts`
+Expected: PASS — all tests green.
+
+- [ ] **Step 5: Lint the new file**
+
+Run: `cd apps/web-ui && bun run lint`
+Expected: no new errors attributable to `lib/agent-chat/ai-content-parts.ts` (the repo has pre-existing lint failures elsewhere; compare against baseline if unsure — the new file should add none).
+
+---
+
+### Task 2: Wire the helper into the history route
+
+**Files:**
+- Modify: `apps/web-ui/app/api/threads/[threadId]/history/route.ts` (add import; rewrite the AI branch of `convertPlainMessage` ~lines 115-123 and `convertMessage` ~lines 139-147)
+
+**Interfaces:**
+- Consumes: `reconstructAiContentParts` from Task 1 (`@/lib/agent-chat/ai-content-parts`).
+- Produces: no new exports. `convertPlainMessage`/`convertMessage` behavior for array-content AI messages changes to emit reconstructed reasoning/text parts; all other inputs are unchanged.
+
+- [ ] **Step 1: Add the import**
+
+In `apps/web-ui/app/api/threads/[threadId]/history/route.ts`, add to the imports (after line 6, the `normalizeLegacyContent` import):
+
+```ts
+import { reconstructAiContentParts } from '@/lib/agent-chat/ai-content-parts';
+```
+
+- [ ] **Step 2: Rewrite the AI branch of `convertPlainMessage`**
+
+Replace the current AI branch (lines 115-123):
+
+```ts
+    if (role === 'ai') {
+        const toolCalls = metadata?.tool_calls as Array<{ id?: string; name: string; args: Record<string, unknown> }> | undefined;
+        const parts: HistoryMessage['parts'] = content ? [...(buildPhaseParts(content) ?? [])] : [];
+        for (const tc of toolCalls ?? []) {
+            parts.push({ type: 'tool-invocation', toolCallId: tc.id ?? `tool-${index}-${tc.name}`, toolName: tc.name, args: tc.args, state: 'call' });
+        }
+        if (parts.length === 0) return null;
+        return { id: `history-${index}`, role: 'assistant', content, parts };
+    }
+```
+
+with:
+
+```ts
+    if (role === 'ai') {
+        const toolCalls = metadata?.tool_calls as Array<{ id?: string; name: string; args: Record<string, unknown> }> | undefined;
+        // Content-block arrays (extended-thinking) are reconstructed block-by-block; everything else keeps the marker path.
+        const reconstructed = reconstructAiContentParts(msg.content);
+        const parts: HistoryMessage['parts'] = reconstructed !== null
+            ? [...reconstructed]
+            : (content ? [...(buildPhaseParts(content) ?? [])] : []);
+        const displayContent = reconstructed !== null
+            ? reconstructed.filter((p) => p.type === 'text').map((p) => p.text).join('')
+            : content;
+        for (const tc of toolCalls ?? []) {
+            parts.push({ type: 'tool-invocation', toolCallId: tc.id ?? `tool-${index}-${tc.name}`, toolName: tc.name, args: tc.args, state: 'call' });
+        }
+        if (parts.length === 0) return null;
+        return { id: `history-${index}`, role: 'assistant', content: displayContent, parts };
+    }
+```
+
+(`msg.content` is the raw stored string; `content` at line 109 is the `extractDisplayText`-processed value used only by the fallback path.)
+
+- [ ] **Step 3: Rewrite the AI branch of `convertMessage` (checkpoint fallback)**
+
+Replace the current AI branch (lines 139-147):
+
+```ts
+    if (msgType === 'ai') {
+        const aiMsg = msg as AIMessage;
+        const parts: HistoryMessage['parts'] = content ? [...(buildPhaseParts(content) ?? [])] : [];
+        for (const tc of aiMsg.tool_calls ?? []) {
+            parts.push({ type: 'tool-invocation', toolCallId: tc.id ?? `tool-${index}-${tc.name}`, toolName: tc.name, args: tc.args as Record<string, unknown>, state: 'call' });
+        }
+        if (parts.length === 0) return null;
+        return { id: `history-${index}`, role: 'assistant', content: content || '', parts };
+    }
+```
+
+with:
+
+```ts
+    if (msgType === 'ai') {
+        const aiMsg = msg as AIMessage;
+        const reconstructed = reconstructAiContentParts(aiMsg.content);
+        const parts: HistoryMessage['parts'] = reconstructed !== null
+            ? [...reconstructed]
+            : (content ? [...(buildPhaseParts(content) ?? [])] : []);
+        const displayContent = reconstructed !== null
+            ? reconstructed.filter((p) => p.type === 'text').map((p) => p.text).join('')
+            : (content || '');
+        for (const tc of aiMsg.tool_calls ?? []) {
+            parts.push({ type: 'tool-invocation', toolCallId: tc.id ?? `tool-${index}-${tc.name}`, toolName: tc.name, args: tc.args as Record<string, unknown>, state: 'call' });
+        }
+        if (parts.length === 0) return null;
+        return { id: `history-${index}`, role: 'assistant', content: displayContent, parts };
+    }
+```
+
+(`aiMsg.content` may be an array directly on the checkpoint path; `reconstructAiContentParts` accepts arrays as well as JSON strings.)
+
+- [ ] **Step 4: Type-check the touched route file**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit 2>&1 | grep -E "history/route|ai-content-parts" || echo "no type errors in touched files"`
+Expected: `no type errors in touched files` (the repo may have unrelated pre-existing type output; only the two touched files must be clean).
+
+- [ ] **Step 5: Run the full web-ui test suite (regression)**
+
+Run: `cd apps/web-ui && bun run test`
+Expected: PASS with no NEW failures versus the known baseline (the same pre-existing failures observed in Phase 1 remain; nothing new). The Task 1 `ai-content-parts.test.ts` is green. Existing `lib/agent-chat/__tests__/*` (events, legacy-normalizer) must stay green — they lock the untouched string/marker path.
+
+- [ ] **Step 6: Lint**
+
+Run: `cd apps/web-ui && bun run lint`
+Expected: no new errors attributable to `history/route.ts`.
+
+- [ ] **Step 7: Commit (only if the human has explicitly asked to commit)**
+
+```bash
+git add apps/web-ui/lib/agent-chat/ai-content-parts.ts apps/web-ui/lib/agent-chat/__tests__/ai-content-parts.test.ts "apps/web-ui/app/api/threads/[threadId]/history/route.ts" docs/superpowers/specs/2026-07-21-aiops-history-reasoning-render-design.md docs/superpowers/plans/2026-07-21-aiops-history-reasoning-render.md
+git commit -m "fix(aiops): render array-content reasoning as thinking blocks in history
+
+History replay stored extended-thinking as JSON.stringify'd content arrays and
+rendered them as raw JSON. Reconstruct such arrays on the read path into
+reasoning/text parts (dropping empty reasoning, matching the live reducer), so a
+reopened session renders reasoning like the live stream. Read-path only; storage
+and the write path are unchanged.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Manual / integration verification (after Task 2)
+
+1. Reopen a previous session that currently shows a raw `[{"type":"reasoning",...}]` blob → the blob is gone; empty reasoning shows nothing, reasoning-with-text shows a "Thought for Ns" block.
+2. Reopen a session with planning/reflection (marker-string) content → unchanged from before.
+3. Reopen a session with tool calls → tool cards render once (no duplicates), answers intact.
+4. Send a NEW message in a reopened session → still works (Phase 1 behavior unaffected).
+
+## Self-Review (completed by plan author)
+
+- **Spec coverage:** helper + block handling → Task 1 Step 3; empty→dropped and text→reasoning → Task 1 tests + parity tests; wiring in both convert functions, AI-role-only → Task 2 Steps 2-3; `content` string field set from text blocks → Task 2 Steps 2-3; regression for marker/human paths → Task 1 null-return test + Task 2 Step 5 (existing events/legacy-normalizer suites) + manual check 2; no write/storage change → nothing in the plan touches `app/api/chat/route.ts`.
+- **Placeholder scan:** none — every code step contains full code and exact commands.
+- **Type consistency:** `reconstructAiContentParts` signature identical in Task 1 Produces, the helper source, and both Task 2 call sites; return element type `{ type: 'reasoning' | 'text'; text: string }` is assignable to `HistoryMessage['parts']` elements (`type: string`, `text?: string`).

--- a/docs/superpowers/plans/2026-07-21-aiops-multiturn-crash-fix.md
+++ b/docs/superpowers/plans/2026-07-21-aiops-multiturn-crash-fix.md
@@ -1,0 +1,231 @@
+# AI Ops Multi-Turn / Resume Crash Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop turn-2 (and resume-and-continue) from crashing Bedrock with "content field is empty" by rewriting reasoning-only AI messages that become empty after reasoning-block stripping into a non-empty placeholder, inside `sanitizeMessagesForBedrock()`.
+
+**Architecture:** On any turn after the first, the backend replays the LangGraph Postgres checkpoint through `sanitizeMessagesForBedrock()` before invoking Bedrock. A turn-1 reasoning-only AI message survives windowing, then `stripReasoningBlocks()` empties its content and it is sent to Bedrock as empty → ValidationException. The fix adds one predicate + in-place content replacement in that single function; message count and role order are preserved so Bedrock's strict Human/AI alternation cannot regress.
+
+**Tech Stack:** TypeScript, LangChain `@langchain/core/messages` (`AIMessage`, `HumanMessage`, `ToolMessage`), Vitest (web-ui), Bun.
+
+## Global Constraints
+
+- Language/style: web-ui files use 4-space indentation in `lib/` service/agent files. Match the existing style in `agent-shared.ts`.
+- No comments unless the "why" is non-obvious (repo + user convention). A short "why" comment on the new predicate IS warranted (it prevents a Bedrock crash) — keep it to a couple of lines, no multi-line docblock beyond the existing helper style.
+- Surgical change: touch only `sanitizeMessagesForBedrock()` and its new local helper in `apps/web-ui/lib/agent/agent-shared.ts`, plus the test file. No refactoring of adjacent code.
+- Placeholder text is exactly `"(reasoning omitted)"`.
+- Tests run from `apps/web-ui` with `bun run test` (Vitest `vitest run`, not watch). A single test file runs with `bunx vitest run <path>`.
+- Do NOT commit unless the human explicitly asks (user global rule). Steps below include a commit step; execute the `git commit` only on explicit user go-ahead — otherwise stop at `git add` / leave staging to the user.
+
+---
+
+### Task 1: Rewrite empty-after-strip AI messages to a placeholder in `sanitizeMessagesForBedrock`
+
+**Files:**
+- Modify: `apps/web-ui/lib/agent/agent-shared.ts` (add a local helper `isEmptyAiMessageContent` near `stripReasoningBlocks` around line 676; edit the push site at lines 711-714)
+- Test: `apps/web-ui/lib/agent/sanitize-bedrock.test.ts`
+
+**Interfaces:**
+- Consumes: existing `stripReasoningBlocks(msg: BaseMessage): BaseMessage`, `sanitizeMessagesForBedrock(messages: BaseMessage[]): BaseMessage[]`, and `isReasoningBlock` (all already in `agent-shared.ts`). LangChain `AIMessage`, `HumanMessage`, `ToolMessage`, `BaseMessage`.
+- Produces: no new exported symbols. `sanitizeMessagesForBedrock` keeps its signature; its behavior changes so that an AI message whose content is empty after stripping and which has no tool calls is emitted with content `"(reasoning omitted)"` instead of empty content. A new module-private helper `isEmptyAiMessageContent(ai: AIMessage): boolean` is added (not exported).
+
+---
+
+- [ ] **Step 1: Write the failing tests**
+
+Append these three tests to `apps/web-ui/lib/agent/sanitize-bedrock.test.ts` inside the existing `describe('sanitizeMessagesForBedrock — reasoning content', ...)` block (or a new adjacent `describe`). The imports `AIMessage, HumanMessage, ToolMessage` already exist at the top of the file.
+
+```ts
+    it('rewrites a reasoning-only AI message (empty after strip, no tool_calls) to a non-empty placeholder', () => {
+        const reasoningOnly = new AIMessage({
+            content: [
+                { reasoningContent: { reasoningText: { text: null, signature: 'sig' } } } as any,
+            ],
+        });
+        const out = sanitizeMessagesForBedrock([
+            new HumanMessage('first question'),
+            reasoningOnly,
+            new HumanMessage('Proceed.'),
+        ]);
+
+        // No AI message may leave sanitize with empty content.
+        const emptyAi = out.find((m) => {
+            if (m._getType() !== 'ai') return false;
+            const c = m.content;
+            if (typeof c === 'string') return c.trim() === '';
+            return Array.isArray(c) && c.length === 0;
+        });
+        expect(emptyAi).toBeUndefined();
+
+        // The rewritten message is present, in place, with the placeholder text.
+        expect(out).toHaveLength(3);
+        expect(out[1]._getType()).toBe('ai');
+        expect(out[1].content).toBe('(reasoning omitted)');
+    });
+
+    it('preserves message count and role order (no consecutive same-role pair)', () => {
+        const input = [
+            new HumanMessage('q1'),
+            new AIMessage({ content: [{ reasoningContent: { reasoningText: { text: null } } } as any] }),
+            new HumanMessage('Proceed.'),
+            new AIMessage({ content: 'the real answer' }),
+            new HumanMessage('q2'),
+        ];
+        const out = sanitizeMessagesForBedrock(input);
+
+        expect(out.map((m) => m._getType())).toEqual(['human', 'ai', 'human', 'ai', 'human']);
+        for (let i = 1; i < out.length; i++) {
+            expect(out[i]._getType()).not.toBe(out[i - 1]._getType());
+        }
+    });
+
+    it('does NOT rewrite an AI message that is empty-after-strip but has tool_calls', () => {
+        const toolTurn = new AIMessage({
+            content: [
+                { reasoningContent: { reasoningText: { text: null } } } as any,
+                { type: 'tool_use', id: 't1', name: 'do_it', input: {} } as any,
+            ],
+            tool_calls: [{ id: 't1', name: 'do_it', args: {}, type: 'tool_call' }],
+        });
+        const out = sanitizeMessagesForBedrock([
+            toolTurn,
+            new ToolMessage({ content: 'ok', tool_call_id: 't1' }),
+        ]);
+
+        const ai = out[0] as AIMessage;
+        expect(ai._getType()).toBe('ai');
+        expect(ai.content).not.toBe('(reasoning omitted)');           // untouched, not rewritten
+        expect(Array.isArray(ai.content)).toBe(true);
+        expect((ai.content as any[]).some((b) => b.type === 'tool_use')).toBe(true);
+        expect(ai.tool_calls?.[0]?.id).toBe('t1');
+        // tool result still re-emitted immediately after its owning AI message
+        expect(out[1]._getType()).toBe('tool');
+        expect((out[1] as any).tool_call_id).toBe('t1');
+    });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/sanitize-bedrock.test.ts`
+
+Expected: the first two new tests FAIL. The first fails because today the reasoning-only message is pushed with `content: []` (so `out[1].content` is `[]`, not `'(reasoning omitted)'`, and `emptyAi` is found). The third test (tool_calls guard) may already PASS — that is fine; it is a regression guard, not a red test.
+
+- [ ] **Step 3: Add the `isEmptyAiMessageContent` helper**
+
+In `apps/web-ui/lib/agent/agent-shared.ts`, immediately AFTER the `stripReasoningBlocks` function (it ends at line 675 with its closing `}`), add:
+
+```ts
+/**
+ * True when an AI message carries no Bedrock-acceptable content AND no tool calls
+ * — i.e. an empty/whitespace string, or an array with no tool_use block and no
+ * non-empty text block. After stripReasoningBlocks() empties a reasoning-only
+ * message, sending it to Bedrock raises "content field ... is empty"; we rewrite
+ * such a message to a placeholder (never drop it, so role alternation is kept).
+ */
+function isEmptyAiMessageContent(ai: AIMessage): boolean {
+    if (Array.isArray(ai.tool_calls) && ai.tool_calls.length > 0) return false;
+
+    const content = ai.content;
+    if (content == null) return true;
+    if (typeof content === 'string') return content.trim() === '';
+    if (!Array.isArray(content)) return false; // unknown non-array content — treat as present
+    if (content.length === 0) return true;
+
+    // Non-empty array: empty only if EVERY block is an empty/whitespace text block.
+    return (content as unknown[]).every((block) => {
+        if (block && typeof block === 'object' && (block as any).type === 'text') {
+            const text = (block as any).text;
+            return typeof text !== 'string' || text.trim() === '';
+        }
+        return false; // tool_use, image, or any other block => real content
+    });
+}
+```
+
+- [ ] **Step 4: Rewrite the push site to substitute the placeholder**
+
+In `sanitizeMessagesForBedrock`, replace the two lines at 711-714 (the comment + `const cleaned = stripReasoningBlocks(msg); result.push(cleaned);`). Current code:
+
+```ts
+        // Strip reasoning/thinking blocks from AI messages — they come back with a
+        // null reasoningText after a checkpoint round-trip and Bedrock rejects them.
+        const cleaned = stripReasoningBlocks(msg);
+        result.push(cleaned);
+```
+
+Replace with:
+
+```ts
+        // Strip reasoning/thinking blocks from AI messages — they come back with a
+        // null reasoningText after a checkpoint round-trip and Bedrock rejects them.
+        let cleaned = stripReasoningBlocks(msg);
+
+        // A reasoning-only AI message becomes empty after stripping. Sending empty
+        // content to Bedrock raises "content field ... is empty" on the next turn.
+        // Rewrite (never drop) so message count + Human/AI alternation are preserved.
+        if (cleaned._getType() === 'ai' && isEmptyAiMessageContent(cleaned as AIMessage)) {
+            const ai = cleaned as AIMessage;
+            cleaned = new AIMessage({
+                content: '(reasoning omitted)',
+                tool_calls: ai.tool_calls,
+                additional_kwargs: ai.additional_kwargs,
+                response_metadata: ai.response_metadata,
+                id: ai.id,
+                name: ai.name,
+                usage_metadata: ai.usage_metadata,
+            });
+        }
+
+        result.push(cleaned);
+```
+
+Note: the block below this (`if (msg._getType() !== 'ai') continue;` … `pendingIds` …) is unchanged. For a rewritten message `pendingIds` is empty (no tool calls), so it is a no-op — correct.
+
+- [ ] **Step 5: Run the new tests to verify they pass**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/sanitize-bedrock.test.ts`
+
+Expected: all tests in the file PASS (the three new ones plus the three pre-existing reasoning tests).
+
+- [ ] **Step 6: Run the full web-ui test suite to confirm no regression**
+
+Run: `cd apps/web-ui && bun run test`
+
+Expected: PASS with no new failures. Pay attention to `tests/agent-ops/agent-shared.test.ts` (the other file that exercises `sanitizeMessagesForBedrock`) — it must remain green.
+
+- [ ] **Step 7: Type-check / lint the changed file**
+
+Run: `cd apps/web-ui && bun run lint`
+
+Expected: no new errors in `lib/agent/agent-shared.ts`.
+
+- [ ] **Step 8: Commit (only if the human has explicitly asked to commit)**
+
+```bash
+git add apps/web-ui/lib/agent/agent-shared.ts apps/web-ui/lib/agent/sanitize-bedrock.test.ts docs/superpowers/specs/2026-07-21-aiops-multiturn-crash-fix-design.md docs/superpowers/plans/2026-07-21-aiops-multiturn-crash-fix.md
+git commit -m "fix(agent): rewrite empty-after-strip reasoning messages to placeholder
+
+A turn-1 reasoning-only AI message becomes empty after stripReasoningBlocks()
+and crashed Bedrock on turn 2 (and on history-session resume) with
+\"content field is empty\". Rewrite it in place to a non-empty placeholder inside
+sanitizeMessagesForBedrock() so message count and Human/AI alternation are
+preserved.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Manual / integration verification (after Task 1)
+
+These are not automated here (they require the running app + Bedrock) but MUST be checked before considering #2/#3 closed:
+
+1. Fresh chat → ask a question that triggers heavy reasoning → ask a **second** question on the same chat. Expected: turn 2 answers, no `ValidationException`.
+2. Reopen a **previous** history session (one that previously failed on the second ask) → ask a new question. Expected: it continues with prior context, no crash.
+3. Confirm a normal single-query chat still works unchanged.
+
+## Self-Review (completed by plan author)
+
+- **Spec coverage:** Fix (replace-not-drop) → Task 1 Steps 3-4. Predicate → `isEmptyAiMessageContent` (Step 3). Testing items 1-4 → Step 1 tests + pre-existing untouched-reference test; item 5 → Step 6. Alternation-safety rationale → enforced by "replace not drop" and asserted by the Step 1 alternation test. Out-of-scope items (#1 render, Gap A) → intentionally absent.
+- **Placeholder scan:** none — every code step shows full code and exact commands.
+- **Type consistency:** helper named `isEmptyAiMessageContent` consistently in Steps 3 and 4; placeholder string `"(reasoning omitted)"` identical in spec, helper doc, Step 1, and Step 4.

--- a/docs/superpowers/specs/2026-07-21-aiops-history-reasoning-render-design.md
+++ b/docs/superpowers/specs/2026-07-21-aiops-history-reasoning-render-design.md
@@ -1,0 +1,164 @@
+# AI Ops Chat — History Reasoning-Block Rendering (Phase 2)
+
+Date: 2026-07-21
+Status: Approved (design)
+Scope: Phase 2 of the 3-part effort. Read-path only. No storage/write change.
+
+## Problem
+
+When a user reopens a previous AI Ops chat session, reasoning content can render
+as a raw JSON blob, e.g.:
+
+    [{"type":"reasoning","reasoning":"","signature":"..."}]
+
+instead of rendering the way the live stream does (a collapsible "Thought for Ns"
+block, or — for empty reasoning — nothing at all). Everything else in a reopened
+session (plan, tool calls, answer) already renders correctly; only reasoning that
+was stored as an array of content blocks is broken.
+
+## Root cause
+
+Live and history both feed the same reducer (`buildTranscript` in
+`lib/agent-chat/events.ts`) → `AgentTurn` → `ThinkingBlock`. A `reasoning` part
+becomes a `thinking` event and renders as the collapsible block. The divergence
+is purely at the persistence boundary.
+
+**Write path** (`app/api/chat/route.ts`, `finally` block):
+- `route.ts:1183` — the phase marker is prepended only when
+  `typeof msg.content === 'string'`. Array content gets no marker.
+- `route.ts:1208` — `const content = typeof m.content === 'string' ? m.content :
+  JSON.stringify(m.content)`. Array content is stringified whole into storage.
+
+**Read path** (`app/api/threads/[threadId]/history/route.ts`):
+- `extractDisplayText` (`:88-105`) parses the JSON array but keeps only
+  `type:'text'` blocks. A pure-reasoning array has no text block, so it returns
+  the raw JSON string unchanged.
+- `convertPlainMessage` (`:107-129`) → `buildPhaseParts` (`:55-79`) →
+  `normalizeLegacyContent` (`legacy-normalizer.ts:24-31`) finds no marker →
+  classifies it as `phase: 'text'` → emits `[{ type: 'text', text: <raw JSON> }]`
+  → the reducer renders it verbatim as an answer.
+
+Marker-prefixed **string** content (planning / reflection / revision / memory,
+and execution/final prose) is unaffected — it reconstructs correctly today. Only
+**array** content with reasoning blocks is broken.
+
+## Key behavioral fact (defines "match live")
+
+The shared reducer drops any reasoning part whose text is empty
+(`events.ts:159-161`: `const text = stripSentinel(part.text ?? ''); if
+(text.length === 0) return;`). In the live stream, the signature-only
+`"reasoning":""` blocks therefore render as **nothing**. So matching live means:
+
+- empty-text reasoning → renders nothing (message vanishes, no empty box);
+- reasoning with real text → a "Thought for Ns" collapsible block;
+- text/answer blocks → the answer, as today.
+
+## Fix — read-path reconstruction (backward-compatible)
+
+All changes are in `app/api/threads/[threadId]/history/route.ts`. Nothing about
+how messages are stored changes, so the fix repairs **already-stored** history
+and future history alike, with no migration and no risk to the write path.
+
+### New helper: `reconstructAiContentParts(content)`
+
+- Input: an AI message's stored content — either the JSON string from
+  `chat_messages` (`convertPlainMessage`) or the raw `msg.content` value from the
+  checkpoint fallback (`convertMessage`).
+- Normalize to an array: if the value is already an array use it; if it is a
+  string that JSON-parses to an array, use that; otherwise return `null`.
+- Return `null` when the content is not a content-block array (so the caller
+  uses the existing string/marker path unchanged).
+- When it is an array, map block-by-block, preserving order, into
+  `HistoryMessage['parts']`:
+  - `text` block (`type === 'text'`, string `text`) → `{ type: 'text', text }`
+  - reasoning block → `{ type: 'reasoning', text: <extracted> }` **only if the
+    extracted text is non-empty**; empty reasoning blocks are skipped at the
+    source (mirrors the reducer's drop, so no empty turns).
+  - `tool_use` block → skipped (tool calls are reconstructed separately from
+    `metadata.tool_calls`; skipping avoids a duplicate tool part).
+  - any other block type → skipped.
+
+Reasoning-block detection + text extraction handles the shapes that occur:
+- `{ type: 'reasoning', reasoning: string, signature? }` → text = `reasoning`
+- `{ type: 'thinking', thinking: string }` → text = `thinking`
+- `{ type: 'redacted_reasoning' | 'redacted_thinking' | 'reasoning_content', … }`
+  → typically no text → contributes nothing
+- `{ reasoningContent: { reasoningText: { text: string } } }` (raw Bedrock) →
+  text = `reasoningText.text`
+
+The emitted `reasoning` part carries no `data-phase`; it renders as a generic
+"Thought for Ns" block (phase-specific banner coloring is not reconstructed for
+raw extended-thinking blocks — consistent with existing reload limitations noted
+in `history/route.ts`).
+
+### Wiring
+
+- `convertPlainMessage` (DB path), **AI branch only**: call
+  `reconstructAiContentParts(msg.content)` first. If non-null, use those parts;
+  else fall back to today's `extractDisplayText` + `buildPhaseParts`. Then append
+  tool-invocation parts from `metadata.tool_calls` exactly as today, and keep the
+  existing `if (parts.length === 0) return null` guard — a message that
+  reconstructs to nothing (empty-reasoning-only, no tool calls) is dropped, so it
+  vanishes like live. The `HistoryMessage.content` string field is set to the
+  concatenation of the reconstructed `text` blocks (empty string when there are
+  none) — reasoning text is never placed in `content`, only in `reasoning` parts.
+- `convertMessage` (checkpoint-fallback path), **AI branch only**: same
+  first-try/fallback, passing the raw `msg.content` (which may already be an
+  array).
+- The human and tool branches are untouched. `extractDisplayText` continues to
+  handle user multimodal text+image arrays; the new reconstruction is gated to
+  the AI role.
+
+## Result
+
+- `[{"type":"reasoning","reasoning":"",...}]` → dropped → nothing shown.
+- reasoning block with text → "Thought for Ns" block.
+- mixed `[reasoning, text]` → a reasoning part + the answer, in order.
+- planning / reflection / marker strings, tool calls, answers → unchanged.
+- raw JSON → gone from the interactive transcript.
+
+## Why it is production-safe
+
+- Read path only. The write path, storage format, and live stream are untouched,
+  so nothing about how sessions are recorded or streamed changes.
+- Additive branch: array content takes a new path; every existing string/marker
+  case falls through to today's exact code. Regression tests lock that.
+- Gated to the AI role, so the human multimodal path cannot regress.
+- No schema, infra, feature-flag, or API-contract change.
+
+## Testing
+
+Unit tests (Vitest) against the history route's conversion. If the target
+functions are not exported, export `reconstructAiContentParts` (and, if needed,
+`convertPlainMessage`) for testing, or add a thin exported wrapper — no behavior
+change.
+
+1. Pure empty-reasoning array (`[{type:'reasoning',reasoning:''}]`) on an AI
+   message with no tool calls → message is dropped (`convertPlainMessage` returns
+   `null`).
+2. Reasoning-with-text array → yields exactly one `reasoning` part carrying that
+   text, no `text` part.
+3. Mixed `[reasoning(text), text]` → yields a `reasoning` part then a `text`
+   part, in that order.
+4. `[reasoning(empty), tool_use]` + `metadata.tool_calls` for the same id →
+   exactly one tool-invocation part, no `reasoning` part, no duplicate tool part.
+5. `{reasoningContent:{reasoningText:{text:'…'}}}` block → reasoning part with
+   that text (raw Bedrock shape).
+6. Regression — marker string content (`PLANNING_PHASE_START\n…`,
+   `REFLECTION_PHASE_START\n…`) → identical output to today (reasoning part,
+   humanized where applicable).
+7. Regression — human multimodal array (`[{type:'text'},{type:'image_url'}]`) →
+   unchanged (still routed through `extractDisplayText`, not the new helper).
+
+Beyond units: reopen a real session that currently shows raw JSON and confirm the
+blob is gone and the transcript matches the live rendering.
+
+## Out of scope (flagged, not fixed here)
+
+- The write/storage format (`route.ts:1183`, `:1208`) — left as-is; the read path
+  interprets it.
+- Export paths (`lib/chat-export.ts`, `lib/agent-ops/export-markdown.ts`,
+  `lib/agent-ops/export-pdf.ts`) may share the raw-JSON / "Thinking:" issue.
+  Separate follow-up unless explicitly pulled in.
+- Phase-banner coloring for reconstructed raw extended-thinking blocks (they
+  render as generic "Thought" blocks).

--- a/docs/superpowers/specs/2026-07-21-aiops-multiturn-crash-fix-design.md
+++ b/docs/superpowers/specs/2026-07-21-aiops-multiturn-crash-fix-design.md
@@ -1,0 +1,145 @@
+# AI Ops Chat — Multi-Turn / Resume Crash Fix (Phase 1)
+
+Date: 2026-07-21
+Status: Approved (design)
+Scope: Phase 1 of a 3-part effort. This spec covers only the crash-fix.
+
+## Problem
+
+On the AI Ops chat, a brand-new chat with a single query works. But a **second
+query on the same chat fails**, and reopening a **previous history session and
+asking again fails** the same way. Both surface as a Bedrock error:
+
+> ValidationException: The content field in the Message object at messages.N is empty.
+
+### Why turn 2+ and resume are the same bug
+
+On any turn after the first — whether a live chat's next query or a reopened
+history session — the backend does **not** trust the browser's message array. It
+reloads the full prior conversation from the LangGraph **Postgres checkpointer**
+(keyed by `thread_id`, no TTL) and appends only the new user message
+(`apps/web-ui/app/api/chat/route.ts:420-486`). This is the intended "resume where
+it left off" design and it already exists. Both #2 (live multi-turn) and the
+functional core of #3 (resume + ask again) flow through this identical replay
+path.
+
+### Root cause
+
+On turn 1, the model can emit an AI message whose `content` array contains
+**only a reasoning/thinking block** (no text block, no tool calls) — e.g. Claude
+Sonnet consumes its output budget mid-reasoning. Turn 1 still succeeds because a
+`finalize` step synthesizes the real answer, but that reasoning-only message is
+checkpointed into thread state.
+
+On the next turn the checkpoint is replayed through
+`sanitizeMessagesForBedrock()` (`apps/web-ui/lib/agent/agent-shared.ts`):
+
+- `getRecentMessages()` filters empty-content messages **before** stripping, so
+  it keeps this message (its content array is non-empty at that point).
+- `sanitizeMessagesForBedrock()` → `stripReasoningBlocks()` removes the reasoning
+  block, leaving `content: []`, and then **pushes it unconditionally**
+  (`agent-shared.ts:713-714`) with no tool calls.
+- The message is sent to Bedrock with empty content → ValidationException.
+
+Nothing re-checks for emptiness *after* stripping. The gap is currently
+untested (`sanitize-bedrock.test.ts` covers null-text reasoning and
+thinking+text+tool_use, but not reasoning-only-becomes-empty).
+
+## Fix
+
+Single change site: `sanitizeMessagesForBedrock()` in
+`apps/web-ui/lib/agent/agent-shared.ts` (lines 711-714). This is the one function
+every Bedrock invoke routes through (`fast-agent.ts:139`,
+`planning-agent.ts:427` and `:767`).
+
+After `const cleaned = stripReasoningBlocks(msg)`: if `cleaned` is an AI message
+with **empty content AND no tool calls**, **replace its content with a minimal
+non-empty placeholder** (`"(reasoning omitted)"`) before pushing it. Do not drop
+it.
+
+### Why replace, not drop
+
+Dropping the message breaks Bedrock's strict Human/AI role alternation.
+`getRecentMessages()` runs *before* `sanitize` and already enforces alternation
+(`agent-shared.ts:593-613`, inserting `"Proceed."` / `"Acknowledged."`); nothing
+merges consecutive same-role messages anywhere before the Bedrock call. Turn 1
+persists both the reasoning-only AI message *and* the `finalize` answer as two
+adjacent AI messages (`fast-agent.ts:270`), so on turn 2 the sequence is
+`[Human(q1), AI(reasoning-only), Human("Proceed."), AI(final), Human(q2)]`.
+Dropping `AI(reasoning-only)` leaves `Human(q1)` and `Human("Proceed.")`
+adjacent → a *different* ValidationException. Replacing the emptied content with
+a placeholder keeps the assistant slot filled, so alternation stays valid:
+`[Human(q1), AI("(reasoning omitted)"), Human("Proceed."), AI(final), Human(q2)]`.
+The placeholder is consistent with the synthetic messages the code already uses
+(`"Proceed."`, `"Acknowledged."`, `"[Tool result unavailable — synthetic
+placeholder]"`).
+
+### Predicate (the safety hinges here)
+
+- `hasToolCalls` = `tool_calls.length > 0` **OR** the content array contains a
+  `tool_use` block.
+- `contentEmpty` = an empty array, or an array whose blocks are all empty /
+  whitespace-only `text` blocks; or a string that is empty / whitespace.
+- **Replace content only when** `isAIMessage && contentEmpty && !hasToolCalls`.
+
+This never touches a valid tool-use turn (empty text but real `tool_calls` is
+legitimate for Bedrock) and never touches a normal text answer. It rewrites only
+the message that is otherwise guaranteed to trigger the empty-content
+ValidationException, and leaves message count and roles intact.
+
+## Why it is production-safe
+
+- The turn-1 single-query path is unaffected: it does not replay old
+  reasoning-only messages, and a live turn never produces an already-empty
+  message at this boundary.
+- Message count and role order are preserved (content is rewritten in place, not
+  removed), so role alternation cannot regress.
+- The tool-result adjacency logic (`agent-shared.ts:718-752`) is untouched — the
+  replaced message has no tool calls, so the `pendingIds` block is a no-op for
+  it.
+- No schema, infra, feature-flag, or API-contract change. One pure function.
+
+## Testing
+
+TDD — write the failing tests first, in
+`apps/web-ui/lib/agent/sanitize-bedrock.test.ts`:
+
+1. **The bug (must fail before the fix):** a reasoning-only AI message
+   (`content: [ { reasoningContent: { reasoningText: { text: null } } } ]`, no
+   text, no tool_calls) placed between valid messages → after `sanitize` that
+   message is present with **non-empty** content (the `"(reasoning omitted)"`
+   placeholder) and no empty-content AI message survives. Today it survives with
+   `content: []`, so this fails before the fix.
+2. **Alternation preserved:** given
+   `[Human, AI(reasoning-only), Human, AI(text), Human]`, the sanitized output
+   has the same length and role order with no consecutive same-role pair.
+3. **The guard (must not over-rewrite):** an AI message with empty content
+   **but** `tool_calls` present → content left untouched, with its `ToolMessage`
+   still re-emitted immediately after it.
+4. **Normal answer untouched:** a plain-text AI message is returned by the same
+   reference (unchanged), as the existing test at
+   `sanitize-bedrock.test.ts:41-46` asserts.
+5. Full existing suite (`cd apps/web-ui && bun run test`) passes — no
+   regression.
+
+Beyond unit tests, verify manually: reproduce a real turn-2 on a fresh chat, and
+reopen a history session and ask again — confirm no ValidationException and the
+agent continues with prior context.
+
+## What this fixes
+
+- #2 — live multi-turn (second query on the same chat).
+- #3 — the functional core of resume: reopening a history session and asking a
+  new question no longer crashes and continues from the restored checkpoint
+  context.
+
+## Out of scope (tracked for later phases)
+
+- **Phase 2 — reasoning render in history (#1):** array-content reasoning is
+  persisted via `JSON.stringify` (`route.ts:1208`) with no phase marker
+  (`route.ts:1183`), so on replay the history route renders it as a raw-JSON
+  `text` answer instead of a "Thought for Ns" thinking block. Separate spec.
+- **Gap A — direct-chat continuity:** greeting / simple-Q&A turns
+  (`apps/web-ui/app/api/chat/direct-chat.ts`) bypass the checkpointer, so a
+  session made only of those has an empty checkpoint and falls back to a lossy
+  display-history replay. Triage separately.


### PR DESCRIPTION
## Summary

Three related fixes/improvements to the AI Ops chat, stacked on `master-v1`.

### 1. Multi-turn / resume crash fix (`47ba4ad`)
A turn-1 reasoning-only assistant message (a lone reasoning block, no text/tool calls) became empty after reasoning-block stripping and crashed Bedrock on turn 2 — and on history-session resume — with `ValidationException: The content field in the Message object ... is empty`. Both paths replay the LangGraph checkpoint through `sanitizeMessagesForBedrock()`.

Fix: rewrite such a message in place to a non-empty placeholder (`(reasoning omitted)`) instead of leaving it empty. Rewriting (not dropping) preserves message count and the Human/AI role alternation Bedrock requires. Restores real multi-turn + resume.

### 2. History reasoning renders as thinking blocks (`3df80a9`)
Reopened sessions rendered extended-thinking (stored as content-block arrays) as a raw `[{"type":"reasoning",...}]` JSON blob. Added a read-path helper that reconstructs such arrays into reasoning/text parts — dropping empty-text reasoning to match the live reducer — and wired it into the history route. **Read-path only**: storage, the write path, and the live stream are unchanged, so it fixes existing and future sessions with no migration.

### 3. Higher input/output limits (`14fdc74`)
- Chat input cap 2000 → 6000 chars (counter warning 1800 → 5400).
- `DEFAULT_MAX_OUTPUT_TOKENS` fallback 4096 → 8192 (only applies when a ProviderModel record sets no `maxTokens`; Bedrock/Anthropic Claude models support it).

## Testing
- `sanitize-bedrock.test.ts`: 7/7 (empty-after-strip regression + alternation + tool-use guards).
- `ai-content-parts.test.ts`: 11/11 (incl. render-parity via `buildTranscript`).
- Full web-ui suite: no new failures vs. baseline.

## Safety
Read-path / config changes only — no schema, infra, or write-path changes. Each change was independently reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
