### PR TITLE
fix(aiops): final answers no longer dropped, fragmented, or duplicated

### DIFF
--- a/apps/web-ui/app/api/threads/[threadId]/history/dedupe-answers.ts
+++ b/apps/web-ui/app/api/threads/[threadId]/history/dedupe-answers.ts
@@ -1,0 +1,58 @@
+/**
+ * Removes the duplicate answer a reloaded thread would otherwise show twice.
+ *
+ * finalNode promotes an already-composed deliverable by re-emitting it verbatim as
+ * a 'final'-phase message. Live that copy never streams (promotion makes no model
+ * call, and the route only emits text from on_chat_model_* events), so the reader
+ * sees the answer once. Persistence has no such filter — both rows are stored — and
+ * history replays 'execution' and 'final' alike, so the report appears twice.
+ *
+ * Dropping the LATER copy keeps the reloaded thread identical to the live view.
+ * Matching is on text, not phase: a fragmented reasoning-model turn is stored as a
+ * raw content-block array with no phase marker at all (route.ts only prefixes the
+ * marker when content is a string), so the execution copy frequently has no phase
+ * to match on. A genuine finalNode fallback answer differs from the execution text
+ * and is therefore never dropped — which is what keeps "did promotion fire?"
+ * readable from the transcript.
+ */
+
+type Part = { type: string; text?: string };
+type Msg = { role: string; content?: string; parts?: Part[] };
+
+/**
+ * Same floor finalNode uses to decide a message is a deliverable. Below it, an
+ * identical repeat is ordinary narration ("Now pulling CloudWatch metrics.") that
+ * legitimately occurs twice in a run.
+ */
+const MIN_DUPLICATE_LENGTH = 800;
+
+function answerText(m: Msg): string {
+    const fromParts = (m.parts ?? [])
+        .filter((p) => p.type === 'text')
+        .map((p) => p.text ?? '')
+        .join('');
+    return (fromParts || m.content || '').trim();
+}
+
+/** A turn that called tools is never a promoted copy — promotion emits text only. */
+function hasToolParts(m: Msg): boolean {
+    return (m.parts ?? []).some((p) => p.type === 'tool-invocation');
+}
+
+export function dropDuplicateAnswers<T extends Msg>(messages: T[]): T[] {
+    const seen = new Set<string>();
+    const kept: T[] = [];
+
+    for (const msg of messages) {
+        if (msg.role === 'assistant' && !hasToolParts(msg)) {
+            const text = answerText(msg);
+            if (text.length >= MIN_DUPLICATE_LENGTH) {
+                if (seen.has(text)) continue;
+                seen.add(text);
+            }
+        }
+        kept.push(msg);
+    }
+
+    return kept;
+}

--- a/apps/web-ui/app/api/threads/[threadId]/history/route.ts
+++ b/apps/web-ui/app/api/threads/[threadId]/history/route.ts
@@ -5,6 +5,7 @@ import { getSessionTenantId, getSessionUserId } from '@/lib/auth-session';
 import { AIMessage, HumanMessage, ToolMessage, BaseMessage } from '@langchain/core/messages';
 import { normalizeLegacyContent } from '@/lib/agent-chat/legacy-normalizer';
 import { reconstructAiContentParts } from '@/lib/agent-chat/ai-content-parts';
+import { dropDuplicateAnswers } from './dedupe-answers';
 import { parseUsageMetadata } from '@/lib/agent-chat/token-usage';
 import { humanizePlanning, stripWorkingMemoryPrelude } from '@/app/api/chat/stream-parts';
 
@@ -288,7 +289,7 @@ export async function GET(
             const msgs = await chatHistory.getMessages(sessionTenantId, sessionUserId, threadId);
             if (msgs.length > 0) {
                 const converted = msgs.map((m, i) => convertPlainMessage(m, i)).filter(Boolean) as HistoryMessage[];
-                return NextResponse.json({ messages: coalesceAssistantTurns(mergeToolResults(converted)), plan, pendingInterrupt });
+                return NextResponse.json({ messages: coalesceAssistantTurns(mergeToolResults(dropDuplicateAnswers(converted))), plan, pendingInterrupt });
             }
         } catch (err) {
             console.warn('[History API] Chat history lookup failed, falling back to checkpoint:', err);
@@ -301,7 +302,7 @@ export async function GET(
         if (!rawMessages?.length) return NextResponse.json({ messages: [], plan, pendingInterrupt });
 
         const converted = rawMessages.map((m, i) => convertMessage(m, i)).filter(Boolean) as HistoryMessage[];
-        return NextResponse.json({ messages: coalesceAssistantTurns(mergeToolResults(converted)), plan, pendingInterrupt });
+        return NextResponse.json({ messages: coalesceAssistantTurns(mergeToolResults(dropDuplicateAnswers(converted))), plan, pendingInterrupt });
     } catch (error) {
         console.error('[History API] Error:', error);
         return NextResponse.json({ error: 'Failed to fetch conversation history' }, { status: 500 });

--- a/apps/web-ui/lib/agent-chat/__tests__/ai-content-parts.test.ts
+++ b/apps/web-ui/lib/agent-chat/__tests__/ai-content-parts.test.ts
@@ -61,6 +61,41 @@ describe('reconstructAiContentParts', () => {
     it('accepts an already-parsed array (checkpoint-fallback path)', () => {
         expect(reconstructAiContentParts([{ type: 'text', text: 'hi' }])).toEqual([{ type: 'text', text: 'hi' }]);
     });
+
+    // A reasoning model keeps every streamed delta as its own block — 644 of them for
+    // one report in the run these tests were written from. One part per block renders
+    // as one UI row per block, shattering the answer into hundreds of fragments.
+    it('coalesces a run of streamed text deltas into a single part', () => {
+        const blocks = ['## Health', ' Report\n\n', 'Cluster is ', 'GREEN.'].map((text) => ({ type: 'text', text }));
+        expect(reconstructAiContentParts(JSON.stringify(blocks)))
+            .toEqual([{ type: 'text', text: '## Health Report\n\nCluster is GREEN.' }]);
+    });
+
+    it('keeps whitespace-only blocks INSIDE a run so words do not fuse', () => {
+        // Real shape: Bedrock splits mid-word and emits bare-space deltas between them.
+        const blocks = ['No long-running queries, no', ' ', 'bl', 'ocking, no idle-in', '-transaction issues.']
+            .map((text) => ({ type: 'text', text }));
+        expect(reconstructAiContentParts(JSON.stringify(blocks)))
+            .toEqual([{ type: 'text', text: 'No long-running queries, no blocking, no idle-in-transaction issues.' }]);
+    });
+
+    it('starts a new part at every type change, preserving order', () => {
+        const raw = JSON.stringify([
+            { type: 'text', text: 'first ' }, { type: 'text', text: 'answer' },
+            { type: 'reasoning', reasoning: 'recon' },
+            { type: 'text', text: 'second ' }, { type: 'text', text: 'answer' },
+        ]);
+        expect(reconstructAiContentParts(raw)).toEqual([
+            { type: 'text', text: 'first answer' },
+            { type: 'reasoning', text: 'recon' },
+            { type: 'text', text: 'second answer' },
+        ]);
+    });
+
+    it('drops a run that is entirely whitespace', () => {
+        const raw = JSON.stringify([{ type: 'text', text: '  ' }, { type: 'text', text: '\n' }]);
+        expect(reconstructAiContentParts(raw)).toEqual([]);
+    });
 });
 
 describe('render parity with live (via buildTranscript)', () => {

--- a/apps/web-ui/lib/agent-chat/ai-content-parts.ts
+++ b/apps/web-ui/lib/agent-chat/ai-content-parts.ts
@@ -35,19 +35,39 @@ export function reconstructAiContentParts(rawContent: unknown): AiContentPart[] 
     const blocks = normalizeToBlockArray(rawContent);
     if (blocks === null) return null;
 
+    // Consecutive blocks of the same kind are ONE part. A reasoning model keeps every
+    // streamed delta as its own block — 644 of them for a single report in the run this
+    // was written from — and one part per block renders as one UI row per block, which
+    // shatters the answer into hundreds of fragments. Whitespace is judged per RUN, not
+    // per block: Bedrock splits mid-word and emits bare-space deltas between the halves,
+    // so dropping those individually fuses words ("no" + " " + "blocking").
     const parts: AiContentPart[] = [];
+    let buf = '';
+    let bufKind: AiContentPart['type'] | null = null;
+
+    const flush = () => {
+        if (bufKind && buf.trim().length > 0) parts.push({ type: bufKind, text: buf.trim() });
+        buf = '';
+        bufKind = null;
+    };
+    const append = (kind: AiContentPart['type'], text: string) => {
+        if (kind !== bufKind) flush();
+        bufKind = kind;
+        buf += text;
+    };
+
     for (const block of blocks) {
         if (!block || typeof block !== 'object') continue;
         const b = block as Record<string, unknown>;
         if (b.type === 'text' && typeof b.text === 'string') {
-            if (b.text.trim().length > 0) parts.push({ type: 'text', text: b.text });
+            append('text', b.text);
             continue;
         }
         if (isReasoningBlock(b)) {
-            const text = extractReasoningText(b);
-            if (text.trim().length > 0) parts.push({ type: 'reasoning', text });
+            append('reasoning', extractReasoningText(b));
         }
         // tool_use / image / unknown → skipped (tool calls come from metadata.tool_calls)
     }
+    flush();
     return parts;
 }

--- a/apps/web-ui/lib/agent/__tests__/rendered-deliverable.test.ts
+++ b/apps/web-ui/lib/agent/__tests__/rendered-deliverable.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import { findRenderedDeliverable, tagMessagePhase } from '@/lib/agent/agent-shared';
+
+const long = (marker: string) => `${marker} ${'x'.repeat(900)}`;
+
+/**
+ * Sonnet 5 returns a reasoning turn as a block array and splits the answer into
+ * one text block per streamed delta — 544 blocks for a single 7k-char report in
+ * the run this test was written from.
+ */
+function sonnet5Blocks(text: string) {
+    const chunks: string[] = [];
+    for (let i = 0; i < text.length; i += 12) chunks.push(text.slice(i, i + 12));
+    return [
+        { type: 'reasoning_content', reasoningText: { signature: 'Eo8F', text: 'deliberating' } },
+        ...chunks.map((t) => ({ type: 'text', text: t })),
+    ];
+}
+
+describe('findRenderedDeliverable', () => {
+    it('promotes a plain-string execution message', () => {
+        const msgs = [tagMessagePhase(new AIMessage({ content: long('REPORT') }), 'execution')];
+        expect(findRenderedDeliverable(msgs)).toBe(long('REPORT'));
+    });
+
+    it('promotes a reasoning-model block array (Sonnet 5 fragmented content)', () => {
+        const report = long('REPORT');
+        const blocks = sonnet5Blocks(report);
+        expect(blocks.length).toBeGreaterThan(50); // genuinely fragmented, not a 2-block array
+        const msgs = [tagMessagePhase(new AIMessage({ content: blocks as never }), 'execution')];
+        expect(findRenderedDeliverable(msgs)).toBe(report);
+    });
+
+    it('ignores a reasoning-only turn that carries no answer text', () => {
+        const msgs = [tagMessagePhase(
+            new AIMessage({ content: [{ type: 'reasoning_content', reasoningText: { signature: 'Eo8F', text: 'x'.repeat(5000) } }] as never }),
+            'execution',
+        )];
+        expect(findRenderedDeliverable(msgs)).toBeNull();
+    });
+
+    it('ignores short narration and non-deliverable phases', () => {
+        expect(findRenderedDeliverable([
+            tagMessagePhase(new AIMessage({ content: 'Now pulling CloudWatch metrics.' }), 'execution'),
+            tagMessagePhase(new AIMessage({ content: long('REFLECTION') }), 'reflection'),
+            tagMessagePhase(new AIMessage({ content: long('PLAN') }), 'planning'),
+            new HumanMessage({ content: long('USER') }),
+        ])).toBeNull();
+    });
+
+    it('returns the latest deliverable when a revision follows the execution', () => {
+        const msgs = [
+            tagMessagePhase(new AIMessage({ content: long('FIRST') }), 'execution'),
+            tagMessagePhase(new AIMessage({ content: sonnet5Blocks(long('REVISED')) as never }), 'revision'),
+        ];
+        expect(findRenderedDeliverable(msgs)).toBe(long('REVISED'));
+    });
+});

--- a/apps/web-ui/lib/agent/agent-shared.ts
+++ b/apps/web-ui/lib/agent/agent-shared.ts
@@ -504,6 +504,32 @@ export function tagMessagePhase<T extends BaseMessage>(msg: T, phase: string): T
     return msg;
 }
 
+/** Phases whose text IS the deliverable the user asked for. */
+const DELIVERABLE_PHASES = new Set(['execution', 'revision']);
+
+/**
+ * The answer the executor (or reviser) already composed in-chat, so finalNode can
+ * promote it verbatim instead of re-synthesizing from a 3-tool-output window.
+ *
+ * Content is normalized through contentToText because a reasoning model does not
+ * return a string: a turn that emits reasoning alongside the answer arrives as a
+ * block array, and Sonnet 5 keeps every streamed delta as its own text block (544
+ * blocks for one 7k-char report in the run this was written from). A raw
+ * `typeof content === 'string'` test silently misses those, which drops a finished
+ * report on the floor and makes the run end in "I wasn't able to produce…".
+ */
+export function findRenderedDeliverable(messages: BaseMessage[], minLength = 800): string | null {
+    let found: string | null = null;
+    for (const m of messages) {
+        if (m._getType() !== 'ai') continue;
+        const phase = (m as unknown as { response_metadata?: { agentPhase?: string } }).response_metadata?.agentPhase ?? '';
+        if (!DELIVERABLE_PHASES.has(phase)) continue;
+        const text = contentToText(m.content);
+        if (text.trim().length >= minLength) found = text; // keep scanning — last one wins (latest revision)
+    }
+    return found;
+}
+
 // Get recent messages safely - ensuring tool call/result pairs are kept together
 // Also filters out empty messages that cause Bedrock API errors
 export function getRecentMessages(messages: BaseMessage[], maxMessages: number = 30): BaseMessage[] {

--- a/apps/web-ui/lib/agent/planning-agent.ts
+++ b/apps/web-ui/lib/agent/planning-agent.ts
@@ -16,6 +16,7 @@ import {
     sanitizeMessagesForBedrock,
     withUnresolvedToolCallsOnly,
     tagMessagePhase,
+    findRenderedDeliverable,
     llmAuditLog,
     getCheckpointer,
     getStore,
@@ -882,18 +883,7 @@ ${accountContext}`);
         // has only the last 3 truncated tool outputs as context, so it invents
         // follow-ups that contradict the real report (observed in live testing).
         // Verbatim promotion = zero drift, zero hallucination surface, zero cost.
-        const deliverablePhases = new Set(['execution', 'revision']);
-        let renderedDeliverable: string | null = null;
-        for (const m of state.messages) {
-            if (
-                m._getType() === 'ai' &&
-                deliverablePhases.has((m as unknown as { response_metadata?: { agentPhase?: string } }).response_metadata?.agentPhase ?? '') &&
-                typeof m.content === 'string' &&
-                m.content.trim().length >= 800
-            ) {
-                renderedDeliverable = m.content; // keep scanning — last one wins (latest revision)
-            }
-        }
+        const renderedDeliverable = findRenderedDeliverable(state.messages);
 
         if (renderedDeliverable) {
             console.log(`--- FINAL: Promoting already-rendered deliverable verbatim (no LLM call) ---`);

--- a/apps/web-ui/tests/history-dedupe-answers.test.ts
+++ b/apps/web-ui/tests/history-dedupe-answers.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { dropDuplicateAnswers } from '@/app/api/threads/[threadId]/history/dedupe-answers';
+
+const report = `# Aurora Serverless V2 Health Report\n\n${'Cluster is GREEN. '.repeat(60)}`;
+
+const answer = (id: string, text: string, extra: Array<Record<string, unknown>> = []) => ({
+    id,
+    role: 'assistant' as const,
+    content: text,
+    parts: [...extra, { type: 'text', text }],
+});
+
+describe('dropDuplicateAnswers', () => {
+    it('drops the promoted final copy and keeps the execution original', () => {
+        const msgs = [
+            { id: 'u', role: 'user' as const, content: 'analyze it', parts: [{ type: 'text', text: 'analyze it' }] },
+            answer('exec', report),
+            answer('final', report, [{ type: 'data-phase', data: { phase: 'final' } }]),
+        ];
+        const out = dropDuplicateAnswers(msgs);
+        expect(out.map((m) => m.id)).toEqual(['u', 'exec']);
+    });
+
+    it('keeps a genuine fallback answer that differs from the execution text', () => {
+        const msgs = [
+            answer('exec', report),
+            answer('final', "I wasn't able to produce the Aurora analysis you requested. " + 'x'.repeat(900)),
+        ];
+        expect(dropDuplicateAnswers(msgs).map((m) => m.id)).toEqual(['exec', 'final']);
+    });
+
+    it('tolerates the trailing-whitespace difference between the two stored copies', () => {
+        const msgs = [answer('exec', report), answer('final', `\n${report}  `)];
+        expect(dropDuplicateAnswers(msgs).map((m) => m.id)).toEqual(['exec']);
+    });
+
+    it('leaves short repeated narration alone', () => {
+        const msgs = [answer('a', 'Now pulling CloudWatch metrics.'), answer('b', 'Now pulling CloudWatch metrics.')];
+        expect(dropDuplicateAnswers(msgs).map((m) => m.id)).toEqual(['a', 'b']);
+    });
+
+    it('never drops a message carrying tool calls, even if its text repeats', () => {
+        const msgs = [
+            answer('exec', report),
+            answer('withTool', report, [{ type: 'tool-invocation', toolCallId: 't1', toolName: 'execute_command' }]),
+        ];
+        expect(dropDuplicateAnswers(msgs).map((m) => m.id)).toEqual(['exec', 'withTool']);
+    });
+
+    it('does not touch user or tool messages', () => {
+        const long = 'y'.repeat(900);
+        const msgs = [
+            { id: 'u1', role: 'user' as const, content: long, parts: [{ type: 'text', text: long }] },
+            { id: 'u2', role: 'user' as const, content: long, parts: [{ type: 'text', text: long }] },
+            { id: 't1', role: 'tool' as const, content: long, parts: [{ type: 'text', text: long }] },
+        ];
+        expect(dropDuplicateAnswers(msgs).map((m) => m.id)).toEqual(['u1', 'u2', 't1']);
+    });
+});


### PR DESCRIPTION
Three fixes for the same end-to-end failure: a finished AI Ops report was thrown away and replaced with "I wasn't able to produce the analysis you requested", and what survived to history came back shattered or duplicated. All three are triggered by reasoning models, which return content-block arrays instead of strings and keep every streamed delta as its own block.

### 1. `fix(aiops): promote a reasoning-model deliverable instead of re-synthesizing it`

`finalNode` promotes an already-composed report verbatim to avoid paying for a closing LLM call, but gated that on `typeof m.content === 'string'`. A reasoning model never returns a string — one 7k-char report arrived as 544 separate text blocks. The gate missed it, so the finished report was dropped and the fallback re-synthesized from `toolResults.slice(-3)`; with only three SSM shell results in view the model said, correctly for what it could see, that it had failed — moments after producing the analysis. The UI then elevated *that* into the Report card.

Extracted the scan as `findRenderedDeliverable()` and routed content through `contentToText()`, which this file already applies in six other places for the same reason.

### 2. `fix(chat): coalesce streamed content blocks when replaying history`

`reconstructAiContentParts` emitted one UI part per persisted block, so a reloaded answer shattered into hundreds of rows split mid-word (`'ikes'`, `' latency <0'`, `'.3'`, `'ms, '`) — 644 for one report. Consecutive same-kind blocks now accumulate into a single part, and whitespace is judged per *run* rather than per block: Bedrock emits bare-space deltas between mid-word splits, and discarding those individually fused halves together (`"no" + " " + "blocking"` → `"noblocking"`). Runs are still trimmed at their ends, so existing leading-whitespace behaviour holds. Applies to every stored thread on reload, not just new runs.

### 3. `fix(history): drop the duplicated promoted answer on reload`

Promotion re-emits the deliverable verbatim as a final-phase message. Live, that copy never reaches the client — promotion makes no model call and the route only emits text from `on_chat_model_*` events. Persistence has no such filter, so both rows were stored and history replayed the report twice: once as execution prose, once inside the Report card.

The later copy is now dropped so a reloaded thread matches the live view. Matching is on text, not phase — a fragmented reasoning-model turn is persisted as a raw content-block array with no phase marker (`route.ts` only prefixes the marker when content is a string), so the execution copy often has no phase to match on. The two stored copies are byte-identical once the marker is stripped (6420 chars each in the thread this was found in), so exact comparison suffices. A genuine `finalNode` fallback answer differs from the execution text and is never dropped, keeping "did promotion fire?" readable from the transcript. The 800-char floor mirrors `finalNode`'s own, so ordinary repeated narration is left alone. Wired into both history paths (chat-history and the checkpoint fallback).

### Tests

26 new/existing tests across the three touched areas pass:

```
cd apps/web-ui && bun run test -- tests/history-dedupe-answers.test.ts \
  lib/agent-chat/__tests__/ai-content-parts.test.ts \
  lib/agent/__tests__/rendered-deliverable.test.ts

Test Files  3 passed (3)
     Tests  26 passed (26)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
